### PR TITLE
Deprecating library mode

### DIFF
--- a/cudaq/test/MixedLanguage/cuda-1.cpp
+++ b/cudaq/test/MixedLanguage/cuda-1.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: nvcc
 
 // RUN: (nvcc -c -Xcompiler -fPIC %p/cuda-1.cu -o %t.o && \
-// RUN: nvq++ --enable-mlir %s %t.o -L `dirname $(which nvcc)`/../lib64 -lcudart -o %t && echo "Success") | \
+// RUN: nvq++ %s %t.o -L `dirname $(which nvcc)`/../lib64 -lcudart -o %t && echo "Success") | \
 // RUN: FileCheck %s
 
 // CHECK-LABEL: Success

--- a/cudaq/test/NVQPP/device_call_realtime_array.cpp
+++ b/cudaq/test/NVQPP/device_call_realtime_array.cpp
@@ -14,9 +14,9 @@
 // Use qpp-cpu explicitly because the custatevec simulator calls
 // cudaDeviceSynchronize(), which conflicts with the persistent dispatch kernel.
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering --enable-mlir -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-array-gpu-dispatch%cudaq_shlibext -o %t/app-gpu
+// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-array-gpu-dispatch%cudaq_shlibext -o %t/app-gpu
 // RUN: LD_LIBRARY_PATH=%cudaq_lib_dir:${LD_LIBRARY_PATH} %t/app-gpu --cudaq-device-call=shared-memory | FileCheck --check-prefix=SHM %s
-// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering --enable-mlir -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-array-host-dispatch%cudaq_shlibext -o %t/app-host
+// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-array-host-dispatch%cudaq_shlibext -o %t/app-host
 // RUN: LD_LIBRARY_PATH=%cudaq_lib_dir:${LD_LIBRARY_PATH} %t/app-host --cudaq-device-call=host-dispatch | FileCheck --check-prefix=HOST %s
 // clang-format on
 

--- a/cudaq/test/NVQPP/device_call_realtime_scalar.cpp
+++ b/cudaq/test/NVQPP/device_call_realtime_scalar.cpp
@@ -14,9 +14,9 @@
 // Use qpp-cpu explicitly because the custatevec simulator calls
 // cudaDeviceSynchronize(), which conflicts with the persistent dispatch kernel.
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering --enable-mlir -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-scalar-gpu-dispatch%cudaq_shlibext -o %t/app-gpu
+// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-scalar-gpu-dispatch%cudaq_shlibext -o %t/app-gpu
 // RUN: LD_LIBRARY_PATH=%cudaq_lib_dir:${LD_LIBRARY_PATH} %t/app-gpu --cudaq-device-call=shared-memory | FileCheck --check-prefix=SHM %s
-// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering --enable-mlir -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-scalar-host-dispatch%cudaq_shlibext -o %t/app-host
+// RUN: cd %t && nvq++ --target qpp-cpu -frealtime-lowering -I%S/Inputs %s %cudaq_lib_dir/%cudaq_shlibprefixcudaq-test-device-call-realtime-scalar-host-dispatch%cudaq_shlibext -o %t/app-host
 // RUN: LD_LIBRARY_PATH=%cudaq_lib_dir:${LD_LIBRARY_PATH} %t/app-host --cudaq-device-call=host-dispatch | FileCheck --check-prefix=HOST %s
 // clang-format on
 

--- a/cudaq/test/NVQPP/pic_option.cpp
+++ b/cudaq/test/NVQPP/pic_option.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir -c %s -v -fPIC -o %t
+// RUN: nvq++ -c %s -v -fPIC -o %t
 
 #include "cudaq.h"
 

--- a/cudaq/test/NVQPP/shared_obj.cpp
+++ b/cudaq/test/NVQPP/shared_obj.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir -shared -fpic %s -o %t && file %t | FileCheck %s
+// RUN: nvq++ -shared -fpic %s -o %t && file %t | FileCheck %s
 
 #include <cudaq.h>
 

--- a/cudaq/tools/nvqpp/nvq++.in
+++ b/cudaq/tools/nvqpp/nvq++.in
@@ -209,9 +209,6 @@ function show_help {
 -shared
 	Create a shared library during linking.
 
---enable-mlir
-	Enable and generate MLIR code for CUDA-Q kernels.
-
 --clang-verbose | -clang-verbose
 	Enable the verbose option (-v) to the C++ compiler.
 
@@ -460,9 +457,7 @@ if [[ ! -z "${CUDAQ_DEFAULT_SIMULATOR}" ]]; then
 	done
 fi
 
-# We default to LIBRARY_MODE, physical
-# Quantum Targets can override this to turn on
-# our MLIR compilation workflow.
+# Kept for orca-photonics.
 LIBRARY_MODE=false
 
 CXX=${LLVMBIN}clang++${llvm_suffix}
@@ -537,8 +532,6 @@ while [ $# -ne 0 ]; do
 		;;
 	--emit-qir | -emit-qir)
 		EMIT_QIR=true
-		# NOTE: QIR is not emitted in library mode, so automatically apply '--enable-mlir'
-		LIBRARY_MODE=false
 		;;
 	--emulate | -emulate)
 		CUDAQ_EMULATE_REMOTE=true
@@ -589,12 +582,6 @@ while [ $# -ne 0 ]; do
 		;;
 	-shared)
 		LINKER_FLAGS="${LINKER_FLAGS} -shared"
-		;;
-	--enable-mlir)
-		LIBRARY_MODE=false
-		;;
-	--library-mode)
-		LIBRARY_MODE=true
 		;;
 	--clang-verbose | -clang-verbose)
 		CLANG_VERBOSE="-v"
@@ -885,7 +872,7 @@ for i in ${SRCS}; do
 	file_with_suffix=$(basename $i)
 	file=${file_with_suffix%.*}
 
-	# If LIBRARY_MODE explicitly requested, then
+	# If the target enables library mode (orca-photonics), then
 	# simply compile with the classical compiler.
 	if ${LIBRARY_MODE}; then
 		run ${CXX} ${CLANG_VERBOSE} ${CLANG_RESOURCE_DIR} ${COMPILER_FLAGS} ${PREPROCESSOR_DEFINES} ${INCLUDES} ${ARGS} -o ${file}.o -c $i

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,7 +15,6 @@
 #   TARGET_OPTION <Option>: extra option for the target
 #   SOURCE_DIR <DIR>: the directory that SOURCE_LOCATION is relative to (if not the default)
 #   LAUNCH_COMMAND <COMMAND>: the command to launch the test (e.g., mpirun)
