### PR TITLE
Fix no-observable evolve paths for intermediate states and collapse noise

### DIFF
--- a/python/cudaq/dynamics/evolution.py
+++ b/python/cudaq/dynamics/evolution.py
@@ -319,15 +319,30 @@ def evolve_single(
         kernels = [kernel for kernel in evolution]
         save_intermediate_states = store_intermediate_results == IntermediateResultSave.ALL
         if len(observables) == 0:
-            return cudaq_runtime.evolve(initial_state, kernels,
-                                        save_intermediate_states)
+            if len(collapse_operators) > 0:
+                cudaq_runtime.set_noise(noise)
+                try:
+                    return cudaq_runtime.evolve(
+                        initial_state,
+                        kernels,
+                        save_intermediate_states=save_intermediate_states)
+                finally:
+                    cudaq_runtime.unset_noise()
+            return cudaq_runtime.evolve(
+                initial_state,
+                kernels,
+                save_intermediate_states=save_intermediate_states)
         if len(collapse_operators) > 0:
             cudaq_runtime.set_noise(noise)
-        result = cudaq_runtime.evolve(initial_state, kernels, parameters,
-                                      observable_spinops, shots_count,
-                                      save_intermediate_states)
-        cudaq_runtime.unset_noise()
-        return result
+            try:
+                return cudaq_runtime.evolve(initial_state, kernels, parameters,
+                                            observable_spinops, shots_count,
+                                            save_intermediate_states)
+            finally:
+                cudaq_runtime.unset_noise()
+        return cudaq_runtime.evolve(initial_state, kernels, parameters,
+                                    observable_spinops, shots_count,
+                                    save_intermediate_states)
     else:
         kernel = next(
             _evolution_kernel(
@@ -337,14 +352,24 @@ def evolve_single(
                 parameters,
                 register_kraus_channel=add_noise_channel_for_step))
         if len(observables) == 0:
+            if len(collapse_operators) > 0:
+                cudaq_runtime.set_noise(noise)
+                try:
+                    return cudaq_runtime.evolve(initial_state, kernel)
+                finally:
+                    cudaq_runtime.unset_noise()
             return cudaq_runtime.evolve(initial_state, kernel)
         # FIXME: permit to compute expectation values for operators defined as matrix
         if len(collapse_operators) > 0:
             cudaq_runtime.set_noise(noise)
-        result = cudaq_runtime.evolve(initial_state, kernel, parameters[-1],
-                                      observable_spinops, shots_count)
-        cudaq_runtime.unset_noise()
-        return result
+            try:
+                return cudaq_runtime.evolve(initial_state, kernel,
+                                            parameters[-1], observable_spinops,
+                                            shots_count)
+            finally:
+                cudaq_runtime.unset_noise()
+        return cudaq_runtime.evolve(initial_state, kernel, parameters[-1],
+                                    observable_spinops, shots_count)
 
 
 # Top level API for the CUDA-Q master equation solver.
@@ -596,8 +621,20 @@ def evolve_single_async(
             split_into_steps=True,
             register_kraus_channel=add_noise_channel_for_step)
         kernels = [kernel for kernel in evolution]
+        save_intermediate_states = store_intermediate_results == IntermediateResultSave.ALL
         if len(observables) == 0:
-            return cudaq_runtime.evolve_async(initial_state, kernels)
+            if len(collapse_operators) > 0:
+                return cudaq_runtime.evolve_async(
+                    initial_state,
+                    kernels,
+                    noise_model=noise,
+                    shots_count=shots_count,
+                    save_intermediate_states=save_intermediate_states)
+            return cudaq_runtime.evolve_async(
+                initial_state,
+                kernels,
+                shots_count=shots_count,
+                save_intermediate_states=save_intermediate_states)
         if len(collapse_operators) > 0:
             return cudaq_runtime.evolve_async(initial_state,
                                               kernels,
@@ -619,6 +656,11 @@ def evolve_single_async(
                 parameters,
                 register_kraus_channel=add_noise_channel_for_step))
         if len(observables) == 0:
+            if len(collapse_operators) > 0:
+                return cudaq_runtime.evolve_async(initial_state,
+                                                  kernel,
+                                                  noise_model=noise,
+                                                  shots_count=shots_count)
             return cudaq_runtime.evolve_async(initial_state, kernel)
         # FIXME: permit to compute expectation values for operators defined as matrix
         if len(collapse_operators) > 0:

--- a/python/tests/dynamics/test_evolve_simulators.py
+++ b/python/tests/dynamics/test_evolve_simulators.py
@@ -396,6 +396,58 @@ def test_evolve_no_intermediate_results():
     assert final_exp_decay[0][1].expectation() != final_exp[0][1].expectation()
 
 
+def test_evolve_intermediate_results_without_observables():
+    """Saving intermediate states should not require observables."""
+
+    hamiltonian = 2 * np.pi * 0.1 * spin.x(0)
+    dimensions = {0: 2}
+    rho0 = cudaq.State.from_data(
+        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.complex128))
+    steps = np.linspace(0, 0.1, 3)
+
+    evolution_result = cudaq.evolve(
+        hamiltonian,
+        dimensions,
+        Schedule(steps, ["time"]),
+        rho0,
+        store_intermediate_results=cudaq.IntermediateResultSave.ALL)
+
+    assert len(evolution_result.intermediate_states()) == len(steps)
+    assert evolution_result.expectation_values() is None
+    assert evolution_result.final_expectation_values() is None
+
+    evolution_result = cudaq.evolve(hamiltonian,
+                                    dimensions,
+                                    Schedule(steps, ["time"]),
+                                    rho0,
+                                    store_intermediate_results=cudaq.
+                                    IntermediateResultSave.EXPECTATION_VALUE)
+
+    assert len(evolution_result.intermediate_states()) == 1
+    assert evolution_result.expectation_values() is None
+    assert evolution_result.final_expectation_values() is None
+
+    for save_mode in [
+            cudaq.IntermediateResultSave.NONE, cudaq.IntermediateResultSave.ALL
+    ]:
+        ideal_result = cudaq.evolve(hamiltonian,
+                                    dimensions,
+                                    Schedule(steps, ["time"]),
+                                    rho0,
+                                    store_intermediate_results=save_mode)
+        decay_result = cudaq.evolve(
+            hamiltonian,
+            dimensions,
+            Schedule(steps, ["time"]),
+            rho0,
+            collapse_operators=[np.sqrt(0.05) * spin.x(0)],
+            store_intermediate_results=save_mode)
+
+        assert not np.allclose(
+            np.array(ideal_result.final_state()).reshape(-1),
+            np.array(decay_result.final_state()).reshape(-1))
+
+
 def test_evolve_async_no_intermediate_results():
     """Test evolve_async with store_intermediate_results=NONE
     to verify the else branch in evolve_single_async is working."""
@@ -458,6 +510,60 @@ def test_evolve_async_no_intermediate_results():
     # inner list is observables. With NONE mode, there's only one time step (final).
     assert final_exp_decay[0][0].expectation() != final_exp[0][0].expectation()
     assert final_exp_decay[0][1].expectation() != final_exp[0][1].expectation()
+
+
+def test_evolve_async_intermediate_results_without_observables():
+    """Saving intermediate states asynchronously should not require observables."""
+
+    hamiltonian = 2 * np.pi * 0.1 * spin.x(0)
+    dimensions = {0: 2}
+    rho0 = cudaq.State.from_data(
+        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.complex128))
+    steps = np.linspace(0, 0.1, 3)
+
+    evolution_result = cudaq.evolve_async(
+        hamiltonian,
+        dimensions,
+        Schedule(steps, ["time"]),
+        rho0,
+        store_intermediate_results=cudaq.IntermediateResultSave.ALL).get()
+
+    assert len(evolution_result.intermediate_states()) == len(steps)
+    assert evolution_result.expectation_values() is None
+    assert evolution_result.final_expectation_values() is None
+
+    evolution_result = cudaq.evolve_async(
+        hamiltonian,
+        dimensions,
+        Schedule(steps, ["time"]),
+        rho0,
+        store_intermediate_results=cudaq.IntermediateResultSave.
+        EXPECTATION_VALUE).get()
+
+    assert len(evolution_result.intermediate_states()) == 1
+    assert evolution_result.expectation_values() is None
+    assert evolution_result.final_expectation_values() is None
+
+    for save_mode in [
+            cudaq.IntermediateResultSave.NONE, cudaq.IntermediateResultSave.ALL
+    ]:
+        ideal_result = cudaq.evolve_async(
+            hamiltonian,
+            dimensions,
+            Schedule(steps, ["time"]),
+            rho0,
+            store_intermediate_results=save_mode).get()
+        decay_result = cudaq.evolve_async(
+            hamiltonian,
+            dimensions,
+            Schedule(steps, ["time"]),
+            rho0,
+            collapse_operators=[np.sqrt(0.05) * spin.x(0)],
+            store_intermediate_results=save_mode).get()
+
+        assert not np.allclose(
+            np.array(ideal_result.final_state()).reshape(-1),
+            np.array(decay_result.final_state()).reshape(-1))
 
 
 @pytest.mark.parametrize("target", ["qpp-cpu", "density-matrix-cpu"])


