### PR TITLE
[core] Add dead quantum elimination (DQE) pass

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -281,6 +281,14 @@ def ConvertToDirectCalls : Pass<"indirect-to-direct-calls", "mlir::ModuleOp"> {
   let dependentDialects = ["cudaq::cc::CCDialect"];
 }
 
+def DeadQuantumElimination : Pass<"dqe"> {
+  let summary = "Dead quantum elimination (DQE).";
+  let description = [{
+    Eliminate any clearly dead quantum (`!quake.ref` or `!quake.wire`)
+    allocations from the IR. (quantum here means some flavor of qudit.)
+  }];
+}
+
 def DeadStoreRemoval : Pass<"dead-store-removal"> {
   let summary = "Dead store removal (DSR).";
   let description = [{

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_cudaq_library(OptTransforms
   CombineMeasurements.cpp
   CombineQuantumAlloc.cpp
   ConstantPropagation.cpp
+  DeadQuantumElimination.cpp
   DeadStoreRemoval.cpp
   Decomposition.cpp
   DecompositionPatterns.cpp

--- a/cudaq/lib/Optimizer/Transforms/DeadQuantumElimination.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DeadQuantumElimination.cpp
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_DEADQUANTUMELIMINATION
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "dqe"
+
+using namespace mlir;
+
+// TODO: We can expand these patterns to cover veqs, struqs, and cables as well.
+// In those cases, there are vacuous uses that must be accounted for in order to
+// partially eliminate those quantum allocations. For example, a
+// `quake.extract_ref` might be a use, but itself have no users.
+
+namespace {
+class RefPattern : public OpRewritePattern<cudaq::quake::AllocaOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::AllocaOp alloc,
+                                PatternRewriter &rewriter) const override {
+    if (std::distance(alloc->getUsers().begin(), alloc->getUsers().end()) > 1)
+      return failure();
+    if (alloc->use_empty()) {
+      rewriter.eraseOp(alloc);
+      return success();
+    }
+    // There is exactly 1 use.
+    auto dealloc =
+        dyn_cast<cudaq::quake::DeallocOp>(*alloc->getUsers().begin());
+    if (!dealloc)
+      return failure();
+    rewriter.eraseOp(dealloc);
+    rewriter.eraseOp(alloc);
+    return success();
+  }
+};
+
+class WirePattern : public OpRewritePattern<cudaq::quake::NullWireOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::NullWireOp nullWire,
+                                PatternRewriter &rewriter) const override {
+    // Wires are linear types. There must be exactly 1 use.
+    auto sink = dyn_cast<cudaq::quake::SinkOp>(*nullWire->getUsers().begin());
+    if (!sink)
+      return failure();
+    rewriter.eraseOp(sink);
+    rewriter.eraseOp(nullWire);
+    return success();
+  }
+};
+
+class DQEPass : public cudaq::opt::impl::DeadQuantumEliminationBase<DQEPass> {
+public:
+  using DeadQuantumEliminationBase::DeadQuantumEliminationBase;
+
+  void runOnOperation() override {
+    auto *op = getOperation();
+    LLVM_DEBUG(llvm::dbgs() << "Before DQE:\n" << *op << '\n');
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<RefPattern, WirePattern>(ctx);
+    if (failed(applyPatternsGreedily(op, std::move(patterns))))
+      signalPassFailure();
+    LLVM_DEBUG(llvm::dbgs() << "After DQE:\n" << *op << '\n');
+  }
+};
+} // namespace

--- a/cudaq/test/CMakeLists.txt
+++ b/cudaq/test/CMakeLists.txt
@@ -56,12 +56,13 @@ get_property(test_cudaq_libraries GLOBAL PROPERTY CUDAQ_RUNTIME_LIBS)
 set(NVQPP_TEST_DEPENDS
     CircuitCheck
     cudaq-opt
-    cudaq-translate
-    FileCheck
-    test_argument_conversion
-    CustomPassPlugin
-    cudaq-target-conf
     cudaq-rest-qpu
+    cudaq-target-conf
+    cudaq-translate
+    CustomPassPlugin
+    FileCheck
+    nvq++
+    test_argument_conversion
 )
 
 if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME AND NOT CUDAQ_DISABLE_CPP_FRONTEND AND