-#   LIBRARY_MODE: compile in library mode instead of the default MLIR mode
 function(add_nvqpp_test TEST_NAME SOURCE_LOCATION)
   cmake_parse_arguments(PARSED_ARGS "" "TARGET;LABELS;SOURCE_DIR;LAUNCH_COMMAND;APPLICATION_ARGS;TARGET_OPTION;EXTRA_COMPILE_ARGS;MIN_GPUS" "" ${ARGN})
   set(NVQPP_COMPILE_ARGS "-I${CMAKE_SOURCE_DIR}/runtime/include")
@@ -55,7 +54,7 @@ add_nvqpp_test(ExpVals examples/cpp/basics/expectation_values.cpp)
 add_nvqpp_test(MidCircuitMeasurements examples/cpp/basics/mid_circuit_measurement.cpp)
 add_nvqpp_test(MeasuringKernels examples/cpp/measuring_kernels.cpp)
 add_nvqpp_test(PhaseEstimation applications/cpp/phase_estimation.cpp)
-add_nvqpp_test(Grover applications/cpp/grover.cpp LIBRARY_MODE)
+add_nvqpp_test(Grover applications/cpp/grover.cpp)
 add_nvqpp_test(QAOA applications/cpp/qaoa_maxcut.cpp)
 add_nvqpp_test(VQEH2 applications/cpp/vqe_h2.cpp)
 add_nvqpp_test(AmplitudeEstimation applications/cpp/amplitude_estimation.cpp)
@@ -165,7 +164,7 @@ if (MPI_CXX_FOUND AND cuTensorNet_FOUND)
     LABELS "gpu_required;mgpus_required")
 endif()
 
-add_nvqpp_test(photonics_sim targets/cpp/photonics.cpp TARGET orca-photonics LIBRARY_MODE)
+add_nvqpp_test(photonics_sim targets/cpp/photonics.cpp TARGET orca-photonics)
 
 # Only add the python tests if we built the python API
 if (CUDAQ_ENABLE_PYTHON)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -164,7 +164,7 @@ if (MPI_CXX_FOUND AND cuTensorNet_FOUND)
     LABELS "gpu_required;mgpus_required")
 endif()
 
-add_nvqpp_test(photonics_sim targets/cpp/photonics.cpp TARGET orca-photonics)
+add_nvqpp_test(photonics_sim targets/cpp/photonics.cpp TARGET orca-photonics LIBRARY_MODE)
 
 # Only add the python tests if we built the python API
 if (CUDAQ_ENABLE_PYTHON)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -17,7 +17,7 @@
 #   LAUNCH_COMMAND <COMMAND>: the command to launch the test (e.g., mpirun)
 function(add_nvqpp_test TEST_NAME SOURCE_LOCATION)
   cmake_parse_arguments(PARSED_ARGS "" "TARGET;LABELS;SOURCE_DIR;LAUNCH_COMMAND;APPLICATION_ARGS;TARGET_OPTION;EXTRA_COMPILE_ARGS;MIN_GPUS" "" ${ARGN})
-  set(NVQPP_COMPILE_ARGS "--library-mode -I${CMAKE_SOURCE_DIR}/runtime/include")
+  set(NVQPP_COMPILE_ARGS "-I${CMAKE_SOURCE_DIR}/runtime/include")
   if(PARSED_ARGS_TARGET)
     set(NVQPP_COMPILE_ARGS "${NVQPP_COMPILE_ARGS} --target ${PARSED_ARGS_TARGET}")
     if (PARSED_ARGS_TARGET_OPTION)

--- a/docs/sphinx/applications/cpp/grover.cpp
+++ b/docs/sphinx/applications/cpp/grover.cpp
@@ -1,6 +1,6 @@
 // Compile and run with:
 // ```
-// nvq++ --library-mode grover.cpp -o grover.x && ./grover.x
+// nvq++ grover.cpp -o grover.x && ./grover.x
 // ```
 
 #include <cmath>

--- a/docs/sphinx/applications/cpp/grover.cpp
+++ b/docs/sphinx/applications/cpp/grover.cpp
@@ -5,7 +5,6 @@
 
 #include <cmath>
 #include <cudaq.h>
