### PR TITLE
[Python] Improved handling of synthesized and lifted arguments

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Builder/Marshal.h
+++ b/cudaq/include/cudaq/Optimizer/Builder/Marshal.h
@@ -28,6 +28,18 @@ inline bool isCodegenArgumentGather(std::size_t kind) {
   return kind == 0 || kind == 2;
 }
 
+/// A kernel is fully synthesized when it has at least one formal argument
+/// and every formal argument has been folded into the body (no uses remain).
+inline bool isFullySynthesized(mlir::func::FuncOp funcOp) {
+  auto args = funcOp.getArguments();
+  if (args.empty())
+    return false;
+  for (mlir::Value arg : args)
+    if (!arg.use_empty())
+      return false;
+  return true;
+}
+
 inline bool isStateType(mlir::Type ty) {
   if (auto ptrTy = dyn_cast<cc::PointerType>(ty))
     return isa<cudaq::quake::StateType>(ptrTy.getElementType());

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -684,17 +684,15 @@ pyLaunchModule(const std::string &name, ModuleOp mod,
     // Must be local simulator
     if (!platform.is_simulator() || platform.is_emulated())
       return false;
-    // TODO: would be nice to check for args synthesized via an attribute
-    // rather than a fragile arg size check. This relies on an assumption
-    // that arg sizes are validated so the only case that the arg sizes
-    // don't match is for synthesized kernels.
     auto func = cudaq::getKernelFuncOp(mod, name);
-    mlir::Type resultTy = cudaq::runtime::getReturnType(func);
-    auto hasResult = !!resultTy;
-    size_t numArgs = rawArgs.size() - (hasResult ? 1 : 0);
-    // Check for args synthesized.
-    if (numArgs != func.getArgumentTypes().size())
+    // Fully synthesized kernels are one-off specializations; caching by name
+    // would collide across distinct specializations of the same source.
+    if (cudaq::opt::marshal::isFullySynthesized(func))
       return false;
+    // Caching for kernels with lifted arguments is not currently supported.
+    for (unsigned i = 0; i < func.getNumArguments(); ++i)
+      if (func.getArgAttr(i, "quake.pylifted"))
+        return false;
     return true;
   }();
 

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -685,8 +685,8 @@ pyLaunchModule(const std::string &name, ModuleOp mod,
     if (!platform.is_simulator() || platform.is_emulated())
       return false;
     auto func = cudaq::getKernelFuncOp(mod, name);
-    // Fully synthesized kernels are one-off specializations; caching by name
-    // would collide across distinct specializations of the same source.
+    // TODO: currently, synthesis is all-or-nothing, but if arg-by-arg
+    // synthesis is supported, then that will need to be detected
     if (cudaq::opt::marshal::isFullySynthesized(func))
       return false;
     // Caching for kernels with lifted arguments is not currently supported.

--- a/python/tests/kernel/test_caching.py
+++ b/python/tests/kernel/test_caching.py
@@ -290,8 +290,7 @@ def test_kernel_with_unused_argument():
     assert k(7) is True
     # Documented limitation: cache slot stays empty because every formal
     # arg is dead, so isFullySynthesized() reports true.
-    assert (not hasattr(k, '_compiled_module')
-            or k._compiled_module.name == "")
+    assert (not hasattr(k, '_compiled_module') or k._compiled_module.name == "")
 
 
 def test_captured_kernel_change_reflected_after_first_launch():
@@ -323,5 +322,5 @@ def test_captured_kernel_change_reflected_after_first_launch():
     # The parent kernel must not have been cached — caching would freeze the
     # captured-kernel body inside the JIT artifact and the rebind above would
     # silently no-op.
-    assert (not hasattr(outer, '_compiled_module')
-            or outer._compiled_module.name == "")
+    assert (not hasattr(outer, '_compiled_module') or
+            outer._compiled_module.name == "")

--- a/python/tests/kernel/test_caching.py
+++ b/python/tests/kernel/test_caching.py
@@ -272,3 +272,56 @@ def test_synthesized_kernel_does_not_cache():
     for _ in range(2):
         assert cudaq.sample(synth_a, shots_count=1).count("111") == 1
         assert cudaq.sample(synth_b, shots_count=1).count("1111") == 1
+
+
+def test_kernel_with_unused_argument():
+    """A kernel that takes an argument but never uses it must still run
+    correctly for varying arg values. (The current predicate marks this kind
+    of kernel as fully-synthesized and bypasses the cache; correctness is
+    preserved, only the perf optimization is lost.)"""
+
+    @cudaq.kernel
+    def k(n: int) -> bool:
+        q = cudaq.qubit()
+        x(q)
+        return mz(q)
+
+    assert k(5) is True
+    assert k(7) is True
+    # Documented limitation: cache slot stays empty because every formal
+    # arg is dead, so isFullySynthesized() reports true.
+    assert (not hasattr(k, '_compiled_module')
+            or k._compiled_module.name == "")
+
+
+def test_captured_kernel_change_reflected_after_first_launch():
+    """A kernel that captures another kernel from its enclosing scope must
+    not cache: rebinding the captured name to a different body has to take
+    effect on the next call, not be masked by a stale JIT artifact."""
+
+    @cudaq.kernel
+    def inner(q: cudaq.qubit):
+        x(q)
+
+    @cudaq.kernel
+    def outer() -> bool:
+        q = cudaq.qubit()
+        inner(q)
+        return mz(q)
+
+    # v1: inner flips |0> -> |1>.
+    assert outer() is True
+
+    # Rebind `inner` to a no-op body. The lifted capture in `outer` must
+    # resolve to this new definition on the next launch.
+    @cudaq.kernel
+    def inner(q: cudaq.qubit):
+        pass
+
+    assert outer() is False
+
+    # The parent kernel must not have been cached — caching would freeze the
+    # captured-kernel body inside the JIT artifact and the rebind above would
+    # silently no-op.
+    assert (not hasattr(outer, '_compiled_module')
+            or outer._compiled_module.name == "")

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -21,6 +21,7 @@
 #include "cudaq_internal/compiler/TracePassInstrumentation.h"
 #include "nvqir/resourcecounter/ResourceCounterScope.h"
 #include "runtime/cudaq/platform/PythonSignalCheck.h"
+#include "cudaq/Optimizer/Builder/Marshal.h"
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
@@ -277,7 +278,6 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
       throw std::runtime_error("no kernel named " + name + " found in module");
     mlir::Type resultTy = cudaq::runtime::getReturnType(funcOp);
 
-    const bool hasResult = !!resultTy;
     auto resultInfo =
         cudaq_internal::compiler::CompiledModuleHelper::createResultInfo(
             resultTy, isEntryPoint, module);
@@ -298,9 +298,8 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
         args.hasTypeErased() ? *args.getTypeErased() : std::span<void *const>();
 
     // Special handling in case the arguments were already synthesized
-    size_t numArgs = rawArgs.size() - (hasResult ? 1 : 0);
     if (isEntryPoint && isLocalSimulator &&
-        numArgs == fromFuncTy.getNumInputs()) {
+        !cudaq::opt::marshal::isFullySynthesized(funcOp)) {
       closureArgsVec = std::vector(rawArgs.begin(), rawArgs.end());
       for (auto [i, ty] : llvm::enumerate(fromFuncTy.getInputs())) {
         if (!isa<cudaq::cc::CallableType>(ty)) {


### PR DESCRIPTION
Replaces adhoc logic with `isFullySynthesized` function to determine if a function has had it's arguments synthesized or not (currently `synthesize` is all-or-nothing). Adds logic to prevent caching kernels with lifted callables.