### PR TITLE
Add CPU-initiated RoCE transport (CpuRoceTransceiver) + HOST_CALL dispatch

### DIFF
--- a/realtime/include/cudaq/realtime/cpu_transport/roce_transceiver.hpp
+++ b/realtime/include/cudaq/realtime/cpu_transport/roce_transceiver.hpp
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+// CpuRoceTransceiver — pure-CPU RDMA RoCEv2 transceiver that mirrors the
+// hololink::operators::GpuRoceTransceiver RX/TX ring-buffer contract but
+// drives the wire from libibverbs on a CPU thread instead of from a
+// DOCA-GPU kernel. Phase 1 of the cpu_transport umbrella.
+//
+// Ring layout per ring (RX and TX symmetric):
+//   addr        : base pointer to a contiguous pinned host buffer of
+//                 stride_num * stride_sz bytes.
+//   stride_sz   : size of one slot (one full payload).
+//   stride_num  : number of slots; must be a power of two so the indexing
+//                 pattern `wqe_idx & (stride_num - 1)` matches the existing
+//                 GPU transceiver's design.
+//   flag        : per-slot uint64; non-zero means "fresh data" (the value
+//                 is the slot's data address) and zero means "consumer has
+//                 released the slot".  Identical convention to
+//                 GpuRoceTransceiver's gpu_rx_ring.flag / gpu_tx_ring.flag.
+//
+// Wire protocol per direction:
+//
+//   RX path (peer -> us): peer issues RDMA_WRITE_WITH_IMMEDIATE that lands
+//   in our rx_data[slot]; recv WQE we pre-posted with wr_id = encoded slot
+//   completes; RX thread publishes rx_flag[slot] = (uint64_t)(rx_data +
+//   slot*stride_sz).  Consumer busy-polls rx_flag, then sets it back to 0
+//   when done so the RX thread can re-post the recv WQE for that slot.
+//   Identical for both Phase 1 (peer is FPGA) and Phase 2 (peer is another
+//   CpuRoceTransceiver).
+//
+//   TX path (us -> peer): producer writes payload into tx_data[slot], then
+//   publishes tx_flag[slot] = (uint64_t)(tx_data + slot*stride_sz).  TX
+//   thread busy-polls tx_flag, claims slot by clearing it, and issues the
+//   wire verb.  The wire verb depends on tx_mode (see CpuRoceTxMode below).
+//
+// Memory ordering: all rx_flag/tx_flag accesses use __ATOMIC_ACQUIRE on
+// loads and __ATOMIC_RELEASE on stores (the CPU equivalent of the GPU
+// transceiver's doca_gpu_dev_verbs_fence_* calls).
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace cudaq::realtime::bridge {
+
+/// Which RDMA wire verb the TX path uses.  The RX path is identical for
+/// both modes (consume RDMA_WRITE_WITH_IMMEDIATE via a pre-posted recv WQE).
+enum class CpuRoceTxMode {
+  /// Phase 1: bridge-to-FPGA.  The FPGA's HSB IP receives Sends only, so
+  /// our TX path issues `IBV_WR_SEND`.  Default for backward compatibility
+  /// with the existing FPGA-facing test harness.
+  kSendForFpga,
+
+  /// Phase 2: cpu_roce caller-to-daemon (or daemon-to-caller).  Both
+  /// endpoints are CpuRoceTransceivers and both can receive Writes.  TX
+  /// uses `IBV_WR_RDMA_WRITE_WITH_IMM` targeting the peer's pre-known
+  /// `rx_data` base + slot offset using the peer's rkey, with the slot
+  /// index carried in the IMM data so the peer can decode it.
+  kWriteWithImmForPeer,
+};
+
+/// Pure-CPU RDMA RoCEv2 transceiver.  Mirrors the public API surface of
+/// `hololink::operators::GpuRoceTransceiver` (HSB) so consumers like
+/// `hololink_bridge_common.h` can swap the GPU transceiver for this CPU
+/// one with minimal wiring changes.
+///
+/// Lifecycle:
+///   1. construct  : capture configuration; no kernel/network activity yet.
+///   2. start()    : open ibv device, build PD/CQs/QP/MRs, pre-post recv WQEs,
+///                   transition QP RST -> INIT -> RTR -> RTS.
+///   3. blocking_monitor() : spawn RX/TX threads (or one unified thread when
+///                   unified=true) and block until close().
+///   4. close()    : signal exit_flag, join threads, release ibv resources.
+class CpuRoceTransceiver {
+public:
+  /// Constructor.  Parameters mirror GpuRoceTransceiver's where applicable
+  /// and add `unified` + `tx_mode` + `peer_rx_*` for the Phase 1 / Phase 2
+  /// modes.
+  ///
+  /// \param ibv_name              IB device name (e.g. "mlx5_0").
+  /// \param ibv_port              IB port number (1-based; typically 1).
+  /// \param tx_ibv_qp             Remote QP number to connect to (the
+  ///                              FPGA's hardcoded QP for Phase 1, or the
+  ///                              peer transceiver's QP for Phase 2).
+  /// \param cu_frame_size         Logical frame size in bytes (one RPC
+  ///                              request/response payload size).
+  /// \param cu_page_size          Per-slot stride in bytes (must be >=
+  ///                              cu_frame_size + header overhead).
+  /// \param pages                 Number of slots per ring (power of two).
+  /// \param peer_ip               Peer IPv4 address for the GID exchange.
+  /// \param forward               When true, RX thread immediately re-sends
+  ///                              the slot back out (loopback latency
+  ///                              baseline); mutually exclusive with rx_only
+  ///                              / tx_only / unified.
+  /// \param rx_only               Skip the TX thread (RX-only mode).
+  /// \param tx_only               Skip the RX thread and recv WQE pre-post.
+  /// \param unified               When true, replace separate RX + dispatcher +
+  ///                              TX threads with a single loop thread that
+  ///                              does poll-CQ -> function-table lookup ->
+  ///                              host_fn -> post-send -> re-arm recv WQE.
+  ///                              CPU analogue of GpuRoceTransceiver's
+  ///                              --unified GPU kernel.  Mutually exclusive
+  ///                              with forward / rx_only / tx_only.
+  /// \param tx_mode               Which wire verb the TX path uses (see
+  ///                              CpuRoceTxMode).  Default is kSendForFpga
+  ///                              for backward-compatible Phase 1 use against
+  ///                              the FPGA, which can only receive Sends.
+  /// \param peer_rx_base_addr     Used when tx_mode == kWriteWithImmForPeer.
+  ///                              The base virtual address of the peer's
+  ///                              rx_data ring; our TX issues
+  ///                              IBV_WR_RDMA_WRITE_WITH_IMM with
+  ///                              remote_addr = peer_rx_base_addr +
+  ///                              slot * cu_page_size.  Ignored for
+  ///                              kSendForFpga.
+  /// \param peer_rx_rkey          Used when tx_mode == kWriteWithImmForPeer.
+  ///                              The rkey associated with the peer's
+  ///                              rx_data MR.  Ignored for kSendForFpga.
+  CpuRoceTransceiver(const char *ibv_name, unsigned ibv_port,
+                     unsigned tx_ibv_qp, std::size_t cu_frame_size,
+                     std::size_t cu_page_size, unsigned pages,
+                     const char *peer_ip, bool forward, bool rx_only,
+                     bool tx_only, bool unified,
+                     CpuRoceTxMode tx_mode = CpuRoceTxMode::kSendForFpga,
+                     std::uint64_t peer_rx_base_addr = 0,
+                     std::uint32_t peer_rx_rkey = 0);
+
+  ~CpuRoceTransceiver();
+
+  // Non-copyable, non-movable (owns ibv resources + threads).
+  CpuRoceTransceiver(const CpuRoceTransceiver &) = delete;
+  CpuRoceTransceiver &operator=(const CpuRoceTransceiver &) = delete;
+  CpuRoceTransceiver(CpuRoceTransceiver &&) = delete;
+  CpuRoceTransceiver &operator=(CpuRoceTransceiver &&) = delete;
+
+  /// Open the ibv device, build PD/CQs/QP/MRs, allocate pinned ring
+  /// memory, pre-post recv WQEs, transition the QP to RTR (or RTS for
+  /// full-duplex).  Returns true on success.
+  bool start();
+
+  /// Spawn the RX/TX (or single unified) thread(s).  Returns when close()
+  /// is called.  Idempotent: a second call returns immediately if the
+  /// monitor is already running, or if start() has not been called.
+  void blocking_monitor();
+
+  /// Signal exit, join threads, release ibv resources.  Safe to call from
+  /// any thread.  Idempotent.
+  void close();
+
+  /// Per-slot dispatch callback for unified mode.  The transport library
+  /// invokes this on every RX CQE — the callback reads the request from
+  /// `rx_slot`, writes the response into `tx_slot`, and returns the number
+  /// of bytes written (or 0 if the slot should be dropped without sending
+  /// a response).  The callback runs on the transceiver's unified thread,
+  /// so it must be quick (otherwise consider the three-thread layout).
+  ///
+  /// Kept transport-agnostic so the cpu_transport library has no
+  /// dependency on cudaq_realtime.h / CUDA.  The bridge tool wraps the
+  /// function-table lookup into a closure and supplies it here.
+  using UnifiedDispatchFn = std::size_t (*)(void *context, const void *rx_slot,
+                                            void *tx_slot,
+                                            std::size_t slot_size);
+
+  /// Provide the unified-mode dispatch callback + opaque context.  Must be
+  /// called between start() and blocking_monitor() when constructed with
+  /// unified=true.  The caller retains ownership of `context`; it must
+  /// outlive blocking_monitor().  No-op when not in unified mode.
+  void set_unified_dispatch(UnifiedDispatchFn fn, void *context);
+
+  // ===========================================================================
+  // Local QP / rkey for the HSB control plane (Phase 1) or out-of-band
+  // rendezvous (Phase 2).  Populated by start().
+  // ===========================================================================
+
+  /// Local QP number assigned by ibv_create_qp.  Pass this to the FPGA
+  /// (Phase 1, via hololink_channel->authenticate) or to the peer
+  /// (Phase 2, via the daemon-prints-stdout rendezvous).
+  std::uint32_t get_qp_number() const;
+
+  /// rkey for our rx_data MR.  Peer needs this to RDMA-write into our
+  /// receive ring.
+  std::uint32_t get_rkey() const;
+
+  /// Logical "base address" of the externally-visible rx_data buffer.
+  /// Returns 0 by convention (we register the rx_data MR with
+  /// ibv_reg_mr_iova so the peer addresses slots by offset alone, with
+  /// the rkey identifying our MR).
+  std::uint64_t external_frame_memory() const;
+
+  // ===========================================================================
+  // Ring accessors mirroring GpuRoceTransceiver's get_*_ring_* surface
+  // exactly.  Consumers in hololink_bridge_common.h populate cudaq_ringbuffer_t
+  // from these.
+  // ===========================================================================
+
+  std::uint8_t *get_rx_ring_data_addr() const;
+  std::size_t get_rx_ring_stride_sz() const;
+  std::uint32_t get_rx_ring_stride_num() const;
+  std::uint64_t *get_rx_ring_flag_addr() const;
+
+  std::uint8_t *get_tx_ring_data_addr() const;
+  std::size_t get_tx_ring_stride_sz() const;
+  std::uint32_t get_tx_ring_stride_num() const;
+  std::uint64_t *get_tx_ring_flag_addr() const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace cudaq::realtime::bridge

--- a/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
@@ -15,7 +15,8 @@
 ///   - hsb_bridge_cpu     (Phase 1, FPGA-facing; default tx_mode_send_for_fpga)
 ///   - CpuRoceChannel     (Phase 2, plugged into PR #4565's DeviceCallChannel
 ///                         framework; tx_mode_write_with_imm_for_peer)
-///   - cpu_roce_test_daemon (Phase 2 service-end; tx_mode_write_with_imm_for_peer)
+///   - cpu_roce_test_daemon (Phase 2 service-end;
+///   tx_mode_write_with_imm_for_peer)
 
 #ifndef CPU_ROCE_WRAPPER_H
 #define CPU_ROCE_WRAPPER_H
@@ -59,11 +60,10 @@ typedef enum {
 /// non-zero (the addresses the peer's `cpu_roce_get_rx_ring_data_addr`
 /// returned + `cpu_roce_get_rkey` returned, exchanged out-of-band).
 cpu_roce_transceiver_t cpu_roce_create_transceiver(
-    const char *device_name, int ib_port, unsigned tx_ibv_qp,
-    size_t frame_size, size_t page_size, unsigned num_pages,
-    const char *peer_ip, int forward, int rx_only, int tx_only, int unified,
-    cpu_roce_tx_mode_t tx_mode, uint64_t peer_rx_base_addr,
-    uint32_t peer_rx_rkey);
+    const char *device_name, int ib_port, unsigned tx_ibv_qp, size_t frame_size,
+    size_t page_size, unsigned num_pages, const char *peer_ip, int forward,
+    int rx_only, int tx_only, int unified, cpu_roce_tx_mode_t tx_mode,
+    uint64_t peer_rx_base_addr, uint32_t peer_rx_rkey);
 
 /// Destroy the transceiver.  Idempotent.  Implicitly calls cpu_roce_close
 /// if the transceiver is still running.

--- a/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
@@ -1,0 +1,127 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// @file roce_wrapper.h
+/// @brief C interface to cudaq::realtime::bridge::CpuRoceTransceiver.
+///
+/// Parallels hololink_wrapper.h (which wraps GpuRoceTransceiver) so the
+/// existing bridge-tool patterns can swap in the CPU transport with
+/// minimal changes.  Used by:
+///   - hsb_bridge_cpu     (Phase 1, FPGA-facing; default tx_mode_send_for_fpga)
+///   - CpuRoceChannel     (Phase 2, plugged into PR #4565's DeviceCallChannel
+///                         framework; tx_mode_write_with_imm_for_peer)
+///   - cpu_roce_test_daemon (Phase 2 service-end; tx_mode_write_with_imm_for_peer)
+
+#ifndef CPU_ROCE_WRAPPER_H
+#define CPU_ROCE_WRAPPER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque handle to CpuRoceTransceiver.
+typedef void *cpu_roce_transceiver_t;
+
+/// Which RDMA wire verb the TX path uses.  Mirrors CpuRoceTxMode in
+/// roce_transceiver.hpp.
+typedef enum {
+  /// Phase 1: bridge-to-FPGA.  TX issues IBV_WR_SEND because the FPGA's
+  /// HSB IP can only receive Sends.
+  CPU_ROCE_TX_MODE_SEND_FOR_FPGA = 0,
+  /// Phase 2: cpu_roce caller ↔ daemon.  TX issues
+  /// IBV_WR_RDMA_WRITE_WITH_IMM targeting the peer's rx_data using the
+  /// peer's rkey; slot index carried in the IMM.
+  CPU_ROCE_TX_MODE_WRITE_WITH_IMM_FOR_PEER = 1,
+} cpu_roce_tx_mode_t;
+
+//==============================================================================
+// Lifecycle
+//==============================================================================
+
+/// Construct a new transceiver.  Returns NULL on invalid arguments
+/// (mutually-exclusive forward/rx_only/tx_only/unified, missing peer_rx_*
+/// for kWriteWithImmForPeer, non-power-of-two num_pages).  Does not start
+/// the transport; call cpu_roce_start() next.
+///
+/// `forward`, `rx_only`, `tx_only`, `unified` are bool-as-int (0 = false,
+/// non-zero = true).  At most one may be true.
+///
+/// `peer_rx_base_addr` and `peer_rx_rkey` are ignored unless `tx_mode` is
+/// CPU_ROCE_TX_MODE_WRITE_WITH_IMM_FOR_PEER, in which case they must be
+/// non-zero (the addresses the peer's `cpu_roce_get_rx_ring_data_addr`
+/// returned + `cpu_roce_get_rkey` returned, exchanged out-of-band).
+cpu_roce_transceiver_t cpu_roce_create_transceiver(
+    const char *device_name, int ib_port, unsigned tx_ibv_qp,
+    size_t frame_size, size_t page_size, unsigned num_pages,
+    const char *peer_ip, int forward, int rx_only, int tx_only, int unified,
+    cpu_roce_tx_mode_t tx_mode, uint64_t peer_rx_base_addr,
+    uint32_t peer_rx_rkey);
+
+/// Destroy the transceiver.  Idempotent.  Implicitly calls cpu_roce_close
+/// if the transceiver is still running.
+void cpu_roce_destroy_transceiver(cpu_roce_transceiver_t handle);
+
+/// Open the ibv device, build PD/CQs/QP/MRs, allocate rings, pre-post recv
+/// WQEs, transition to RTS.  Returns 1 on success, 0 on failure.
+int cpu_roce_start(cpu_roce_transceiver_t handle);
+
+/// Signal exit, join I/O threads, release ibv/memory resources.
+/// Idempotent.  Safe to call from any thread.
+void cpu_roce_close(cpu_roce_transceiver_t handle);
+
+/// Spawn the configured I/O thread(s) and block until cpu_roce_close().
+/// Idempotent.  Throws on start() not having succeeded (returned to the
+/// C ABI as a return-without-blocking).
+void cpu_roce_blocking_monitor(cpu_roce_transceiver_t handle);
+
+/// Per-slot dispatch callback for unified mode.  Returns number of bytes
+/// written to tx_slot (0 = drop without sending).  See
+/// CpuRoceTransceiver::UnifiedDispatchFn in roce_transceiver.hpp.
+typedef size_t (*cpu_roce_unified_dispatch_fn_t)(void *context,
+                                                 const void *rx_slot,
+                                                 void *tx_slot,
+                                                 size_t slot_size);
+
+/// Install the unified-mode dispatch callback + opaque context.  No-op
+/// when the transceiver was not constructed with unified=1.  Caller
+/// retains ownership of `context`; it must outlive
+/// cpu_roce_blocking_monitor.
+void cpu_roce_set_unified_dispatch(cpu_roce_transceiver_t handle,
+                                   cpu_roce_unified_dispatch_fn_t fn,
+                                   void *context);
+
+//==============================================================================
+// QP / rkey for rendezvous
+//==============================================================================
+
+/// Local QP number assigned by ibv_create_qp.  Pass to peer.
+uint32_t cpu_roce_get_qp_number(cpu_roce_transceiver_t handle);
+
+/// rkey of our rx_data MR.  Peer uses this to RDMA-write into our RX ring.
+uint32_t cpu_roce_get_rkey(cpu_roce_transceiver_t handle);
+
+//==============================================================================
+// Ring buffer accessors (mirroring hololink_wrapper.h's surface)
+//==============================================================================
+
+void *cpu_roce_get_rx_ring_data_addr(cpu_roce_transceiver_t handle);
+uint64_t *cpu_roce_get_rx_ring_flag_addr(cpu_roce_transceiver_t handle);
+void *cpu_roce_get_tx_ring_data_addr(cpu_roce_transceiver_t handle);
+uint64_t *cpu_roce_get_tx_ring_flag_addr(cpu_roce_transceiver_t handle);
+
+size_t cpu_roce_get_page_size(cpu_roce_transceiver_t handle);
+unsigned cpu_roce_get_num_pages(cpu_roce_transceiver_t handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CPU_ROCE_WRAPPER_H

--- a/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
@@ -108,6 +108,11 @@ uint32_t cpu_roce_get_qp_number(cpu_roce_transceiver_t handle);
 /// rkey of our rx_data MR.  Peer uses this to RDMA-write into our RX ring.
 uint32_t cpu_roce_get_rkey(cpu_roce_transceiver_t handle);
 
+/// IOVA base of the externally-visible rx_data buffer.  Peer addresses
+/// our slots by remote_addr = cpu_roce_get_buffer_addr() + slot*stride.
+/// Currently equals the virtual address of rx_data (plain ibv_reg_mr).
+uint64_t cpu_roce_get_buffer_addr(cpu_roce_transceiver_t handle);
+
 //==============================================================================
 // Ring buffer accessors (mirroring hololink_wrapper.h's surface)
 //==============================================================================

--- a/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/roce_wrapper.h
@@ -39,7 +39,7 @@ typedef enum {
   CPU_ROCE_TX_MODE_SEND_FOR_FPGA = 0,
   /// Phase 2: cpu_roce caller ↔ daemon.  TX issues
   /// IBV_WR_RDMA_WRITE_WITH_IMM targeting the peer's rx_data using the
-  /// peer's rkey; slot index carried in the IMM.
+  /// peer's `rkey`; slot index carried in the IMM.
   CPU_ROCE_TX_MODE_WRITE_WITH_IMM_FOR_PEER = 1,
 } cpu_roce_tx_mode_t;
 
@@ -69,11 +69,11 @@ cpu_roce_transceiver_t cpu_roce_create_transceiver(
 /// if the transceiver is still running.
 void cpu_roce_destroy_transceiver(cpu_roce_transceiver_t handle);
 
-/// Open the ibv device, build PD/CQs/QP/MRs, allocate rings, pre-post recv
+/// Open the `ibv` device, build PD/CQs/QP/MRs, allocate rings, pre-post `recv`
 /// WQEs, transition to RTS.  Returns 1 on success, 0 on failure.
 int cpu_roce_start(cpu_roce_transceiver_t handle);
 
-/// Signal exit, join I/O threads, release ibv/memory resources.
+/// Signal exit, join I/O threads, release `ibv`/memory resources.
 /// Idempotent.  Safe to call from any thread.
 void cpu_roce_close(cpu_roce_transceiver_t handle);
 
@@ -105,7 +105,7 @@ void cpu_roce_set_unified_dispatch(cpu_roce_transceiver_t handle,
 /// Local QP number assigned by ibv_create_qp.  Pass to peer.
 uint32_t cpu_roce_get_qp_number(cpu_roce_transceiver_t handle);
 
-/// rkey of our rx_data MR.  Peer uses this to RDMA-write into our RX ring.
+/// `rkey` of our rx_data MR.  Peer uses this to RDMA-write into our RX ring.
 uint32_t cpu_roce_get_rkey(cpu_roce_transceiver_t handle);
 
 /// IOVA base of the externally-visible rx_data buffer.  Peer addresses

--- a/realtime/include/cudaq/realtime/daemon/dispatcher/cudaq_realtime.h
+++ b/realtime/include/cudaq/realtime/daemon/dispatcher/cudaq_realtime.h
@@ -52,8 +52,16 @@ typedef enum {
 } cudaq_kernel_type_t;
 
 // Dispatch invocation mode.
-// For CUDAQ_DISPATCH_PATH_HOST only GRAPH_LAUNCH is dispatched; DEVICE_CALL and
-// HOST_CALL table entries are dropped (slot cleared and advanced).
+//
+// On CUDAQ_DISPATCH_PATH_HOST:
+//   - GRAPH_LAUNCH: launched on a graph worker (worker pool, cudaGraphLaunch).
+//   - HOST_CALL:    invoked synchronously inline as a plain C++ function via
+//                   entry->handler.host_fn.  Bypasses the worker pool.  No
+//                   CUDA graph required.  Use for GPU-less bridges (e.g. the
+//                   CPU RoCE transport in lib/cpu_transport/) or for
+//                   handlers whose work fits on a single CPU thread.
+//   - DEVICE_CALL:  table entries are dropped (DEVICE_CALL belongs on the
+//                   GPU dispatch path).
 typedef enum {
   CUDAQ_DISPATCH_DEVICE_CALL = 0,
   CUDAQ_DISPATCH_GRAPH_LAUNCH = 1,

--- a/realtime/lib/CMakeLists.txt
+++ b/realtime/lib/CMakeLists.txt
@@ -15,3 +15,4 @@ install(DIRECTORY ${CUDAQ_REALTIME_INCLUDE_DIR}/cudaq
 )
 
 add_subdirectory(daemon)
+add_subdirectory(cpu_transport)

--- a/realtime/lib/cpu_transport/CMakeLists.txt
+++ b/realtime/lib/cpu_transport/CMakeLists.txt
@@ -1,0 +1,57 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+# ==============================================================================
+# CPU RoCE transport library (Phase 1 of cpu_transport umbrella)
+#
+# Builds cudaq-realtime-cpu-transport, a static library exporting the
+# CpuRoceTransceiver class plus its extern-C wrapper. Used by:
+#   - hsb_bridge_cpu (Phase 1, FPGA-facing test binary; tx_mode=kSendForFpga)
+#   - CpuRoceChannel and cpu_roce_test_daemon (Phase 2, both with
+#     tx_mode=kWriteWithImmForPeer)
+#
+# Depends only on libibverbs + standard C++; deliberately no DOCA, no Hololink,
+# no Holoscan, no CUDA at link time so the library is buildable on hosts
+# without GPUs.
+# ==============================================================================
+
+find_library(IBVERBS_LIBRARY NAMES ibverbs)
+if (NOT IBVERBS_LIBRARY)
+  message(STATUS "  - cpu_transport: libibverbs not found, skipping")
+  return()
+endif()
+
+add_library(cudaq-realtime-cpu-transport STATIC
+  roce_transceiver.cpp  # class CpuRoceTransceiver: ibv setup, RX/TX threads, ring lifecycle
+  roce_wrapper.cpp      # extern-C shim used by bridge tools and CpuRoceChannel
+)
+
+target_include_directories(cudaq-realtime-cpu-transport
+  PUBLIC
+    $<BUILD_INTERFACE:${CUDAQ_REALTIME_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(cudaq-realtime-cpu-transport
+  PUBLIC
+    ${IBVERBS_LIBRARY}
+    Threads::Threads
+)
+
+set_target_properties(cudaq-realtime-cpu-transport PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+)
+
+install(TARGETS cudaq-realtime-cpu-transport
+  EXPORT cudaq-realtime-targets
+  COMPONENT realtime-lib
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+message(STATUS "  - cudaq-realtime-cpu-transport (CPU RoCE transport; libibverbs)")

--- a/realtime/lib/cpu_transport/roce_transceiver.cpp
+++ b/realtime/lib/cpu_transport/roce_transceiver.cpp
@@ -230,25 +230,45 @@ bool CpuRoceTransceiver::Impl::open_ib_device() {
 }
 
 bool CpuRoceTransceiver::Impl::find_roce_v2_gid() {
-  // Scan GIDs on the chosen port for the first RoCEv2 entry (matches HSB's
-  // RoceReceiver and GpuRoceTransceiver behavior).  Stores the index in
-  // gid_index for later use in modify_qp(RTR).
-  for (std::uint32_t i = 0;; ++i) {
+  // Scan GIDs on the chosen port for an IPv4-mapped RoCEv2 entry — the
+  // GID format HSB uses (and therefore what the FPGA's RoCEv2 stack
+  // expects).  The IPv4-mapped IPv6 wire format is:
+  //   bytes 0-9  = 0
+  //   bytes 10-11 = 0xFFFF
+  //   bytes 12-15 = IPv4 address (network byte order)
+  //
+  // We compare on `entry.gid.raw[]` to stay endianness-independent — some
+  // libibverbs versions byte-swap `interface_id` to host order despite
+  // the `__be64` typedef, others leave the wire bytes as-is.
+  //
+  // The loop terminates on `r == ENODATA` (end of GID table) or on any
+  // other ibv error.  Hard cap at 256 as a belt-and-braces safety
+  // (gid_tbl_len is well below this on any real NIC).
+  constexpr std::uint32_t kMaxGidIndex = 256;
+  for (std::uint32_t i = 0; i < kMaxGidIndex; ++i) {
     ibv_gid_entry entry{};
     int r = ibv_query_gid_ex(ctx, ibv_port, i, &entry, 0);
-    if (r != 0 && errno != ENODATA)
-      break;
+    if (r == ENODATA)
+      break; // walked past the last entry
+    if (r != 0)
+      break; // some other ibv error — give up
     if (entry.gid_type != IBV_GID_TYPE_ROCE_V2)
       continue;
-    if (entry.gid.global.subnet_prefix != 0)
+    const std::uint8_t *raw = entry.gid.raw;
+    bool prefix_zero = true;
+    for (int b = 0; b < 10; ++b)
+      if (raw[b] != 0) { prefix_zero = false; break; }
+    if (!prefix_zero)
       continue;
-    if ((entry.gid.global.interface_id & 0xFFFFFFFFull) != 0xFFFF0000ull)
+    if (raw[10] != 0xff || raw[11] != 0xff)
       continue;
     gid_index = i;
     return true;
   }
   std::fprintf(stderr,
-               "CpuRoceTransceiver: no RoCEv2 GID found on %s port %u\n",
+               "CpuRoceTransceiver: no IPv4-mapped RoCEv2 GID found on %s "
+               "port %u (did you add the IPv4 address to the interface and "
+               "wait for the GID to populate?)\n",
                ibv_name, ibv_port);
   return false;
 }

--- a/realtime/lib/cpu_transport/roce_transceiver.cpp
+++ b/realtime/lib/cpu_transport/roce_transceiver.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
 #include <vector>
@@ -132,6 +133,15 @@ struct CpuRoceTransceiver::Impl {
   std::thread forward_thread;
   std::thread unified_thread;
 
+  // Serializes shutdown.  blocking_monitor() and close() can run on
+  // different threads (the bridge blocks in blocking_monitor() on one
+  // thread and calls close() from a signal handler / dtor on another), so
+  // both could otherwise race on the same std::thread::join().  The mutex
+  // makes each joinable()+join() pair atomic, and resources_released
+  // guards release_resources() so it runs exactly once.
+  std::mutex lifecycle_mutex;
+  bool resources_released = false;
+
   // -- unified-mode dispatch hook (set by set_unified_dispatch) --
   CpuRoceTransceiver::UnifiedDispatchFn unified_fn = nullptr;
   void *unified_ctx = nullptr;
@@ -176,6 +186,18 @@ struct CpuRoceTransceiver::Impl {
   void unified_loop();
 
   void release_resources() noexcept;
+
+  // Join all worker threads exactly once.  Holds lifecycle_mutex so the
+  // joinable()+join() pairs can't race between blocking_monitor() and
+  // close() (concurrent join() on the same std::thread is UB).  Threads
+  // that were never spawned are default-constructed and joinable() is
+  // false, so they're skipped.
+  void join_all_workers() noexcept;
+
+  // Release ibv / pinned-memory resources exactly once, even if close() is
+  // called multiple times or concurrently (e.g. an explicit close()
+  // followed by the destructor's close()).
+  void release_resources_once() noexcept;
 };
 
 // ----------------------------------------------------------------------------
@@ -915,6 +937,28 @@ void CpuRoceTransceiver::Impl::release_resources() noexcept {
   started = false;
 }
 
+void CpuRoceTransceiver::Impl::join_all_workers() noexcept {
+  std::lock_guard<std::mutex> lk(lifecycle_mutex);
+  // Under the lock, each joinable() check and its join() are atomic with
+  // respect to the other caller, so a given thread is joined exactly once.
+  if (forward_thread.joinable())
+    forward_thread.join();
+  if (unified_thread.joinable())
+    unified_thread.join();
+  if (rx_thread.joinable())
+    rx_thread.join();
+  if (tx_thread.joinable())
+    tx_thread.join();
+}
+
+void CpuRoceTransceiver::Impl::release_resources_once() noexcept {
+  std::lock_guard<std::mutex> lk(lifecycle_mutex);
+  if (resources_released)
+    return;
+  resources_released = true;
+  release_resources();
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -1026,16 +1070,9 @@ void CpuRoceTransceiver::blocking_monitor() {
   }
 
   // Block until close() is called (or workers exit on their own due to a
-  // fatal CQE error etc.).  Joining each present thread is enough; the
-  // others are default-constructed and joinable() returns false on them.
-  if (impl_->forward_thread.joinable())
-    impl_->forward_thread.join();
-  if (impl_->unified_thread.joinable())
-    impl_->unified_thread.join();
-  if (impl_->rx_thread.joinable())
-    impl_->rx_thread.join();
-  if (impl_->tx_thread.joinable())
-    impl_->tx_thread.join();
+  // fatal CQE error etc.).  join_all_workers() is mutex-protected so a
+  // concurrent close() on another thread can't race these joins.
+  impl_->join_all_workers();
   impl_->monitor_running = false;
 }
 
@@ -1051,23 +1088,18 @@ void CpuRoceTransceiver::close() {
   if (!impl_)
     return;
   // Signal exit BEFORE joining; the worker loops poll exit_flag with
-  // ACQUIRE semantics, so a RELEASE store here will be observed.
+  // ACQUIRE semantics, so a RELEASE store here will be observed.  This must
+  // happen before we contend for lifecycle_mutex: if blocking_monitor() is
+  // already holding the mutex inside its join, setting the flag first lets
+  // those workers exit so its join (and thus our lock acquisition) can
+  // complete.
   impl_->exit_flag.store(1, std::memory_order_release);
 
-  // Join workers if they're running and we're not the calling thread of
-  // blocking_monitor (which will join them itself).  We join here as the
-  // safety net for the destructor path where close() is the only thing
-  // that runs cleanup.
-  if (impl_->forward_thread.joinable())
-    impl_->forward_thread.join();
-  if (impl_->unified_thread.joinable())
-    impl_->unified_thread.join();
-  if (impl_->rx_thread.joinable())
-    impl_->rx_thread.join();
-  if (impl_->tx_thread.joinable())
-    impl_->tx_thread.join();
-
-  impl_->release_resources();
+  // Join workers, then release resources -- both serialized and run-once.
+  // Safe whether close() is the calling thread of blocking_monitor(), a
+  // separate shutdown thread, or the destructor.
+  impl_->join_all_workers();
+  impl_->release_resources_once();
 }
 
 std::uint32_t CpuRoceTransceiver::get_qp_number() const {

--- a/realtime/lib/cpu_transport/roce_transceiver.cpp
+++ b/realtime/lib/cpu_transport/roce_transceiver.cpp
@@ -1,0 +1,1009 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// CpuRoceTransceiver implementation.  See roce_transceiver.hpp for the
+// design overview and ring/wire protocol description.
+
+#include "cudaq/realtime/cpu_transport/roce_transceiver.hpp"
+
+#include <arpa/inet.h>
+#include <infiniband/verbs.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace cudaq::realtime::bridge {
+
+// Architecture-portable busy-wait hint.  ARM yield / x86 pause.
+static inline void cpu_relax() {
+#if defined(__aarch64__)
+  asm volatile("yield" ::: "memory");
+#elif defined(__x86_64__) || defined(__i386__)
+  asm volatile("pause" ::: "memory");
+#else
+  asm volatile("" ::: "memory");
+#endif
+}
+
+namespace {
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// Pre-posted recv WQE encoding: lower 32 bits = slot index, upper 32 bits =
+// generation counter (so a stale completion that bypasses our re-arm
+// handshake is detectable).  Matches the §4.1 pre-post plan: "wr_id =
+// (slot << 16) | generation" was a sketch; we promote both to 32 bits for
+// 4M slots * 4G generations of headroom.
+constexpr std::uint64_t encode_wr_id(std::uint32_t slot,
+                                     std::uint32_t generation) {
+  return (static_cast<std::uint64_t>(generation) << 32) | slot;
+}
+constexpr std::uint32_t decode_slot(std::uint64_t wr_id) {
+  return static_cast<std::uint32_t>(wr_id & 0xFFFFFFFFu);
+}
+[[maybe_unused]] constexpr std::uint32_t decode_generation(std::uint64_t wr_id) {
+  return static_cast<std::uint32_t>(wr_id >> 32);
+}
+
+// Allocate pinned host memory aligned to the host page size and mlock it
+// so the NIC's DMA target doesn't get paged out from under us.  Throws on
+// failure.  The buffer is also memset to zero so flag arrays start clean
+// and data slots start in a predictable state.
+void *allocate_pinned(std::size_t bytes, std::size_t alignment) {
+  void *ptr = nullptr;
+  if (posix_memalign(&ptr, alignment, bytes) != 0)
+    throw std::runtime_error("CpuRoceTransceiver: posix_memalign failed");
+  std::memset(ptr, 0, bytes);
+  // Best-effort mlock; not fatal if it fails (e.g. RLIMIT_MEMLOCK too low).
+  // The NIC DMA still works without mlock, just with possible page-fault
+  // jitter on first touch.
+  (void)mlock(ptr, bytes);
+  return ptr;
+}
+
+} // namespace
+
+// ============================================================================
+// Pimpl
+// ============================================================================
+
+struct CpuRoceTransceiver::Impl {
+  // -- configuration captured at construction --
+  const char *ibv_name = nullptr;
+  unsigned ibv_port = 0;
+  unsigned tx_ibv_qp = 0;
+  std::size_t cu_frame_size = 0;
+  std::size_t cu_page_size = 0;
+  unsigned pages = 0;
+  const char *peer_ip = nullptr;
+  bool forward = false;
+  bool rx_only = false;
+  bool tx_only = false;
+  bool unified = false;
+  CpuRoceTxMode tx_mode = CpuRoceTxMode::kSendForFpga;
+  std::uint64_t peer_rx_base_addr = 0;
+  std::uint32_t peer_rx_rkey = 0;
+
+  // -- ibv resources populated by start() --
+  ibv_context *ctx = nullptr;
+  ibv_pd *pd = nullptr;
+  ibv_cq *rq_cq = nullptr;
+  ibv_cq *sq_cq = nullptr;
+  ibv_qp *qp = nullptr;
+  ibv_mr *rx_data_mr = nullptr;
+  ibv_mr *tx_data_mr = nullptr;
+  std::uint32_t qp_number = 0;
+  std::uint32_t rkey = 0;
+  std::uint32_t local_tx_lkey = 0;
+  std::uint32_t gid_index = 0;
+
+  // -- ring buffers (pinned host memory) --
+  std::uint8_t *rx_data = nullptr;
+  std::uint8_t *tx_data = nullptr;
+  std::uint64_t *rx_flags = nullptr;
+  std::uint64_t *tx_flags = nullptr;
+  std::size_t stride_sz = 0;
+  std::uint32_t stride_num = 0;
+
+  // -- runtime state --
+  bool started = false;
+  bool monitor_running = false;
+  std::atomic<int> exit_flag{0};
+
+  // -- I/O threads spawned by blocking_monitor(), joined by close() --
+  std::thread rx_thread;
+  std::thread tx_thread;
+  std::thread forward_thread;
+  std::thread unified_thread;
+
+  // -- unified-mode dispatch hook (set by set_unified_dispatch) --
+  CpuRoceTransceiver::UnifiedDispatchFn unified_fn = nullptr;
+  void *unified_ctx = nullptr;
+
+  // -- start() helpers --
+  bool open_ib_device();
+  bool find_roce_v2_gid();
+  bool allocate_rings();
+  bool register_mrs();
+  bool create_qp_and_cqs();
+  bool transition_qp_to_init();
+  bool post_initial_recv_wqes();
+  bool transition_qp_to_rtr_rts();
+
+  // -- I/O thread loops --
+  // Normal-mode RX loop: poll RQ CQ, decode slot from wr_id, wait for the
+  // consumer's release of the slot, publish rx_flag[slot] = data address,
+  // re-post the recv WQE with bumped generation.  Exits when exit_flag is
+  // set.  Mirrors the GPU rx_only kernel.
+  void rx_loop();
+
+  // Forward-mode loop: RX thread does double duty — on every CQE, instead
+  // of publishing rx_flag, immediately re-sends the slot's bytes back to
+  // the peer.  Skips the consumer handshake entirely.  Useful as a wire-
+  // round-trip latency baseline (no dispatch overhead).  Mirrors the GPU
+  // forward kernel.
+  void forward_loop();
+
+  // Normal-mode TX loop: walk slots round-robin, busy-poll tx_flag[slot]
+  // for a non-zero "ready to send" sentinel (producer publishes the slot's
+  // tx_data address), claim it by clearing the flag, then issue the wire
+  // verb selected by tx_mode (Send for FPGA, Write-With-Imm for peer).
+  // Mirrors the GPU tx_only / tx_only_bf kernel.
+  void tx_loop();
+
+  // Unified-mode loop: collapses RX + dispatch + TX into a single thread.
+  // The lowest-latency Phase 1 configuration when the dispatch callback
+  // is cheap enough to run on the polling thread (e.g. the increment
+  // handler).  Skips both flag arrays entirely (the consumer/producer
+  // handshake collapses because the thread IS the consumer/producer).
+  // Mirrors the GPU unified_dispatch_kernel concept but on the CPU.
+  void unified_loop();
+
+  void release_resources() noexcept;
+};
+
+// ----------------------------------------------------------------------------
+// start() helpers
+// ----------------------------------------------------------------------------
+
+bool CpuRoceTransceiver::Impl::open_ib_device() {
+  // ibverbs has reentrancy concerns when the process forks; init once per
+  // process.  Matches the pattern in HSB's RoceReceiver::start.
+  static std::atomic<bool> ibv_fork_init_done{false};
+  bool expected = false;
+  if (ibv_fork_init_done.compare_exchange_strong(expected, true)) {
+    if (ibv_fork_init() != 0) {
+      std::fprintf(stderr, "CpuRoceTransceiver: ibv_fork_init failed\n");
+      return false;
+    }
+  }
+
+  int num_devices = 0;
+  ibv_device **devs = ibv_get_device_list(&num_devices);
+  if (!devs) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv_get_device_list failed errno=%d\n",
+                 errno);
+    return false;
+  }
+  ibv_device *picked = nullptr;
+  for (int i = 0; i < num_devices; ++i) {
+    if (std::strcmp(ibv_get_device_name(devs[i]), ibv_name) == 0) {
+      picked = devs[i];
+      break;
+    }
+  }
+  if (!picked) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv device '%s' not found among %d\n",
+                 ibv_name, num_devices);
+    ibv_free_device_list(devs);
+    return false;
+  }
+  ctx = ibv_open_device(picked);
+  ibv_free_device_list(devs);
+  if (!ctx) {
+    std::fprintf(stderr, "CpuRoceTransceiver: ibv_open_device failed\n");
+    return false;
+  }
+  pd = ibv_alloc_pd(ctx);
+  if (!pd) {
+    std::fprintf(stderr, "CpuRoceTransceiver: ibv_alloc_pd failed\n");
+    return false;
+  }
+  return true;
+}
+
+bool CpuRoceTransceiver::Impl::find_roce_v2_gid() {
+  // Scan GIDs on the chosen port for the first RoCEv2 entry (matches HSB's
+  // RoceReceiver and GpuRoceTransceiver behavior).  Stores the index in
+  // gid_index for later use in modify_qp(RTR).
+  for (std::uint32_t i = 0;; ++i) {
+    ibv_gid_entry entry{};
+    int r = ibv_query_gid_ex(ctx, ibv_port, i, &entry, 0);
+    if (r != 0 && errno != ENODATA)
+      break;
+    if (entry.gid_type != IBV_GID_TYPE_ROCE_V2)
+      continue;
+    if (entry.gid.global.subnet_prefix != 0)
+      continue;
+    if ((entry.gid.global.interface_id & 0xFFFFFFFFull) != 0xFFFF0000ull)
+      continue;
+    gid_index = i;
+    return true;
+  }
+  std::fprintf(stderr,
+               "CpuRoceTransceiver: no RoCEv2 GID found on %s port %u\n",
+               ibv_name, ibv_port);
+  return false;
+}
+
+bool CpuRoceTransceiver::Impl::allocate_rings() {
+  const std::size_t page_sz = static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
+  const std::size_t data_bytes = static_cast<std::size_t>(stride_num) * stride_sz;
+  const std::size_t flags_bytes =
+      static_cast<std::size_t>(stride_num) * sizeof(std::uint64_t);
+
+  // Data buffers: pinned at page granularity (NIC DMA target).
+  rx_data = static_cast<std::uint8_t *>(allocate_pinned(data_bytes, page_sz));
+  tx_data = static_cast<std::uint8_t *>(allocate_pinned(data_bytes, page_sz));
+
+  // Flag arrays: cache-line-aligned to avoid false sharing between adjacent
+  // slots.  Not NIC-DMA'd, so no MR registration; just CPU-shared state.
+  rx_flags = static_cast<std::uint64_t *>(allocate_pinned(flags_bytes, 64));
+  tx_flags = static_cast<std::uint64_t *>(allocate_pinned(flags_bytes, 64));
+  return true;
+}
+
+bool CpuRoceTransceiver::Impl::register_mrs() {
+  const std::size_t data_bytes = static_cast<std::size_t>(stride_num) * stride_sz;
+
+  // RX ring is RDMA-write target: needs LOCAL_WRITE + REMOTE_WRITE.  rkey is
+  // exported to the peer (FPGA via HSB control plane, or peer transceiver
+  // via out-of-band rendezvous).
+  //
+  // CRITICAL: register with iova=0 so the peer's remote_addr=0+slot*stride
+  // resolves to "start of rx_data + slot*stride" on our side.  This matches
+  // the convention exposed via external_frame_memory() (= 0) and the
+  // "Buffer Addr: 0x0" line we print to stdout.  If we used plain
+  // ibv_reg_mr (which sets iova=virtual_addr), the peer would have to use
+  // our virtual address — which we don't want to leak across the wire and
+  // can't safely use anyway.
+  rx_data_mr = ibv_reg_mr_iova(pd, rx_data, data_bytes, /*iova=*/0,
+                               IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+  if (!rx_data_mr) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv_reg_mr_iova(rx_data) failed errno=%d\n",
+                 errno);
+    return false;
+  }
+  rkey = rx_data_mr->rkey;
+
+  // TX ring is local-only (we read from it to populate Send / Write
+  // payloads); peer never addresses it.  Plain ibv_reg_mr is fine — local
+  // SGEs use the actual virtual address regardless of iova choice.
+  tx_data_mr = ibv_reg_mr(pd, tx_data, data_bytes, IBV_ACCESS_LOCAL_WRITE);
+  if (!tx_data_mr) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv_reg_mr(tx_data) failed errno=%d\n",
+                 errno);
+    return false;
+  }
+  local_tx_lkey = tx_data_mr->lkey;
+  return true;
+}
+
+bool CpuRoceTransceiver::Impl::create_qp_and_cqs() {
+  // Busy-poll model: no completion channel (we never block on poll_cq).
+  // CQs sized to stride_num so we never lose completions even at full
+  // queue depth.
+  const int cqe_count = static_cast<int>(stride_num);
+  rq_cq = ibv_create_cq(ctx, cqe_count, nullptr, nullptr, 0);
+  sq_cq = ibv_create_cq(ctx, cqe_count, nullptr, nullptr, 0);
+  if (!rq_cq || !sq_cq) {
+    std::fprintf(stderr, "CpuRoceTransceiver: ibv_create_cq failed errno=%d\n",
+                 errno);
+    return false;
+  }
+
+  // IBV_QPT_UC: unreliable connected.  Supports RDMA Write (incl.
+  // Write-With-Imm) but not Read/Atomics.  Matches HSB's RoceReceiver and
+  // GpuRoceTransceiver choice; the FPGA's HSB IP speaks the same QP type.
+  ibv_qp_init_attr init{};
+  init.send_cq = sq_cq;
+  init.recv_cq = rq_cq;
+  init.cap.max_send_wr = stride_num;
+  init.cap.max_recv_wr = stride_num;
+  init.cap.max_send_sge = 1;
+  init.cap.max_recv_sge = 1;
+  init.qp_type = IBV_QPT_UC;
+  init.sq_sig_all = 0; // we'll opt slots into completions on a schedule
+
+  qp = ibv_create_qp(pd, &init);
+  if (!qp) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv_create_qp failed errno=%d\n", errno);
+    return false;
+  }
+  qp_number = qp->qp_num;
+  return true;
+}
+
+bool CpuRoceTransceiver::Impl::transition_qp_to_init() {
+  ibv_qp_attr a{};
+  a.qp_state = IBV_QPS_INIT;
+  a.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
+  a.pkey_index = 0;
+  a.port_num = static_cast<std::uint8_t>(ibv_port);
+  if (ibv_modify_qp(qp, &a,
+                    IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+                        IBV_QP_ACCESS_FLAGS) != 0) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv_modify_qp(INIT) failed errno=%d\n",
+                 errno);
+    return false;
+  }
+  return true;
+}
+
+bool CpuRoceTransceiver::Impl::post_initial_recv_wqes() {
+  // Pre-post stride_num receive WQEs, each pointing at one specific slot in
+  // rx_data with wr_id encoding the slot.  When the peer's RDMA writes
+  // complete, the CQE's wr_id tells us which slot was written into.
+  for (std::uint32_t slot = 0; slot < stride_num; ++slot) {
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
+    sge.length = static_cast<std::uint32_t>(stride_sz);
+    sge.lkey = rx_data_mr->lkey;
+
+    ibv_recv_wr wr{};
+    wr.wr_id = encode_wr_id(slot, /*generation=*/0);
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.next = nullptr;
+
+    ibv_recv_wr *bad = nullptr;
+    if (ibv_post_recv(qp, &wr, &bad) != 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver: ibv_post_recv slot=%u failed errno=%d\n",
+                   slot, errno);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool CpuRoceTransceiver::Impl::transition_qp_to_rtr_rts() {
+  // Convert peer IP to a RoCEv2 GID using the same scheme HSB uses (and
+  // therefore the same scheme the FPGA's HSB IP expects):
+  //   subnet_prefix = 0
+  //   interface_id  = (peer_ip_in_network_byte_order << 32) | 0xFFFF0000
+  in_addr_t peer = 0;
+  if (inet_pton(AF_INET, peer_ip, &peer) != 1) {
+    std::fprintf(stderr, "CpuRoceTransceiver: bad peer_ip '%s'\n", peer_ip);
+    return false;
+  }
+  ibv_gid remote{};
+  remote.global.subnet_prefix = 0;
+  remote.global.interface_id =
+      (static_cast<std::uint64_t>(peer) << 32) | 0xFFFF0000ull;
+
+  // RST -> INIT -> RTR
+  ibv_qp_attr rtr{};
+  rtr.qp_state = IBV_QPS_RTR;
+  rtr.path_mtu = IBV_MTU_4096;
+  rtr.rq_psn = 0;
+  rtr.dest_qp_num = tx_ibv_qp;
+  rtr.ah_attr.grh.dgid = remote;
+  rtr.ah_attr.grh.sgid_index = static_cast<std::uint8_t>(gid_index);
+  rtr.ah_attr.grh.hop_limit = 0xFF;
+  rtr.ah_attr.is_global = 1;
+  rtr.ah_attr.port_num = static_cast<std::uint8_t>(ibv_port);
+  // Retry a few times: HSB notes occasional ETIMEDOUT on this transition
+  // that succeeds on retry.
+  int r = -1;
+  for (int attempt = 0; attempt < 5; ++attempt) {
+    r = ibv_modify_qp(qp, &rtr,
+                      IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
+                          IBV_QP_DEST_QPN | IBV_QP_RQ_PSN);
+    if (r == 0)
+      break;
+    usleep(200 * 1000);
+  }
+  if (r != 0) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv_modify_qp(RTR) failed errno=%d\n", r);
+    return false;
+  }
+
+  // RTR -> RTS so our TX path can post sends.  Even rx_only mode goes to
+  // RTS for simplicity; we just won't post anything in that mode.  UC QPs
+  // ignore most retry parameters.
+  ibv_qp_attr rts{};
+  rts.qp_state = IBV_QPS_RTS;
+  rts.sq_psn = 0;
+  if (ibv_modify_qp(qp, &rts, IBV_QP_STATE | IBV_QP_SQ_PSN) != 0) {
+    std::fprintf(stderr,
+                 "CpuRoceTransceiver: ibv_modify_qp(RTS) failed errno=%d\n",
+                 errno);
+    return false;
+  }
+  return true;
+}
+
+void CpuRoceTransceiver::Impl::rx_loop() {
+  // Per-slot generation counter to defeat stale CQEs (paranoia: with UC QPs
+  // and a single consumer, this is unlikely to matter, but keeping it
+  // available is cheap).  Indexed [slot].
+  std::vector<std::uint32_t> generation(stride_num, 1);
+
+  // Polling loop: poll one CQE at a time for simplicity (we can batch in a
+  // follow-up if profiling shows the CQE-read overhead is meaningful).
+  ibv_wc wc{};
+  while (exit_flag.load(std::memory_order_acquire) == 0) {
+    int n = ibv_poll_cq(rq_cq, 1, &wc);
+    if (n < 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver: ibv_poll_cq(rq) failed errno=%d\n",
+                   errno);
+      break;
+    }
+    if (n == 0) {
+      cpu_relax();
+      continue;
+    }
+    if (wc.status != IBV_WC_SUCCESS) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver: RX CQE status=%d (%s) wr_id=%lu\n",
+                   wc.status, ibv_wc_status_str(wc.status),
+                   static_cast<unsigned long>(wc.wr_id));
+      continue;
+    }
+    const std::uint32_t slot = decode_slot(wc.wr_id);
+    if (slot >= stride_num) {
+      std::fprintf(stderr, "CpuRoceTransceiver: RX bad slot=%u (>= %u)\n",
+                   slot, stride_num);
+      continue;
+    }
+
+    // Slot publish handshake: wait for consumer to release the slot (set
+    // rx_flag[slot] to 0).  This matches the GPU rx_only kernel's
+    // back-pressure loop.  Yield to the scheduler periodically in case the
+    // consumer is genuinely slow.
+    auto &flag = *(volatile std::uint64_t *)&rx_flags[slot];
+    while (__atomic_load_n(&flag, __ATOMIC_ACQUIRE) != 0) {
+      if (exit_flag.load(std::memory_order_acquire) != 0)
+        return;
+      cpu_relax();
+    }
+
+    // Publish: writing the data address (non-zero) signals "fresh data".
+    __atomic_store_n(&flag,
+                     reinterpret_cast<std::uint64_t>(rx_data + slot * stride_sz),
+                     __ATOMIC_RELEASE);
+
+    // Re-post the recv WQE for this slot so future inbound writes have
+    // somewhere to land.  We do this immediately rather than waiting for
+    // the consumer to fully drain, because the recv queue is what the NIC
+    // dequeues from on incoming Write-With-Imm.  The flag handshake above
+    // ensures we don't overwrite a slot that still has fresh data.
+    generation[slot]++;
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
+    sge.length = static_cast<std::uint32_t>(stride_sz);
+    sge.lkey = rx_data_mr->lkey;
+
+    ibv_recv_wr wr{};
+    wr.wr_id = encode_wr_id(slot, generation[slot]);
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.next = nullptr;
+    ibv_recv_wr *bad = nullptr;
+    if (ibv_post_recv(qp, &wr, &bad) != 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver: ibv_post_recv re-arm slot=%u failed errno=%d\n",
+                   slot, errno);
+      // Continue rather than break; the next CQE may still be processable.
+    }
+  }
+}
+
+void CpuRoceTransceiver::Impl::forward_loop() {
+  // Forward mode: every incoming write is immediately re-sent to the peer
+  // from the same slot.  No rx_flag/tx_flag handshake involved (we do the
+  // wire round-trip directly).  Mirrors the GPU forward kernel.
+  std::vector<std::uint32_t> generation(stride_num, 1);
+  ibv_wc wc{};
+  while (exit_flag.load(std::memory_order_acquire) == 0) {
+    int n = ibv_poll_cq(rq_cq, 1, &wc);
+    if (n < 0)
+      break;
+    if (n == 0) {
+      cpu_relax();
+      continue;
+    }
+    if (wc.status != IBV_WC_SUCCESS)
+      continue;
+    const std::uint32_t slot = decode_slot(wc.wr_id);
+    if (slot >= stride_num)
+      continue;
+
+    // Re-send the slot's bytes back to the peer.  TX verb depends on
+    // tx_mode (matches the TX thread's logic in the tx_loop todo).
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
+    sge.length = static_cast<std::uint32_t>(stride_sz);
+    sge.lkey = rx_data_mr->lkey;
+
+    ibv_send_wr swr{};
+    swr.wr_id = wc.wr_id;
+    swr.sg_list = &sge;
+    swr.num_sge = 1;
+    swr.send_flags = 0; // unsignalled; we don't poll SQ in forward mode
+    swr.next = nullptr;
+    if (tx_mode == CpuRoceTxMode::kWriteWithImmForPeer) {
+      swr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+      swr.wr.rdma.remote_addr = peer_rx_base_addr + slot * stride_sz;
+      swr.wr.rdma.rkey = peer_rx_rkey;
+      swr.imm_data = htonl(slot);
+    } else {
+      swr.opcode = IBV_WR_SEND;
+    }
+    ibv_send_wr *bad = nullptr;
+    (void)ibv_post_send(qp, &swr, &bad);
+
+    // Re-post the recv WQE for the same slot.
+    generation[slot]++;
+    ibv_recv_wr rwr{};
+    rwr.wr_id = encode_wr_id(slot, generation[slot]);
+    rwr.sg_list = &sge;
+    rwr.num_sge = 1;
+    rwr.next = nullptr;
+    ibv_recv_wr *rbad = nullptr;
+    (void)ibv_post_recv(qp, &rwr, &rbad);
+  }
+}
+
+void CpuRoceTransceiver::Impl::tx_loop() {
+  // Producer publishes tx_flag[slot] = (address of tx_data + slot*stride).
+  // We walk slots round-robin (matching the GPU tx_only kernel's
+  // wqe_idx & mask indexing).  On non-zero flag: claim by clearing,
+  // post the wire verb, advance.  Periodically drain the SQ CQ so we
+  // never block on max_send_wr.
+  const std::uint32_t mask = stride_num - 1;
+  std::uint64_t wqe_idx = 0;
+
+  // SQ CQ drain: signal every N WQEs (matches "signal-every-N" pattern
+  // from §9 open questions; N=16 is a common starting point and amortizes
+  // the CQE cost across batches without bloating the in-flight window).
+  constexpr int kSignalEvery = 16;
+  std::uint32_t since_signal = 0;
+  ibv_wc swc[kSignalEvery]{};
+
+  while (exit_flag.load(std::memory_order_acquire) == 0) {
+    const std::uint32_t slot = static_cast<std::uint32_t>(wqe_idx & mask);
+    auto &flag = *(volatile std::uint64_t *)&tx_flags[slot];
+    const std::uint64_t addr = __atomic_load_n(&flag, __ATOMIC_ACQUIRE);
+    if (addr == 0) {
+      cpu_relax();
+      continue;
+    }
+    // Claim: clear the flag.  Producer must wait for the flag to be 0
+    // before publishing again into the same slot.
+    __atomic_store_n(&flag, 0, __ATOMIC_RELEASE);
+
+    // Build the send WQE.  Use the slot's data address as the SGE source;
+    // the slot index is encoded in the IMM for Write-With-Imm mode (so the
+    // peer can decode which slot the bytes belong to).
+    ibv_sge sge{};
+    sge.addr = addr;
+    sge.length = static_cast<std::uint32_t>(stride_sz);
+    sge.lkey = local_tx_lkey;
+
+    ibv_send_wr swr{};
+    swr.wr_id = slot;
+    swr.sg_list = &sge;
+    swr.num_sge = 1;
+    swr.next = nullptr;
+    // Signal completion every kSignalEvery WQEs so we can drain the SQ CQ
+    // and free up max_send_wr capacity.  Other WQEs are unsignalled.
+    const bool signal_this = (++since_signal % kSignalEvery) == 0;
+    swr.send_flags = signal_this ? IBV_SEND_SIGNALED : 0;
+    if (tx_mode == CpuRoceTxMode::kWriteWithImmForPeer) {
+      // Phase 2 wire pattern.  remote_addr = peer_rx_base + slot*stride;
+      // peer decodes the slot from imm_data (which is in network byte
+      // order on the wire).
+      swr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+      swr.wr.rdma.remote_addr = peer_rx_base_addr + slot * stride_sz;
+      swr.wr.rdma.rkey = peer_rx_rkey;
+      swr.imm_data = htonl(slot);
+    } else {
+      // Phase 1 wire pattern (FPGA-facing).  FPGA's HSB IP receives Sends;
+      // slot is identified on the peer side by which pre-posted recv WQE
+      // the Send consumed (peer's wr_id encoding).
+      swr.opcode = IBV_WR_SEND;
+    }
+
+    ibv_send_wr *bad = nullptr;
+    if (ibv_post_send(qp, &swr, &bad) != 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver: ibv_post_send slot=%u failed errno=%d\n",
+                   slot, errno);
+      // Restore the flag so the producer doesn't lose track of an in-flight
+      // request that we failed to actually ship.
+      __atomic_store_n(&flag, addr, __ATOMIC_RELEASE);
+      continue;
+    }
+
+    // Drain SQ CQ opportunistically when we just signalled a WQE.  The
+    // poll is non-blocking (returns 0 immediately if nothing's ready).
+    if (signal_this) {
+      int n = ibv_poll_cq(sq_cq, kSignalEvery, swc);
+      (void)n; // we don't track per-send completion semantics; CQEs are
+               // just consumed to free max_send_wr capacity.
+    }
+    wqe_idx++;
+  }
+}
+
+void CpuRoceTransceiver::Impl::unified_loop() {
+  // Single thread: RX CQE → dispatch → TX in one body, no flag handshake.
+  std::vector<std::uint32_t> generation(stride_num, 1);
+  // SQ-CQ drain on a signal-every-N schedule (same as tx_loop).
+  constexpr int kSignalEvery = 16;
+  std::uint32_t since_signal = 0;
+  ibv_wc swc[kSignalEvery]{};
+
+  ibv_wc wc{};
+  while (exit_flag.load(std::memory_order_acquire) == 0) {
+    int n = ibv_poll_cq(rq_cq, 1, &wc);
+    if (n < 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver(unified): ibv_poll_cq(rq) failed errno=%d\n",
+                   errno);
+      break;
+    }
+    if (n == 0) {
+      cpu_relax();
+      continue;
+    }
+    if (wc.status != IBV_WC_SUCCESS) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver(unified): RX CQE status=%d (%s)\n",
+                   wc.status, ibv_wc_status_str(wc.status));
+      continue;
+    }
+    const std::uint32_t slot = decode_slot(wc.wr_id);
+    if (slot >= stride_num)
+      continue;
+
+    // Dispatch: hand the slot to the user-supplied callback.  The callback
+    // produces the response in tx_data[slot] and returns the response byte
+    // count.  When no callback is set, treat as drop-and-rearm (lets the
+    // tx_only / forward-style baseline benchmarks reuse this loop with a
+    // null callback).
+    const std::uint8_t *rx_slot = rx_data + slot * stride_sz;
+    std::uint8_t *tx_slot = tx_data + slot * stride_sz;
+    std::size_t resp_bytes = 0;
+    if (unified_fn)
+      resp_bytes = unified_fn(unified_ctx, rx_slot, tx_slot, stride_sz);
+
+    // Send the response on the wire if the callback produced one.
+    if (resp_bytes > 0) {
+      ibv_sge sge{};
+      sge.addr = reinterpret_cast<std::uintptr_t>(tx_slot);
+      sge.length = static_cast<std::uint32_t>(resp_bytes);
+      sge.lkey = local_tx_lkey;
+
+      ibv_send_wr swr{};
+      swr.wr_id = slot;
+      swr.sg_list = &sge;
+      swr.num_sge = 1;
+      swr.next = nullptr;
+      const bool signal_this = (++since_signal % kSignalEvery) == 0;
+      swr.send_flags = signal_this ? IBV_SEND_SIGNALED : 0;
+      if (tx_mode == CpuRoceTxMode::kWriteWithImmForPeer) {
+        swr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+        swr.wr.rdma.remote_addr = peer_rx_base_addr + slot * stride_sz;
+        swr.wr.rdma.rkey = peer_rx_rkey;
+        swr.imm_data = htonl(slot);
+      } else {
+        swr.opcode = IBV_WR_SEND;
+      }
+      ibv_send_wr *bad = nullptr;
+      if (ibv_post_send(qp, &swr, &bad) != 0) {
+        std::fprintf(stderr,
+                     "CpuRoceTransceiver(unified): ibv_post_send slot=%u failed errno=%d\n",
+                     slot, errno);
+      }
+      if (signal_this) {
+        int drained = ibv_poll_cq(sq_cq, kSignalEvery, swc);
+        (void)drained;
+      }
+    }
+
+    // Re-arm the recv WQE for this slot.
+    generation[slot]++;
+    ibv_sge rsge{};
+    rsge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
+    rsge.length = static_cast<std::uint32_t>(stride_sz);
+    rsge.lkey = rx_data_mr->lkey;
+
+    ibv_recv_wr rwr{};
+    rwr.wr_id = encode_wr_id(slot, generation[slot]);
+    rwr.sg_list = &rsge;
+    rwr.num_sge = 1;
+    rwr.next = nullptr;
+    ibv_recv_wr *rbad = nullptr;
+    if (ibv_post_recv(qp, &rwr, &rbad) != 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver(unified): ibv_post_recv re-arm slot=%u failed errno=%d\n",
+                   slot, errno);
+    }
+  }
+}
+
+void CpuRoceTransceiver::Impl::release_resources() noexcept {
+  if (qp) {
+    ibv_destroy_qp(qp);
+    qp = nullptr;
+  }
+  if (rx_data_mr) {
+    ibv_dereg_mr(rx_data_mr);
+    rx_data_mr = nullptr;
+  }
+  if (tx_data_mr) {
+    ibv_dereg_mr(tx_data_mr);
+    tx_data_mr = nullptr;
+  }
+  if (rq_cq) {
+    ibv_destroy_cq(rq_cq);
+    rq_cq = nullptr;
+  }
+  if (sq_cq) {
+    ibv_destroy_cq(sq_cq);
+    sq_cq = nullptr;
+  }
+  if (pd) {
+    ibv_dealloc_pd(pd);
+    pd = nullptr;
+  }
+  if (ctx) {
+    ibv_close_device(ctx);
+    ctx = nullptr;
+  }
+  const std::size_t data_bytes = static_cast<std::size_t>(stride_num) * stride_sz;
+  if (rx_data) {
+    munlock(rx_data, data_bytes);
+    free(rx_data);
+    rx_data = nullptr;
+  }
+  if (tx_data) {
+    munlock(tx_data, data_bytes);
+    free(tx_data);
+    tx_data = nullptr;
+  }
+  const std::size_t flags_bytes =
+      static_cast<std::size_t>(stride_num) * sizeof(std::uint64_t);
+  if (rx_flags) {
+    munlock(rx_flags, flags_bytes);
+    free(rx_flags);
+    rx_flags = nullptr;
+  }
+  if (tx_flags) {
+    munlock(tx_flags, flags_bytes);
+    free(tx_flags);
+    tx_flags = nullptr;
+  }
+  started = false;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+CpuRoceTransceiver::CpuRoceTransceiver(
+    const char *ibv_name, unsigned ibv_port, unsigned tx_ibv_qp,
+    std::size_t cu_frame_size, std::size_t cu_page_size, unsigned pages,
+    const char *peer_ip, bool forward, bool rx_only, bool tx_only,
+    bool unified, CpuRoceTxMode tx_mode, std::uint64_t peer_rx_base_addr,
+    std::uint32_t peer_rx_rkey)
+    : impl_(std::make_unique<Impl>()) {
+  const int mode_count = (forward ? 1 : 0) + (rx_only ? 1 : 0) +
+                         (tx_only ? 1 : 0) + (unified ? 1 : 0);
+  if (mode_count > 1)
+    throw std::invalid_argument(
+        "CpuRoceTransceiver: forward / rx_only / tx_only / unified are "
+        "mutually exclusive (at most one may be true)");
+  if (tx_mode == CpuRoceTxMode::kWriteWithImmForPeer &&
+      (peer_rx_base_addr == 0 || peer_rx_rkey == 0))
+    throw std::invalid_argument(
+        "CpuRoceTransceiver: tx_mode=kWriteWithImmForPeer requires "
+        "peer_rx_base_addr and peer_rx_rkey to be non-zero");
+  if (pages == 0 || (pages & (pages - 1)) != 0)
+    throw std::invalid_argument(
+        "CpuRoceTransceiver: pages must be a non-zero power of two");
+
+  impl_->ibv_name = ibv_name;
+  impl_->ibv_port = ibv_port;
+  impl_->tx_ibv_qp = tx_ibv_qp;
+  impl_->cu_frame_size = cu_frame_size;
+  impl_->cu_page_size = cu_page_size;
+  impl_->pages = pages;
+  impl_->peer_ip = peer_ip;
+  impl_->forward = forward;
+  impl_->rx_only = rx_only;
+  impl_->tx_only = tx_only;
+  impl_->unified = unified;
+  impl_->tx_mode = tx_mode;
+  impl_->peer_rx_base_addr = peer_rx_base_addr;
+  impl_->peer_rx_rkey = peer_rx_rkey;
+  impl_->stride_sz = cu_page_size;
+  impl_->stride_num = pages;
+}
+
+CpuRoceTransceiver::~CpuRoceTransceiver() {
+  try {
+    close();
+  } catch (...) {
+  }
+}
+
+bool CpuRoceTransceiver::start() {
+  if (impl_->started)
+    return true;
+  // Sequence:  open device -> alloc + register rings -> create QP+CQs ->
+  // INIT -> pre-post recv WQEs -> RTR -> RTS.  On any failure unwind
+  // everything via release_resources so a second start() call won't trip
+  // over half-built state.
+  bool ok = impl_->open_ib_device() && impl_->find_roce_v2_gid() &&
+            impl_->allocate_rings() && impl_->register_mrs() &&
+            impl_->create_qp_and_cqs() && impl_->transition_qp_to_init();
+  if (!ok) {
+    impl_->release_resources();
+    return false;
+  }
+  // Skip recv WQE pre-post in tx_only (no incoming traffic expected).
+  if (!impl_->tx_only) {
+    if (!impl_->post_initial_recv_wqes()) {
+      impl_->release_resources();
+      return false;
+    }
+  }
+  if (!impl_->transition_qp_to_rtr_rts()) {
+    impl_->release_resources();
+    return false;
+  }
+  impl_->started = true;
+  return true;
+}
+
+void CpuRoceTransceiver::blocking_monitor() {
+  // Spawn the I/O thread(s) appropriate for the configured mode, then block
+  // by joining them.  close() (called from another thread / signal handler /
+  // dtor) sets exit_flag, which causes the worker loops to exit, which
+  // causes our joins to return.
+  if (!impl_->started)
+    throw std::logic_error(
+        "CpuRoceTransceiver::blocking_monitor: start() must succeed first");
+  if (impl_->monitor_running)
+    return; // idempotent: already running on another caller
+  impl_->monitor_running = true;
+  impl_->exit_flag.store(0, std::memory_order_release);
+
+  // Mode selection (mutual exclusion was already enforced at construction).
+  if (impl_->forward) {
+    impl_->forward_thread = std::thread([impl = impl_.get()] { impl->forward_loop(); });
+  } else if (impl_->unified) {
+    impl_->unified_thread = std::thread([impl = impl_.get()] { impl->unified_loop(); });
+  } else {
+    // Normal three-thread layout (the §4.2 default).  tx_only / rx_only
+    // skip one or the other thread; the consumer / dispatcher is on a
+    // separate thread that this class doesn't own.
+    if (!impl_->tx_only)
+      impl_->rx_thread = std::thread([impl = impl_.get()] { impl->rx_loop(); });
+    if (!impl_->rx_only)
+      impl_->tx_thread = std::thread([impl = impl_.get()] { impl->tx_loop(); });
+  }
+
+  // Block until close() is called (or workers exit on their own due to a
+  // fatal CQE error etc.).  Joining each present thread is enough; the
+  // others are default-constructed and joinable() returns false on them.
+  if (impl_->forward_thread.joinable())
+    impl_->forward_thread.join();
+  if (impl_->unified_thread.joinable())
+    impl_->unified_thread.join();
+  if (impl_->rx_thread.joinable())
+    impl_->rx_thread.join();
+  if (impl_->tx_thread.joinable())
+    impl_->tx_thread.join();
+  impl_->monitor_running = false;
+}
+
+void CpuRoceTransceiver::set_unified_dispatch(UnifiedDispatchFn fn,
+                                              void *context) {
+  if (!impl_)
+    return;
+  impl_->unified_fn = fn;
+  impl_->unified_ctx = context;
+}
+
+void CpuRoceTransceiver::close() {
+  if (!impl_)
+    return;
+  // Signal exit BEFORE joining; the worker loops poll exit_flag with
+  // ACQUIRE semantics, so a RELEASE store here will be observed.
+  impl_->exit_flag.store(1, std::memory_order_release);
+
+  // Join workers if they're running and we're not the calling thread of
+  // blocking_monitor (which will join them itself).  We join here as the
+  // safety net for the destructor path where close() is the only thing
+  // that runs cleanup.
+  if (impl_->forward_thread.joinable())
+    impl_->forward_thread.join();
+  if (impl_->unified_thread.joinable())
+    impl_->unified_thread.join();
+  if (impl_->rx_thread.joinable())
+    impl_->rx_thread.join();
+  if (impl_->tx_thread.joinable())
+    impl_->tx_thread.join();
+
+  impl_->release_resources();
+}
+
+std::uint32_t CpuRoceTransceiver::get_qp_number() const {
+  return impl_->qp_number;
+}
+
+std::uint32_t CpuRoceTransceiver::get_rkey() const { return impl_->rkey; }
+
+std::uint64_t CpuRoceTransceiver::external_frame_memory() const { return 0; }
+
+std::uint8_t *CpuRoceTransceiver::get_rx_ring_data_addr() const {
+  return impl_->rx_data;
+}
+
+std::size_t CpuRoceTransceiver::get_rx_ring_stride_sz() const {
+  return impl_->stride_sz;
+}
+
+std::uint32_t CpuRoceTransceiver::get_rx_ring_stride_num() const {
+  return impl_->stride_num;
+}
+
+std::uint64_t *CpuRoceTransceiver::get_rx_ring_flag_addr() const {
+  return impl_->rx_flags;
+}
+
+std::uint8_t *CpuRoceTransceiver::get_tx_ring_data_addr() const {
+  return impl_->tx_data;
+}
+
+std::size_t CpuRoceTransceiver::get_tx_ring_stride_sz() const {
+  return impl_->stride_sz;
+}
+
+std::uint32_t CpuRoceTransceiver::get_tx_ring_stride_num() const {
+  return impl_->stride_num;
+}
+
+std::uint64_t *CpuRoceTransceiver::get_tx_ring_flag_addr() const {
+  return impl_->tx_flags;
+}
+
+} // namespace cudaq::realtime::bridge