-#include <numbers>
 
 __qpu__ void reflect_about_uniform(cudaq::qvector<> &qs) {
   auto ctrlQubits = qs.front(qs.size() - 1);
@@ -23,41 +22,39 @@ __qpu__ void reflect_about_uniform(cudaq::qvector<> &qs) {
 
 struct run_grover {
   template <typename CallableKernel>
-  __qpu__ auto operator()(const int n_qubits, CallableKernel &&oracle) {
-    int n_iterations = round(0.25 * std::numbers::pi * sqrt(2 ^ n_qubits));
+  __qpu__ auto operator()(const int n_qubits, const long target_state,
+                          CallableKernel &&oracle) {
+    int n_iterations = round(0.25 * M_PI * sqrt(2 ^ n_qubits));
 
     cudaq::qvector qs(n_qubits);
     h(qs);
     for (int i = 0; i < n_iterations; i++) {
-      oracle(qs);
+      oracle(target_state, qs);
       reflect_about_uniform(qs);
     }
     mz(qs);
   }
 };
 
-struct oracle {
-  const long target_state;
+__qpu__ void apply_target_mask(cudaq::qvector<> &qs, const long target_state) {
+  for (int i = 1; i <= qs.size(); ++i) {
+    auto target_bit_set = (1 << (qs.size() - i)) & target_state;
+    if (!target_bit_set)
+      x(qs[i - 1]);
+  }
+}
 
-  void operator()(cudaq::qvector<> &qs) __qpu__ {
-    cudaq::compute_action(
-        [&]() {
-          for (int i = 1; i <= qs.size(); ++i) {
-            auto target_bit_set = (1 << (qs.size() - i)) & target_state;
-            if (!target_bit_set)
-              x(qs[i - 1]);
-          }
-        },
-        [&]() {
-          auto ctrlQubits = qs.front(qs.size() - 1);
-          z<cudaq::ctrl>(ctrlQubits, qs.back());
-        });
+struct oracle {
+  void operator()(const long target_state, cudaq::qvector<> &qs) __qpu__ {
+    apply_target_mask(qs, target_state);
+    auto ctrlQubits = qs.front(qs.size() - 1);
+    z<cudaq::ctrl>(ctrlQubits, qs.back());
+    apply_target_mask(qs, target_state);
   }
 };
 
 int main(int argc, char *argv[]) {
   auto secret = 1 < argc ? strtol(argv[1], NULL, 2) : 0b1011;
-  oracle compute_oracle{.target_state = secret};
-  auto counts = cudaq::sample(run_grover{}, 4, compute_oracle);
+  auto counts = cudaq::sample(run_grover{}, 4, secret, oracle{});
   printf("Found string %s\n", counts.most_probable().c_str());
 }

--- a/docs/sphinx/applications/cpp/grover.cpp
+++ b/docs/sphinx/applications/cpp/grover.cpp
@@ -36,20 +36,20 @@ struct run_grover {
   }
 };
 
-__qpu__ void apply_target_mask(cudaq::qvector<> &qs, const long target_state) {
-  for (int i = 1; i <= qs.size(); ++i) {
-    auto target_bit_set = (1 << (qs.size() - i)) & target_state;
-    if (!target_bit_set)
-      x(qs[i - 1]);
-  }
-}
-
 struct oracle {
   void operator()(const long target_state, cudaq::qvector<> &qs) __qpu__ {
-    apply_target_mask(qs, target_state);
-    auto ctrlQubits = qs.front(qs.size() - 1);
-    z<cudaq::ctrl>(ctrlQubits, qs.back());
-    apply_target_mask(qs, target_state);
+    cudaq::compute_action(
+        [&]() {
+          std::size_t n = qs.size();
+          for (std::size_t i = 1; i <= n; ++i) {
+            if (!((1 << (n - i)) & target_state))
+              x(qs[i - 1]);
+          }
+        },
+        [&]() {
+          auto ctrlQubits = qs.front(qs.size() - 1);
+          z<cudaq::ctrl>(ctrlQubits, qs.back());
+        });
   }
 };
 

--- a/docs/sphinx/applications/cpp/trotter_kernel_mode.cpp
+++ b/docs/sphinx/applications/cpp/trotter_kernel_mode.cpp
@@ -8,7 +8,7 @@
 
 // Compile and run with:
 // ```
-// nvq++ --enable-mlir -v trotter_kernel_mode.cpp -o trotter.x && ./trotter.x
+// nvq++ -v trotter_kernel_mode.cpp -o trotter.x && ./trotter.x
 // ```
 
 #include <complex>
@@ -44,7 +44,7 @@ int STEPS = 10; // set to around 100 for `nvidia` target
 // Compile and run with:
 // clang-format off
 // ```
-// nvq++ --enable-mlir -v trotter_kernel_mode.cpp -o trotter.x --target nvidia && ./trotter.x
+// nvq++ -v trotter_kernel_mode.cpp -o trotter.x --target nvidia && ./trotter.x
 // ```
 // clang-format off
 

--- a/docs/sphinx/examples/cpp/basics/noise_callback.cpp
+++ b/docs/sphinx/examples/cpp/basics/noise_callback.cpp
@@ -14,6 +14,14 @@
 // case, we will examine the dynamic noise channel specified as a callback
 // function.
 
+struct kernel {
+  void operator()(double angle) __qpu__ {
+    cudaq::qubit q;
+    rx(angle, q);
+    mz(q);
+  }
+};
+
 int main() {
 
   // We will begin by defining an empty noise model that we will add
@@ -41,12 +49,6 @@ int main() {
   // Bind the noise model callback function to the `rx` gate
   noise.add_channel<cudaq::types::rx>(rx_noise);
 
-  auto kernel = [](double angle) __qpu__ {
-    cudaq::qubit q;
-    rx(angle, q);
-    mz(q);
-  };
-
   // Now let's set the noise and we're ready to run the simulation!
   cudaq::set_noise(noise);
 
@@ -54,13 +56,13 @@ int main() {
   // indicating that the noise has successfully impacted the system. Note: a
   // `rx(pi)` is equivalent to a Pauli X gate, and thus, it should be in the |1>
   // state if no noise is present.
-  auto noisy_counts = cudaq::sample(kernel, M_PI);
+  auto noisy_counts = cudaq::sample(kernel{}, M_PI);
   std::cout << "Noisy result:\n";
   noisy_counts.dump();
 
   // To confirm this, we can run the simulation again without noise.
   cudaq::unset_noise();
-  auto noiseless_counts = cudaq::sample(kernel, M_PI);
+  auto noiseless_counts = cudaq::sample(kernel{}, M_PI);
   std::cout << "Noiseless result:\n";
   noiseless_counts.dump();
   return 0;

--- a/docs/sphinx/targets/cpp/photonics.cpp
+++ b/docs/sphinx/targets/cpp/photonics.cpp
@@ -1,6 +1,6 @@
 // Compile and run with:
 // ```
-// nvq++ --library-mode --target orca-photonics photonics.cpp
+// nvq++ --target orca-photonics photonics.cpp
 // ./a.out
 // ```
 

--- a/docs/sphinx/targets/cpp/photonics_tbi_get_state.cpp
+++ b/docs/sphinx/targets/cpp/photonics_tbi_get_state.cpp
@@ -1,6 +1,6 @@
 // Compile and run with:
 // ```
-// nvq++ --library-mode --target orca-photonics photonics_tbi_get_state.cpp
+// nvq++ --target orca-photonics photonics_tbi_get_state.cpp
 // ./a.out
 // ```
 

--- a/docs/sphinx/targets/cpp/photonics_tbi_sample.cpp
+++ b/docs/sphinx/targets/cpp/photonics_tbi_sample.cpp
@@ -1,6 +1,6 @@
 // Compile and run with:
 // ```
-// nvq++ --library-mode --target orca-photonics photonics_tbi_sample.cpp
+// nvq++ --target orca-photonics photonics_tbi_sample.cpp
 // ./a.out
 // ```
 

--- a/docs/sphinx/using/backends/sims/photonics.rst
+++ b/docs/sphinx/using/backends/sims/photonics.rst
@@ -37,7 +37,7 @@ To execute a program on the :code:`orca-photonics` target, use the following com
 
     .. code:: bash
 
-        nvq++ --library-mode --target orca-photonics program.cpp [...] -o program.x
+        nvq++ --target orca-photonics program.cpp [...] -o program.x
 
 
 Photonics 101

--- a/docs/sphinx/using/extending/backend.rst
+++ b/docs/sphinx/using/extending/backend.rst
@@ -229,9 +229,7 @@ Create a ``YAML`` configuration file for your target:
       # Tell the rest-qpu that we are generating QIR base profile.
       # As of the time of this writing, qasm2, qir-base and qir-adaptive are supported.
       codegen-emission: qir-base
-      # Library mode is only for simulators, physical backends must turn this off
-      library-mode: false
-    
+
     # Some examples of target arguments are shown below.
     # You do not need to add any arguments for your backend if you do not need them.
     target-arguments:

--- a/python/tests/interop/quantum_lib/CMakeLists.txt
+++ b/python/tests/interop/quantum_lib/CMakeLists.txt
@@ -9,7 +9,7 @@
 set(CMAKE_CXX_COMPILER "${CMAKE_BINARY_DIR}/bin/nvq++")
 
 set(CMAKE_CXX_COMPILE_OBJECT
-  "<CMAKE_CXX_COMPILER> -fPIC --enable-mlir --disable-mlir-links <DEFINES> <INCLUDES> -o <OBJECT> -c <SOURCE>")
+  "<CMAKE_CXX_COMPILER> -fPIC --disable-mlir-links <DEFINES> <INCLUDES> -o <OBJECT> -c <SOURCE>")
 
 # FIXME Error with SHARED, it pulls in all the mlir libraries anyway
 add_library(quantum_lib

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
@@ -16,3 +16,4 @@ config:
   # basis. The basis preserves T-family gates and unresolved single-qubit
   # rotations for layer-one FTQC metrics.
   jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),func.func(regtomem),decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)}"
+  

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
@@ -16,4 +16,3 @@ config:
   # basis. The basis preserves T-family gates and unresolved single-qubit
   # rotations for layer-one FTQC metrics.
   jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),func.func(regtomem),decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)}"
-  library-mode: false

--- a/runtime/cudaq/platform/default/compiler-bench-nisq.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-nisq.yml
@@ -25,4 +25,3 @@ config:
   # before final decomposition so resource counting sees the normalized
   # CZ/rotation basis. With no device argument, routing is bypassed.
   jit-mid-level-pipeline: "decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(regtomem),quake-to-cc-prep,decomposition{basis=h,rx,ry,rz,x,z(1)}"
-  library-mode: false

--- a/runtime/cudaq/platform/default/compiler-bench-nisq.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-nisq.yml
@@ -25,3 +25,4 @@ config:
   # before final decomposition so resource counting sees the normalized
   # CZ/rotation basis. With no device argument, routing is bypassed.
   jit-mid-level-pipeline: "decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(regtomem),quake-to-cc-prep,decomposition{basis=h,rx,ry,rz,x,z(1)}"
+  

--- a/runtime/cudaq/platform/default/opt-test.yml
+++ b/runtime/cudaq/platform/default/opt-test.yml
@@ -23,18 +23,15 @@ configuration-matrix:
       nvqir-simulation-backend: cusvsim-fp32, custatevec-fp32
       preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP32"]
       target-pass-pipeline: "func.func(unwind-lowering,canonicalize),lambda-lifting,func.func(memtoreg{quantum=0},canonicalize),apply-op-specialization,kernel-execution,aggressive-inlining,func.func(quake-add-metadata,constant-propagation,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader{use-quake=1},func.func(canonicalize,cse,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
-      library-mode: false
   - name: dep-analysis-fp64
     option-flags: [dep-analysis, fp64]
     config:
       nvqir-simulation-backend: cusvsim-fp64, custatevec-fp64
       preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
       target-pass-pipeline: "func.func(unwind-lowering,canonicalize),lambda-lifting,func.func(memtoreg{quantum=0},canonicalize),apply-op-specialization,kernel-execution,aggressive-inlining,func.func(quake-add-metadata,constant-propagation,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader{use-quake=1},func.func(canonicalize,cse,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
-      library-mode: false
   - name: dep-analysis-qpp
     option-flags: [dep-analysis, qpp]
     config:
       nvqir-simulation-backend: qpp
       preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
       target-pass-pipeline: "func.func(unwind-lowering,canonicalize),lambda-lifting,func.func(memtoreg{quantum=0},canonicalize),apply-op-specialization,kernel-execution,aggressive-inlining,func.func(quake-add-metadata,constant-propagation,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader{use-quake=1},func.func(canonicalize,cse,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
-      library-mode: false

--- a/runtime/cudaq/platform/default/rest/helpers/anyon/anyon.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/anyon/anyon.yml
@@ -22,8 +22,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,anyon-%Q_GATE%-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)"
   # Tell the rest-qpu that we are generating Adaptive QIR.
   codegen-emission: qir-adaptive
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: url