--- a/cudaq/test/Transforms/dqe.qke
+++ b/cudaq/test/Transforms/dqe.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --add-dealloc --canonicalize --factor-quantum-alloc --dqe --combine-quantum-alloc %s | cudaq-opt | FileCheck %s
+// RUN: cudaq-opt --add-dealloc --canonicalize --factor-quantum-alloc --dqe --combine-quantum-alloc %s | FileCheck %s
 
 func.func @smiling_lettuce() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %c5_i64 = arith.constant 5 : i64

--- a/cudaq/test/Transforms/dqe.qke
+++ b/cudaq/test/Transforms/dqe.qke
@@ -1,0 +1,119 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --add-dealloc --canonicalize --factor-quantum-alloc --dqe --cominbine-quantum-alloc %s | cudaq-opt | FileCheck %s
+
+func.func @smiling_lettuce() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %c5_i64 = arith.constant 5 : i64
+  %0 = quake.alloca !quake.veq<?>[%c5_i64 : i64]
+  %c0_i64 = arith.constant 0 : i64
+  %1 = quake.veq_size %0 : (!quake.veq<?>) -> i64
+  %c0_i64_0 = arith.constant 0 : i64
+  %2 = arith.cmpi slt, %c0_i64, %c0_i64_0 : i64
+  %3 = arith.addi %c0_i64, %1 : i64
+  %4 = arith.select %2, %3, %c0_i64 : i64
+  %5 = quake.extract_ref %0[%4] : (!quake.veq<?>, i64) -> !quake.ref
+  quake.h %5 : (!quake.ref) -> ()
+  quake.h %5 : (!quake.ref) -> ()
+  quake.dealloc %0 : !quake.veq<?>
+
+  %c5_i64_1 = arith.constant 5 : i64
+  %6 = quake.alloca !quake.veq<?>[%c5_i64_1 : i64]
+  %c0_i64_2 = arith.constant 0 : i64
+  %7 = quake.veq_size %6 : (!quake.veq<?>) -> i64
+  %c0_i64_3 = arith.constant 0 : i64
+  %8 = arith.cmpi slt, %c0_i64_2, %c0_i64_3 : i64
+  %9 = arith.addi %c0_i64_2, %7 : i64
+  %10 = arith.select %8, %9, %c0_i64_2 : i64
+  %11 = quake.extract_ref %6[%10] : (!quake.veq<?>, i64) -> !quake.ref
+  quake.h %11 : (!quake.ref) -> ()
+  quake.h %11 : (!quake.ref) -> ()
+  quake.dealloc %6 : !quake.veq<?>
+
+  %c5_i64_4 = arith.constant 5 : i64
+  %12 = quake.alloca !quake.veq<?>[%c5_i64_4 : i64]
+  %c0_i64_5 = arith.constant 0 : i64
+  %13 = quake.veq_size %12 : (!quake.veq<?>) -> i64
+  %c0_i64_6 = arith.constant 0 : i64
+  %14 = arith.cmpi slt, %c0_i64_5, %c0_i64_6 : i64
+  %15 = arith.addi %c0_i64_5, %13 : i64
+  %16 = arith.select %14, %15, %c0_i64_5 : i64
+  %17 = quake.extract_ref %12[%16] : (!quake.veq<?>, i64) -> !quake.ref
+  quake.h %17 : (!quake.ref) -> ()
+  %measOut = quake.mz %17 : (!quake.ref) -> !quake.measure
+  return
+}
+
+// CHECK-LABEL:   func.func @smiling_lettuce()
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<3>
+// CHECK:           %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_0]][0] : (!quake.veq<3>) -> !quake.ref
+// CHECK:           quake.h %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
+// CHECK:           quake.h %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
+// CHECK:           %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_0]][1] : (!quake.veq<3>) -> !quake.ref
+// CHECK:           quake.h %[[EXTRACT_REF_1]] : (!quake.ref) -> ()
+// CHECK:           quake.h %[[EXTRACT_REF_1]] : (!quake.ref) -> ()
+// CHECK:           %[[EXTRACT_REF_2:.*]] = quake.extract_ref %[[ALLOCA_0]][2] : (!quake.veq<3>) -> !quake.ref
+// CHECK:           quake.h %[[EXTRACT_REF_2]] : (!quake.ref) -> ()
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[EXTRACT_REF_2]] : (!quake.ref) -> !quake.measure
+// CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<3>
+// CHECK:           return
+
+func.func @squirrel_tomahawk() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2 = quake.null_wire
+  %3 = quake.null_wire
+  %4 = quake.null_wire
+  %5 = quake.h %0 : (!quake.wire) -> !quake.wire
+  %6 = quake.h %5 : (!quake.wire) -> !quake.wire
+  quake.sink %6 : !quake.wire
+  quake.sink %1 : !quake.wire
+  quake.sink %2 : !quake.wire
+  quake.sink %3 : !quake.wire
+  quake.sink %4 : !quake.wire
+  %7 = quake.null_wire
+  %8 = quake.null_wire
+  %9 = quake.null_wire
+  %10 = quake.null_wire
+  %11 = quake.null_wire
+  %12 = quake.h %7 : (!quake.wire) -> !quake.wire
+  %13 = quake.h %12 : (!quake.wire) -> !quake.wire
+  quake.sink %13 : !quake.wire
+  quake.sink %8 : !quake.wire
+  quake.sink %9 : !quake.wire
+  quake.sink %10 : !quake.wire
+  quake.sink %11 : !quake.wire
+  %14 = quake.null_wire
+  %15 = quake.null_wire
+  %16 = quake.null_wire
+  %17 = quake.null_wire
+  %18 = quake.null_wire
+  %19 = quake.h %14 : (!quake.wire) -> !quake.wire
+  %measOut, %wires = quake.mz %19 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.sink %wires : !quake.wire
+  quake.sink %15 : !quake.wire
+  quake.sink %16 : !quake.wire
+  quake.sink %17 : !quake.wire
+  quake.sink %18 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @squirrel_tomahawk()
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.sink %[[H_1]] : !quake.wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[H_2:.*]] = quake.h %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[H_3:.*]] = quake.h %[[H_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.sink %[[H_3]] : !quake.wire
+// CHECK:           %[[NULL_WIRE_2:.*]] = quake.null_wire
+// CHECK:           %[[H_4:.*]] = quake.h %[[NULL_WIRE_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[H_4]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           quake.sink %[[MZ_0]] : !quake.wire
+// CHECK:           return

--- a/cudaq/test/Transforms/dqe.qke
+++ b/cudaq/test/Transforms/dqe.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --add-dealloc --canonicalize --factor-quantum-alloc --dqe --cominbine-quantum-alloc %s | cudaq-opt | FileCheck %s
+// RUN: cudaq-opt --add-dealloc --canonicalize --factor-quantum-alloc --dqe --combine-quantum-alloc %s | cudaq-opt | FileCheck %s
 
 func.func @smiling_lettuce() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %c5_i64 = arith.constant 5 : i64

--- a/cudaq/tools/nvqpp/CMakeLists.txt
+++ b/cudaq/tools/nvqpp/CMakeLists.txt
@@ -17,6 +17,7 @@ if (CUDAQ_ENABLE_REALTIME)
 endif()
 
 add_custom_target(nvq++)
+add_dependencies(nvq++ cudaq-builder nvqir-qpp)
 configure_file("nvq++.in"
                "${CUDAQ_BINARY_DIR}/bin/nvq++" 
                FILE_PERMISSIONS


### PR DESCRIPTION
Introduce a dedicated pass to eliminate qubits that are unused from the IR. As unused qubits can increase time and space demands in simulation, we generally want to get rid of them if they aren't used in the kernel.

This pass can be expanded in the future to cover other quake types and cases.