### PR DESCRIPTION
## Summary

This fixes several broken no-observable paths in the non-`dynamics` simulator implementation of `cudaq.evolve` and `cudaq.evolve_async`.

The affected paths are triggered when all of the following are true:

- The target uses the non-`dynamics` simulator implementation, for example `qpp-cpu` or `density-matrix-cpu`.
- The caller does not provide `observables`.
- The caller requests intermediate results, provides `collapse_operators`, or uses the async API.

The main user-visible failure was that sync intermediate-state evolution without observables failed before returning states:

```text
TypeError: evolve(): incompatible function arguments
Invoked with types: State, list, bool
```
There were also related no-observable correctness issues: collapse operators could be ignored when no observables were requested, async intermediate-state evolution relied on the binding default for save_intermediate_states, and no-observable result semantics needed to remain None for expectation values.

## Root cause
evolve_single and evolve_single_async have separate early-return branches for the case where observables is empty. Those branches had drifted away from the observable branches.

For sync intermediate-state evolution, the no-observable branch called:
```
cudaq_runtime.evolve(initial_state, kernels, save_intermediate_states)
```
but the vector-kernel runtime binding expects the third positional argument to be params, not save_intermediate_states:
```
evolve(initial_state, kernels, params, observables, shots_count,
       save_intermediate_states)
```
As a result, the boolean was interpreted as schedule parameters and the call failed with:
```
Invoked with types: State, list, bool
```
The same early-return structure also skipped collapse-noise setup. The generated Kraus channels were registered into an internal NoiseModel, but the no-observable branches returned before installing or passing that noise model. This affected both final-state-only evolution and intermediate-state evolution.