--- a/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
@@ -22,8 +22,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: machine

--- a/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
@@ -23,8 +23,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(memtoreg{quantum=0})"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: machine

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
@@ -24,8 +24,6 @@ config:
   # Additional passes to run after lowering to QIR
   # This is required due to https://github.com/NVIDIA/cuda-quantum/issues/512
   post-codegen-passes: "remove-measurements"
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: machine

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
@@ -22,8 +22,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),iqm-gate-set-mapping"
   # Tell the rest-qpu that we are generating IQM JSON.
   codegen-emission: iqm
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: server-url

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
@@ -22,8 +22,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: email

--- a/runtime/cudaq/platform/default/rest/helpers/qbraid/qbraid.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/qbraid/qbraid.yml
@@ -24,8 +24,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM.
   codegen-emission: qasm2
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: machine

--- a/runtime/cudaq/platform/default/rest/helpers/qci/qci.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/qci/qci.yml
@@ -20,9 +20,6 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
 
-  # Library mode must be off for remote backends.
-  library-mode: false
-
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
 

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
@@ -23,8 +23,6 @@ config:
   jit-low-level-pipeline: "func.func(combine-quantum-alloc,qubit-reset-before-reuse)"
   # Tell the rest-qpu that we are generating Adaptive QIR.
   codegen-emission: qir-adaptive:0.1:int_computations
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: url

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -22,8 +22,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: url

--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/scaleway.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/scaleway.yml
@@ -22,8 +22,6 @@ config:
   jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qasm2
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: url

--- a/runtime/cudaq/platform/default/rest/helpers/tii/tii.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/tii/tii.yml
@@ -22,8 +22,6 @@ config:
   jit-high-level-pipeline: "expand-measurements"
   jit-mid-level-pipeline: "lower-to-cfg,func.func(canonicalize,multicontrol-decomposition),decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,canonicalize),symbol-dce"
   codegen-emission: qasm2
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: api-key

--- a/runtime/cudaq/platform/fermioniq/fermioniq.yml
+++ b/runtime/cudaq/platform/fermioniq/fermioniq.yml
@@ -17,8 +17,6 @@ config:
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Add the fermioniq-qpu library to the link list
   link-libs: ["-lcudaq-fermioniq-qpu"]
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
   jit-high-level-pipeline: "expand-measurements"
   jit-mid-level-pipeline: "fermioniq-gate-set-mapping"
   # Tell the rest-qpu that we are generating QIR.

--- a/runtime/cudaq/platform/orca/orca.yml
+++ b/runtime/cudaq/platform/orca/orca.yml
@@ -15,8 +15,6 @@ config:
   gen-target-backend: true
   # Add the orca-qpu library to the link list
   link-libs: ["-lcudaq-orca-qpu"]
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
   # Allow use of the multi-QPU library
   platform-library: mqpu
 

