### PR TITLE
Fix cudaq.evolve dropping idle qubits for local Hamiltonians

### DIFF
--- a/python/cudaq/dynamics/evolution.py
+++ b/python/cudaq/dynamics/evolution.py
@@ -45,12 +45,40 @@ def _taylor_series_expm(op_matrix: NDArray[numpy.complexfloating],
     return result
 
 
+def _validate_system_dimensions(dimensions: Mapping[int, int]):
+    actual_degrees = set(dimensions.keys())
+    expected_degrees = set(range(len(dimensions)))
+    if actual_degrees != expected_degrees:
+        raise ValueError(
+            "`dimensions` must define contiguous degrees starting at 0.")
+
+
+def _validate_operator_degrees(operator: Operator, dimensions: Mapping[int,
+                                                                       int]):
+    operator_degrees = set(operator.degrees)
+    missing_degrees = operator_degrees - set(dimensions.keys())
+    if missing_degrees:
+        raise ValueError(
+            f"operator degrees {sorted(missing_degrees)} are not present in the provided dimensions"
+        )
+
+
+def _canonicalize_operator_to_dimensions(
+        operator: Operator, dimensions: Mapping[int, int]) -> Operator:
+    _validate_operator_degrees(operator, dimensions)
+    system_operator = operator.copy()
+    system_operator.canonicalize(set(dimensions.keys()))
+    return system_operator
+
+
 def _compute_step_matrix(hamiltonian: Operator,
                          dimensions: Mapping[int, int],
                          parameters: Mapping[str, NumericType],
                          dt: float,
                          use_gpu: bool = False) -> NDArray[complexfloating]:
-    op_matrix = hamiltonian.to_matrix(dimensions, **parameters)
+    op_matrix = hamiltonian.to_matrix(dimensions,
+                                      invert_order=True,
+                                      **parameters)
     op_matrix = -1j * op_matrix * dt
 
     if use_gpu:
@@ -68,7 +96,7 @@ def _add_noise_channel_for_step(step_kernel_name: str,
                                 parameters: Mapping[str,
                                                     NumericType], dt: float):
     for collapse_op in collapse_operators:
-        L = collapse_op.to_matrix(dimensions, **parameters)
+        L = collapse_op.to_matrix(dimensions, invert_order=True, **parameters)
         G = -0.5 * numpy.dot(L.conj().T, L)
         M0 = G * dt + numpy.eye(2**len(dimensions))
         M1 = numpy.sqrt(dt) * L
@@ -237,7 +265,15 @@ def evolve_single(
             "collapse operators can only be defined when using the dynamics or density-matrix-cpu target"
         )
 
-    num_qubits = len(hamiltonian.degrees)
+    _validate_system_dimensions(dimensions)
+    num_qubits = len(dimensions)
+    hamiltonian = _canonicalize_operator_to_dimensions(hamiltonian, dimensions)
+    collapse_operators = [
+        _canonicalize_operator_to_dimensions(op, dimensions)
+        for op in collapse_operators
+    ]
+    for observable in observables:
+        _validate_operator_degrees(observable, dimensions)
     parameters = [mapping for mapping in schedule]
     schedule.reset()
     tlist = [schedule.current_step for _ in schedule]
@@ -527,7 +563,15 @@ def evolve_single_async(
         raise ValueError(
             "collapse operators can only be defined when using the dynamics or density-matrix-cpu target"
         )
-    num_qubits = len(hamiltonian.degrees)
+    _validate_system_dimensions(dimensions)
+    num_qubits = len(dimensions)
+    hamiltonian = _canonicalize_operator_to_dimensions(hamiltonian, dimensions)
+    collapse_operators = [
+        _canonicalize_operator_to_dimensions(op, dimensions)
+        for op in collapse_operators
+    ]
+    for observable in observables:
+        _validate_operator_degrees(observable, dimensions)
     parameters = [mapping for mapping in schedule]
     schedule.reset()
     tlist = [schedule.current_step for _ in schedule]

--- a/python/tests/dynamics/test_evolve_simulators.py
+++ b/python/tests/dynamics/test_evolve_simulators.py
@@ -460,6 +460,226 @@ def test_evolve_async_no_intermediate_results():
     assert final_exp_decay[0][1].expectation() != final_exp[0][1].expectation()
 
 
+@pytest.mark.parametrize("target", ["qpp-cpu", "density-matrix-cpu"])
+def test_evolve_preserves_qubits_not_in_hamiltonian(target):
+    """A local Hamiltonian should not shrink the full system state."""
+
+    cudaq.reset_target()
+    cudaq.set_target(target)
+
+    hamiltonian = spin.x(0)
+    dimensions = {0: 2, 1: 2}
+    schedule = Schedule([0.0, np.pi / 2.0], ["time"])
+
+    # State vector ordering is little-endian: index 2 is q0=0, q1=1.
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[2] = 1.0
+
+    result = cudaq.evolve(
+        hamiltonian,
+        dimensions,
+        schedule,
+        cudaq.State.from_data(psi0),
+        observables=[spin.z(1)],
+        collapse_operators=[],
+        store_intermediate_results=cudaq.IntermediateResultSave.NONE)
+
+    expected = np.zeros(4, dtype=np.complex128)
+    expected[3] = -1j
+    if target == "density-matrix-cpu":
+        expected = np.outer(expected, np.conj(expected)).reshape(-1)
+
+    final_state = np.array(result.final_state()).reshape(-1)
+    np.testing.assert_allclose(final_state, expected, atol=1e-12)
+    assert np.isclose(result.expectation_values()[0][0].expectation(), -1.0)
+
+
+@pytest.mark.parametrize("target", ["qpp-cpu", "density-matrix-cpu"])
+def test_evolve_async_preserves_qubits_not_in_hamiltonian(target):
+    """The async path should embed local Hamiltonians in the full system."""
+
+    cudaq.reset_target()
+    cudaq.set_target(target)
+
+    hamiltonian = spin.x(0)
+    dimensions = {0: 2, 1: 2}
+    schedule = Schedule([0.0, np.pi / 2.0], ["time"])
+
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[2] = 1.0
+
+    result = cudaq.evolve_async(
+        hamiltonian,
+        dimensions,
+        schedule,
+        cudaq.State.from_data(psi0),
+        observables=[spin.z(1)],
+        collapse_operators=[],
+        store_intermediate_results=cudaq.IntermediateResultSave.NONE).get()
+
+    expected = np.zeros(4, dtype=np.complex128)
+    expected[3] = -1j
+    if target == "density-matrix-cpu":
+        expected = np.outer(expected, np.conj(expected)).reshape(-1)
+
+    final_state = np.array(result.final_state()).reshape(-1)
+    np.testing.assert_allclose(final_state, expected, atol=1e-12)
+    assert np.isclose(result.expectation_values()[0][0].expectation(), -1.0)
+
+
+@pytest.mark.parametrize("target", ["qpp-cpu", "density-matrix-cpu"])
+def test_evolve_preserves_order_for_asymmetric_two_qubit_hamiltonian(target):
+    """Non-symmetric product terms must keep the operator target order."""
+
+    cudaq.reset_target()
+    cudaq.set_target(target)
+
+    hamiltonian = spin.x(0) * spin.z(1)
+    dimensions = {0: 2, 1: 2}
+    schedule = Schedule([0.0, np.pi / 2.0], ["time"])
+
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[2] = 1.0
+
+    result = cudaq.evolve(
+        hamiltonian,
+        dimensions,
+        schedule,
+        cudaq.State.from_data(psi0),
+        observables=[spin.z(1)],
+        collapse_operators=[],
+        store_intermediate_results=cudaq.IntermediateResultSave.NONE)
+
+    expected = np.zeros(4, dtype=np.complex128)
+    expected[3] = 1j
+    if target == "density-matrix-cpu":
+        expected = np.outer(expected, np.conj(expected)).reshape(-1)
+
+    final_state = np.array(result.final_state()).reshape(-1)
+    np.testing.assert_allclose(final_state, expected, atol=1e-12)
+    assert np.isclose(result.expectation_values()[0][0].expectation(), -1.0)
+
+
+def test_evolve_canonicalizes_local_collapse_operator():
+    """Local collapse operators should act on the requested full-system qubit."""
+
+    cudaq.reset_target()
+    cudaq.set_target("density-matrix-cpu")
+
+    dimensions = {0: 2, 1: 2}
+    schedule = Schedule([0.0, 0.1], ["time"])
+
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[2] = 1.0
+
+    result = cudaq.evolve(
+        0.0 * spin.x(0),
+        dimensions,
+        schedule,
+        cudaq.State.from_data(psi0),
+        observables=[spin.z(0), spin.z(1)],
+        collapse_operators=[np.sqrt(0.05) * spin.x(0)],
+        store_intermediate_results=cudaq.IntermediateResultSave.NONE)
+
+    final_expectations = result.expectation_values()[0]
+    assert final_expectations[0].expectation() < 1.0
+    assert np.isclose(final_expectations[1].expectation(), -1.0, atol=1e-3)
+
+
+def test_evolve_rejects_non_contiguous_dimensions():
+    cudaq.reset_target()
+    cudaq.set_target("qpp-cpu")
+
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[0] = 1.0
+
+    with pytest.raises(ValueError, match="contiguous degrees"):
+        cudaq.evolve(
+            spin.x(1), {
+                1: 2,
+                3: 2
+            },
+            Schedule([0.0, 0.1], ["time"]),
+            cudaq.State.from_data(psi0),
+            store_intermediate_results=cudaq.IntermediateResultSave.NONE)
+
+
+@pytest.mark.parametrize("kwargs", [{
+    "hamiltonian": spin.x(2),
+    "observables": [],
+    "collapse_operators": []
+}, {
+    "hamiltonian": spin.x(0),
+    "observables": [spin.z(2)],
+    "collapse_operators": []
+}])
+def test_evolve_rejects_operator_degrees_missing_from_dimensions(kwargs):
+    cudaq.reset_target()
+    cudaq.set_target("qpp-cpu")
+
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[0] = 1.0
+
+    with pytest.raises(ValueError, match="operator degrees \\[2\\]"):
+        cudaq.evolve(
+            kwargs["hamiltonian"], {
+                0: 2,
+                1: 2
+            },
+            Schedule([0.0, 0.1], ["time"]),
+            cudaq.State.from_data(psi0),
+            observables=kwargs["observables"],
+            collapse_operators=kwargs["collapse_operators"],
+            store_intermediate_results=cudaq.IntermediateResultSave.NONE)
+
+
+def test_evolve_rejects_collapse_operator_degrees_missing_from_dimensions():
+    cudaq.reset_target()
+    cudaq.set_target("density-matrix-cpu")
+
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[0] = 1.0
+
+    with pytest.raises(ValueError, match="operator degrees \\[2\\]"):
+        cudaq.evolve(
+            spin.x(0), {
+                0: 2,
+                1: 2
+            },
+            Schedule([0.0, 0.1], ["time"]),
+            cudaq.State.from_data(psi0),
+            collapse_operators=[spin.x(2)],
+            store_intermediate_results=cudaq.IntermediateResultSave.NONE)
+
+
+def test_evolve_async_rejects_invalid_dimensions_and_operator_degrees():
+    cudaq.reset_target()
+    cudaq.set_target("qpp-cpu")
+
+    psi0 = np.zeros(4, dtype=np.complex128)
+    psi0[0] = 1.0
+
+    with pytest.raises(ValueError, match="contiguous degrees"):
+        cudaq.evolve_async(
+            spin.x(1), {
+                1: 2,
+                3: 2
+            },
+            Schedule([0.0, 0.1], ["time"]),
+            cudaq.State.from_data(psi0),
+            store_intermediate_results=cudaq.IntermediateResultSave.NONE).get()
+
+    with pytest.raises(ValueError, match="operator degrees \\[2\\]"):
+        cudaq.evolve_async(
+            spin.x(2), {
+                0: 2,
+                1: 2
+            },
+            Schedule([0.0, 0.1], ["time"]),
+            cudaq.State.from_data(psi0),
+            store_intermediate_results=cudaq.IntermediateResultSave.NONE).get()
+
+
 def test_final_expectation_values_without_observables():
     """Test that final_expectation_values returns None instead of crashing
     when evolve is called without observables."""


### PR DESCRIPTION
## Summary

This fixes a silent wrong-answer bug in the non-`dynamics` simulator implementation of `cudaq.evolve`.

The bug is triggered when all of the following are true:

- The target uses the non-`dynamics` simulator path, for example `qpp-cpu` or `density-matrix-cpu`.
- `dimensions` describes a larger qubit system.
- The Hamiltonian only acts on a subset of those degrees.
- The initial state, observables, or collapse operators rely on degrees that are present in `dimensions` but absent from the Hamiltonian.

A minimal example is:

```python
dimensions = {0: 2, 1: 2}
hamiltonian = spin.x(0)
initial_state = q0=0, q1=1
```

Physically, this means:
```
H_full = X0 ⊗ I1
```
The untouched qubit q1 is still part of the system and should be preserved. The old implementation instead sized the generated kernel from:
```
num_qubits = len(hamiltonian.degrees)
```
so it generated a one-qubit evolution for spin.x(0) and silently dropped the idle qubit.

## How to repro
```
import numpy as np
import cudaq
from cudaq.operators import spin
from cudaq.dynamics import Schedule

cudaq.set_target("qpp-cpu")

dimensions = {0: 2, 1: 2}
hamiltonian = spin.x(1)
schedule = Schedule([0.0, np.pi / 2.0], ["time"])

# CUDA-Q state vector ordering is little-endian:
# index = q0 + 2*q1.
#
# This initializes q0=1, q1=0.
psi0 = np.zeros(4, dtype=np.complex128)
psi0[1] = 1.0

result = cudaq.evolve(
    hamiltonian,
    dimensions,
    schedule,
    cudaq.State.from_data(psi0),
    observables=[spin.z(0), spin.z(1)],
    collapse_operators=[],
)

state = np.asarray(result.final_state()).reshape(-1)
expectations = [x.expectation() for x in result.expectation_values()[0]]

print("final state:", state)
print("<Z0>, <Z1>:", expectations)
print("expected final state:", np.array([0, 0, 0, -1j], dtype=np.complex128))
print("expected <Z0>, <Z1>:", [-1.0, -1.0])

cudaq.reset_target()
```
before fix:
```
final state: [0.0000000e+00-1.j 8.7793107e-18+0.j 0.0000000e+00+0.j 0.0000000e+00+0.j]
<Z0>, <Z1>: [1.0, 1.0]
expected final state: [ 0.+0.j  0.+0.j  0.+0.j -0.-1.j]
expected <Z0>, <Z1>: [-1.0, -1.0]
```
after fix:
```
final state: [0.0000000e+00+0.j 8.7793107e-18+0.j 0.0000000e+00+0.j 0.0000000e+00-1.j]
<Z0>, <Z1>: [-1.0, -1.0]
expected final state: [ 0.+0.j  0.+0.j  0.+0.j -0.-1.j]
expected <Z0>, <Z1>: [-1.0, -1.0]
```

## This change:

* Sizes the generated simulator kernel from len(dimensions).
* Canonicalizes Hamiltonian and collapse operators to the full system degrees.
* Uses invert_order=True when converting evolution and Kraus matrices.
* Validates that dimensions defines contiguous degrees starting at 0.
* Validates that Hamiltonian, observable, and collapse-operator degrees are present in dimensions.
* Applies the same behavior to evolve_single and evolve_single_async.