--- a/realtime/lib/cpu_transport/roce_transceiver.cpp
+++ b/realtime/lib/cpu_transport/roce_transceiver.cpp
@@ -56,7 +56,8 @@ constexpr std::uint64_t encode_wr_id(std::uint32_t slot,
 constexpr std::uint32_t decode_slot(std::uint64_t wr_id) {
   return static_cast<std::uint32_t>(wr_id & 0xFFFFFFFFu);
 }
-[[maybe_unused]] constexpr std::uint32_t decode_generation(std::uint64_t wr_id) {
+[[maybe_unused]] constexpr std::uint32_t
+decode_generation(std::uint64_t wr_id) {
   return static_cast<std::uint32_t>(wr_id >> 32);
 }
 
@@ -257,7 +258,10 @@ bool CpuRoceTransceiver::Impl::find_roce_v2_gid() {
     const std::uint8_t *raw = entry.gid.raw;
     bool prefix_zero = true;
     for (int b = 0; b < 10; ++b)
-      if (raw[b] != 0) { prefix_zero = false; break; }
+      if (raw[b] != 0) {
+        prefix_zero = false;
+        break;
+      }
     if (!prefix_zero)
       continue;
     if (raw[10] != 0xff || raw[11] != 0xff)
@@ -275,7 +279,8 @@ bool CpuRoceTransceiver::Impl::find_roce_v2_gid() {
 
 bool CpuRoceTransceiver::Impl::allocate_rings() {
   const std::size_t page_sz = static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
-  const std::size_t data_bytes = static_cast<std::size_t>(stride_num) * stride_sz;
+  const std::size_t data_bytes =
+      static_cast<std::size_t>(stride_num) * stride_sz;
   const std::size_t flags_bytes =
       static_cast<std::size_t>(stride_num) * sizeof(std::uint64_t);
 
@@ -291,7 +296,8 @@ bool CpuRoceTransceiver::Impl::allocate_rings() {
 }
 
 bool CpuRoceTransceiver::Impl::register_mrs() {
-  const std::size_t data_bytes = static_cast<std::size_t>(stride_num) * stride_sz;
+  const std::size_t data_bytes =
+      static_cast<std::size_t>(stride_num) * stride_sz;
 
   // RX ring is RDMA-write target: needs LOCAL_WRITE + REMOTE_WRITE.  rkey is
   // exported to the peer (FPGA via HSB control plane, or peer transceiver
@@ -313,12 +319,14 @@ bool CpuRoceTransceiver::Impl::register_mrs() {
   // for both local reads (Send source) and local writes (Recv target).
   // post_initial_recv_wqes(), forward_loop, and any other code that
   // builds an SGE referencing rx_data_mr->lkey must follow this rule.
-  rx_data_mr = ibv_reg_mr_iova(pd, rx_data, data_bytes, /*iova=*/0,
-                               IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+  rx_data_mr =
+      ibv_reg_mr_iova(pd, rx_data, data_bytes, /*iova=*/0,
+                      IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
   if (!rx_data_mr) {
-    std::fprintf(stderr,
-                 "CpuRoceTransceiver: ibv_reg_mr_iova(rx_data) failed errno=%d\n",
-                 errno);
+    std::fprintf(
+        stderr,
+        "CpuRoceTransceiver: ibv_reg_mr_iova(rx_data) failed errno=%d\n",
+        errno);
     return false;
   }
   rkey = rx_data_mr->rkey;
@@ -367,8 +375,8 @@ bool CpuRoceTransceiver::Impl::create_qp_and_cqs() {
 
   qp = ibv_create_qp(pd, &init);
   if (!qp) {
-    std::fprintf(stderr,
-                 "CpuRoceTransceiver: ibv_create_qp failed errno=%d\n", errno);
+    std::fprintf(stderr, "CpuRoceTransceiver: ibv_create_qp failed errno=%d\n",
+                 errno);
     return false;
   }
   qp_number = qp->qp_num;
@@ -415,9 +423,9 @@ bool CpuRoceTransceiver::Impl::post_initial_recv_wqes() {
 
     ibv_recv_wr *bad = nullptr;
     if (ibv_post_recv(qp, &wr, &bad) != 0) {
-      std::fprintf(stderr,
-                   "CpuRoceTransceiver: ibv_post_recv slot=%u failed errno=%d\n",
-                   slot, errno);
+      std::fprintf(
+          stderr, "CpuRoceTransceiver: ibv_post_recv slot=%u failed errno=%d\n",
+          slot, errno);
       return false;
     }
   }
@@ -512,8 +520,8 @@ void CpuRoceTransceiver::Impl::rx_loop() {
     }
     const std::uint32_t slot = decode_slot(wc.wr_id);
     if (slot >= stride_num) {
-      std::fprintf(stderr, "CpuRoceTransceiver: RX bad slot=%u (>= %u)\n",
-                   slot, stride_num);
+      std::fprintf(stderr, "CpuRoceTransceiver: RX bad slot=%u (>= %u)\n", slot,
+                   stride_num);
       continue;
     }
 
@@ -529,9 +537,9 @@ void CpuRoceTransceiver::Impl::rx_loop() {
     }
 
     // Publish: writing the data address (non-zero) signals "fresh data".
-    __atomic_store_n(&flag,
-                     reinterpret_cast<std::uint64_t>(rx_data + slot * stride_sz),
-                     __ATOMIC_RELEASE);
+    __atomic_store_n(
+        &flag, reinterpret_cast<std::uint64_t>(rx_data + slot * stride_sz),
+        __ATOMIC_RELEASE);
 
     // Re-post the recv WQE for this slot so future inbound writes have
     // somewhere to land.  IOVA-based addr (see post_initial_recv_wqes).
@@ -548,9 +556,10 @@ void CpuRoceTransceiver::Impl::rx_loop() {
     wr.next = nullptr;
     ibv_recv_wr *bad = nullptr;
     if (ibv_post_recv(qp, &wr, &bad) != 0) {
-      std::fprintf(stderr,
-                   "CpuRoceTransceiver: ibv_post_recv re-arm slot=%u failed errno=%d\n",
-                   slot, errno);
+      std::fprintf(
+          stderr,
+          "CpuRoceTransceiver: ibv_post_recv re-arm slot=%u failed errno=%d\n",
+          slot, errno);
       // Continue rather than break; the next CQE may still be processable.
     }
   }
@@ -574,9 +583,10 @@ void CpuRoceTransceiver::Impl::forward_loop() {
   while (exit_flag.load(std::memory_order_acquire) == 0) {
     int n = ibv_poll_cq(rq_cq, 1, &wc);
     if (n < 0) {
-      std::fprintf(stderr,
-                   "CpuRoceTransceiver(forward): ibv_poll_cq(rq) failed errno=%d\n",
-                   errno);
+      std::fprintf(
+          stderr,
+          "CpuRoceTransceiver(forward): ibv_poll_cq(rq) failed errno=%d\n",
+          errno);
       break;
     }
     if (n == 0) {
@@ -584,10 +594,11 @@ void CpuRoceTransceiver::Impl::forward_loop() {
       continue;
     }
     if (wc.status != IBV_WC_SUCCESS) {
-      std::fprintf(stderr,
-                   "CpuRoceTransceiver(forward): RX CQE status=%d (%s) wr_id=%lu\n",
-                   wc.status, ibv_wc_status_str(wc.status),
-                   static_cast<unsigned long>(wc.wr_id));
+      std::fprintf(
+          stderr,
+          "CpuRoceTransceiver(forward): RX CQE status=%d (%s) wr_id=%lu\n",
+          wc.status, ibv_wc_status_str(wc.status),
+          static_cast<unsigned long>(wc.wr_id));
       continue;
     }
     const std::uint32_t slot = decode_slot(wc.wr_id);
@@ -622,17 +633,19 @@ void CpuRoceTransceiver::Impl::forward_loop() {
     ibv_send_wr *bad_send = nullptr;
     if (ibv_post_send(qp, &swr, &bad_send) != 0) {
       std::fprintf(stderr,
-                   "CpuRoceTransceiver(forward): ibv_post_send slot=%u failed errno=%d\n",
+                   "CpuRoceTransceiver(forward): ibv_post_send slot=%u failed "
+                   "errno=%d\n",
                    slot, errno);
     }
     if (signal_this) {
       int drained = ibv_poll_cq(sq_cq, kSignalEvery, swc);
       for (int k = 0; k < drained; ++k) {
         if (swc[k].status != IBV_WC_SUCCESS) {
-          std::fprintf(stderr,
-                       "CpuRoceTransceiver(forward): SQ CQE wr_id=%lu status=%d (%s)\n",
-                       (unsigned long)swc[k].wr_id, swc[k].status,
-                       ibv_wc_status_str(swc[k].status));
+          std::fprintf(
+              stderr,
+              "CpuRoceTransceiver(forward): SQ CQE wr_id=%lu status=%d (%s)\n",
+              (unsigned long)swc[k].wr_id, swc[k].status,
+              ibv_wc_status_str(swc[k].status));
         }
       }
     }
@@ -654,7 +667,8 @@ void CpuRoceTransceiver::Impl::forward_loop() {
     ibv_recv_wr *bad_recv = nullptr;
     if (ibv_post_recv(qp, &rwr, &bad_recv) != 0) {
       std::fprintf(stderr,
-                   "CpuRoceTransceiver(forward): ibv_post_recv re-arm slot=%u failed errno=%d\n",
+                   "CpuRoceTransceiver(forward): ibv_post_recv re-arm slot=%u "
+                   "failed errno=%d\n",
                    slot, errno);
     }
   }
@@ -725,9 +739,9 @@ void CpuRoceTransceiver::Impl::tx_loop() {
 
     ibv_send_wr *bad = nullptr;
     if (ibv_post_send(qp, &swr, &bad) != 0) {
-      std::fprintf(stderr,
-                   "CpuRoceTransceiver: ibv_post_send slot=%u failed errno=%d\n",
-                   slot, errno);
+      std::fprintf(
+          stderr, "CpuRoceTransceiver: ibv_post_send slot=%u failed errno=%d\n",
+          slot, errno);
       // Restore the flag so the producer doesn't lose track of an in-flight
       // request that we failed to actually ship.
       __atomic_store_n(&flag, addr, __ATOMIC_RELEASE);
@@ -757,9 +771,10 @@ void CpuRoceTransceiver::Impl::unified_loop() {
   while (exit_flag.load(std::memory_order_acquire) == 0) {
     int n = ibv_poll_cq(rq_cq, 1, &wc);
     if (n < 0) {
-      std::fprintf(stderr,
-                   "CpuRoceTransceiver(unified): ibv_poll_cq(rq) failed errno=%d\n",
-                   errno);
+      std::fprintf(
+          stderr,
+          "CpuRoceTransceiver(unified): ibv_poll_cq(rq) failed errno=%d\n",
+          errno);
       break;
     }
     if (n == 0) {
@@ -812,7 +827,8 @@ void CpuRoceTransceiver::Impl::unified_loop() {
       ibv_send_wr *bad = nullptr;
       if (ibv_post_send(qp, &swr, &bad) != 0) {
         std::fprintf(stderr,
-                     "CpuRoceTransceiver(unified): ibv_post_send slot=%u failed errno=%d\n",
+                     "CpuRoceTransceiver(unified): ibv_post_send slot=%u "
+                     "failed errno=%d\n",
                      slot, errno);
       }
       if (signal_this) {
@@ -836,7 +852,8 @@ void CpuRoceTransceiver::Impl::unified_loop() {
     ibv_recv_wr *rbad = nullptr;
     if (ibv_post_recv(qp, &rwr, &rbad) != 0) {
       std::fprintf(stderr,
-                   "CpuRoceTransceiver(unified): ibv_post_recv re-arm slot=%u failed errno=%d\n",
+                   "CpuRoceTransceiver(unified): ibv_post_recv re-arm slot=%u "
+                   "failed errno=%d\n",
                    slot, errno);
     }
   }
@@ -871,7 +888,8 @@ void CpuRoceTransceiver::Impl::release_resources() noexcept {
     ibv_close_device(ctx);
     ctx = nullptr;
   }
-  const std::size_t data_bytes = static_cast<std::size_t>(stride_num) * stride_sz;
+  const std::size_t data_bytes =
+      static_cast<std::size_t>(stride_num) * stride_sz;
   if (rx_data) {
     munlock(rx_data, data_bytes);
     free(rx_data);
@@ -904,8 +922,8 @@ void CpuRoceTransceiver::Impl::release_resources() noexcept {
 CpuRoceTransceiver::CpuRoceTransceiver(
     const char *ibv_name, unsigned ibv_port, unsigned tx_ibv_qp,
     std::size_t cu_frame_size, std::size_t cu_page_size, unsigned pages,
-    const char *peer_ip, bool forward, bool rx_only, bool tx_only,
-    bool unified, CpuRoceTxMode tx_mode, std::uint64_t peer_rx_base_addr,
+    const char *peer_ip, bool forward, bool rx_only, bool tx_only, bool unified,
+    CpuRoceTxMode tx_mode, std::uint64_t peer_rx_base_addr,
     std::uint32_t peer_rx_rkey)
     : impl_(std::make_unique<Impl>()) {
   const int mode_count = (forward ? 1 : 0) + (rx_only ? 1 : 0) +
@@ -992,9 +1010,11 @@ void CpuRoceTransceiver::blocking_monitor() {
 
   // Mode selection (mutual exclusion was already enforced at construction).
   if (impl_->forward) {
-    impl_->forward_thread = std::thread([impl = impl_.get()] { impl->forward_loop(); });
+    impl_->forward_thread =
+        std::thread([impl = impl_.get()] { impl->forward_loop(); });
   } else if (impl_->unified) {
-    impl_->unified_thread = std::thread([impl = impl_.get()] { impl->unified_loop(); });
+    impl_->unified_thread =
+        std::thread([impl = impl_.get()] { impl->unified_loop(); });
   } else {
     // Normal three-thread layout (the §4.2 default).  tx_only / rx_only
     // skip one or the other thread; the consumer / dispatcher is on a

--- a/realtime/lib/cpu_transport/roce_transceiver.cpp
+++ b/realtime/lib/cpu_transport/roce_transceiver.cpp
@@ -297,13 +297,22 @@ bool CpuRoceTransceiver::Impl::register_mrs() {
   // exported to the peer (FPGA via HSB control plane, or peer transceiver
   // via out-of-band rendezvous).
   //
-  // CRITICAL: register with iova=0 so the peer's remote_addr=0+slot*stride
-  // resolves to "start of rx_data + slot*stride" on our side.  This matches
-  // the convention exposed via external_frame_memory() (= 0) and the
-  // "Buffer Addr: 0x0" line we print to stdout.  If we used plain
-  // ibv_reg_mr (which sets iova=virtual_addr), the peer would have to use
-  // our virtual address — which we don't want to leak across the wire and
-  // can't safely use anyway.
+  // Register with iova=0 so the peer addresses our slots by offset alone:
+  //   remote_addr = 0 + slot*stride_sz
+  // Why iova=0 and not iova=vaddr?  The HSB library enforces a hard limit
+  // PAGES(highest_address) <= UINT32_MAX where PAGES = >> 7, so the
+  // highest addressed byte must be below 2^39 = 512 GB.  Modern Linux on
+  // aarch64 returns virtual addresses in the 48-bit range, well past
+  // 512 GB, so vaddr-as-iova would trip the HSB limit at runtime in the
+  // playback tool.
+  //
+  // CRITICAL consequence: on this mlx5/libibverbs stack, local SGEs that
+  // reference this MR via its lkey must use IOVA-based addresses
+  // (0 + slot*stride_sz), NOT virtual addresses (rx_data + slot*stride_sz).
+  // The NIC validates the SGE addr against the iova range [0, data_bytes)
+  // for both local reads (Send source) and local writes (Recv target).
+  // post_initial_recv_wqes(), forward_loop, and any other code that
+  // builds an SGE referencing rx_data_mr->lkey must follow this rule.
   rx_data_mr = ibv_reg_mr_iova(pd, rx_data, data_bytes, /*iova=*/0,
                                IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
   if (!rx_data_mr) {
@@ -315,8 +324,10 @@ bool CpuRoceTransceiver::Impl::register_mrs() {
   rkey = rx_data_mr->rkey;
 
   // TX ring is local-only (we read from it to populate Send / Write
-  // payloads); peer never addresses it.  Plain ibv_reg_mr is fine — local
-  // SGEs use the actual virtual address regardless of iova choice.
+  // payloads); peer never addresses it.  Plain ibv_reg_mr (iova=vaddr) is
+  // fine — SGEs from tx_loop reference tx_data_mr->lkey with vaddr-based
+  // addresses, and there's no IOVA-vs-vaddr conflict because tx_data isn't
+  // remotely addressable.
   tx_data_mr = ibv_reg_mr(pd, tx_data, data_bytes, IBV_ACCESS_LOCAL_WRITE);
   if (!tx_data_mr) {
     std::fprintf(stderr,
@@ -385,9 +396,14 @@ bool CpuRoceTransceiver::Impl::post_initial_recv_wqes() {
   // Pre-post stride_num receive WQEs, each pointing at one specific slot in
   // rx_data with wr_id encoding the slot.  When the peer's RDMA writes
   // complete, the CQE's wr_id tells us which slot was written into.
+  //
+  // SGE addr is IOVA-based (slot*stride_sz, offset from iova=0), NOT
+  // vaddr-based.  Required because rx_data_mr is registered with iova=0
+  // and the mlx5 NIC validates local SGE addrs against the iova range.
+  // See register_mrs() for the rationale.
   for (std::uint32_t slot = 0; slot < stride_num; ++slot) {
     ibv_sge sge{};
-    sge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
+    sge.addr = static_cast<std::uint64_t>(slot) * stride_sz;
     sge.length = static_cast<std::uint32_t>(stride_sz);
     sge.lkey = rx_data_mr->lkey;
 
@@ -518,13 +534,10 @@ void CpuRoceTransceiver::Impl::rx_loop() {
                      __ATOMIC_RELEASE);
 
     // Re-post the recv WQE for this slot so future inbound writes have
-    // somewhere to land.  We do this immediately rather than waiting for
-    // the consumer to fully drain, because the recv queue is what the NIC
-    // dequeues from on incoming Write-With-Imm.  The flag handshake above
-    // ensures we don't overwrite a slot that still has fresh data.
+    // somewhere to land.  IOVA-based addr (see post_initial_recv_wqes).
     generation[slot]++;
     ibv_sge sge{};
-    sge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
+    sge.addr = static_cast<std::uint64_t>(slot) * stride_sz;
     sge.length = static_cast<std::uint32_t>(stride_sz);
     sge.lkey = rx_data_mr->lkey;
 
@@ -548,34 +561,56 @@ void CpuRoceTransceiver::Impl::forward_loop() {
   // from the same slot.  No rx_flag/tx_flag handshake involved (we do the
   // wire round-trip directly).  Mirrors the GPU forward kernel.
   std::vector<std::uint32_t> generation(stride_num, 1);
+
+  // SQ drain via signal-every-N (same pattern as tx_loop).  Required
+  // because the SQ slots are only freed when a signaled WQE completes
+  // (and sweeps preceding unsignaled WQEs).  Without this, after
+  // max_send_wr (= stride_num) sends, ibv_post_send returns ENOMEM.
+  constexpr int kSignalEvery = 16;
+  std::uint32_t since_signal = 0;
+  ibv_wc swc[kSignalEvery]{};
+
   ibv_wc wc{};
   while (exit_flag.load(std::memory_order_acquire) == 0) {
     int n = ibv_poll_cq(rq_cq, 1, &wc);
-    if (n < 0)
+    if (n < 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver(forward): ibv_poll_cq(rq) failed errno=%d\n",
+                   errno);
       break;
+    }
     if (n == 0) {
       cpu_relax();
       continue;
     }
-    if (wc.status != IBV_WC_SUCCESS)
+    if (wc.status != IBV_WC_SUCCESS) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver(forward): RX CQE status=%d (%s) wr_id=%lu\n",
+                   wc.status, ibv_wc_status_str(wc.status),
+                   static_cast<unsigned long>(wc.wr_id));
       continue;
+    }
     const std::uint32_t slot = decode_slot(wc.wr_id);
-    if (slot >= stride_num)
+    if (slot >= stride_num) {
+      std::fprintf(stderr, "CpuRoceTransceiver(forward): bad slot=%u\n", slot);
       continue;
+    }
 
-    // Re-send the slot's bytes back to the peer.  TX verb depends on
-    // tx_mode (matches the TX thread's logic in the tx_loop todo).
-    ibv_sge sge{};
-    sge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
-    sge.length = static_cast<std::uint32_t>(stride_sz);
-    sge.lkey = rx_data_mr->lkey;
+    // Re-send the slot's bytes back to the peer.  IOVA-based addr (see
+    // register_mrs / post_initial_recv_wqes).  Length uses cu_frame_size
+    // for parity with tx_loop and the GPU bridge's forward kernel.
+    ibv_sge send_sge{};
+    send_sge.addr = static_cast<std::uint64_t>(slot) * stride_sz;
+    send_sge.length = static_cast<std::uint32_t>(cu_frame_size);
+    send_sge.lkey = rx_data_mr->lkey;
 
     ibv_send_wr swr{};
     swr.wr_id = wc.wr_id;
-    swr.sg_list = &sge;
+    swr.sg_list = &send_sge;
     swr.num_sge = 1;
-    swr.send_flags = 0; // unsignalled; we don't poll SQ in forward mode
     swr.next = nullptr;
+    const bool signal_this = (++since_signal % kSignalEvery) == 0;
+    swr.send_flags = signal_this ? IBV_SEND_SIGNALED : 0;
     if (tx_mode == CpuRoceTxMode::kWriteWithImmForPeer) {
       swr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
       swr.wr.rdma.remote_addr = peer_rx_base_addr + slot * stride_sz;
@@ -584,18 +619,44 @@ void CpuRoceTransceiver::Impl::forward_loop() {
     } else {
       swr.opcode = IBV_WR_SEND;
     }
-    ibv_send_wr *bad = nullptr;
-    (void)ibv_post_send(qp, &swr, &bad);
+    ibv_send_wr *bad_send = nullptr;
+    if (ibv_post_send(qp, &swr, &bad_send) != 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver(forward): ibv_post_send slot=%u failed errno=%d\n",
+                   slot, errno);
+    }
+    if (signal_this) {
+      int drained = ibv_poll_cq(sq_cq, kSignalEvery, swc);
+      for (int k = 0; k < drained; ++k) {
+        if (swc[k].status != IBV_WC_SUCCESS) {
+          std::fprintf(stderr,
+                       "CpuRoceTransceiver(forward): SQ CQE wr_id=%lu status=%d (%s)\n",
+                       (unsigned long)swc[k].wr_id, swc[k].status,
+                       ibv_wc_status_str(swc[k].status));
+        }
+      }
+    }
 
-    // Re-post the recv WQE for the same slot.
+    // Re-post the recv WQE for this slot.  SEPARATE SGE from the send:
+    // recv buffer must be sized to stride_sz to accept any future inbound
+    // write (which might be larger than the original cu_frame_size).
+    // IOVA-based addr (see register_mrs).
     generation[slot]++;
+    ibv_sge recv_sge{};
+    recv_sge.addr = static_cast<std::uint64_t>(slot) * stride_sz;
+    recv_sge.length = static_cast<std::uint32_t>(stride_sz);
+    recv_sge.lkey = rx_data_mr->lkey;
     ibv_recv_wr rwr{};
     rwr.wr_id = encode_wr_id(slot, generation[slot]);
-    rwr.sg_list = &sge;
+    rwr.sg_list = &recv_sge;
     rwr.num_sge = 1;
     rwr.next = nullptr;
-    ibv_recv_wr *rbad = nullptr;
-    (void)ibv_post_recv(qp, &rwr, &rbad);
+    ibv_recv_wr *bad_recv = nullptr;
+    if (ibv_post_recv(qp, &rwr, &bad_recv) != 0) {
+      std::fprintf(stderr,
+                   "CpuRoceTransceiver(forward): ibv_post_recv re-arm slot=%u failed errno=%d\n",
+                   slot, errno);
+    }
   }
 }
 
@@ -629,10 +690,13 @@ void CpuRoceTransceiver::Impl::tx_loop() {
 
     // Build the send WQE.  Use the slot's data address as the SGE source;
     // the slot index is encoded in the IMM for Write-With-Imm mode (so the
-    // peer can decode which slot the bytes belong to).
+    // peer can decode which slot the bytes belong to).  SGE length uses
+    // cu_frame_size (the actual RPC frame size, RPCHeader + payload),
+    // NOT stride_sz (the full slot), so we don't transmit unused slot
+    // tail bytes.  Matches the GPU bridge's "frame_size" convention.
     ibv_sge sge{};
     sge.addr = addr;
-    sge.length = static_cast<std::uint32_t>(stride_sz);
+    sge.length = static_cast<std::uint32_t>(cu_frame_size);
     sge.lkey = local_tx_lkey;
 
     ibv_send_wr swr{};
@@ -760,7 +824,7 @@ void CpuRoceTransceiver::Impl::unified_loop() {
     // Re-arm the recv WQE for this slot.
     generation[slot]++;
     ibv_sge rsge{};
-    rsge.addr = reinterpret_cast<std::uintptr_t>(rx_data + slot * stride_sz);
+    rsge.addr = static_cast<std::uint64_t>(slot) * stride_sz;
     rsge.length = static_cast<std::uint32_t>(stride_sz);
     rsge.lkey = rx_data_mr->lkey;
 
@@ -992,7 +1056,12 @@ std::uint32_t CpuRoceTransceiver::get_qp_number() const {
 
 std::uint32_t CpuRoceTransceiver::get_rkey() const { return impl_->rkey; }
 
-std::uint64_t CpuRoceTransceiver::external_frame_memory() const { return 0; }
+std::uint64_t CpuRoceTransceiver::external_frame_memory() const {
+  // rx_data_mr is registered with iova=0; peer addresses slots by offset
+  // alone.  See register_mrs() for why iova=0 (HSB 32-bit page address
+  // limit forces it).
+  return 0;
+}
 
 std::uint8_t *CpuRoceTransceiver::get_rx_ring_data_addr() const {
   return impl_->rx_data;

--- a/realtime/lib/cpu_transport/roce_wrapper.cpp
+++ b/realtime/lib/cpu_transport/roce_wrapper.cpp
@@ -103,6 +103,10 @@ uint32_t cpu_roce_get_rkey(cpu_roce_transceiver_t handle) {
   return handle ? as_cpp(handle)->get_rkey() : 0;
 }
 
+uint64_t cpu_roce_get_buffer_addr(cpu_roce_transceiver_t handle) {
+  return handle ? as_cpp(handle)->external_frame_memory() : 0;
+}
+
 void *cpu_roce_get_rx_ring_data_addr(cpu_roce_transceiver_t handle) {
   return handle ? static_cast<void *>(as_cpp(handle)->get_rx_ring_data_addr())
                 : nullptr;

--- a/realtime/lib/cpu_transport/roce_wrapper.cpp
+++ b/realtime/lib/cpu_transport/roce_wrapper.cpp
@@ -30,11 +30,10 @@ CpuRoceTransceiver *as_cpp(cpu_roce_transceiver_t h) {
 extern "C" {
 
 cpu_roce_transceiver_t cpu_roce_create_transceiver(
-    const char *device_name, int ib_port, unsigned tx_ibv_qp,
-    size_t frame_size, size_t page_size, unsigned num_pages,
-    const char *peer_ip, int forward, int rx_only, int tx_only, int unified,
-    cpu_roce_tx_mode_t tx_mode, uint64_t peer_rx_base_addr,
-    uint32_t peer_rx_rkey) {
+    const char *device_name, int ib_port, unsigned tx_ibv_qp, size_t frame_size,
+    size_t page_size, unsigned num_pages, const char *peer_ip, int forward,
+    int rx_only, int tx_only, int unified, cpu_roce_tx_mode_t tx_mode,
+    uint64_t peer_rx_base_addr, uint32_t peer_rx_rkey) {
   try {
     // Translate the C enum to the C++ enum.  An out-of-range value falls
     // through to the FPGA default — the constructor will validate further.
@@ -44,8 +43,8 @@ cpu_roce_transceiver_t cpu_roce_create_transceiver(
             : CpuRoceTxMode::kSendForFpga;
     auto *t = new CpuRoceTransceiver(
         device_name, static_cast<unsigned>(ib_port), tx_ibv_qp, frame_size,
-        page_size, num_pages, peer_ip, forward != 0, rx_only != 0,
-        tx_only != 0, unified != 0, cpp_mode, peer_rx_base_addr, peer_rx_rkey);
+        page_size, num_pages, peer_ip, forward != 0, rx_only != 0, tx_only != 0,
+        unified != 0, cpp_mode, peer_rx_base_addr, peer_rx_rkey);
     return t;
   } catch (const std::exception &e) {
     std::fprintf(stderr, "cpu_roce_create_transceiver: %s\n", e.what());

--- a/realtime/lib/cpu_transport/roce_wrapper.cpp
+++ b/realtime/lib/cpu_transport/roce_wrapper.cpp
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// C ABI shim over CpuRoceTransceiver.  Translates the typed handle to a
+// `void *` and bridges the C bool-as-int / enum-as-int convention to the
+// underlying C++ types.  All entry points are noexcept at the C boundary;
+// std::exceptions from the C++ side are caught and reported to stderr.
+
+#include "cudaq/realtime/cpu_transport/roce_wrapper.h"
+
+#include "cudaq/realtime/cpu_transport/roce_transceiver.hpp"
+
+#include <cstdio>
+#include <exception>
+
+using cudaq::realtime::bridge::CpuRoceTransceiver;
+using cudaq::realtime::bridge::CpuRoceTxMode;
+
+namespace {
+CpuRoceTransceiver *as_cpp(cpu_roce_transceiver_t h) {
+  return static_cast<CpuRoceTransceiver *>(h);
+}
+} // namespace
+
+extern "C" {
+
+cpu_roce_transceiver_t cpu_roce_create_transceiver(
+    const char *device_name, int ib_port, unsigned tx_ibv_qp,
+    size_t frame_size, size_t page_size, unsigned num_pages,
+    const char *peer_ip, int forward, int rx_only, int tx_only, int unified,
+    cpu_roce_tx_mode_t tx_mode, uint64_t peer_rx_base_addr,
+    uint32_t peer_rx_rkey) {
+  try {
+    // Translate the C enum to the C++ enum.  An out-of-range value falls
+    // through to the FPGA default — the constructor will validate further.
+    const CpuRoceTxMode cpp_mode =
+        (tx_mode == CPU_ROCE_TX_MODE_WRITE_WITH_IMM_FOR_PEER)
+            ? CpuRoceTxMode::kWriteWithImmForPeer
+            : CpuRoceTxMode::kSendForFpga;
+    auto *t = new CpuRoceTransceiver(
+        device_name, static_cast<unsigned>(ib_port), tx_ibv_qp, frame_size,
+        page_size, num_pages, peer_ip, forward != 0, rx_only != 0,
+        tx_only != 0, unified != 0, cpp_mode, peer_rx_base_addr, peer_rx_rkey);
+    return t;
+  } catch (const std::exception &e) {
+    std::fprintf(stderr, "cpu_roce_create_transceiver: %s\n", e.what());
+    return nullptr;
+  }
+}
+
+void cpu_roce_destroy_transceiver(cpu_roce_transceiver_t handle) {
+  delete as_cpp(handle);
+}
+
+int cpu_roce_start(cpu_roce_transceiver_t handle) {
+  if (!handle)
+    return 0;
+  try {
+    return as_cpp(handle)->start() ? 1 : 0;
+  } catch (const std::exception &e) {
+    std::fprintf(stderr, "cpu_roce_start: %s\n", e.what());
+    return 0;
+  }
+}
+
+void cpu_roce_close(cpu_roce_transceiver_t handle) {
+  if (handle)
+    as_cpp(handle)->close();
+}
+
+void cpu_roce_blocking_monitor(cpu_roce_transceiver_t handle) {
+  if (!handle)
+    return;
+  try {
+    as_cpp(handle)->blocking_monitor();
+  } catch (const std::exception &e) {
+    std::fprintf(stderr, "cpu_roce_blocking_monitor: %s\n", e.what());
+  }
+}
+
+void cpu_roce_set_unified_dispatch(cpu_roce_transceiver_t handle,
+                                   cpu_roce_unified_dispatch_fn_t fn,
+                                   void *context) {
+  if (!handle)
+    return;
+  // The C and C++ function pointer types have identical signatures
+  // (size_t/std::size_t are the same; void* are the same) so a direct
+  // reinterpret is safe.
+  as_cpp(handle)->set_unified_dispatch(
+      reinterpret_cast<CpuRoceTransceiver::UnifiedDispatchFn>(fn), context);
+}
+
+uint32_t cpu_roce_get_qp_number(cpu_roce_transceiver_t handle) {
+  return handle ? as_cpp(handle)->get_qp_number() : 0;
+}
+
+uint32_t cpu_roce_get_rkey(cpu_roce_transceiver_t handle) {
+  return handle ? as_cpp(handle)->get_rkey() : 0;
+}
+
+void *cpu_roce_get_rx_ring_data_addr(cpu_roce_transceiver_t handle) {
+  return handle ? static_cast<void *>(as_cpp(handle)->get_rx_ring_data_addr())
+                : nullptr;
+}
+
+uint64_t *cpu_roce_get_rx_ring_flag_addr(cpu_roce_transceiver_t handle) {
+  return handle ? as_cpp(handle)->get_rx_ring_flag_addr() : nullptr;
+}
+
+void *cpu_roce_get_tx_ring_data_addr(cpu_roce_transceiver_t handle) {
+  return handle ? static_cast<void *>(as_cpp(handle)->get_tx_ring_data_addr())
+                : nullptr;
+}
+
+uint64_t *cpu_roce_get_tx_ring_flag_addr(cpu_roce_transceiver_t handle) {
+  return handle ? as_cpp(handle)->get_tx_ring_flag_addr() : nullptr;
+}
+
+size_t cpu_roce_get_page_size(cpu_roce_transceiver_t handle) {
+  return handle ? as_cpp(handle)->get_rx_ring_stride_sz() : 0;
+}
+
+unsigned cpu_roce_get_num_pages(cpu_roce_transceiver_t handle) {
+  return handle ? as_cpp(handle)->get_rx_ring_stride_num() : 0;
+}
+
+} // extern "C"

--- a/realtime/lib/daemon/dispatcher/host_dispatcher.cu
+++ b/realtime/lib/daemon/dispatcher/host_dispatcher.cu
@@ -9,6 +9,7 @@
 #include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
 #include "cudaq/realtime/daemon/dispatcher/host_dispatcher.h"
 
+#include <cstring>
 #include <cuda/std/atomic>
 
 using atomic_uint64_sys = cuda::std::atomic<uint64_t>;
@@ -86,6 +87,39 @@ static void finish_slot_and_advance(const cudaq_host_dispatch_loop_ctx_t *ctx,
     as_atomic_u64(ctx->live_dispatched)
         ->fetch_add(1, cuda::std::memory_order_relaxed);
   current_slot = (current_slot + 1) % num_slots;
+}
+
+// CUDAQ_DISPATCH_HOST_CALL handler: synchronous pure-C++ dispatch.  No GPU
+// graph worker is acquired (HOST_CALL bypasses the worker pool entirely).
+// Semantics match the user-facing `cudaq_host_rpc_fn_t(void *slot, size_t)`
+// ABI: the host_fn reads RPCHeader+args from `slot`, writes RPCResponse+
+// result back into the same slot.  Since our dispatcher uses separate
+// RX/TX rings (host-loop bridge requirement), we first memcpy the RX slot
+// into the TX slot so the in-place rewrite produces the response in the
+// TX ring where the consumer (e.g. CpuRoceTransceiver TX thread or
+// Hololink TX kernel) expects it.
+static void handle_host_call(const cudaq_host_dispatch_loop_ctx_t *ctx,
+                             const cudaq_function_entry_t *entry,
+                             void *slot_host, size_t current_slot) {
+  if (!entry || !entry->handler.host_fn)
+    return;
+  const size_t rx_stride = ctx->ringbuffer.rx_stride_sz;
+  const size_t tx_stride = ctx->ringbuffer.tx_stride_sz;
+  // Use the smaller of the two strides as the safe copy size; in practice
+  // RX and TX strides are equal (the bridge configures both from the same
+  // slot_size), so this is just defensive against a future asymmetric
+  // configuration.
+  const size_t copy_bytes = rx_stride < tx_stride ? rx_stride : tx_stride;
+  uint8_t *tx_slot = ctx->ringbuffer.tx_data_host + current_slot * tx_stride;
+  std::memcpy(tx_slot, slot_host, copy_bytes);
+  entry->handler.host_fn(tx_slot, tx_stride);
+  // Publish: writing the slot's address to tx_flag signals "fresh data" to
+  // the consumer.  No in-flight sentinel needed because this entire path
+  // is synchronous from the consumer's POV (the store happens after the
+  // host_fn has already filled tx_slot).
+  as_atomic_u64(ctx->ringbuffer.tx_flags_host)[current_slot].store(
+      reinterpret_cast<uint64_t>(tx_slot),
+      cuda::std::memory_order_release);
 }
 
 static int acquire_graph_worker(const cudaq_host_dispatch_loop_ctx_t *ctx,
@@ -218,6 +252,17 @@ cudaq_host_dispatcher_loop(const cudaq_host_dispatch_loop_ctx_t *ctx) {
       entry = parsed.entry;
     }
 
+    // Mode dispatch.  HOST_CALL is handled synchronously inline (no graph
+    // worker pool).  DEVICE_CALL slots are dropped on the host loop (the
+    // header comment in cudaq_realtime.h documents this — device calls
+    // belong on the GPU dispatch path).  GRAPH_LAUNCH falls through to the
+    // worker-pool path below.
+    if (entry && entry->dispatch_mode == CUDAQ_DISPATCH_HOST_CALL) {
+      handle_host_call(ctx, entry, slot_host, current_slot);
+      finish_slot_and_advance(ctx, current_slot, num_slots,
+                              packets_dispatched);
+      continue;
+    }
     if (entry && entry->dispatch_mode != CUDAQ_DISPATCH_GRAPH_LAUNCH) {
       as_atomic_u64(ctx->ringbuffer.rx_flags_host)[current_slot].store(
           0, cuda::std::memory_order_release);

--- a/realtime/unittests/CMakeLists.txt
+++ b/realtime/unittests/CMakeLists.txt
@@ -110,3 +110,8 @@ if (CUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS)
   add_subdirectory(utils)
   add_subdirectory(bridge_interface/hololink)
 endif()
+
+# CPU RoCE transport (Phase 1 of cpu_transport umbrella).
+# Self-gates on TARGET cudaq-realtime-cpu-transport so this is harmless when
+# libibverbs is not available.
+add_subdirectory(cpu_transport)

--- a/realtime/unittests/cpu_transport/CMakeLists.txt
+++ b/realtime/unittests/cpu_transport/CMakeLists.txt
@@ -1,0 +1,67 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+# ==============================================================================
+# CPU RoCE transport test binaries + helpers (Phase 1)
+#
+# Test artifacts that consume cudaq-realtime-cpu-transport:
+#   - hsb_bridge_cpu              GPU-less bridge binary; mirrors hololink_bridge
+#                                 but uses CpuRoceTransceiver +
+#                                 CUDAQ_DISPATCH_HOST_CALL.
+#   - hsb_test_cpu.sh             Orchestration script (built artifact; copy at
+#                                 install time).
+#
+# All gated on TARGET cudaq-realtime-cpu-transport so this dir is silently
+# skipped on hosts without libibverbs.
+# ==============================================================================
+
+if (NOT TARGET cudaq-realtime-cpu-transport)
+  return()
+endif()
+
+# CUDA include path is needed because cudaq_realtime.h transitively includes
+# <cuda_runtime.h> (for cudaGraphExec_t typedef in the function-entry union).
+# We don't link CUDA runtime — only the headers.
+find_package(CUDAToolkit REQUIRED)
+
+# ----------------------------------------------------------------------------
+# hsb_bridge_cpu: GPU-less bridge binary.
+# ----------------------------------------------------------------------------
+add_executable(hsb_bridge_cpu
+  hsb_bridge_cpu.cpp
+  init_rpc_increment_function_table_host.cpp
+)
+
+target_include_directories(hsb_bridge_cpu PRIVATE
+  ${CUDAQ_REALTIME_INCLUDE_DIR}
+  ${CUDAToolkit_INCLUDE_DIRS}
+)
+
+target_link_libraries(hsb_bridge_cpu PRIVATE
+  cudaq-realtime-cpu-transport     # CpuRoceTransceiver + C wrapper
+  cudaq-realtime-host-dispatch     # cudaq_host_dispatcher_loop (HOST_CALL path)
+  Threads::Threads
+)
+
+set_target_properties(hsb_bridge_cpu PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/unittests/utils
+)
+
+install(TARGETS hsb_bridge_cpu
+  COMPONENT realtime-tests
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# ----------------------------------------------------------------------------
+# hsb_test_cpu.sh: orchestration script, copied to the same output dir as the
+# binary so the existing test-script convention (sibling of binary) works.
+# ----------------------------------------------------------------------------
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hsb_test_cpu.sh
+               ${CMAKE_BINARY_DIR}/unittests/utils/hsb_test_cpu.sh COPYONLY)
+
+message(STATUS "  - hsb_bridge_cpu (GPU-less Phase 1 bridge)")

--- a/realtime/unittests/cpu_transport/hsb_bridge_cpu.cpp
+++ b/realtime/unittests/cpu_transport/hsb_bridge_cpu.cpp
@@ -1,0 +1,309 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// @file hsb_bridge_cpu.cpp
+/// @brief Phase 1 GPU-less HSB bridge using CpuRoceTransceiver +
+///        CUDAQ_DISPATCH_HOST_CALL.
+///
+/// Replaces hololink_bridge for the CPU-data-path test case.  No
+/// libhololink dependency, no GPU, no DOCA — only libibverbs + libcudaq-
+/// realtime + libcudaq-realtime-cpu-transport.
+///
+/// The FPGA-side rendezvous (telling the FPGA our QP number and rkey) is
+/// out-of-band: this binary prints them to stdout and the orchestration
+/// script (hsb_test_cpu.sh) feeds them to the emulator / FPGA control
+/// plane separately.
+///
+/// Usage:
+///   hsb_bridge_cpu --device=mlx5_0 --peer-ip=192.168.0.2 \
+///                  --remote-qp=2 --num-pages=64 --page-size=384 \
+///                  --timeout=60 [--unified]
+
+#include "cudaq/realtime/cpu_transport/roce_wrapper.h"
+#include "cudaq/realtime/daemon/dispatcher/cudaq_realtime.h"
+#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
+#include "cudaq/realtime/daemon/dispatcher/host_dispatcher.h"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>
+
+// Provided by init_rpc_increment_function_table_host.cpp.
+extern "C" void
+setup_rpc_increment_function_table_host(cudaq_function_entry_t *h_entries);
+
+// Provided by init_rpc_increment_function_table_host.cpp via internal
+// linkage; we need the same handler for unified mode's dispatch callback,
+// so re-declare its C ABI here.
+extern "C" void rpc_increment_handler_host(void *slot_host,
+                                           std::size_t slot_size);
+
+namespace {
+
+// ============================================================================
+// Argument parsing — small and self-contained; no shared parse_bridge_args.
+// ============================================================================
+struct CpuBridgeConfig {
+  std::string device = "mlx5_0";
+  std::string peer_ip = "192.168.0.2";
+  unsigned remote_qp = 2;
+  unsigned num_pages = 64;
+  std::size_t page_size = 384;
+  unsigned payload_size = 24; // bytes after RPCHeader; default matches FPGA
+                              // emulator's increment-handler stimulus
+  int timeout_sec = 60;
+  bool unified = false;
+};
+
+bool starts_with(const std::string &s, const char *prefix) {
+  std::size_t n = std::strlen(prefix);
+  return s.size() >= n && std::memcmp(s.data(), prefix, n) == 0;
+}
+
+bool parse_args(int argc, char **argv, CpuBridgeConfig &cfg) {
+  for (int i = 1; i < argc; ++i) {
+    std::string a = argv[i];
+    if (a == "--help" || a == "-h") {
+      std::cout
+          << "Usage: " << argv[0] << " [options]\n\n"
+          << "Phase 1 CPU-RoCE bridge for libcudaq-realtime HOST_CALL "
+          << "dispatch.\n\n"
+          << "Options:\n"
+          << "  --device=NAME       IB device (default: mlx5_0)\n"
+          << "  --peer-ip=ADDR      Peer IPv4 (FPGA / emulator) (default: "
+             "192.168.0.2)\n"
+          << "  --remote-qp=N       Remote QP number (default: 2)\n"
+          << "  --num-pages=N       Ring slots, power of two (default: 64)\n"
+          << "  --page-size=N       Per-slot stride in bytes (default: 384)\n"
+          << "  --payload-size=N    RPC payload bytes (default: 24)\n"
+          << "  --timeout=N         Run timeout in seconds (default: 60)\n"
+          << "  --unified           Use single-thread unified RX+dispatch+TX\n";
+      return false;
+    } else if (starts_with(a, "--device="))
+      cfg.device = a.substr(9);
+    else if (starts_with(a, "--peer-ip="))
+      cfg.peer_ip = a.substr(10);
+    else if (starts_with(a, "--remote-qp="))
+      cfg.remote_qp = static_cast<unsigned>(std::stoul(a.substr(12), nullptr, 0));
+    else if (starts_with(a, "--num-pages="))
+      cfg.num_pages = static_cast<unsigned>(std::stoul(a.substr(12)));
+    else if (starts_with(a, "--page-size="))
+      cfg.page_size = std::stoull(a.substr(12));
+    else if (starts_with(a, "--payload-size="))
+      cfg.payload_size = static_cast<unsigned>(std::stoul(a.substr(15)));
+    else if (starts_with(a, "--timeout="))
+      cfg.timeout_sec = std::stoi(a.substr(10));
+    else if (a == "--unified")
+      cfg.unified = true;
+    else {
+      std::cerr << "Unknown argument: " << a << "  (use --help)" << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+// ============================================================================
+// Shutdown signal handling
+// ============================================================================
+std::atomic<int> g_shutdown{0};
+void on_signal(int) { g_shutdown.store(1, std::memory_order_release); }
+
+// ============================================================================
+// Unified-mode dispatch callback.  Forwards directly to the host increment
+// handler.  The dispatcher copy that the three-thread path does in
+// handle_host_call is done explicitly here (rx_slot -> tx_slot) since the
+// unified loop hands us both sides.
+// ============================================================================
+std::size_t unified_dispatch_cb(void * /*context*/, const void *rx_slot,
+                                void *tx_slot, std::size_t slot_size) {
+  using cudaq::realtime::RPC_MAGIC_REQUEST;
+  using cudaq::realtime::RPCHeader;
+  const auto *header = static_cast<const RPCHeader *>(rx_slot);
+  if (header->magic != RPC_MAGIC_REQUEST)
+    return 0; // drop without sending — silent for non-RPC noise
+  std::memcpy(tx_slot, rx_slot, slot_size);
+  rpc_increment_handler_host(tx_slot, slot_size);
+  // Response length: response header + payload bytes (use full slot to
+  // match the three-thread / FPGA TX framing, since the FPGA expects a
+  // fixed-size payload per slot).
+  return slot_size;
+}
+
+} // namespace
+
+// ============================================================================
+// main
+// ============================================================================
+int main(int argc, char **argv) {
+  CpuBridgeConfig cfg;
+  if (!parse_args(argc, argv, cfg))
+    return 0;
+
+  std::signal(SIGINT, on_signal);
+  std::signal(SIGTERM, on_signal);
+
+  std::cout << "=== HSB CPU Bridge (Phase 1) ===" << std::endl;
+  std::cout << "Device:        " << cfg.device << std::endl;
+  std::cout << "Peer IP:       " << cfg.peer_ip << std::endl;
+  std::cout << "Remote QP:     0x" << std::hex << cfg.remote_qp << std::dec
+            << std::endl;
+  std::cout << "Pages:         " << cfg.num_pages << std::endl;
+  std::cout << "Page size:     " << cfg.page_size << " bytes" << std::endl;
+  std::cout << "Mode:          " << (cfg.unified ? "UNIFIED" : "3-thread")
+            << std::endl;
+
+  // ------------------------------------------------------------------------
+  // [1] Create CpuRoceTransceiver.  In default (3-thread) mode the host
+  //     dispatcher consumes RX flags / produces TX flags; in unified mode
+  //     the transceiver's unified_loop does both inline.
+  // ------------------------------------------------------------------------
+  const int forward = 0;
+  const int rx_only = 0;
+  const int tx_only = 0;
+  cpu_roce_transceiver_t xcvr = cpu_roce_create_transceiver(
+      cfg.device.c_str(), /*ib_port=*/1, cfg.remote_qp, cfg.page_size,
+      cfg.page_size, cfg.num_pages, cfg.peer_ip.c_str(), forward, rx_only,
+      tx_only, cfg.unified ? 1 : 0,
+      /*tx_mode=*/CPU_ROCE_TX_MODE_SEND_FOR_FPGA,
+      /*peer_rx_base_addr=*/0, /*peer_rx_rkey=*/0);
+  if (!xcvr) {
+    std::cerr << "ERROR: cpu_roce_create_transceiver failed" << std::endl;
+    return 1;
+  }
+
+  if (!cpu_roce_start(xcvr)) {
+    std::cerr << "ERROR: cpu_roce_start failed" << std::endl;
+    cpu_roce_destroy_transceiver(xcvr);
+    return 1;
+  }
+
+  const uint32_t our_qp = cpu_roce_get_qp_number(xcvr);
+  const uint32_t our_rkey = cpu_roce_get_rkey(xcvr);
+
+  // ------------------------------------------------------------------------
+  // [2] Set up the HOST_CALL function table (always one entry: increment).
+  // ------------------------------------------------------------------------
+  cudaq_function_entry_t h_entries[1];
+  setup_rpc_increment_function_table_host(h_entries);
+
+  // ------------------------------------------------------------------------
+  // [3] Mode-specific wiring.
+  // ------------------------------------------------------------------------
+  std::thread dispatcher_thread;
+  std::atomic<int> dispatcher_shutdown{0};
+  cudaq_host_dispatch_loop_ctx_t dctx{};
+  uint64_t packets_dispatched = 0;
+  if (cfg.unified) {
+    // Unified: install the dispatch closure; the transceiver's unified
+    // thread will invoke it.  No cudaq_host_dispatcher_loop needed.
+    cpu_roce_set_unified_dispatch(xcvr, &unified_dispatch_cb,
+                                  /*context=*/nullptr);
+  } else {
+    // 3-thread layout: spawn cudaq_host_dispatcher_loop on a dedicated
+    // thread.  It busy-polls rx_flags_host (the transceiver's RX thread
+    // publishes them), invokes our HOST_CALL handler synchronously, and
+    // publishes tx_flags_host (the transceiver's TX thread consumes
+    // them).  Worker-pool fields are zero/null because HOST_CALL bypasses
+    // the worker pool; skip_stream_sweep prevents the dispatcher from
+    // poking workers that don't exist.
+    dctx.ringbuffer.rx_flags_host = reinterpret_cast<volatile uint64_t *>(
+        cpu_roce_get_rx_ring_flag_addr(xcvr));
+    dctx.ringbuffer.tx_flags_host = reinterpret_cast<volatile uint64_t *>(
+        cpu_roce_get_tx_ring_flag_addr(xcvr));
+    dctx.ringbuffer.rx_data_host = reinterpret_cast<uint8_t *>(
+        cpu_roce_get_rx_ring_data_addr(xcvr));
+    dctx.ringbuffer.tx_data_host = reinterpret_cast<uint8_t *>(
+        cpu_roce_get_tx_ring_data_addr(xcvr));
+    dctx.ringbuffer.rx_stride_sz = cfg.page_size;
+    dctx.ringbuffer.tx_stride_sz = cfg.page_size;
+    dctx.config.num_slots = cfg.num_pages;
+    dctx.config.slot_size = static_cast<uint32_t>(cfg.page_size);
+    dctx.config.dispatch_path = CUDAQ_DISPATCH_PATH_HOST;
+    dctx.config.dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
+    dctx.config.skip_tx_markers = 1; // we own the TX path; sentinel pattern
+                                     // (used to avoid Hololink TX kernel
+                                     // confusion) is irrelevant here.
+    dctx.function_table.entries = h_entries;
+    dctx.function_table.count = 1;
+    dctx.shutdown_flag = &dispatcher_shutdown;
+    dctx.stats_counter = &packets_dispatched;
+    dctx.skip_stream_sweep = true; // no graph workers, no streams to sweep
+
+    dispatcher_thread = std::thread([&dctx]() {
+      cudaq_host_dispatcher_loop(&dctx);
+    });
+  }
+
+  // ------------------------------------------------------------------------
+  // [4] Print rendezvous info for the orchestration script.
+  // ------------------------------------------------------------------------
+  // NOTE: output format MUST match hololink_bridge_common.h exactly —
+  // "  KEY: VALUE" with a single space after the colon — because the
+  // orchestration script (hsb_test_cpu.sh, mirrored from hololink_test.sh)
+  // uses strict regexes like 'QP Number: 0x\K...' to parse it.
+  std::cout << "\n=== Bridge Ready ===" << std::endl;
+  std::cout << "  QP Number: 0x" << std::hex << our_qp << std::dec
+            << std::endl;
+  std::cout << "  RKey: " << our_rkey << std::endl;
+  std::cout << "  Buffer Addr: 0x0" << std::endl; // ibv_reg_mr convention:
+                                                  // peer addresses slots by
+                                                  // offset from 0, MR
+                                                  // identified by rkey.
+  std::cout << "\nWaiting (Ctrl+C to stop, timeout=" << cfg.timeout_sec
+            << "s)..." << std::endl;
+  std::cout.flush();
+
+  // ------------------------------------------------------------------------
+  // [5] Run the transceiver I/O threads on the main thread until shutdown.
+  // ------------------------------------------------------------------------
+  std::thread xcvr_monitor(
+      [xcvr]() { cpu_roce_blocking_monitor(xcvr); });
+
+  // Timeout / signal wait loop.
+  auto t0 = std::chrono::steady_clock::now();
+  while (g_shutdown.load(std::memory_order_acquire) == 0) {
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                       std::chrono::steady_clock::now() - t0)
+                       .count();
+    if (elapsed > cfg.timeout_sec) {
+      std::cout << "\nTimeout reached (" << cfg.timeout_sec << "s)"
+                << std::endl;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+
+  // ------------------------------------------------------------------------
+  // [6] Orderly shutdown: signal the dispatcher, then the transceiver,
+  //     then join both.
+  // ------------------------------------------------------------------------
+  std::cout << "\n=== Shutting down ===" << std::endl;
+  if (!cfg.unified) {
+    dispatcher_shutdown.store(1, std::memory_order_release);
+    if (dispatcher_thread.joinable())
+      dispatcher_thread.join();
+  }
+  cpu_roce_close(xcvr);
+  if (xcvr_monitor.joinable())
+    xcvr_monitor.join();
+
+  if (!cfg.unified)
+    std::cout << "Packets dispatched: " << packets_dispatched << std::endl;
+
+  cpu_roce_destroy_transceiver(xcvr);
+  std::cout << "Done." << std::endl;
+  return 0;
+}

--- a/realtime/unittests/cpu_transport/hsb_bridge_cpu.cpp
+++ b/realtime/unittests/cpu_transport/hsb_bridge_cpu.cpp
@@ -102,7 +102,8 @@ bool parse_args(int argc, char **argv, CpuBridgeConfig &cfg) {
     else if (starts_with(a, "--peer-ip="))
       cfg.peer_ip = a.substr(10);
     else if (starts_with(a, "--remote-qp="))
-      cfg.remote_qp = static_cast<unsigned>(std::stoul(a.substr(12), nullptr, 0));
+      cfg.remote_qp =
+          static_cast<unsigned>(std::stoul(a.substr(12), nullptr, 0));
     else if (starts_with(a, "--num-pages="))
       cfg.num_pages = static_cast<unsigned>(std::stoul(a.substr(12)));
     else if (starts_with(a, "--page-size="))
@@ -175,9 +176,9 @@ int main(int argc, char **argv) {
   const std::size_t frame_size =
       sizeof(cudaq::realtime::RPCHeader) + cfg.payload_size;
 
-  const char *mode_str = cfg.forward     ? "FORWARD"
-                         : cfg.unified   ? "UNIFIED"
-                                         : "3-thread";
+  const char *mode_str = cfg.forward   ? "FORWARD"
+                         : cfg.unified ? "UNIFIED"
+                                       : "3-thread";
 
   std::cout << "=== HSB CPU Bridge (Phase 1) ===" << std::endl;
   std::cout << "Device:        " << cfg.device << std::endl;
@@ -201,8 +202,8 @@ int main(int argc, char **argv) {
   const int tx_only = 0;
   cpu_roce_transceiver_t xcvr = cpu_roce_create_transceiver(
       cfg.device.c_str(), /*ib_port=*/1, cfg.remote_qp, frame_size,
-      cfg.page_size, cfg.num_pages, cfg.peer_ip.c_str(),
-      cfg.forward ? 1 : 0, rx_only, tx_only, cfg.unified ? 1 : 0,
+      cfg.page_size, cfg.num_pages, cfg.peer_ip.c_str(), cfg.forward ? 1 : 0,
+      rx_only, tx_only, cfg.unified ? 1 : 0,
       /*tx_mode=*/CPU_ROCE_TX_MODE_SEND_FOR_FPGA,
       /*peer_rx_base_addr=*/0, /*peer_rx_rkey=*/0);
   if (!xcvr) {
@@ -258,10 +259,10 @@ int main(int argc, char **argv) {
         cpu_roce_get_rx_ring_flag_addr(xcvr));
     dctx.ringbuffer.tx_flags_host = reinterpret_cast<volatile uint64_t *>(
         cpu_roce_get_tx_ring_flag_addr(xcvr));
-    dctx.ringbuffer.rx_data_host = reinterpret_cast<uint8_t *>(
-        cpu_roce_get_rx_ring_data_addr(xcvr));
-    dctx.ringbuffer.tx_data_host = reinterpret_cast<uint8_t *>(
-        cpu_roce_get_tx_ring_data_addr(xcvr));
+    dctx.ringbuffer.rx_data_host =
+        reinterpret_cast<uint8_t *>(cpu_roce_get_rx_ring_data_addr(xcvr));
+    dctx.ringbuffer.tx_data_host =
+        reinterpret_cast<uint8_t *>(cpu_roce_get_tx_ring_data_addr(xcvr));
     dctx.ringbuffer.rx_stride_sz = cfg.page_size;
     dctx.ringbuffer.tx_stride_sz = cfg.page_size;
     dctx.config.num_slots = cfg.num_pages;
@@ -277,9 +278,8 @@ int main(int argc, char **argv) {
     dctx.stats_counter = &packets_dispatched;
     dctx.skip_stream_sweep = true; // no graph workers, no streams to sweep
 
-    dispatcher_thread = std::thread([&dctx]() {
-      cudaq_host_dispatcher_loop(&dctx);
-    });
+    dispatcher_thread =
+        std::thread([&dctx]() { cudaq_host_dispatcher_loop(&dctx); });
   }
 
   // ------------------------------------------------------------------------
@@ -290,8 +290,7 @@ int main(int argc, char **argv) {
   // orchestration script (hsb_test_cpu.sh, mirrored from hololink_test.sh)
   // uses strict regexes like 'QP Number: 0x\K...' to parse it.
   std::cout << "\n=== Bridge Ready ===" << std::endl;
-  std::cout << "  QP Number: 0x" << std::hex << our_qp << std::dec
-            << std::endl;
+  std::cout << "  QP Number: 0x" << std::hex << our_qp << std::dec << std::endl;
   std::cout << "  RKey: " << our_rkey << std::endl;
   std::cout << "  Buffer Addr: 0x" << std::hex << our_buffer << std::dec
             << std::endl;
@@ -302,8 +301,7 @@ int main(int argc, char **argv) {
   // ------------------------------------------------------------------------
   // [5] Run the transceiver I/O threads on the main thread until shutdown.
   // ------------------------------------------------------------------------
-  std::thread xcvr_monitor(
-      [xcvr]() { cpu_roce_blocking_monitor(xcvr); });
+  std::thread xcvr_monitor([xcvr]() { cpu_roce_blocking_monitor(xcvr); });
 
   // Timeout / signal wait loop.
   auto t0 = std::chrono::steady_clock::now();

--- a/realtime/unittests/cpu_transport/hsb_bridge_cpu.cpp
+++ b/realtime/unittests/cpu_transport/hsb_bridge_cpu.cpp
@@ -65,6 +65,10 @@ struct CpuBridgeConfig {
                               // emulator's increment-handler stimulus
   int timeout_sec = 60;
   bool unified = false;
+  bool forward = false; // CpuRoceTransceiver forward mode: RX thread loops
+                        // every incoming slot back to the peer; no dispatch,
+                        // no HOST_CALL.  Wire-RTT baseline; mutually
+                        // exclusive with --unified.
 };
 
 bool starts_with(const std::string &s, const char *prefix) {
@@ -89,7 +93,9 @@ bool parse_args(int argc, char **argv, CpuBridgeConfig &cfg) {
           << "  --page-size=N       Per-slot stride in bytes (default: 384)\n"
           << "  --payload-size=N    RPC payload bytes (default: 24)\n"
           << "  --timeout=N         Run timeout in seconds (default: 60)\n"
-          << "  --unified           Use single-thread unified RX+dispatch+TX\n";
+          << "  --unified           Use single-thread unified RX+dispatch+TX\n"
+          << "  --forward           Echo every incoming slot back to peer "
+             "(wire-RTT baseline, no dispatch)\n";
       return false;
     } else if (starts_with(a, "--device="))
       cfg.device = a.substr(9);
@@ -107,6 +113,8 @@ bool parse_args(int argc, char **argv, CpuBridgeConfig &cfg) {
       cfg.timeout_sec = std::stoi(a.substr(10));
     else if (a == "--unified")
       cfg.unified = true;
+    else if (a == "--forward")
+      cfg.forward = true;
     else {
       std::cerr << "Unknown argument: " << a << "  (use --help)" << std::endl;
       return false;
@@ -155,6 +163,22 @@ int main(int argc, char **argv) {
   std::signal(SIGINT, on_signal);
   std::signal(SIGTERM, on_signal);
 
+  if (cfg.unified && cfg.forward) {
+    std::cerr << "ERROR: --unified and --forward are mutually exclusive"
+              << std::endl;
+    return 1;
+  }
+
+  // RPC frame = RPCHeader (24B) + payload.  Passed to the transceiver as
+  // cu_frame_size, which is the SGE length on every TX (Send / Write-With-
+  // Imm) so we don't transmit unused slot tail bytes.
+  const std::size_t frame_size =
+      sizeof(cudaq::realtime::RPCHeader) + cfg.payload_size;
+
+  const char *mode_str = cfg.forward     ? "FORWARD"
+                         : cfg.unified   ? "UNIFIED"
+                                         : "3-thread";
+
   std::cout << "=== HSB CPU Bridge (Phase 1) ===" << std::endl;
   std::cout << "Device:        " << cfg.device << std::endl;
   std::cout << "Peer IP:       " << cfg.peer_ip << std::endl;
@@ -162,21 +186,23 @@ int main(int argc, char **argv) {
             << std::endl;
   std::cout << "Pages:         " << cfg.num_pages << std::endl;
   std::cout << "Page size:     " << cfg.page_size << " bytes" << std::endl;
-  std::cout << "Mode:          " << (cfg.unified ? "UNIFIED" : "3-thread")
-            << std::endl;
+  std::cout << "Frame size:    " << frame_size << " bytes" << std::endl;
+  std::cout << "Mode:          " << mode_str << std::endl;
 
   // ------------------------------------------------------------------------
-  // [1] Create CpuRoceTransceiver.  In default (3-thread) mode the host
-  //     dispatcher consumes RX flags / produces TX flags; in unified mode
-  //     the transceiver's unified_loop does both inline.
+  // [1] Create CpuRoceTransceiver.
+  //     3-thread: cudaq_host_dispatcher_loop consumes RX flags / produces TX
+  //               flags; transceiver's RX+TX threads do the wire I/O.
+  //     unified:  transceiver's unified_loop does RX + dispatch + TX inline.
+  //     forward:  transceiver's forward_loop echoes every RX slot back to
+  //               the peer; no host dispatcher needed.
   // ------------------------------------------------------------------------
-  const int forward = 0;
   const int rx_only = 0;
   const int tx_only = 0;
   cpu_roce_transceiver_t xcvr = cpu_roce_create_transceiver(
-      cfg.device.c_str(), /*ib_port=*/1, cfg.remote_qp, cfg.page_size,
-      cfg.page_size, cfg.num_pages, cfg.peer_ip.c_str(), forward, rx_only,
-      tx_only, cfg.unified ? 1 : 0,
+      cfg.device.c_str(), /*ib_port=*/1, cfg.remote_qp, frame_size,
+      cfg.page_size, cfg.num_pages, cfg.peer_ip.c_str(),
+      cfg.forward ? 1 : 0, rx_only, tx_only, cfg.unified ? 1 : 0,
       /*tx_mode=*/CPU_ROCE_TX_MODE_SEND_FOR_FPGA,
       /*peer_rx_base_addr=*/0, /*peer_rx_rkey=*/0);
   if (!xcvr) {
@@ -192,12 +218,17 @@ int main(int argc, char **argv) {
 
   const uint32_t our_qp = cpu_roce_get_qp_number(xcvr);
   const uint32_t our_rkey = cpu_roce_get_rkey(xcvr);
+  const uint64_t our_buffer = cpu_roce_get_buffer_addr(xcvr); // always 0 with
+                                                              // iova=0 MR
+                                                              // registration
 
   // ------------------------------------------------------------------------
-  // [2] Set up the HOST_CALL function table (always one entry: increment).
+  // [2] Set up the HOST_CALL function table.  Skipped in forward mode (no
+  //     dispatch happens there).
   // ------------------------------------------------------------------------
   cudaq_function_entry_t h_entries[1];
-  setup_rpc_increment_function_table_host(h_entries);
+  if (!cfg.forward)
+    setup_rpc_increment_function_table_host(h_entries);
 
   // ------------------------------------------------------------------------
   // [3] Mode-specific wiring.
@@ -206,7 +237,11 @@ int main(int argc, char **argv) {
   std::atomic<int> dispatcher_shutdown{0};
   cudaq_host_dispatch_loop_ctx_t dctx{};
   uint64_t packets_dispatched = 0;
-  if (cfg.unified) {
+  if (cfg.forward) {
+    // Forward: the transceiver's forward_loop echoes every RX slot back
+    // to the peer.  No dispatcher, no callback to install.  cu_frame_size
+    // determines the bytes-on-wire.
+  } else if (cfg.unified) {
     // Unified: install the dispatch closure; the transceiver's unified
     // thread will invoke it.  No cudaq_host_dispatcher_loop needed.
     cpu_roce_set_unified_dispatch(xcvr, &unified_dispatch_cb,
@@ -258,10 +293,8 @@ int main(int argc, char **argv) {
   std::cout << "  QP Number: 0x" << std::hex << our_qp << std::dec
             << std::endl;
   std::cout << "  RKey: " << our_rkey << std::endl;
-  std::cout << "  Buffer Addr: 0x0" << std::endl; // ibv_reg_mr convention:
-                                                  // peer addresses slots by
-                                                  // offset from 0, MR
-                                                  // identified by rkey.
+  std::cout << "  Buffer Addr: 0x" << std::hex << our_buffer << std::dec
+            << std::endl;
   std::cout << "\nWaiting (Ctrl+C to stop, timeout=" << cfg.timeout_sec
             << "s)..." << std::endl;
   std::cout.flush();
@@ -291,7 +324,9 @@ int main(int argc, char **argv) {
   //     then join both.
   // ------------------------------------------------------------------------
   std::cout << "\n=== Shutting down ===" << std::endl;
-  if (!cfg.unified) {
+  // Only the 3-thread mode runs a separate host-dispatcher thread.
+  const bool runs_dispatcher = !cfg.unified && !cfg.forward;
+  if (runs_dispatcher) {
     dispatcher_shutdown.store(1, std::memory_order_release);
     if (dispatcher_thread.joinable())
       dispatcher_thread.join();
@@ -300,7 +335,7 @@ int main(int argc, char **argv) {
   if (xcvr_monitor.joinable())
     xcvr_monitor.join();
 
-  if (!cfg.unified)
+  if (runs_dispatcher)
     std::cout << "Packets dispatched: " << packets_dispatched << std::endl;
 
   cpu_roce_destroy_transceiver(xcvr);

--- a/realtime/unittests/cpu_transport/hsb_test_cpu.sh
+++ b/realtime/unittests/cpu_transport/hsb_test_cpu.sh
@@ -53,6 +53,7 @@ DO_SETUP_NETWORK=false
 DO_RUN=true
 VERIFY=true
 UNIFIED=false
+FORWARD=false
 
 # Directory defaults.  Per the plan we point at the current HSB source
 # checkout at /workspaces/holoscan-sensor-bridge (not the legacy
@@ -89,7 +90,11 @@ Usage: hsb_test_cpu.sh [options]
 
 Modes:
   --emulate              Use FPGA emulator (3-tool mode, no FPGA needed)
-  --unified              Run hsb_bridge_cpu with --unified
+  --unified              Run hsb_bridge_cpu with --unified (single thread
+                         RX+dispatch+TX)
+  --forward              Run hsb_bridge_cpu with --forward (wire-RTT
+                         baseline; bridge echoes every slot, no dispatch).
+                         Mutually exclusive with --unified.
 
 Actions:
   --build                Build all required tools before running
@@ -129,6 +134,7 @@ while [[ $# -gt 0 ]]; do
         --no-run)           DO_RUN=false ;;
         --no-verify)        VERIFY=false ;;
         --unified)          UNIFIED=true ;;
+        --forward)          FORWARD=true ;;
         --hololink-dir)     HOLOLINK_DIR="$2"; shift ;;
         --cuda-quantum-dir) CUDA_QUANTUM_DIR="$2"; shift ;;
         --bin-dir)          BIN_DIR="$2"; shift ;;
@@ -427,7 +433,10 @@ do_run() {
         FPGA_TARGET_IP="$FPGA_IP"
     fi
 
-    echo "--- Starting bridge (mode: $(if $UNIFIED; then echo "UNIFIED"; else echo "3-thread"; fi)) ---"
+    local mode_name="3-thread"
+    if $UNIFIED; then mode_name="UNIFIED"; fi
+    if $FORWARD; then mode_name="FORWARD"; fi
+    echo "--- Starting bridge (mode: $mode_name) ---"
     > /tmp/bridge.log
     local bridge_args=(
         --device="$IB_DEVICE"
@@ -440,6 +449,9 @@ do_run() {
     )
     if $UNIFIED; then
         bridge_args+=(--unified)
+    fi
+    if $FORWARD; then
+        bridge_args+=(--forward)
     fi
     "$bridge_bin" "${bridge_args[@]}" > /tmp/bridge.log 2>&1 &
     BRIDGE_PID=$!
@@ -496,6 +508,11 @@ do_run() {
     if ! $VERIFY; then
         playback_args+=(--no-verify)
     fi
+    if $FORWARD; then
+        # Tells playback to expect echoed RPC_MAGIC_REQUEST instead of
+        # converted RPC_MAGIC_RESPONSE, and to skip the +1 payload check.
+        playback_args+=(--forward)
+    fi
 
     "$playback_bin" "${playback_args[@]}"
     PLAYBACK_EXIT=$?
@@ -516,9 +533,18 @@ do_run() {
 # Main
 # ============================================================================
 
+if $UNIFIED && $FORWARD; then
+    echo "ERROR: --unified and --forward are mutually exclusive" >&2
+    exit 1
+fi
+
 echo "=== HSB CPU Bridge Test ==="
 echo "Mode: $(if $EMULATE; then echo "emulated"; else echo "FPGA"; fi)"
-echo "Dispatch: $(if $UNIFIED; then echo "UNIFIED"; else echo "3-thread"; fi)"
+echo -n "Dispatch: "
+if   $FORWARD; then echo "FORWARD"
+elif $UNIFIED; then echo "UNIFIED"
+else                echo "3-thread"
+fi
 
 if [ -n "$BIN_DIR" ]; then
    if $DO_BUILD; then

--- a/realtime/unittests/cpu_transport/hsb_test_cpu.sh
+++ b/realtime/unittests/cpu_transport/hsb_test_cpu.sh
@@ -1,0 +1,541 @@
+#!/bin/bash
+# ============================================================================#
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         #
+# All rights reserved.                                                        #
+#                                                                             #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================#
+#
+# hsb_test_cpu.sh
+#
+# Phase 1 orchestration: end-to-end CPU-RoCE bridge test.  Sibling of
+# hololink_test.sh but driving hsb_bridge_cpu (CpuRoceTransceiver +
+# CUDAQ_DISPATCH_HOST_CALL) instead of hololink_bridge (GpuRoceTransceiver +
+# device-side dispatch kernel).
+#
+# Reuses the existing hololink_fpga_emulator and hololink_fpga_playback
+# because the on-wire RDMA framing is identical to the GPU bridge — only
+# the bridge endpoint changes from GPU memory to CPU memory.
+#
+# Modes:
+#   Default (FPGA):   bridge + playback        (requires real FPGA)
+#   --emulate:        emulator + bridge + playback   (no FPGA needed)
+#
+# Actions (can be combined):
+#   --build            Build all required tools (hsb_bridge_cpu plus the
+#                      existing hololink_fpga_emulator and
+#                      hololink_fpga_playback that this test reuses).
+#   --setup-network    Configure ConnectX interfaces (calls into the
+#                      same loopback setup as hololink_test.sh).
+#   --unified          Run the bridge with --unified (single-thread RX +
+#                      dispatch + TX).  Default is the three-thread layout.
+#
+# Examples:
+#   # Full emulated test, build + network + run, default 3-thread mode
+#   ./hsb_test_cpu.sh --emulate --build --setup-network
+#
+#   # Emulated, unified mode only (assumes already built/configured)
+#   ./hsb_test_cpu.sh --emulate --unified
+#
+#   # Real FPGA, both 3-thread and unified back-to-back
+#   ./hsb_test_cpu.sh --fpga-ip 192.168.0.2
+#   ./hsb_test_cpu.sh --fpga-ip 192.168.0.2 --unified
+set -euo pipefail
+
+# ============================================================================
+# Defaults
+# ============================================================================
+
+EMULATE=false
+DO_BUILD=false
+DO_SETUP_NETWORK=false
+DO_RUN=true
+VERIFY=true
+UNIFIED=false
+
+# Directory defaults.  Per the plan we point at the current HSB source
+# checkout at /workspaces/holoscan-sensor-bridge (not the legacy
+# /workspaces/hololink path).  --hololink-dir lets the caller override
+# if needed.
+HOLOLINK_DIR="/workspaces/holoscan-sensor-bridge"
+CUDA_QUANTUM_DIR="/workspaces/cuda-quantum"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR=""
+
+# Network defaults (match hololink_test.sh so the loopback wiring is
+# interchangeable on the same NIC pair).
+IB_DEVICE=""           # auto-detect
+BRIDGE_IP="10.0.0.1"
+EMULATOR_IP="10.0.0.2"
+FPGA_IP="192.168.0.2"
+MTU=4096
+
+# Run defaults
+TIMEOUT=60
+NUM_MESSAGES=100
+PAYLOAD_SIZE=8
+PAGE_SIZE=384
+NUM_PAGES=128
+CONTROL_PORT=8193
+JOBS=$(nproc 2>/dev/null || echo 8)
+
+# ============================================================================
+# Argument parsing
+# ============================================================================
+print_usage() {
+    cat <<'EOF'
+Usage: hsb_test_cpu.sh [options]
+
+Modes:
+  --emulate              Use FPGA emulator (3-tool mode, no FPGA needed)
+  --unified              Run hsb_bridge_cpu with --unified
+
+Actions:
+  --build                Build all required tools before running
+  --setup-network        Configure ConnectX network interfaces
+  --no-run               Skip running the test (useful with --build)
+
+Build options:
+  --hololink-dir DIR     HSB source dir (default: /workspaces/holoscan-sensor-bridge)
+  --cuda-quantum-dir DIR cuda-quantum source dir (default: /workspaces/cuda-quantum)
+  --jobs N               Parallel build jobs (default: nproc)
+
+Network options:
+  --device DEV           ConnectX IB device name (default: auto-detect)
+  --bridge-ip ADDR       Bridge tool IP (default: 10.0.0.1)
+  --emulator-ip ADDR     Emulator IP (default: 10.0.0.2)
+  --fpga-ip ADDR         FPGA IP for non-emulate mode (default: 192.168.0.2)
+  --mtu N                MTU size (default: 4096)
+
+Run options:
+  --timeout N            Timeout in seconds (default: 60)
+  --no-verify            Skip ILA response verification
+  --num-messages N       Number of RPC messages (default: 100)
+  --payload-size N       Bytes per RPC payload (default: 8)
+  --page-size N          Ring buffer slot size in bytes (default: 384)
+  --num-pages N          Number of ring buffer slots (default: 128)
+  --control-port N       UDP control port for emulator (default: 8193)
+  --bin-dir DIR          Binary directory containing executables
+  --help, -h             Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --emulate)          EMULATE=true ;;
+        --build)            DO_BUILD=true ;;
+        --setup-network)    DO_SETUP_NETWORK=true ;;
+        --no-run)           DO_RUN=false ;;
+        --no-verify)        VERIFY=false ;;
+        --unified)          UNIFIED=true ;;
+        --hololink-dir)     HOLOLINK_DIR="$2"; shift ;;
+        --cuda-quantum-dir) CUDA_QUANTUM_DIR="$2"; shift ;;
+        --bin-dir)          BIN_DIR="$2"; shift ;;
+        --jobs)             JOBS="$2"; shift ;;
+        --device)           IB_DEVICE="$2"; shift ;;
+        --bridge-ip)        BRIDGE_IP="$2"; shift ;;
+        --emulator-ip)      EMULATOR_IP="$2"; shift ;;
+        --fpga-ip)          FPGA_IP="$2"; shift ;;
+        --mtu)              MTU="$2"; shift ;;
+        --timeout)          TIMEOUT="$2"; shift ;;
+        --num-messages)     NUM_MESSAGES="$2"; shift ;;
+        --payload-size)     PAYLOAD_SIZE="$2"; shift ;;
+        --page-size)        PAGE_SIZE="$2"; shift ;;
+        --num-pages)        NUM_PAGES="$2"; shift ;;
+        --control-port)     CONTROL_PORT="$2"; shift ;;
+        --help|-h)          print_usage; exit 0 ;;
+        *)
+            echo "ERROR: Unknown option: $1" >&2
+            print_usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# ============================================================================
+# Helpers (most are direct ports from hololink_test.sh)
+# ============================================================================
+
+detect_ib_device() {
+    if [[ -n "$IB_DEVICE" ]]; then
+        echo "$IB_DEVICE"
+        return
+    fi
+    local dev
+    dev=$(ibstat -l 2>/dev/null | head -1 || true)
+    if [[ -z "$dev" ]]; then
+        dev=$(ls /sys/class/infiniband/ 2>/dev/null | head -1 || true)
+    fi
+    if [[ -z "$dev" ]]; then
+        echo "ERROR: Could not auto-detect IB device. Use --device." >&2
+        exit 1
+    fi
+    echo "$dev"
+}
+
+get_netdev() {
+    local ib_dev=$1
+    local netdev
+    netdev=$(ls "/sys/class/infiniband/$ib_dev/device/net/" 2>/dev/null | head -1 || true)
+    echo "$netdev"
+}
+
+detect_cuda_arch() {
+    local max_arch
+    max_arch=$(nvcc --list-gpu-arch 2>/dev/null \
+        | grep -oP 'compute_\K[0-9]+' | sort -n | tail -1)
+    if [ -n "$max_arch" ]; then
+        echo "$max_arch"
+    fi
+}
+
+# ============================================================================
+# Build
+# ============================================================================
+do_build() {
+    echo "=== Building tools ==="
+
+    local realtime_dir="$CUDA_QUANTUM_DIR/realtime"
+    local realtime_build="$realtime_dir/build"
+    local hololink_build="$HOLOLINK_DIR/build"
+
+    local arch
+    arch=$(uname -m)
+    local target_arch="amd64"
+    if [[ "$arch" == "aarch64" ]]; then
+        target_arch="arm64"
+    fi
+
+    if [[ -x /usr/local/cuda/bin/nvcc ]]; then
+        case ":$PATH:" in
+            *":/usr/local/cuda/bin:"*) ;;
+            *) export PATH="/usr/local/cuda/bin:$PATH" ;;
+        esac
+    fi
+
+    local cuda_arch
+    cuda_arch=$(detect_cuda_arch)
+    local cuda_arch_flag=""
+    if [ -n "$cuda_arch" ]; then
+        cuda_arch_flag="-DCMAKE_CUDA_ARCHITECTURES=$cuda_arch"
+        echo "  CUDA arch: $cuda_arch"
+    fi
+
+    # Build hololink — we only need the libraries that hololink_fpga_emulator
+    # and hololink_fpga_playback link against (we reuse those binaries for
+    # the wire-format-compatible playback path).
+    echo "--- Building hololink ($target_arch) ---"
+    cmake -G Ninja -S "$HOLOLINK_DIR" -B "$hololink_build" \
+        -DCMAKE_BUILD_TYPE=Release \
+        $cuda_arch_flag \
+        -DTARGET_ARCH="$target_arch" \
+        -DHOLOLINK_BUILD_ONLY_NATIVE=OFF \
+        -DHOLOLINK_BUILD_PYTHON=OFF \
+        -DHOLOLINK_BUILD_TESTS=OFF \
+        -DHOLOLINK_BUILD_TOOLS=OFF \
+        -DHOLOLINK_BUILD_EXAMPLES=OFF \
+        -DHOLOLINK_BUILD_EMULATOR=OFF
+    cmake --build "$hololink_build" -j"$JOBS" \
+        --target roce_receiver gpu_roce_transceiver hololink_core
+
+    # Build cuda-quantum/realtime — hsb_bridge_cpu is gated only on
+    # libibverbs (no hololink dep), but we keep the hololink tools
+    # enabled here so the emulator + playback are also built into the
+    # same tree for the test harness to find.
+    echo "--- Building cuda-quantum/realtime ---"
+    cmake -G Ninja -S "$realtime_dir" -B "$realtime_build" \
+        -DCMAKE_BUILD_TYPE=Release \
+        $cuda_arch_flag \
+        -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=ON \
+        -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR="$HOLOLINK_DIR" \
+        -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR="$hololink_build"
+    cmake --build "$realtime_build" -j"$JOBS" \
+        --target hsb_bridge_cpu hololink_fpga_emulator hololink_fpga_playback
+
+    echo "=== Build complete ==="
+}
+
+# ============================================================================
+# Network setup (shared logic with hololink_test.sh; copy rather than
+# source so the script stays standalone)
+# ============================================================================
+
+setup_port() {
+    local iface="$1"
+    local ip="$2"
+    local mtu="$3"
+
+    echo "  Configuring $iface: ip=$ip mtu=$mtu"
+
+    local other
+    for other in $(ip -o addr show to "${ip}/24" 2>/dev/null | awk '{print $2}' | sort -u); do
+        if [[ "$other" != "$iface" ]]; then
+            echo "    Removing stale ${ip}/24 from $other"
+            sudo ip addr del "${ip}/24" dev "$other" 2>/dev/null || true
+        fi
+    done
+
+    sudo ip link set "$iface" up
+    sudo ip link set "$iface" mtu "$mtu"
+    sudo ip addr flush dev "$iface"
+    sudo ip addr add "${ip}/24" dev "$iface"
+
+    local ib_dev
+    if command -v ibdev2netdev &>/dev/null; then
+        ib_dev=$(ibdev2netdev | awk -v iface="$iface" '$5 == iface { print $1 }')
+    fi
+    if [[ -z "$ib_dev" ]]; then
+        ib_dev=$(basename "$(ls -d /sys/class/net/$iface/device/infiniband/* 2>/dev/null | head -1)" 2>/dev/null || true)
+    fi
+    if [[ -n "$ib_dev" ]]; then
+        local has_rocev2=false
+        for f in /sys/class/infiniband/${ib_dev}/ports/*/gid_attrs/types/*; do
+            if [[ -f "$f" ]] && grep -q "RoCE v2" "$f" 2>/dev/null; then
+                has_rocev2=true; break
+            fi
+        done
+        if $has_rocev2; then
+            echo "    RoCEv2 GID available for $ib_dev"
+        elif command -v rdma &>/dev/null && rdma link set --help &>/dev/null; then
+            local port_count
+            port_count=$(ls -d "/sys/class/infiniband/${ib_dev}/ports/"* 2>/dev/null | wc -l)
+            for p in $(seq 1 "$port_count"); do
+                sudo rdma link set "${ib_dev}/${p}" type eth || true
+            done
+            echo "    RoCEv2 mode configured for $ib_dev"
+        else
+            echo "    WARNING: Could not verify RoCEv2 mode for $ib_dev"
+        fi
+    fi
+
+    if command -v mlnx_qos &>/dev/null; then
+        sudo mlnx_qos -i "$iface" --trust=dscp 2>/dev/null || true
+    fi
+    if command -v ethtool &>/dev/null; then
+        sudo ethtool -C "$iface" adaptive-rx off rx-usecs 0 2>/dev/null || true
+    fi
+    echo "    Done: $iface is up at $ip"
+}
+
+do_setup_network() {
+    IB_DEVICE=$(detect_ib_device)
+    local netdev
+    netdev=$(get_netdev "$IB_DEVICE")
+
+    echo "=== Setting up network ==="
+    echo "  IB device: $IB_DEVICE"
+    echo "  Net device: $netdev"
+
+    if [[ -z "$netdev" ]]; then
+        echo "ERROR: No network device found for $IB_DEVICE" >&2
+        exit 1
+    fi
+
+    if $EMULATE; then
+        setup_port "$netdev" "$BRIDGE_IP" "$MTU"
+        sudo ip addr add "$EMULATOR_IP/24" dev "$netdev" 2>/dev/null || true
+        local mac
+        mac=$(cat /sys/class/net/$netdev/address)
+        sudo ip neigh replace "$BRIDGE_IP" lladdr "$mac" dev "$netdev" nud permanent 2>/dev/null || true
+        sudo ip neigh replace "$EMULATOR_IP" lladdr "$mac" dev "$netdev" nud permanent 2>/dev/null || true
+    else
+        setup_port "$netdev" "$BRIDGE_IP" "$MTU"
+    fi
+
+    echo "=== Network setup complete ==="
+}
+
+# ============================================================================
+# Run
+# ============================================================================
+
+cleanup_pids() {
+    for pid in "${PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -INT "$pid" 2>/dev/null || true
+        fi
+    done
+    sleep 1
+    for pid in "${PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    done
+    for pid in "${PIDS[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+}
+
+do_run() {
+    IB_DEVICE=$(detect_ib_device)
+    local build_dir="$CUDA_QUANTUM_DIR/realtime/build"
+    local utils_dir="$build_dir/unittests/utils"
+
+    if [ -n "$BIN_DIR" ]; then
+        local bridge_bin="$BIN_DIR/hsb_bridge_cpu"
+        local emulator_bin="$BIN_DIR/hololink_fpga_emulator"
+        local playback_bin="$BIN_DIR/hololink_fpga_playback"
+    else
+        local bridge_bin="$utils_dir/hsb_bridge_cpu"
+        local emulator_bin="$utils_dir/hololink_fpga_emulator"
+        local playback_bin="$utils_dir/hololink_fpga_playback"
+    fi
+
+    for bin in "$bridge_bin"; do
+        if [[ ! -x "$bin" ]]; then
+            echo "ERROR: $bin not found. Run with --build first." >&2
+            exit 1
+        fi
+    done
+
+    PIDS=()
+    trap cleanup_pids EXIT
+
+    local FPGA_QP
+    local FPGA_TARGET_IP
+
+    if $EMULATE; then
+        echo "=== Emulated mode ==="
+
+        echo "--- Starting emulator ---"
+        > /tmp/emulator.log
+        "$emulator_bin" \
+            --device="$IB_DEVICE" \
+            --port="$CONTROL_PORT" \
+            --bridge-ip="$BRIDGE_IP" \
+            --page-size="$PAGE_SIZE" \
+            > /tmp/emulator.log 2>&1 &
+        PIDS+=($!)
+        tail -f /tmp/emulator.log &
+        PIDS+=($!)
+
+        sleep 2
+        FPGA_QP=$(grep -oP 'QP Number: 0x\K[0-9a-fA-F]+' /tmp/emulator.log | head -1)
+        if [[ -z "$FPGA_QP" ]]; then
+            echo "ERROR: Could not parse emulator QP from log" >&2
+            exit 1
+        fi
+        FPGA_QP="0x$FPGA_QP"
+        FPGA_TARGET_IP="$EMULATOR_IP"
+
+        echo "  Emulator QP: $FPGA_QP"
+    else
+        echo "=== FPGA mode ==="
+        FPGA_QP="0x2"
+        FPGA_TARGET_IP="$FPGA_IP"
+    fi
+
+    echo "--- Starting bridge (mode: $(if $UNIFIED; then echo "UNIFIED"; else echo "3-thread"; fi)) ---"
+    > /tmp/bridge.log
+    local bridge_args=(
+        --device="$IB_DEVICE"
+        --peer-ip="$FPGA_TARGET_IP"
+        --remote-qp="$FPGA_QP"
+        --timeout="$TIMEOUT"
+        --payload-size="$PAYLOAD_SIZE"
+        --page-size="$PAGE_SIZE"
+        --num-pages="$NUM_PAGES"
+    )
+    if $UNIFIED; then
+        bridge_args+=(--unified)
+    fi
+    "$bridge_bin" "${bridge_args[@]}" > /tmp/bridge.log 2>&1 &
+    BRIDGE_PID=$!
+    PIDS+=($BRIDGE_PID)
+    tail -f /tmp/bridge.log &
+    PIDS+=($!)
+
+    local wait_elapsed=0
+    while ! grep -q "Bridge Ready" /tmp/bridge.log 2>/dev/null; do
+        if ! kill -0 "$BRIDGE_PID" 2>/dev/null; then
+            echo "ERROR: Bridge process died during startup" >&2
+            cat /tmp/bridge.log >&2
+            exit 1
+        fi
+        if (( wait_elapsed >= 30 )); then
+            echo "ERROR: Bridge did not become ready within 30s" >&2
+            cat /tmp/bridge.log >&2
+            exit 1
+        fi
+        sleep 1
+        (( wait_elapsed++ )) || true
+    done
+
+    local BRIDGE_QP BRIDGE_RKEY BRIDGE_BUFFER
+    BRIDGE_QP=$(grep -oP 'QP Number: 0x\K[0-9a-fA-F]+' /tmp/bridge.log | tail -1)
+    BRIDGE_RKEY=$(grep -oP 'RKey: \K[0-9]+' /tmp/bridge.log | tail -1)
+    BRIDGE_BUFFER=$(grep -oP 'Buffer Addr: 0x\K[0-9a-fA-F]+' /tmp/bridge.log | tail -1)
+
+    if [[ -z "$BRIDGE_QP" || -z "$BRIDGE_RKEY" || -z "$BRIDGE_BUFFER" ]]; then
+        echo "ERROR: Could not parse bridge QP info from log" >&2
+        echo "  QP=$BRIDGE_QP RKEY=$BRIDGE_RKEY BUFFER=$BRIDGE_BUFFER" >&2
+        exit 1
+    fi
+
+    echo "  Bridge QP: 0x$BRIDGE_QP"
+    echo "  Bridge RKey: $BRIDGE_RKEY"
+    echo "  Bridge Buffer: 0x$BRIDGE_BUFFER"
+
+    echo "--- Starting playback ---"
+    local playback_args=(
+        --hololink="$FPGA_TARGET_IP"
+        --bridge-qp="0x$BRIDGE_QP"
+        --bridge-rkey="$BRIDGE_RKEY"
+        --bridge-buffer="0x$BRIDGE_BUFFER"
+        --page-size="$PAGE_SIZE"
+        --num-pages="$NUM_PAGES"
+        --num-messages="$NUM_MESSAGES"
+        --payload-size="$PAYLOAD_SIZE"
+        --bridge-ip="$BRIDGE_IP"
+    )
+    if $EMULATE; then
+        playback_args+=(--emulator --control-port="$CONTROL_PORT")
+    fi
+    if ! $VERIFY; then
+        playback_args+=(--no-verify)
+    fi
+
+    "$playback_bin" "${playback_args[@]}"
+    PLAYBACK_EXIT=$?
+
+    sleep 2
+    cleanup_pids
+
+    echo ""
+    if [[ $PLAYBACK_EXIT -eq 0 ]]; then
+        echo "*** TEST PASSED ***"
+    else
+        echo "*** TEST FAILED ***"
+    fi
+    exit $PLAYBACK_EXIT
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+echo "=== HSB CPU Bridge Test ==="
+echo "Mode: $(if $EMULATE; then echo "emulated"; else echo "FPGA"; fi)"
+echo "Dispatch: $(if $UNIFIED; then echo "UNIFIED"; else echo "3-thread"; fi)"
+
+if [ -n "$BIN_DIR" ]; then
+   if $DO_BUILD; then
+    echo "Cannot request a build when the binary directory is provided."
+   fi
+fi
+
+if $DO_BUILD; then
+    do_build
+fi
+
+if $DO_SETUP_NETWORK; then
+    do_setup_network
+fi
+
+if $DO_RUN; then
+    do_run
+fi
+
+echo "Done."

--- a/realtime/unittests/cpu_transport/init_rpc_increment_function_table_host.cpp
+++ b/realtime/unittests/cpu_transport/init_rpc_increment_function_table_host.cpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// @file init_rpc_increment_function_table_host.cpp
+/// @brief Host-side (pure-C++) increment RPC handler + function-table
+///        initialiser for CUDAQ_DISPATCH_HOST_CALL.
+///
+/// Parallels init_rpc_increment_function_table.cu (device-side, dispatch
+/// mode CUDAQ_DISPATCH_DEVICE_CALL) but compiled by the C++ host compiler
+/// — no nvcc, no CUDA, no graph.  Used by hsb_bridge_cpu (Phase 1) which
+/// is GPU-less by design.
+
+#include "cudaq/realtime/daemon/dispatcher/cudaq_realtime.h"
+#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
+
+#include <cstdint>
+#include <cstring>
+
+using cudaq::realtime::fnv1a_hash;
+using cudaq::realtime::RPCHeader;
+using cudaq::realtime::RPCResponse;
+using cudaq::realtime::RPC_MAGIC_REQUEST;
+using cudaq::realtime::RPC_MAGIC_RESPONSE;
+
+namespace {
+
+constexpr std::uint32_t RPC_INCREMENT_FUNCTION_ID =
+    fnv1a_hash("rpc_increment");
+
+/// Host-side increment handler.  Signature matches `cudaq_host_rpc_fn_t`:
+///   void (*)(void *slot_host, size_t slot_size)
+///
+/// The host dispatcher's HOST_CALL path pre-copies the RX slot bytes into
+/// the TX slot and passes us a pointer to the TX slot.  We:
+///   1. Read the RPCHeader (in place at slot[0..24]).
+///   2. Read the payload at slot[24..24+arg_len].
+///   3. Overwrite slot[0..24] with the RPCResponse (RPCHeader and
+///      RPCResponse are both 24 bytes packed; the layout overlaps
+///      magic/status/result_len/request_id/ptp_timestamp safely).
+///   4. Write the incremented bytes back to slot[24..24+arg_len].
+///
+/// Wire-compatible with the device-side handler: same function_id, same
+/// payload semantics (add 1 to each byte), same first-8-bytes PTP echo
+/// (preserved by the RPCResponse.ptp_timestamp copy from the header).
+extern "C" void
+rpc_increment_handler_host(void *slot_host, std::size_t slot_size) {
+  auto *header = static_cast<RPCHeader *>(slot_host);
+  if (header->magic != RPC_MAGIC_REQUEST)
+    return; // dispatcher already filtered, but be defensive
+
+  const std::uint32_t arg_len = header->arg_len;
+  const std::uint32_t request_id = header->request_id;
+  const std::uint64_t ptp_timestamp = header->ptp_timestamp;
+  std::uint8_t *payload_in =
+      static_cast<std::uint8_t *>(slot_host) + sizeof(RPCHeader);
+
+  // Bound the work by the slot size so a malformed arg_len can't write
+  // past the slot.  This mirrors what the dispatcher's max_result_len
+  // guard does for the device-side handler.
+  const std::size_t max_payload =
+      slot_size > sizeof(RPCResponse) ? slot_size - sizeof(RPCResponse) : 0;
+  const std::uint32_t len =
+      arg_len < max_payload ? arg_len : static_cast<std::uint32_t>(max_payload);
+
+  // Increment in place.  Header bytes will be overwritten next; payload
+  // bytes live entirely after sizeof(RPCResponse) which is the same as
+  // sizeof(RPCHeader), so the indices don't shift.
+  for (std::uint32_t i = 0; i < len; ++i)
+    payload_in[i] = static_cast<std::uint8_t>(payload_in[i] + 1);
+
+  // Write the RPCResponse over the RPCHeader.  Same byte layout for the
+  // common fields (request_id, ptp_timestamp); magic/function_id slot is
+  // overwritten with magic/status; arg_len slot is overwritten with
+  // result_len.  All four fields are read above into locals first to
+  // avoid reading after partial overwrite.
+  auto *response = static_cast<RPCResponse *>(slot_host);
+  response->magic = RPC_MAGIC_RESPONSE;
+  response->status = 0;
+  response->result_len = len;
+  response->request_id = request_id;
+  response->ptp_timestamp = ptp_timestamp;
+}
+
+} // anonymous namespace
+
+//==============================================================================
+// Setup function for hsb_bridge_cpu (and future host-call test binaries)
+//==============================================================================
+
+/// Populate one cudaq_function_entry_t with the host-side increment handler.
+/// Unlike the device-side variant this takes an entry pointer that lives
+/// in plain host memory (the function table is in host memory for
+/// HOST_CALL).
+extern "C" void setup_rpc_increment_function_table_host(
+    cudaq_function_entry_t *h_entries) {
+  std::memset(h_entries, 0, sizeof(cudaq_function_entry_t));
+  h_entries[0].handler.host_fn = &rpc_increment_handler_host;
+  h_entries[0].function_id = RPC_INCREMENT_FUNCTION_ID;
+  h_entries[0].dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
+
+  // Schema mirrors the device-side entry: 1 array argument (uint8), 1
+  // array result (uint8).  Sizes left at 0 because the handler is
+  // dynamically bounded by arg_len.
+  h_entries[0].schema.num_args = 1;
+  h_entries[0].schema.num_results = 1;
+  h_entries[0].schema.args[0].type_id = CUDAQ_TYPE_ARRAY_UINT8;
+  h_entries[0].schema.results[0].type_id = CUDAQ_TYPE_ARRAY_UINT8;
+}

--- a/realtime/unittests/cpu_transport/init_rpc_increment_function_table_host.cpp
+++ b/realtime/unittests/cpu_transport/init_rpc_increment_function_table_host.cpp
@@ -22,15 +22,14 @@
 #include <cstring>
 
 using cudaq::realtime::fnv1a_hash;
-using cudaq::realtime::RPCHeader;
-using cudaq::realtime::RPCResponse;
 using cudaq::realtime::RPC_MAGIC_REQUEST;
 using cudaq::realtime::RPC_MAGIC_RESPONSE;
+using cudaq::realtime::RPCHeader;
+using cudaq::realtime::RPCResponse;
 
 namespace {
 
-constexpr std::uint32_t RPC_INCREMENT_FUNCTION_ID =
-    fnv1a_hash("rpc_increment");
+constexpr std::uint32_t RPC_INCREMENT_FUNCTION_ID = fnv1a_hash("rpc_increment");
 
 /// Host-side increment handler.  Signature matches `cudaq_host_rpc_fn_t`:
 ///   void (*)(void *slot_host, size_t slot_size)
@@ -47,8 +46,8 @@ constexpr std::uint32_t RPC_INCREMENT_FUNCTION_ID =
 /// Wire-compatible with the device-side handler: same function_id, same
 /// payload semantics (add 1 to each byte), same first-8-bytes PTP echo
 /// (preserved by the RPCResponse.ptp_timestamp copy from the header).
-extern "C" void
-rpc_increment_handler_host(void *slot_host, std::size_t slot_size) {
+extern "C" void rpc_increment_handler_host(void *slot_host,
+                                           std::size_t slot_size) {
   auto *header = static_cast<RPCHeader *>(slot_host);
   if (header->magic != RPC_MAGIC_REQUEST)
     return; // dispatcher already filtered, but be defensive
@@ -96,8 +95,8 @@ rpc_increment_handler_host(void *slot_host, std::size_t slot_size) {
 /// Unlike the device-side variant this takes an entry pointer that lives
 /// in plain host memory (the function table is in host memory for
 /// HOST_CALL).
-extern "C" void setup_rpc_increment_function_table_host(
-    cudaq_function_entry_t *h_entries) {
+extern "C" void
+setup_rpc_increment_function_table_host(cudaq_function_entry_t *h_entries) {
   std::memset(h_entries, 0, sizeof(cudaq_function_entry_t));
   h_entries[0].handler.host_fn = &rpc_increment_handler_host;
   h_entries[0].function_id = RPC_INCREMENT_FUNCTION_ID;


### PR DESCRIPTION
Adds a low-latency, CPU-initiated RoCEv2 transport that lands data in CPU
memory (vs. the existing GpuRoceTransceiver, which targets GPU memory),
plus the `CUDAQ_DISPATCH_HOST_CALL` path needed to drive it without a GPU.