--- a/runtime/cudaq/platform/pasqal/pasqal.yml
+++ b/runtime/cudaq/platform/pasqal/pasqal.yml
@@ -15,8 +15,6 @@ config:
   link-libs: ["-lcudaq-pasqal-qpu", "-lcudaq-serverhelper-pasqal"]
   # Allow evolve API in C++
   preprocessor-defines: ["-D CUDAQ_ANALOG_TARGET"]
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
   # Tell NVQ++ to generate glue code to set the target backend name
   gen-target-backend: true
 

--- a/runtime/cudaq/platform/quera/quera.yml
+++ b/runtime/cudaq/platform/quera/quera.yml
@@ -17,8 +17,6 @@ config:
   link-libs: ["-lcudaq-quera-qpu"]
   # Allow evolve API in C++
   preprocessor-defines: ["-D CUDAQ_ANALOG_TARGET"]
-  # Library mode is only for simulators, physical backends must turn this off
-  library-mode: false
 
 target-arguments:
   - key: machine

--- a/runtime/cudaq/qis/managers/photonics/orca-photonics.yml
+++ b/runtime/cudaq/qis/managers/photonics/orca-photonics.yml
@@ -9,4 +9,8 @@
 name: orca-photonics
 description: "Photonics simulator"
 config:
+  # `orca-photonics` executes kernels via direct host invocation through the
+  # photonics execution manager. Enabling library mode internally here lets the
+  # target work without the (now removed) user-facing `--library-mode` flag.
+  library-mode: true
   library-mode-execution-manager: photonics

--- a/runtime/nvqir/cudensitymat/dynamics.yml
+++ b/runtime/nvqir/cudensitymat/dynamics.yml
@@ -13,4 +13,3 @@ config:
   nvqir-simulation-backend: dynamics
   platform-library: mqpu
   preprocessor-defines: ["-D CUDAQ_ANALOG_TARGET", "-D CUDAQ_SIMULATION_SCALAR_FP64"]
-  library-mode: true

--- a/scripts/validate_installation.sh
+++ b/scripts/validate_installation.sh
@@ -234,11 +234,6 @@ do
     if [ -n "$intended_target" ]; then
         echo "Intended for execution on $intended_target backend."
     fi
-    use_library_mode=$(sed -e '/^$/,$d' "$ex" | grep -o '^//[[:space:]]*nvq++.*-library-mode' | head -1)
-    if [ -n "$use_library_mode" ]; then
-        nvqpp_extra_options="--library-mode"
-    fi
-
     for t in $requested_backends
     do
         # Skipping dynamics examples if target is not dynamics and ex is dynamics

--- a/targettests/Kernel/inline-qpu-func.cpp
+++ b/targettests/Kernel/inline-qpu-func.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include "cudaq.h"
 

--- a/targettests/Kernel/signature-0.cpp
+++ b/targettests/Kernel/signature-0.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iomanip>

--- a/targettests/Kernel/signature-1.cpp
+++ b/targettests/Kernel/signature-1.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 // All tests should pass.
 

--- a/targettests/Kernel/signature-2.cpp
+++ b/targettests/Kernel/signature-2.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 // All tests should pass.
 

--- a/targettests/Kernel/signature-3.cpp
+++ b/targettests/Kernel/signature-3.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iomanip>

--- a/targettests/Kernel/signature-4.cpp
+++ b/targettests/Kernel/signature-4.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iomanip>

--- a/targettests/Kernel/signature-5.cpp
+++ b/targettests/Kernel/signature-5.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iomanip>

--- a/targettests/SeparateCompilation/arith_spans.cpp
+++ b/targettests/SeparateCompilation/arith_spans.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/span_dumps.cpp -o %t/span_dumps.o && \
-// RUN: nvq++ --enable-mlir -c %t/span_exercise.cpp -o %t/span_exercise.o && \
-// RUN: nvq++ --enable-mlir %t/span_dumps.o %t/span_exercise.o -o %t/spanaroo.out && \
+// RUN: nvq++ -c %t/span_dumps.cpp -o %t/span_dumps.o && \
+// RUN: nvq++ -c %t/span_exercise.cpp -o %t/span_exercise.o && \
+// RUN: nvq++ %t/span_dumps.o %t/span_exercise.o -o %t/spanaroo.out && \
 // RUN: %t/spanaroo.out | FileCheck %s ; else \
 // RUN: echo "skipping" ; fi
 // clang-format on

--- a/targettests/SeparateCompilation/basic.cpp
+++ b/targettests/SeparateCompilation/basic.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/baselib.cpp -o %t/baselib.o && \
-// RUN: nvq++ --enable-mlir -c %t/baseuser.cpp -o %t/baseuser.o && \
-// RUN: nvq++ --enable-mlir %t/baselib.o %t/baseuser.o -o %t/base.a.out && \
+// RUN: nvq++ -c %t/baselib.cpp -o %t/baselib.o && \
+// RUN: nvq++ -c %t/baseuser.cpp -o %t/baseuser.o && \
+// RUN: nvq++ %t/baselib.o %t/baseuser.o -o %t/base.a.out && \
 // RUN: %t/base.a.out | FileCheck %s ; else \
 // RUN: echo "skipping"; fi
 // clang-format on

--- a/targettests/SeparateCompilation/class.cpp
+++ b/targettests/SeparateCompilation/class.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/classlib.cpp -o %t/classlib.o && \
-// RUN: nvq++ --enable-mlir -c %t/classuser.cpp -o %t/classuser.o && \
-// RUN: nvq++ --enable-mlir %t/classlib.o %t/classuser.o -o %t/class.a.out && \
+// RUN: nvq++ -c %t/classlib.cpp -o %t/classlib.o && \
+// RUN: nvq++ -c %t/classuser.cpp -o %t/classuser.o && \
+// RUN: nvq++ %t/classlib.o %t/classuser.o -o %t/class.a.out && \
 // RUN: %t/class.a.out | FileCheck %s ; else \
 // RUN: echo "skipping" ; fi
 // clang-format on

--- a/targettests/SeparateCompilation/deduction_guide.cpp
+++ b/targettests/SeparateCompilation/deduction_guide.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/udedgulib.cpp -o %t/udedgulib.o && \
-// RUN: nvq++ --enable-mlir -c %t/udedguuser.cpp -o %t/udedguuser.o && \
-// RUN: nvq++ --enable-mlir %t/udedgulib.o %t/udedguuser.o -o %t/udedgu.x && \
+// RUN: nvq++ -c %t/udedgulib.cpp -o %t/udedgulib.o && \
+// RUN: nvq++ -c %t/udedguuser.cpp -o %t/udedguuser.o && \
+// RUN: nvq++ %t/udedgulib.o %t/udedguuser.o -o %t/udedgu.x && \
 // RUN: %t/udedgu.x | FileCheck %s ; else \
 // RUN: echo "skipping" ; fi
 // clang-format on

