### PR TITLE
[python] Surface dem_from_kernel errors as RuntimeError

### DIFF
--- a/python/runtime/cudaq/analysis/py_dem.cpp
+++ b/python/runtime/cudaq/analysis/py_dem.cpp
@@ -36,8 +36,10 @@ static std::string dem_from_kernel_impl(const std::string &kernelName,
           [[maybe_unused]] auto result =
               cudaq::marshal_and_launch_module(kernelName, kernelMod, args);
         });
+  } catch (nanobind::python_error &) {
+    throw; // keep real Python exceptions (e.g. from argument marshalling)
   } catch (const std::exception &e) {
-    throw std::runtime_error(e.what());
+    throw std::runtime_error(e.what()); // dem_from_kernel reports via RuntimeError
   } catch (...) {
     throw std::runtime_error(
         "cudaq::dem_from_kernel failed: the kernel uses an operation the Stim "

--- a/python/runtime/cudaq/analysis/py_dem.cpp
+++ b/python/runtime/cudaq/analysis/py_dem.cpp
@@ -15,6 +15,7 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <optional>
+#include <stdexcept>
 #include <string>
 
 using namespace cudaq;
@@ -27,10 +28,21 @@ static std::string dem_from_kernel_impl(const std::string &kernelName,
   args = simplifiedValidateInputArguments(args);
 
   const cudaq::noise_model *noisePtr = noise ? &(*noise) : nullptr;
-  return cudaq::detail::runDemFromKernel(kernelName, platform, noisePtr, [&]() {
-    [[maybe_unused]] auto result =
-        cudaq::marshal_and_launch_module(kernelName, kernelMod, args);
-  });
+  // Re-throw as a module-local RuntimeError; plugin exceptions otherwise
+  // escape uncaught on macOS and abort instead of raising in Python.
+  try {
+    return cudaq::detail::runDemFromKernel(
+        kernelName, platform, noisePtr, [&]() {
+          [[maybe_unused]] auto result =
+              cudaq::marshal_and_launch_module(kernelName, kernelMod, args);
+        });
+  } catch (const std::exception &e) {
+    throw std::runtime_error(e.what());
+  } catch (...) {
+    throw std::runtime_error(
+        "cudaq::dem_from_kernel failed: the kernel uses an operation the Stim "
+        "analysis backend cannot simulate (only Clifford gates are supported).");
+  }
 }
 
 void cudaq::bindDemFromKernel(nanobind::module_ &mod) {


### PR DESCRIPTION
cudaq.dem_from_kernel runs the kernel under a dlopen'd `stim` analysis plugin. A non-Clifford gate makes Stim throw `std::runtime_error` from inside that plugin; on macOS the exception escapes uncaught at the binding boundary and the process aborts (SIGABRT / "Fatal Python error: Aborted"), crashing the test worker instead of raising in Python.

Wrap the call in dem_from_kernel_impl and re-throw a fresh runtime_error owned by this module (with a catch-all fallback) so the error reliably surfaces as a Python RuntimeError on all platforms. Mirrors the catch-and-rethrow guard already used at other binding boundaries (e.g. runtime/cudaq/realtime.cpp).

Fixes the macOS 'Python metapackage validation' failure on test_dem_from_kernel.py::test_non_clifford_raises.

See https://github.com/NVIDIA/cuda-quantum/actions/runs/26986910544/job/79748077581

```
[gw0] node down: Not properly terminated
Thread 0x000000016e587000 (most recent call first):
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 534 in read
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 567 in from_io
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 341 in run
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn

Current thread 0x00000001f300e2c0 (most recent call first):
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/cudaq/runtime/dem.py", line 52 in dem_from_kernel
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/cudaq/util/trace.py", line 64 in wrapper
  File "/Users/runner/work/cuda-quantum/cuda-quantum/build/validation/tests/analysis/test_dem_from_kernel.py", line 165 in test_non_clifford_raises
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/python.py", line 166 in pytest_pyfunc_call
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/python.py", line 1720 in runtest
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/runner.py", line 179 in pytest_runtest_call
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/runner.py", line 245 in <lambda>
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/runner.py", line 353 in from_call
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/runner.py", line 244 in call_and_report
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/runner.py", line 137 in runtestprotocol
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/runner.py", line 118 in pytest_runtest_protocol
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/xdist/remote.py", line 227 in run_one_test
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/xdist/remote.py", line 206 in pytest_runtestloop
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/main.py", line 372 in _main
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/main.py", line 318 in wrap_session
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/_pytest/main.py", line 365 in pytest_cmdline_main
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/xdist/remote.py", line 427 in <module>
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 1291 in executetask
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 341 in run
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 389 in integrate_as_primary_thread
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 1273 in serve
  File "/Users/runner/.venv/cudaq-validation/lib/python3.12/site-packages/execnet/gateway_base.py", line 1806 in serve
  File "<string>", line 8 in <module>
  File "<string>", line 1 in <module>

Extension modules: numpy.core._multiarray_umath, numpy.core._multiarray_tests, numpy.linalg._umath_linalg, numpy.fft._pocketfft_internal, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator, scipy._lib._ccallback_c, scipy.special._ufuncs_cxx, scipy.special._ellip_harm_2, scipy.special._special_ufuncs, scipy.special._gufuncs, scipy.special._ufuncs, scipy.special._specfun, scipy.special._comb, scipy.linalg._fblas, scipy.linalg._flapack, _cyutility, scipy._cyutility, scipy.linalg.cython_lapack, scipy.linalg._cythonized_array_utils, scipy.linalg._solve_toeplitz, scipy.linalg._decomp_lu_cython, scipy.linalg._matfuncs_schur_sqrtm, scipy.linalg._matfuncs_expm, scipy.linalg._linalg_pythran, scipy.linalg.cython_blas, scipy.linalg._decomp_update, scipy.sparse._sparsetools, _csparsetools, scipy.sparse._csparsetools, scipy.integrate._odepack, scipy.integrate._quadpack, scipy.integrate._vode, scipy.integrate._dop, scipy.integrate._lsoda, scipy.sparse.linalg._dsolve._superlu, scipy.sparse.linalg._eigen.arpack._arpack, scipy.sparse.linalg._propack._spropack, scipy.sparse.linalg._propack._dpropack, scipy.sparse.linalg._propack._cpropack, scipy.sparse.linalg._propack._zpropack, scipy.optimize._group_columns, scipy._lib.messagestream, scipy.optimize._trlib._trlib, scipy.optimize._lbfgsb, _moduleTNC, scipy.optimize._moduleTNC, scipy.optimize._slsqplib, scipy.optimize._minpack, scipy.optimize._lsq.givens_elimination, scipy.optimize._zeros, scipy._lib._uarray._uarray, scipy.linalg._decomp_interpolative, scipy.optimize._bglu_dense, scipy.optimize._lsap, scipy.spatial._ckdtree, scipy.spatial._qhull, scipy.spatial._voronoi, scipy.spatial._hausdorff, scipy.spatial._distance_wrap, scipy.spatial.transform._rotation, scipy.spatial.transform._rigid_transform, scipy.optimize._direct (total: 70)
[gw0] [  9%] FAILED ../../../../../../../Users/runner/work/cuda-quantum/cuda-quantum/build/validation/tests/analysis/test_dem_from_kernel.py::test_non_clifford_raises 
```