The async no-observable intermediate path had another mismatch: it called
```
cudaq_runtime.evolve_async(initial_state, kernels)
```
without passing save_intermediate_states. The Python binding defaults save_intermediate_states to True, so IntermediateResultSave.EXPECTATION_VALUE could incorrectly save all intermediate states unless the flag is passed explicitly.

## How to repro
```
import numpy as np
import cudaq
from cudaq.operators import spin
from cudaq.dynamics import Schedule

cudaq.set_target("density-matrix-cpu")

hamiltonian = 2 * np.pi * 0.1 * spin.x(0)
dimensions = {0: 2}
schedule = Schedule(np.linspace(0, 0.1, 3), ["time"])
rho0 = cudaq.State.from_data(
    np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.complex128))

result = cudaq.evolve(
    hamiltonian,
    dimensions,
    schedule,
    rho0,
    store_intermediate_results=cudaq.IntermediateResultSave.ALL,
)

print(len(result.intermediate_states()))
print(result.expectation_values())
print(result.final_expectation_values())

cudaq.reset_target()
```
Before this fix:
```
TypeError: evolve(): incompatible function arguments
Invoked with types: State, list, bool
```
After this fix:
```
3
None
None
```

## This change
* Passes save_intermediate_states by keyword in sync no-observable intermediate evolution, so it is not interpreted as params.
* Preserves no-observable result semantics: expectation_values() and final_expectation_values() remain None.
* Applies collapse noise even when no observables are requested.
* Uses try/finally around internally installed sync noise models so the internal collapse noise is cleaned up only when this code installed it.
* Passes noise_model, shots_count, and save_intermediate_states explicitly in async no-observable paths.
* Adds sync and async regression coverage for no-observable evolution on density-matrix-cpu.