--- a/targettests/SeparateCompilation/lambda.cpp
+++ b/targettests/SeparateCompilation/lambda.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/anonlib.cpp -o %t/anonlib.o && \
-// RUN: nvq++ --enable-mlir -c %t/anonuser.cpp -o %t/anonuser.o && \
-// RUN: nvq++ --enable-mlir %t/anonlib.o %t/anonuser.o -o %t/anon.a.out && \
+// RUN: nvq++ -c %t/anonlib.cpp -o %t/anonlib.o && \
+// RUN: nvq++ -c %t/anonuser.cpp -o %t/anonuser.o && \
+// RUN: nvq++ %t/anonlib.o %t/anonuser.o -o %t/anon.a.out && \
 // RUN: %t/anon.a.out | FileCheck %s ; else \
 // RUN: echo "skipping" ; fi
 // clang-format on

--- a/targettests/SeparateCompilation/multiple_callables.cpp
+++ b/targettests/SeparateCompilation/multiple_callables.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t
+// RUN: nvq++ %s -o %t && %t
 
 #include "cudaq.h"
 

--- a/targettests/SeparateCompilation/pauli_words.cpp
+++ b/targettests/SeparateCompilation/pauli_words.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/pauli_word_display.cpp -o %t/pauli_word_display.o && \
-// RUN: nvq++ --enable-mlir -c %t/pauli_wordle.cpp -o %t/pauli_wordle.o && \
-// RUN: nvq++ --enable-mlir %t/pauli_word_display.o %t/pauli_wordle.o -o %t/pauli_wordle.out && \
+// RUN: nvq++ -c %t/pauli_word_display.cpp -o %t/pauli_word_display.o && \
+// RUN: nvq++ -c %t/pauli_wordle.cpp -o %t/pauli_wordle.o && \
+// RUN: nvq++ %t/pauli_word_display.o %t/pauli_wordle.o -o %t/pauli_wordle.out && \
 // RUN: %t/pauli_wordle.out | FileCheck %s ; else \
 // RUN: echo "skipping" ; fi
 // clang-format on

--- a/targettests/SeparateCompilation/pure_device.cpp
+++ b/targettests/SeparateCompilation/pure_device.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/pd_lib.cpp -o %t/pd_lib.o && \
-// RUN: nvq++ --enable-mlir -c %t/pd_main.cpp -o %t/pd_main.o && \
-// RUN: nvq++ --enable-mlir %t/pd_lib.o %t/pd_main.o -o %t/pd.a.out && \
+// RUN: nvq++ -c %t/pd_lib.cpp -o %t/pd_lib.o && \
+// RUN: nvq++ -c %t/pd_main.cpp -o %t/pd_main.o && \
+// RUN: nvq++ %t/pd_lib.o %t/pd_main.o -o %t/pd.a.out && \
 // RUN: %t/pd.a.out | FileCheck %s ; else \
 // RUN: echo "skipping" ; fi
 // clang-format on

--- a/targettests/SeparateCompilation/vector_return.cpp
+++ b/targettests/SeparateCompilation/vector_return.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: if [ command -v split-file ]; then \
 // RUN: split-file %s %t && \
-// RUN: nvq++ --enable-mlir -c %t/vector_return_lib.cpp -o %t/vector_return_lib.o && \
-// RUN: nvq++ --enable-mlir -c %t/vector_return_main.cpp -o %t/vector_return_main.o && \
-// RUN: nvq++ --enable-mlir %t/vector_return_lib.o %t/vector_return_main.o -o %t/vector_return.a.out && \
+// RUN: nvq++ -c %t/vector_return_lib.cpp -o %t/vector_return_lib.o && \
+// RUN: nvq++ -c %t/vector_return_main.cpp -o %t/vector_return_main.o && \
+// RUN: nvq++ %t/vector_return_lib.o %t/vector_return_main.o -o %t/vector_return.a.out && \
 // RUN: %t/vector_return.a.out | FileCheck %s ; else \
 // RUN: echo "skipping" ; fi
 // clang-format on

--- a/targettests/execution/adjoint.cpp
+++ b/targettests/execution/adjoint.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t
+// RUN: nvq++ %s -o %t && %t
 // XFAIL: *
 // TODO: this currently should fail due to ApplyOpSpecialization not handling
 // loops with multiple arguments, remove XFAIL when this is resolved.

--- a/targettests/execution/adjoint_control.cpp
+++ b/targettests/execution/adjoint_control.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // clang-format on
 
 // Verify that the controlled-adjoint of a kernel produces the correct inverse

--- a/targettests/execution/auto_kernel.cpp
+++ b/targettests/execution/auto_kernel.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 

--- a/targettests/execution/cast.cpp
+++ b/targettests/execution/cast.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/complex_vector_synthesis.cpp
+++ b/targettests/execution/complex_vector_synthesis.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // TODO-FIX-KERNEL-EXEC
 // RUN: nvq++ --target quantinuum --emulate -fkernel-exec-kind=2 %s -o %t  && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t  && %t | FileCheck %s

--- a/targettests/execution/conditional_run.cpp
+++ b/targettests/execution/conditional_run.cpp
@@ -9,7 +9,7 @@
 // clang-format off
 // RUN: nvq++ --target quantinuum --quantinuum-machine Helios-1SC --emulate %s -o %t && %t
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t && %t
+// RUN: nvq++ %s -o %t && %t
 // clang-format on
 
 // The test here is the assert statement.

--- a/targettests/execution/cudaq_run.cpp
+++ b/targettests/execution/cudaq_run.cpp
@@ -8,7 +8,6 @@
 
 // clang-format off
 // RUN: nvq++ %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>
@@ -53,11 +52,7 @@ struct vector_mz_test {
     cudaq::qvector q(5);
     cudaq::qubit p;
     x(q);
-#ifdef CUDAQ_LIBRARY_MODE
-    return cudaq::measure_result::to_bool_vector(mz(q));
-#else
     return cudaq::to_bools(mz(q));
-#endif
   }
 };
 

--- a/targettests/execution/cudaq_run_free_function.cpp
+++ b/targettests/execution/cudaq_run_free_function.cpp
@@ -8,7 +8,6 @@
 
 // clang-format off
 // RUN: nvq++ %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/cudaq_run_noisy.cpp
