### PR TITLE
[python] Remove PythonLauncher and move compilation out of QPU

### DIFF
--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -328,15 +328,6 @@ else()
   set(_origin_prefix "$ORIGIN")
 endif()
 
-## Retain all linked libraries (e.g. libcudaq) so that static initializers
-## (ModuleLauncher registry and PythonLauncher registration) run and resolve
-## in the same process. Without --no-as-needed the linker may drop libcudaq
-## and the launcher is never registered.
-if(CUDAQ_FORCE_LINK_FLAG)
-  target_link_options(CUDAQuantumPythonCAPI PRIVATE
-    ${CUDAQ_FORCE_LINK_FLAG})
-endif()
-
 if (NOT SKBUILD)
   list(APPEND CMAKE_INSTALL_RPATH "${_origin_prefix}/../../lib" "${_origin_prefix}/../../lib/plugins")
   set_property(TARGET CUDAQuantumPythonModules.extension._quakeDialects.dso

--- a/python/extension/CUDAQuantumExtension.cpp
+++ b/python/extension/CUDAQuantumExtension.cpp
@@ -68,12 +68,7 @@ using namespace cudaq;
 
 static std::unique_ptr<LinkedLibraryHolder> holder;
 
-extern "C" void cudaq_ensure_default_launcher_linked(void);
-
 NB_MODULE(_quakeDialects, m) {
-  // Ensure the TU that registers PythonLauncher ("default") is linked so
-  // kernel launches work without an explicit set_target().
-  cudaq_ensure_default_launcher_linked();
   holder = std::make_unique<LinkedLibraryHolder>();
 
   bindRegisterDialects(m);

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -714,8 +714,9 @@ compileModuleImpl(const std::string &name, ModuleOp mod,
     auto *ctx = cudaq::getExecutionContext();
     if (!ctx) {
       auto target = cudaq::get_compile_target(cudaq::other_policies{});
-      return cudaq_internal::compiler::compileModule<void>(
-          nullptr, std::move(target), src, {rawArgs}, isEntryPoint);
+      return cudaq_internal::compiler::compileModule(cudaq::other_policies{},
+                                                     std::move(target), src,
+                                                     {rawArgs}, isEntryPoint);
     }
 
     return cudaq::policies::withPolicy(ctx->name, [&](auto policy) {

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -12,6 +12,7 @@
 #include "common/Environment.h"
 #include "common/Timing.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"
+#include "cudaq_internal/compiler/Compiler.h"
 #include "cudaq_internal/compiler/LayoutInfo.h"
 #include "cudaq_internal/compiler/TracePassInstrumentation.h"
 #include "runtime/cudaq/algorithms/py_utils.h"
@@ -26,6 +27,7 @@
 #include "cudaq/Optimizer/CodeGen/OptUtils.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
+#include "cudaq/algorithms/policy_dispatch.h"
 #include "cudaq/platform.h"
 #include "cudaq/platform/nvqpp_interface.h"
 #include "cudaq/platform/qpu.h"
@@ -45,6 +47,7 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/Passes.h"
 #include <fmt/core.h>
+#include <mlir/IR/OwningOpRef.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/complex.h>
@@ -668,17 +671,81 @@ static void appendTheResultValue(ModuleOp module, const std::string &name,
   runtimeArgs.emplace_back(buf, [](void *ptr) { std::free(ptr); });
 }
 
+/// In a sample launch context, the (`JIT` compiled) CompiledModule may be
+/// cached so that it can be called many times in a loop without being
+/// recompiled. This exploits the fact that the arguments processed at the
+/// sample callsite are invariant by the definition of a `CUDA-Q` kernel.
+template <std::invocable F>
+  requires std::is_invocable_r_v<cudaq::CompiledModule, F>
+static cudaq::CompiledModule with_compiled_module_cache(F &&f) {
+  auto *currentExecCtx = cudaq::getExecutionContext();
+
+  auto getCache = [currentExecCtx]() -> std::optional<cudaq::CompiledModule> {
+    if (currentExecCtx && currentExecCtx->allowCompiledModuleCaching)
+      return currentExecCtx->cachedCompiledModule;
+    return std::nullopt;
+  };
+  auto saveCache = [currentExecCtx](cudaq::CompiledModule compiled) {
+    if (currentExecCtx && currentExecCtx->allowCompiledModuleCaching) {
+      if (!currentExecCtx->cachedCompiledModule)
+        currentExecCtx->cachedCompiledModule = compiled;
+    }
+  };
+
+  auto cachedModule = getCache();
+  if (cachedModule)
+    return *cachedModule;
+  auto compiled = f();
+  saveCache(compiled);
+  return compiled;
+}
+
+static cudaq::CompiledModule
+compileModuleImpl(const std::string &name, ModuleOp mod,
+                  const std::vector<void *> &rawArgs, bool isEntryPoint) {
+  cudaq::SourceModule src{name, mod.getAsOpaquePointer()};
+
+  // Only cache on local simulators
+  auto cacheable =
+      cudaq::is_simulator_platform() && !cudaq::is_emulated_platform();
+
+  auto compile = [&]() {
+    cudaq::CompiledModule compiled;
+    auto *ctx = cudaq::getExecutionContext();
+    if (!ctx) {
+      auto target = cudaq::get_compile_target(cudaq::other_policies{});
+      return cudaq_internal::compiler::compileModule<void>(
+          nullptr, std::move(target), src, {rawArgs}, isEntryPoint);
+    }
+
+    return cudaq::policies::withPolicy(ctx->name, [&](auto policy) {
+      using Policy = std::decay_t<decltype(policy)>;
+      if constexpr (std::is_same_v<Policy, cudaq::observe_policy>) {
+        policy.spin = ctx->spin.value();
+      }
+      auto target = cudaq::get_compile_target(policy);
+      return cudaq_internal::compiler::compileModule(
+          &policy, std::move(target), src, {rawArgs}, isEntryPoint);
+    });
+  };
+
+  if (!cacheable) {
+    return compile();
+  }
+  return with_compiled_module_cache(compile);
+}
+
 // Launching the module \p mod will modify its content, such as by argument
 // synthesis into the entry-point kernel. Make a clone before we launch to
 // preserve (cache) the IR, and erase the clone after the kernel is done.
 static cudaq::KernelThunkResultType
 pyLaunchModule(const std::string &name, ModuleOp mod,
-               cudaq::CompiledModule *compiled,
+               cudaq::CompiledModule *cachedModule,
                const std::vector<void *> &rawArgs) {
   bool isCachable = [&]() {
     // Must have a slot to read/write the cache from. Callers opt out of the
     // cache by passing nullptr.
-    if (!compiled)
+    if (!cachedModule)
       return false;
     auto &platform = cudaq::get_platform();
     // Must be local simulator
@@ -699,15 +766,14 @@ pyLaunchModule(const std::string &name, ModuleOp mod,
   // Cache hit only if the cached module's entry point matches this launch's.
   // Notably, run has a different entry point so can't share a cache with
   // other launch modes.
-  if (isCachable && compiled->getName() == name)
-    return cudaq::streamlinedLaunchModule(*compiled, rawArgs);
+  if (isCachable && cachedModule->getName() == name)
+    return cudaq::streamlinedLaunchModule(*cachedModule, rawArgs);
 
-  auto clone = mod.clone();
-  auto jitted = cudaq::streamlinedCompileModule(name, clone, rawArgs, true);
-  auto res = cudaq::streamlinedLaunchModule(jitted, rawArgs);
+  mlir::OwningOpRef<ModuleOp> clone = mod.clone();
+  auto compiled = compileModuleImpl(name, clone.get(), rawArgs, true);
+  auto res = cudaq::streamlinedLaunchModule(compiled, rawArgs);
   if (isCachable)
-    *compiled = std::move(jitted);
-  clone.erase();
+    *cachedModule = std::move(compiled);
   return res;
 }
 
@@ -1000,10 +1066,8 @@ marshal_and_retain_module(const std::string &name, MlirModule module,
       cudaq::marshal_arguments_for_module_launch(mod, runtimeArgs, kernelFunc);
   // Append space for a result, as needed, to the vector of arguments.
   auto rawArgs = appendResultToArgsVector(args, retTy, mod, name);
-  auto clone = mod.clone();
-  auto compiled =
-      cudaq::streamlinedCompileModule(name, clone, rawArgs, isEntryPoint);
-  clone.erase();
+  mlir::OwningOpRef<ModuleOp> clone = mod.clone();
+  auto compiled = compileModuleImpl(name, clone.get(), rawArgs, isEntryPoint);
   return compiled;
 }
 

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -14,9 +14,7 @@
 #include "common/KernelExecution.h"
 #include "common/Resources.h"
 #include "common/ServerHelper.h"
-#include "cudaq_internal/compiler/CompiledModuleHelper.h"
 #include "cudaq_internal/compiler/Compiler.h"
-#include "cudaq_internal/compiler/JIT.h"
 #include "nvqir/AnalysisScope.h"
 #include "nvqir/resourcecounter/ResourceCounterScope.h"
 #include "cudaq/Target/TargetConfig.h"
@@ -84,23 +82,6 @@ protected:
 
   /// @brief The target configuration
   cudaq::config::TargetConfig targetConfig;
-
-  template <typename Policy>
-  CompiledModule compileModuleImpl(Policy &policy, const SourceModule &src,
-                                   KernelArgs args, bool isEntryPoint) {
-    const auto &kernelName = src.getName();
-    auto modulePtr = src.getMlirOpaqueModulePtr();
-    CUDAQ_INFO("specializing remote rest kernel via module ({}) with {} policy",
-               kernelName, policy.name);
-    Compiler compiler(getCompileTarget(policy));
-    auto compiled =
-        compiler.runPassPipeline(kernelName, modulePtr, args, isEntryPoint);
-    if constexpr (std::is_same_v<Policy, sample_policy>) {
-      if (compiler.hasWarnedNamedMeasurements())
-        policy.warnedNamedMeasurements = true;
-    }
-    return compiled;
-  }
 
 public:
   /// @brief The constructor
@@ -297,29 +278,6 @@ public:
     target->pauliTermSplitObservable = policy.spin;
     target->pipelineConfig.replaceStateWithKernel = true;
     return target;
-  }
-
-  CompiledModule compileModule(const other_policies &policy,
-                               const SourceModule &src, KernelArgs args,
-                               bool isEntryPoint) override {
-    const auto &kernelName = src.getName();
-    auto modulePtr = src.getMlirOpaqueModulePtr();
-    CUDAQ_INFO("specializing remote rest kernel via module ({})", kernelName);
-
-    Compiler compiler(getCompileTarget(policy, getExecutionContext()));
-    return compiler.runPassPipeline(kernelName, modulePtr, args, isEntryPoint);
-  }
-
-  CompiledModule compileModule(const sample_policy &policy,
-                               const SourceModule &src, KernelArgs args,
-                               bool isEntryPoint) override {
-    return compileModuleImpl(policy, src, args, isEntryPoint);
-  }
-
-  CompiledModule compileModule(const observe_policy &policy,
-                               const SourceModule &src, KernelArgs args,
-                               bool isEntryPoint) override {
-    return compileModuleImpl(policy, src, args, isEntryPoint);
   }
 
   /// @brief Build the list of kernel executions for the given module under

--- a/runtime/cudaq/platform.h
+++ b/runtime/cudaq/platform.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cudaq/algorithms/policies.h"
 #include "cudaq/builder/kernel_builder.h"
 #include "cudaq/platform/qpu_types.h"
 #include "cudaq/platform/quantum_platform.h"
@@ -35,6 +36,36 @@ inline bool is_remote_platform() {
 inline bool is_emulated_platform() {
   return getQuantumPlatformInternal()->is_emulated();
 }
+
+/// @brief Return true if the quantum platform is a simulator.
+inline bool is_simulator_platform() {
+  return getQuantumPlatformInternal()->is_simulator();
+}
+
+inline std::unique_ptr<cudaq::CompileTarget>
+get_compile_target(const cudaq::sample_policy &policy) {
+  return getQuantumPlatformInternal()->getCompileTarget(policy);
+}
+
+inline std::unique_ptr<cudaq::CompileTarget>
+get_compile_target(const cudaq::observe_policy &policy) {
+  return getQuantumPlatformInternal()->getCompileTarget(policy);
+}
+
+inline std::unique_ptr<cudaq::CompileTarget>
+get_compile_target(const cudaq::other_policies &policy) {
+  auto *ctx = cudaq::getExecutionContext();
+  return getQuantumPlatformInternal()->getCompileTarget(policy, ctx);
+}
+
+/// Get the default compile target configuration used when JITing for Python.
+std::unique_ptr<cudaq::CompileTarget>
+getDefaultPythonCompileTarget(const sample_policy &policy);
+std::unique_ptr<cudaq::CompileTarget>
+getDefaultPythonCompileTarget(const observe_policy &policy);
+std::unique_ptr<cudaq::CompileTarget>
+getDefaultPythonCompileTarget(const other_policies &policy,
+                              ExecutionContext *context);
 
 // Declare this function, implemented elsewhere
 std::string getQIR(const std::string &);

--- a/runtime/cudaq/platform.h
+++ b/runtime/cudaq/platform.h
@@ -42,20 +42,9 @@ inline bool is_simulator_platform() {
   return getQuantumPlatformInternal()->is_simulator();
 }
 
-inline std::unique_ptr<cudaq::CompileTarget>
-get_compile_target(const cudaq::sample_policy &policy) {
+template <typename Policy>
+std::unique_ptr<cudaq::CompileTarget> get_compile_target(const Policy &policy) {
   return getQuantumPlatformInternal()->getCompileTarget(policy);
-}
-
-inline std::unique_ptr<cudaq::CompileTarget>
-get_compile_target(const cudaq::observe_policy &policy) {
-  return getQuantumPlatformInternal()->getCompileTarget(policy);
-}
-
-inline std::unique_ptr<cudaq::CompileTarget>
-get_compile_target(const cudaq::other_policies &policy) {
-  auto *ctx = cudaq::getExecutionContext();
-  return getQuantumPlatformInternal()->getCompileTarget(policy, ctx);
 }
 
 /// Get the default compile target configuration used when JITing for Python.

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -76,20 +76,23 @@ cudaq::DefaultQPU::launchKernel(async_observe_policy &policy,
 
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::DefaultQPU::getCompileTarget(const sample_policy &policy) {
-  // A python-only target suffices, as C++ compilation is done AOT
+  // Currently this is only used for Python kernels, as C++ kernels skip JIT
+  // compilation and call the AOT-generated function directly.
   return getDefaultPythonCompileTarget(policy);
 }
 
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::DefaultQPU::getCompileTarget(const observe_policy &policy) {
-  // A python-only target suffices, as C++ compilation is done AOT
+  // Currently this is only used for Python kernels, as C++ kernels skip JIT
+  // compilation and call the AOT-generated function directly.
   return getDefaultPythonCompileTarget(policy);
 }
 
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::DefaultQPU::getCompileTarget(const other_policies &policy,
                                     ExecutionContext *context) {
-  // A python-only target suffices, as C++ compilation is done AOT
+  // Currently this is only used for Python kernels, as C++ kernels skip JIT
+  // compilation and call the AOT-generated function directly.
   return getDefaultPythonCompileTarget(policy, context);
 }
 

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -10,6 +10,7 @@
 #include "common/ExecutionContext.h"
 #include "common/Timing.h"
 #include "cudaq/algorithms/policies.h"
+#include "cudaq/platform.h"
 #include "cudaq/runtime/logger/logger.h"
 
 cudaq::DefaultQPU::~DefaultQPU() = default;
@@ -71,6 +72,25 @@ cudaq::DefaultQPU::launchKernel(async_observe_policy &policy,
                                 cudaq::KernelArgs args) {
   throw std::runtime_error(
       "DefaultQPU does not support launching the async_observe_policy.");
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::DefaultQPU::getCompileTarget(const sample_policy &policy) {
+  // A python-only target suffices, as C++ compilation is done AOT
+  return getDefaultPythonCompileTarget(policy);
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::DefaultQPU::getCompileTarget(const observe_policy &policy) {
+  // A python-only target suffices, as C++ compilation is done AOT
+  return getDefaultPythonCompileTarget(policy);
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::DefaultQPU::getCompileTarget(const other_policies &policy,
+                                    ExecutionContext *context) {
+  // A python-only target suffices, as C++ compilation is done AOT
+  return getDefaultPythonCompileTarget(policy, context);
 }
 
 void cudaq::DefaultQPU::configureExecutionContext(

--- a/runtime/cudaq/platform/default/DefaultQPU.h
+++ b/runtime/cudaq/platform/default/DefaultQPU.h
@@ -39,6 +39,16 @@ public:
                                     const AnyModule &module,
                                     KernelArgs args) override;
 
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(const sample_policy &policy) override;
+
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(const observe_policy &policy) override;
+
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(const other_policies &policy,
+                   ExecutionContext *context) override;
+
   void configureExecutionContext(ExecutionContext &context) const override;
   void beginExecution() override;
   void endExecution() override;

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -34,42 +34,6 @@
 
 using namespace mlir;
 
-static std::unique_ptr<cudaq::CompileTarget>
-getCompileTarget(cudaq::ExecutionContext *context) {
-  const bool enablePythonCodegenDump =
-      cudaq::getEnvBool("CUDAQ_PYTHON_CODEGEN_DUMP", false);
-  if (enablePythonCodegenDump) {
-    CUDAQ_WARN("CUDAQ_PYTHON_CODEGEN_DUMP is no longer supported and will be "
-               "ignored. Use CUDAQ_MLIR_PRINT_EACH_PASS instead.");
-  }
-  std::unique_ptr<cudaq::CompileTarget> ct;
-  auto *rt = cudaq::get_platform().get_runtime_target();
-  if (!rt) {
-    ct = std::make_unique<cudaq::CompileTarget>();
-    ct->pipelineConfig.skipTargetLoweringPipeline = true;
-  } else {
-    ct = std::make_unique<cudaq::CompileTarget>(rt->config, rt->runtimeConfig,
-                                                cudaq::is_emulated_platform());
-  }
-
-  if (context && context->name == "dem") {
-    ct->emitJit = true;
-    ct->emitTargetCode = false;
-    ct->pipelineConfig.skipTargetLoweringPipeline = true;
-  }
-
-  bool isLocalSimulator =
-      !(cudaq::is_remote_platform() || cudaq::is_emulated_platform());
-
-  ct->fullySpecialize = !isLocalSimulator;
-  ct->supportDeviceCalls = true;
-  ct->emitResourceCounts = context && context->name == "resource-count";
-  ct->argumentSynthChangeSemantics = false;
-  ct->pipelineConfig.codegenTranslation = "qir:";
-  ct->emitJit = true;
-  return ct;
-}
-
 /// Lowers \p module to LLVM code. The LLVM code will use "full QIR" as the
 /// transport layer. If \p kernelName and \p args are provided, they will
 /// specialize the selected entry-point kernel.
@@ -79,7 +43,8 @@ std::string cudaq::detail::lower_to_qir_llvm(const std::string &name,
                                              const std::string &format) {
   ScopedTraceWithContext(cudaq::TIMING_JIT, "getQIR", name);
 
-  auto target = getCompileTarget(cudaq::getExecutionContext());
+  auto target = getDefaultPythonCompileTarget(other_policies{},
+                                              cudaq::getExecutionContext());
   target->fullySpecialize = true;
   cudaq_internal::compiler::Compiler compiler(std::move(target));
 
@@ -122,7 +87,8 @@ std::string cudaq::detail::lower_to_openqasm(const std::string &name,
                                              OpaqueArguments &args) {
   ScopedTraceWithContext(cudaq::TIMING_JIT, "getASM", name);
 
-  auto target = getCompileTarget(cudaq::getExecutionContext());
+  auto target = getDefaultPythonCompileTarget(other_policies{},
+                                              cudaq::getExecutionContext());
   target->fullySpecialize = true;
   cudaq_internal::compiler::Compiler compiler(std::move(target));
 
@@ -155,56 +121,3 @@ std::string cudaq::detail::lower_to_openqasm(const std::string &name,
   os.flush();
   return result;
 }
-
-namespace {
-struct PythonLauncher : public cudaq::ModuleLauncher {
-  using cudaq::ModuleLauncher::getCompileTarget;
-  std::unique_ptr<cudaq::CompileTarget>
-  getCompileTarget(cudaq::ExecutionContext *context) override {
-    return ::getCompileTarget(context);
-  }
-
-  cudaq::CompiledModule compileModule(const cudaq::SourceModule &src,
-                                      cudaq::KernelArgs args,
-                                      bool isEntryPoint) override {
-
-    ScopedTraceWithContext(cudaq::TIMING_LAUNCH,
-                           "PythonLauncher::compileModule");
-    const auto &kernelName = src.getName();
-    auto modulePtr = src.getMlirOpaqueModulePtr();
-    assert(modulePtr &&
-           "PythonLauncher::compileModule requires an MLIR artifact");
-
-    cudaq_internal::compiler::Compiler compiler(
-        getCompileTarget(cudaq::getExecutionContext()));
-    return compiler.runPassPipeline(kernelName, modulePtr, args, isEntryPoint);
-  }
-};
-} // namespace
-
-// PythonLauncher registration. This TU only builds into the Python extension
-// (_quakeDialects.so), but `launchModule` / `specializeModule` live in
-// libcudaq.so. CUDA-Q Registry uses `static inline Head/Tail`, so each DSO
-// that instantiates the template gets its own copy — `CUDAQ_REGISTER_TYPE`
-// would add the node to the extension's (unseen-by-libcudaq) registry. We
-// instead call the `cudaq_add_module_launcher_node` bridge defined in
-// libcudaq.so so the registration lands in the registry that `launchModule`
-// actually reads. Mirrors the `cudaq_add_qpu_node` pattern used for QPUs.
-extern "C" void cudaq_add_module_launcher_node(void *node_ptr);
-
-namespace {
-struct PythonLauncherRegistration {
-  cudaq::RegistryEntry<cudaq::ModuleLauncher> entry;
-  cudaq::Registry<cudaq::ModuleLauncher>::node node;
-  PythonLauncherRegistration()
-      : entry("default", &PythonLauncherRegistration::ctorFn), node(entry) {
-    cudaq_add_module_launcher_node(&node);
-  }
-  static std::unique_ptr<cudaq::ModuleLauncher> ctorFn() {
-    return std::make_unique<PythonLauncher>();
-  }
-};
-static PythonLauncherRegistration s_pythonLauncherRegistration;
-} // namespace
-
-extern "C" void cudaq_ensure_default_launcher_linked(void) {}

--- a/runtime/cudaq/platform/nvqpp_interface.h
+++ b/runtime/cudaq/platform/nvqpp_interface.h
@@ -10,8 +10,6 @@
 
 #include "common/CompiledModule.h"
 #include "common/ThunkInterface.h"
-#include <optional>
-#include <string>
 #include <vector>
 
 namespace mlir {
@@ -58,9 +56,5 @@ hybridLaunchKernel(const char *kernelName, KernelThunkType kernel, void *args,
 [[nodiscard]] KernelThunkResultType
 streamlinedLaunchModule(const CompiledModule &compiled,
                         const std::vector<void *> &rawArgs);
-
-[[nodiscard]] CompiledModule
-streamlinedCompileModule(const std::string &kernelName, mlir::ModuleOp moduleOp,
-                         const std::vector<void *> &rawArgs, bool isEntryPoint);
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -24,18 +24,6 @@
 using namespace cudaq_internal::compiler;
 using namespace cudaq;
 
-CUDAQ_INSTANTIATE_REGISTRY(cudaq::ModuleLauncher::RegistryType)
-
-// Bridge so the Python extension can register PythonLauncher into this DSO's
-// registry. CUDA-Q Registry uses static inline Head/Tail, so each DSO that
-// instantiates the template gets its own copy; launchModule runs in this DSO
-// and reads the empty list. Registering via this function adds to our list.
-extern "C" void cudaq_add_module_launcher_node(void *node_ptr) {
-  using Node = cudaq::Registry<cudaq::ModuleLauncher>::node;
-  cudaq::Registry<cudaq::ModuleLauncher>::add_node(
-      static_cast<Node *>(node_ptr));
-}
-
 cudaq::KernelThunkResultType
 cudaq::QPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
   if (std::holds_alternative<SourceModule>(module))
@@ -123,51 +111,20 @@ cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
   return {nullptr, 0};
 }
 
-cudaq::CompiledModule cudaq::QPU::compileModule(const sample_policy &,
-                                                const SourceModule &src,
-                                                KernelArgs args,
-                                                bool isEntryPoint) {
-  return compileModule(other_policies{}, src, args, isEntryPoint);
-}
-
-cudaq::CompiledModule cudaq::QPU::compileModule(const observe_policy &,
-                                                const SourceModule &src,
-                                                KernelArgs args,
-                                                bool isEntryPoint) {
-  return compileModule(other_policies{}, src, args, isEntryPoint);
-}
-
-std::unique_ptr<cudaq::CompileTarget>
-cudaq::QPU::getCompileTarget(const other_policies &,
-                             ExecutionContext *context) {
-  auto launcher = registry::get<ModuleLauncher>("default");
-  if (!launcher)
-    throw std::runtime_error(
-        "No ModuleLauncher registered with name 'default'. This may be a "
-        "result of attempting to use `compileModule` outside Python.");
-  return launcher->getCompileTarget(context);
-}
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::QPU::getCompileTarget(const sample_policy &) {
   throw std::runtime_error(
-      "no CompileTarget defined for sample_policy this QPU");
+      "no CompileTarget defined for sample_policy on this QPU");
 }
+
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::QPU::getCompileTarget(const observe_policy &) {
   throw std::runtime_error(
-      "no CompileTarget defined for observe_policy this QPU");
+      "no CompileTarget defined for observe_policy on this QPU");
 }
 
-cudaq::CompiledModule cudaq::QPU::compileModule(const other_policies &,
-                                                const SourceModule &src,
-                                                KernelArgs args,
-                                                bool isEntryPoint) {
-  auto launcher = registry::get<ModuleLauncher>("default");
-  if (!launcher)
-    throw std::runtime_error(
-        "No ModuleLauncher registered with name 'default'. This may be a "
-        "result of attempting to use `compileModule` outside Python.");
-  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::compileModule",
-                         src.getName());
-  return launcher->compileModule(src, args, isEntryPoint);
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::QPU::getCompileTarget(const other_policies &olicy, ExecutionContext *) {
+  throw std::runtime_error(
+      "no CompileTarget defined for other_policies on this QPU");
 }

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -155,46 +155,18 @@ public:
   [[nodiscard]] virtual KernelThunkResultType
   unifiedLaunchModule(const AnyModule &module, KernelArgs args);
 
-  /// Get the compile target of the QPU
-  // Overload for sample policy
+  /// Get the compile target of the QPU for the given policy.
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(const sample_policy &policy);
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(const observe_policy &policy);
   // Overload for currently unsupported policies (to be removed).
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
-  getCompileTarget(const other_policies &, ExecutionContext *context);
-
-  [[nodiscard]] virtual CompiledModule compileModule(const other_policies &,
-                                                     const SourceModule &src,
-                                                     KernelArgs args,
-                                                     bool isEntryPoint);
-
-  [[nodiscard]] virtual CompiledModule compileModule(const sample_policy &,
-                                                     const SourceModule &src,
-                                                     KernelArgs args,
-                                                     bool isEntryPoint);
-
-  [[nodiscard]] virtual CompiledModule compileModule(const observe_policy &,
-                                                     const SourceModule &src,
-                                                     KernelArgs args,
-                                                     bool isEntryPoint);
+  getCompileTarget(const other_policies &policy, ExecutionContext *context);
 
   /// @brief Notify the QPU that a new random seed value is set.
   /// By default do nothing, let subclasses override.
   virtual void onRandomSeedSet(std::size_t seed) {}
-};
-
-struct ModuleLauncher : public registry::RegisteredType<ModuleLauncher> {
-  virtual ~ModuleLauncher() = default;
-
-  /// Compile (specialize + JIT) a kernel module and return a ready-to-execute
-  /// CompiledModule.
-  virtual CompiledModule compileModule(const SourceModule &src, KernelArgs args,
-                                       bool isEntryPoint) = 0;
-
-  virtual std::unique_ptr<CompileTarget>
-  getCompileTarget(ExecutionContext *context) = 0;
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -281,30 +281,6 @@ quantum_platform::unifiedLaunchModule(const AnyModule &module, KernelArgs args,
   return qpu->unifiedLaunchModule(module, args);
 }
 
-std::unique_ptr<cudaq::CompileTarget>
-quantum_platform::getCompileTarget(const cudaq::other_policies &policy,
-                                   ExecutionContext *ctx, std::size_t qpu_id) {
-  validateQpuId(qpu_id);
-  auto &qpu = platformQPUs[qpu_id];
-  return qpu->getCompileTarget(policy, ctx);
-}
-
-std::unique_ptr<cudaq::CompileTarget>
-quantum_platform::getCompileTarget(const sample_policy &policy,
-                                   std::size_t qpu_id) {
-  validateQpuId(qpu_id);
-  auto &qpu = platformQPUs[qpu_id];
-  return qpu->getCompileTarget(policy);
-}
-
-std::unique_ptr<cudaq::CompileTarget>
-quantum_platform::getCompileTarget(const observe_policy &policy,
-                                   std::size_t qpu_id) {
-  validateQpuId(qpu_id);
-  auto &qpu = platformQPUs[qpu_id];
-  return qpu->getCompileTarget(policy);
-}
-
 void quantum_platform::onRandomSeedSet(std::size_t seed) {
   // Send on the notification to all QPUs.
   for (auto &qpu : platformQPUs)

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -8,6 +8,7 @@
 
 #include "cudaq/platform/quantum_platform.h"
 #include "common/CompiledModule.h"
+#include "common/Environment.h"
 #include "common/ExecutionContext.h"
 #include "common/PluginUtils.h"
 #include "common/RuntimeTarget.h"
@@ -88,6 +89,59 @@ const noise_model *quantum_platform::get_noise(std::size_t qpu_id) {
 void quantum_platform::reset_noise(std::size_t qpu_id) {
   validateQpuId(qpu_id);
   set_noise(nullptr, qpu_id);
+}
+
+static std::unique_ptr<cudaq::CompileTarget>
+getDefaultPythonCompileTargetImpl() {
+  auto *platform = getQuantumPlatformInternal();
+
+  const bool enablePythonCodegenDump =
+      cudaq::getEnvBool("CUDAQ_PYTHON_CODEGEN_DUMP", false);
+  if (enablePythonCodegenDump) {
+    CUDAQ_WARN("CUDAQ_PYTHON_CODEGEN_DUMP is no longer supported and will be "
+               "ignored. Use CUDAQ_MLIR_PRINT_EACH_PASS instead.");
+  }
+  std::unique_ptr<cudaq::CompileTarget> ct;
+  auto *rt = platform->get_runtime_target();
+  if (!rt) {
+    ct = std::make_unique<cudaq::CompileTarget>();
+    ct->pipelineConfig.skipTargetLoweringPipeline = true;
+  } else {
+    ct = std::make_unique<cudaq::CompileTarget>(rt->config, rt->runtimeConfig,
+                                                platform->is_emulated());
+  }
+
+  bool isLocalSimulator = !(platform->is_remote() || platform->is_emulated());
+
+  ct->fullySpecialize = !isLocalSimulator;
+  ct->supportDeviceCalls = true;
+  ct->argumentSynthChangeSemantics = false;
+  ct->pipelineConfig.codegenTranslation = "qir:";
+  ct->emitJit = true;
+  return ct;
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+getDefaultPythonCompileTarget(const sample_policy &) {
+  return getDefaultPythonCompileTargetImpl();
+}
+std::unique_ptr<cudaq::CompileTarget>
+getDefaultPythonCompileTarget(const observe_policy &) {
+  return getDefaultPythonCompileTargetImpl();
+}
+std::unique_ptr<cudaq::CompileTarget>
+getDefaultPythonCompileTarget(const other_policies &,
+                              ExecutionContext *context) {
+  auto ct = getDefaultPythonCompileTargetImpl();
+
+  if (context && context->name == "dem") {
+    ct->emitJit = true;
+    ct->emitTargetCode = false;
+    ct->pipelineConfig.skipTargetLoweringPipeline = true;
+  }
+  ct->emitResourceCounts = context && context->name == "resource-count";
+
+  return ct;
 }
 
 std::future<sample_result>
@@ -227,23 +281,28 @@ quantum_platform::unifiedLaunchModule(const AnyModule &module, KernelArgs args,
   return qpu->unifiedLaunchModule(module, args);
 }
 
-CompiledModule quantum_platform::compileModule(const SourceModule &src,
-                                               const KernelArgs &args,
-                                               std::size_t qpu_id,
-                                               bool isEntryPoint) {
+std::unique_ptr<cudaq::CompileTarget>
+quantum_platform::getCompileTarget(const cudaq::other_policies &policy,
+                                   ExecutionContext *ctx, std::size_t qpu_id) {
   validateQpuId(qpu_id);
   auto &qpu = platformQPUs[qpu_id];
-  auto ctx = cudaq::getExecutionContext();
-  if (!ctx)
-    return qpu->compileModule(other_policies{}, src, args, isEntryPoint);
+  return qpu->getCompileTarget(policy, ctx);
+}
 
-  return cudaq::policies::withPolicy(ctx->name, [&](auto policy) {
-    using Policy = std::decay_t<decltype(policy)>;
-    if constexpr (std::is_same_v<Policy, observe_policy>) {
-      policy.spin = ctx->spin.value();
-    }
-    return qpu->compileModule(policy, src, args, isEntryPoint);
-  });
+std::unique_ptr<cudaq::CompileTarget>
+quantum_platform::getCompileTarget(const sample_policy &policy,
+                                   std::size_t qpu_id) {
+  validateQpuId(qpu_id);
+  auto &qpu = platformQPUs[qpu_id];
+  return qpu->getCompileTarget(policy);
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+quantum_platform::getCompileTarget(const observe_policy &policy,
+                                   std::size_t qpu_id) {
+  validateQpuId(qpu_id);
+  auto &qpu = platformQPUs[qpu_id];
+  return qpu->getCompileTarget(policy);
 }
 
 void quantum_platform::onRandomSeedSet(std::size_t seed) {
@@ -347,55 +406,6 @@ cudaq::streamlinedLaunchModule(const CompiledModule &compiled,
   auto &platform = *getQuantumPlatformInternal();
   std::size_t qpu_id = getCurrentQpuId();
   return platform.unifiedLaunchModule(compiled, {rawArgs}, qpu_id);
-}
-
-/// In a sample launch context, the (`JIT` compiled) CompiledModule may be
-/// cached so that it can be called many times in a loop without being
-/// recompiled. This exploits the fact that the arguments processed at the
-/// sample callsite are invariant by the definition of a `CUDA-Q` kernel.
-template <std::invocable F>
-  requires std::is_invocable_r_v<cudaq::CompiledModule, F>
-static cudaq::CompiledModule with_compiled_module_cache(F &&f) {
-  auto *currentExecCtx = cudaq::getExecutionContext();
-
-  auto getCache = [currentExecCtx]() -> std::optional<cudaq::CompiledModule> {
-    if (currentExecCtx && currentExecCtx->allowCompiledModuleCaching)
-      return currentExecCtx->cachedCompiledModule;
-    return std::nullopt;
-  };
-  auto saveCache = [currentExecCtx](cudaq::CompiledModule compiled) {
-    if (currentExecCtx && currentExecCtx->allowCompiledModuleCaching) {
-      if (!currentExecCtx->cachedCompiledModule)
-        currentExecCtx->cachedCompiledModule = compiled;
-    }
-  };
-
-  auto cachedModule = getCache();
-  if (cachedModule)
-    return *cachedModule;
-  auto compiled = f();
-  saveCache(compiled);
-  return compiled;
-}
-
-cudaq::CompiledModule cudaq::streamlinedCompileModule(
-    const std::string &kernelName, mlir::ModuleOp moduleOp,
-    const std::vector<void *> &rawArgs, bool isEntryPoint) {
-  ScopedTraceWithContext("streamlinedCompileModule", kernelName,
-                         rawArgs.size());
-  auto &platform = *getQuantumPlatformInternal();
-  std::size_t qpu_id = getCurrentQpuId();
-  // Only cache on local simulators
-  auto cacheable =
-      platform.is_simulator(qpu_id) && !platform.is_emulated(qpu_id);
-  if (!cacheable) {
-    SourceModule src{kernelName, moduleOp.getAsOpaquePointer()};
-    return platform.compileModule(src, {rawArgs}, qpu_id, isEntryPoint);
-  }
-  return with_compiled_module_cache([&]() {
-    SourceModule src{kernelName, moduleOp.getAsOpaquePointer()};
-    return platform.compileModule(src, {rawArgs}, qpu_id, isEntryPoint);
-  });
 }
 
 cudaq::KernelThunkResultType

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -17,6 +17,7 @@
 #include "common/ThunkInterface.h"
 #include "nvqpp_interface.h"
 #include "cudaq/Target/CompileTarget.h"
+#include "cudaq/platform/qpu.h"
 #include "cudaq/remote_capabilities.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <cstring>
@@ -206,13 +207,22 @@ public:
   unifiedLaunchModule(const AnyModule &module, KernelArgs args,
                       std::size_t qpu_id = 0);
 
+  template <typename Policy>
   [[nodiscard]] std::unique_ptr<cudaq::CompileTarget>
-  getCompileTarget(const cudaq::sample_policy &policy, std::size_t qpu_id = 0);
-  [[nodiscard]] std::unique_ptr<cudaq::CompileTarget>
-  getCompileTarget(const cudaq::observe_policy &policy, std::size_t qpu_id = 0);
+  getCompileTarget(const Policy &policy, std::size_t qpu_id = 0) {
+    validateQpuId(qpu_id);
+    auto &qpu = platformQPUs[qpu_id];
+    return qpu->getCompileTarget(policy);
+  }
+
   [[nodiscard]] std::unique_ptr<cudaq::CompileTarget>
   getCompileTarget(const cudaq::other_policies &policy,
-                   ExecutionContext *context, std::size_t qpu_id = 0);
+                   std::size_t qpu_id = 0) {
+    auto *ctx = getExecutionContext();
+    validateQpuId(qpu_id);
+    auto &qpu = platformQPUs[qpu_id];
+    return qpu->getCompileTarget(policy, ctx);
+  }
 
   /// List all available platforms
   static std::vector<std::string> list_platforms();

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -16,6 +16,7 @@
 #include "common/ObserveResult.h"
 #include "common/ThunkInterface.h"
 #include "nvqpp_interface.h"
+#include "cudaq/Target/CompileTarget.h"
 #include "cudaq/remote_capabilities.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <cstring>
@@ -205,10 +206,13 @@ public:
   unifiedLaunchModule(const AnyModule &module, KernelArgs args,
                       std::size_t qpu_id = 0);
 
-  [[nodiscard]] CompiledModule compileModule(const SourceModule &src,
-                                             const KernelArgs &args,
-                                             std::size_t qpu_id,
-                                             bool isEntryPoint);
+  [[nodiscard]] std::unique_ptr<cudaq::CompileTarget>
+  getCompileTarget(const cudaq::sample_policy &policy, std::size_t qpu_id = 0);
+  [[nodiscard]] std::unique_ptr<cudaq::CompileTarget>
+  getCompileTarget(const cudaq::observe_policy &policy, std::size_t qpu_id = 0);
+  [[nodiscard]] std::unique_ptr<cudaq::CompileTarget>
+  getCompileTarget(const cudaq::other_policies &policy,
+                   ExecutionContext *context, std::size_t qpu_id = 0);
 
   /// List all available platforms
   static std::vector<std::string> list_platforms();

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -13,6 +13,7 @@
 #include "common/FmtCore.h"
 #include "common/KernelExecution.h"
 #include "common/Resources.h"
+#include "common/Timing.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"
 #include "cudaq_internal/compiler/JIT.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"
@@ -399,6 +400,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
     const std::string &kernelName, const void *modulePtr,
     cudaq::KernelArgs args, bool isEntryPoint,
     std::shared_ptr<mlir::MLIRContext> context) {
+  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "Compiler::runPassPipeline");
   mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
   assert(!context || context.get() == m_module.getContext());
   auto [moduleOp, epFunc, isFullySpecialized] =

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -11,6 +11,7 @@
 #include "common/KernelArgs.h"
 #include "cudaq_internal/compiler/CompiledModuleHelper.h"
 #include "cudaq/Target/CompileTarget.h"
+#include "cudaq/algorithms/sample/policy.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -133,5 +134,27 @@ public:
 /// finalizeStage are fixed stages interleaved between the config-provided
 /// stages. Pass empty strings to skip them.
 std::string getPassPipeline(const cudaq::CompileTarget &target);
+
+/// Compile a source module for the given policy, compile target and
+/// arguments.
+template <typename Policy>
+cudaq::CompiledModule
+compileModule(Policy *policy, std::unique_ptr<cudaq::CompileTarget> &&target,
+              const cudaq::SourceModule &src, cudaq::KernelArgs args,
+              bool isEntryPoint = true) {
+  const auto &kernelName = src.getName();
+  auto modulePtr = src.getMlirOpaqueModulePtr();
+  assert(modulePtr && "Compiler::compileModule requires an MLIR artifact");
+
+  Compiler compiler(std::move(target));
+  auto compiled =
+      compiler.runPassPipeline(kernelName, modulePtr, args, isEntryPoint);
+
+  if constexpr (std::is_same_v<Policy, cudaq::sample_policy>) {
+    if (compiler.hasWarnedNamedMeasurements())
+      policy->warnedNamedMeasurements = true;
+  }
+  return compiled;
+}
 
 } // namespace cudaq_internal::compiler

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -139,7 +139,8 @@ std::string getPassPipeline(const cudaq::CompileTarget &target);
 /// arguments.
 template <typename Policy>
 cudaq::CompiledModule
-compileModule(Policy *policy, std::unique_ptr<cudaq::CompileTarget> target,
+compileModule(const Policy &policy,
+              std::unique_ptr<cudaq::CompileTarget> target,
               const cudaq::SourceModule &src, cudaq::KernelArgs args,
               bool isEntryPoint = true) {
   const auto &kernelName = src.getName();
@@ -152,7 +153,7 @@ compileModule(Policy *policy, std::unique_ptr<cudaq::CompileTarget> target,
 
   if constexpr (std::is_same_v<Policy, cudaq::sample_policy>) {
     if (compiler.hasWarnedNamedMeasurements())
-      policy->warnedNamedMeasurements = true;
+      policy.warnedNamedMeasurements = true;
   }
   return compiled;
 }

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -139,7 +139,7 @@ std::string getPassPipeline(const cudaq::CompileTarget &target);
 /// arguments.
 template <typename Policy>
 cudaq::CompiledModule
-compileModule(Policy *policy, std::unique_ptr<cudaq::CompileTarget> &&target,
+compileModule(Policy *policy, std::unique_ptr<cudaq::CompileTarget> target,
               const cudaq::SourceModule &src, cudaq::KernelArgs args,
               bool isEntryPoint = true) {
   const auto &kernelName = src.getName();


### PR DESCRIPTION
In this PR, we finally pull compilation out of the QPUs (for Python). This means that we can remove the `PythonLauncher` "hack" entirely (a plugin system loaded at runtime, only ever used with a single plugin, whose purpose was to decouple the base QPU class from MLIR).

We are one step closer to (and one step away from) freeing the QPU classes of their MLIR dependency! The last remaining MLIR dependency is within BaseRemoteRESTQPU::launchKernel, which is currently required to JIT compile kernels that were launched from C++. 