+++ b/targettests/execution/cudaq_run_noisy.cpp
@@ -8,7 +8,6 @@
 
 // clang-format off
 // RUN: nvq++ --target density-matrix-cpu  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode --target density-matrix-cpu  %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/cudaq_run_sample_observe.cpp
+++ b/targettests/execution/cudaq_run_sample_observe.cpp
@@ -8,7 +8,6 @@
 
 // clang-format off
 // RUN: nvq++ %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/custom_operation_adj.cpp
+++ b/targettests/execution/custom_operation_adj.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // RUN: if %anyon_avail; then nvq++ --target anyon --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %ionq_avail; then nvq++ --target ionq  --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %iqm_avail; then nvq++ --target iqm   --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s; fi

--- a/targettests/execution/custom_operation_basic.cpp
+++ b/targettests/execution/custom_operation_basic.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // RUN: if %anyon_avail; then nvq++ --target anyon --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %ionq_avail; then nvq++ --target ionq  --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %iqm_avail; then nvq++ --target iqm   --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s; fi

--- a/targettests/execution/custom_operation_ctrl.cpp
+++ b/targettests/execution/custom_operation_ctrl.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // RUN: if %anyon_avail; then nvq++ --target anyon --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %ionq_avail; then nvq++ --target ionq  --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %iqm_avail; then nvq++ --target iqm   --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s; fi

--- a/targettests/execution/custom_operation_toffoli.cpp
+++ b/targettests/execution/custom_operation_toffoli.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t %s 2>&1 | FileCheck %s -check-prefix=FAIL
 // clang-format on
 

--- a/targettests/execution/custom_pass.cpp
+++ b/targettests/execution/custom_pass.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin%cudaq_plugin_ext --opt-pass 'func.func(cudaq-custom-pass)'  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --opt-plugin %cudaq_lib_dir/CustomPassPlugin%cudaq_plugin_ext --opt-pass 'func.func(cudaq-custom-pass)'  %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/dem_from_kernel.cpp
+++ b/targettests/execution/dem_from_kernel.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cctype>
 #include <cstdio>

--- a/targettests/execution/dem_from_kernel_emulate.cpp
+++ b/targettests/execution/dem_from_kernel_emulate.cpp
@@ -7,14 +7,14 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir --target anyon      --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir --target infleqtion --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir --target ionq       --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
-// RUN: nvq++ --enable-mlir --target oqc        --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir --target qbraid     --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir --target quantinuum --emulate %s -o %t && %t | FileCheck %s
-// RUN: if %qci_avail; then nvq++ --enable-mlir --target qci --emulate %s -o %t && %t | FileCheck %s; fi
+// RUN: nvq++ --target anyon      --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target infleqtion --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target ionq       --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
+// RUN: nvq++ --target oqc        --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target qbraid     --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
+// RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // clang-format on
 
 #include <cctype>

--- a/targettests/execution/device_code_loaded.cpp
+++ b/targettests/execution/device_code_loaded.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 

--- a/targettests/execution/exp_pauli-0.cpp
+++ b/targettests/execution/exp_pauli-0.cpp
@@ -8,7 +8,7 @@
 
 // clang-format off
 // Simulators
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 //
 // Quantum emulators
 // RUN: nvq++ -fkernel-exec-kind=2 -target quantinuum --emulate %s -o %t && %t | FileCheck %s

--- a/targettests/execution/gen_device_code.cpp
+++ b/targettests/execution/gen_device_code.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ %s --enable-mlir -fno-aggressive-inline -o %t && %t | \
+// RUN: nvq++ %s -fno-aggressive-inline -o %t && %t | \
 // RUN: FileCheck %s
 
 #include <cudaq.h>

--- a/targettests/execution/include.cpp
+++ b/targettests/execution/include.cpp
@@ -6,10 +6,10 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // What is the following bit of script for precisely?
 // RUN: if [ $(echo | cut -c4- ) -ge 20 ]; then \
-// RUN:   nvq++ --enable-mlir %s -o %t && %t | FileCheck %s; \
+// RUN:   nvq++ %s -o %t && %t | FileCheck %s; \
 // RUN: fi
 
 #include "include/include.h"

--- a/targettests/execution/issue_3806.cpp
+++ b/targettests/execution/issue_3806.cpp
@@ -8,7 +8,6 @@
 
 // clang-format off
 // RUN: nvq++ %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --quantinuum-machine Helios-1SC --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // clang-format on

--- a/targettests/execution/lambda_introspection.cpp
+++ b/targettests/execution/lambda_introspection.cpp
@@ -6,9 +6,9 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // RUN: if [ $(echo | cut -c4- ) -ge 20 ]; then \
-// RUN:   nvq++ --enable-mlir %s -o %t && %t | FileCheck %s; \
+// RUN:   nvq++ %s -o %t && %t | FileCheck %s; \
 // RUN: fi
 
 #include <cudaq.h>

--- a/targettests/execution/mid_circuit_measurement_sim.cpp
+++ b/targettests/execution/mid_circuit_measurement_sim.cpp
@@ -8,7 +8,6 @@
 
 // Simulators
 // RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/mid_circuit_measurement_sim.cpp
+++ b/targettests/execution/mid_circuit_measurement_sim.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // Simulators
-// RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/mixed_basis_sample.cpp
+++ b/targettests/execution/mixed_basis_sample.cpp
@@ -10,7 +10,7 @@
 // Verify that mixing mz/mx/my in a sampled kernel produces bitstrings that
 // include all measured qubits.
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cassert>
 #include <cudaq.h>

--- a/targettests/execution/mixed_basis_sample.cpp
+++ b/targettests/execution/mixed_basis_sample.cpp
@@ -11,7 +11,6 @@
 // include all measured qubits.
 
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 
 #include <cassert>
 #include <cudaq.h>

--- a/targettests/execution/other_introspection.cpp
+++ b/targettests/execution/other_introspection.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | grep lookhere | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | grep lookhere | FileCheck %s
 
 #include <iostream>
 #include <cudaq.h>

--- a/targettests/execution/predefined_mlir_mode.cpp
+++ b/targettests/execution/predefined_mlir_mode.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 // clang-format off
-// RUN: nvq++ --enable-mlir -DTEST_DEF -DMY_VAR=\"CUDAQ\" %s -o %t && %t | FileCheck %s
+// RUN: nvq++ -DTEST_DEF -DMY_VAR=\"CUDAQ\" %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <iostream>

--- a/targettests/execution/preprocessor_defines.cpp
+++ b/targettests/execution/preprocessor_defines.cpp
@@ -7,10 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir -DCUDAQ_HELLO_WORLD %s -o %t && %t | FileCheck --check-prefixes=DEFINE_ON %s
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ -DCUDAQ_HELLO_WORLD %s -o %t && %t | FileCheck --check-prefixes=DEFINE_ON %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // RUN: if [ $(echo | cut -c4- ) -ge 20 ]; then \
-// RUN:   nvq++ --enable-mlir %s -o %t && %t | FileCheck %s; \
+// RUN:   nvq++ %s -o %t && %t | FileCheck %s; \
 // RUN: fi
 // clang-format on
 

--- a/targettests/execution/qir_simple_cond-1.cpp
+++ b/targettests/execution/qir_simple_cond-1.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: if %stim_avail; then nvq++ --target stim --enable-mlir %s -o %t && %t | FileCheck %s ; fi
+// RUN: if %stim_avail; then nvq++ --target stim %s -o %t && %t | FileCheck %s ; fi
 // RUN: nvq++ --target quantinuum --quantinuum-machine Helios-1SC --emulate %s -o %t && %t | FileCheck %s
 // clang-format on
 

--- a/targettests/execution/qvector_init_from_state.cpp
+++ b/targettests/execution/qvector_init_from_state.cpp
@@ -8,7 +8,6 @@
 
 // Simulators
 // RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qvector_init_from_state.cpp
+++ b/targettests/execution/qvector_init_from_state.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // Simulators
-// RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qvector_init_from_state_builder.cpp
+++ b/targettests/execution/qvector_init_from_state_builder.cpp
@@ -9,7 +9,6 @@
 // clang-format off
 // Simulators
 // RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/qvector_init_from_state_builder.cpp
+++ b/targettests/execution/qvector_init_from_state_builder.cpp
@@ -8,7 +8,7 @@
 
 // clang-format off
 // Simulators
-// RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/qvector_init_from_state_c_func.cpp
+++ b/targettests/execution/qvector_init_from_state_c_func.cpp
@@ -8,7 +8,6 @@
 
 // Simulators
 // RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qvector_init_from_state_c_func.cpp
+++ b/targettests/execution/qvector_init_from_state_c_func.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // Simulators
-// RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qvector_init_from_state_pauli.cpp
+++ b/targettests/execution/qvector_init_from_state_pauli.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // Simulators
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/sim_gate_timing.cpp
+++ b/targettests/execution/sim_gate_timing.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --target qpp-cpu --enable-mlir %s -o %t && CUDAQ_TIMING_TAGS=5 %t | FileCheck %s
+// RUN: nvq++ --target qpp-cpu %s -o %t && CUDAQ_TIMING_TAGS=5 %t | FileCheck %s
 // clang-format on
 
 // This test performs per-gate timing measurements. The FileCheck criteria is

--- a/targettests/execution/state_init.cpp
+++ b/targettests/execution/state_init.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t  && %t | FileCheck %s
+// RUN: nvq++ %s -o %t  && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/swap_gate.cpp
+++ b/targettests/execution/swap_gate.cpp
@@ -16,7 +16,7 @@
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include "cudaq.h"

--- a/targettests/execution/template_introspection.cpp
+++ b/targettests/execution/template_introspection.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 

--- a/targettests/execution/trivial_inliner.cpp
+++ b/targettests/execution/trivial_inliner.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 

--- a/targettests/execution/trotter.cpp
+++ b/targettests/execution/trotter.cpp
@@ -52,7 +52,7 @@ int STEPS = 4; // set to around 100 for `nvidia` target
 // Compile and run with:
 // clang-format off
 // ```
-// nvq++ --enable-mlir -v trotter_kernel_mode.cpp -o trotter.x --target nvidia && ./trotter.x
+// nvq++ -v trotter_kernel_mode.cpp -o trotter.x --target nvidia && ./trotter.x
 // ```
 // clang-format on
 

--- a/targettests/execution/uccsd.cpp
+++ b/targettests/execution/uccsd.cpp
@@ -14,7 +14,7 @@
 // RUN: if %oqc_avail; then nvq++ --target oqc  --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
+// RUN: nvq++ %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/vector_bool_parameter.cpp
+++ b/targettests/execution/vector_bool_parameter.cpp
@@ -9,7 +9,6 @@
 // clang-format off
 // Simulators
 // RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/vector_bool_parameter.cpp
+++ b/targettests/execution/vector_bool_parameter.cpp
@@ -8,7 +8,7 @@
 
 // clang-format off
 // Simulators
-// RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/vector_int_parameter.cpp
+++ b/targettests/execution/vector_int_parameter.cpp
@@ -8,7 +8,6 @@
 
 // Simulators
 // RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/vector_int_parameter.cpp
+++ b/targettests/execution/vector_int_parameter.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // Simulators
-// RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -19,9 +19,8 @@ SET(CMAKE_SHARED_LINKER_FLAGS "")
 # calls reach the inline bodies in `runtime/cudaq/qis/qubit_qis.h` on the
 # host.
 #
-# The user-facing `--library-mode` flag has been removed, but the macro it
-# used to set survives as an internal implementation detail for host
-# execution (`orca-photonics`).
+# The user-facing `--library-mode` flag has been removed, but the macro it set
+# survives as an internal implementation detail.
 add_compile_definitions(CUDAQ_LIBRARY_MODE)
 
 # ctest's PROCESSORS property tells the scheduler how many CPU slots each test

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -17,14 +17,11 @@ SET(CMAKE_SHARED_LINKER_FLAGS "")
 # call `cudaq::sample(myKernel)` directly from C++ test code, with no `nvq++`
 # / `cudaq-quake` step. The AST bridge never runs, so measurement and gate
 # calls reach the inline bodies in `runtime/cudaq/qis/qubit_qis.h` on the
-# host. That is the same execution model as library mode, but without the
-# `CUDAQ_LIBRARY_MODE` macro the headers' MLIR-mode branches are selected
-# and any future trap on host invocation breaks the test binaries silently.
+# host.
 #
-# This is a temporary workaround until library mode is removed and a proper
-# runtime-isolation harness replaces it. Defining the macro at directory
-# scope routes every target below this point through the library-mode
-# inline bodies that work on host today.
+# The user-facing `--library-mode` flag has been removed, but the macro it
+# used to set survives as an internal implementation detail for host
+# execution (`orca-photonics`).
 add_compile_definitions(CUDAQ_LIBRARY_MODE)
 
 # ctest's PROCESSORS property tells the scheduler how many CPU slots each test


### PR DESCRIPTION
Removing the user-facing library-mode compilation path from CUDA-Q. The `--library-mode` and `--enable-mlir` flags are gone. All kernels now compile through the MLIR path. The `CUDAQ_LIBRARY_MODE` macro and its host-execution code paths are retained internally as an implementation detail for the targets that still need direct host invocation (`orca-photonics`).