### PR TITLE
Move warnNamedMeasurement out of ExecutionContext

### DIFF
--- a/python/tests/backends/test_Quantinuum_LocalEmulation_kernel.py
+++ b/python/tests/backends/test_Quantinuum_LocalEmulation_kernel.py
@@ -438,7 +438,7 @@ def test_named_reg_in_sample(capfd):
 
     cudaq.sample(foo).dump()
     captured = capfd.readouterr()
-    assert "WARNING" in captured.err
+    assert "[warning]" in captured.err
 
 
 def test_sample_with_conditional():

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -2919,7 +2919,7 @@ def test_named_reg_in_sample(capfd):
 
     cudaq.sample(baz)
     captured = capfd.readouterr()
-    assert "WARNING" in captured.err
+    assert "[warning]" in captured.err
 
 
 # TODO: Update when `ApplyOpSpecialization` can handle multi-argument loops

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -82,10 +82,6 @@ protected:
     Compiler compiler(getCompileTarget(policy));
     auto compiled =
         compiler.runPassPipeline(kernelName, modulePtr, args, isEntryPoint);
-    if constexpr (std::is_same_v<Policy, sample_policy>) {
-      if (compiler.hasWarnedNamedMeasurements())
-        policy.warnedNamedMeasurements = true;
-    }
     return compiled;
   }
 
@@ -276,7 +272,7 @@ public:
 
     auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
         serverHelper.get(), platformPath, targetConfig, backendConfig, emulate);
-    target->warnNamedMeasurements = !policy.warnedNamedMeasurements;
+    target->warnNamedMeasurements = true;
     target->supportConditionalsOnMeasureResults = !emulate;
     target->pipelineConfig.addMeasurements = true;
     target->storeReorderIdx = true;
@@ -319,10 +315,6 @@ public:
 
       compiled = compiler.runPassPipeline(kernelName, moduleOp, args, true,
                                           std::move(context));
-      if constexpr (std::is_same_v<Policy, sample_policy>) {
-        if (compiler.hasWarnedNamedMeasurements())
-          policy.warnedNamedMeasurements = true;
-      }
     } else {
       compiled = std::get<CompiledModule>(module);
       kernelName = compiled->getName();
@@ -556,8 +548,6 @@ public:
     // observe) one time each.
     for (std::size_t i = 0; i < codes.size(); i++) {
       cudaq::ExecutionContext context("sample", localShots);
-      // Avoid emitting the warning again during execution
-      context.warnedNamedMeasurements = policy.warnedNamedMeasurements;
       sample_policy localPolicy;
       localPolicy.options.shots = localShots;
       localPolicy.reorderIdx = std::move(codes[i].mapping_reorder_idx);

--- a/runtime/common/CMakeLists.txt
+++ b/runtime/common/CMakeLists.txt
@@ -21,6 +21,7 @@ set(COMMON_RUNTIME_SRC
   ExtraPayloadProvider.cpp
   Future.cpp
   KernelExecution.cpp
+  NamedMeasurementWarning.cpp
   NoiseModel.cpp
   RecordLogParser.cpp
   Resources.cpp

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -124,10 +124,6 @@ public:
   /// order.
   bool explicitMeasurements = false;
 
-  /// @brief Flag to indicate that a warning about named measurement registers
-  /// in sampling context has already been emitted.
-  bool warnedNamedMeasurements = false;
-
   /// @brief Probability of occurrence of each error mechanism (column) in
   /// Measurement Syndrome Matrix (0-1 range).
   std::optional<std::vector<double>> msm_probabilities;

--- a/runtime/common/NamedMeasurementWarning.cpp
+++ b/runtime/common/NamedMeasurementWarning.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ *reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "common/SampleResult.h"
+#include "cudaq/runtime/logger/logger.h"
+
+#include <mutex>
+
+/// @brief The default explanatory detail appended to the named-measurement
+/// deprecation warning. Describes the standard sampling-mode behavior.
+static constexpr std::string_view defaultNamedMeasurementsWarningDetail =
+    "invoked in sampling mode. Support for sub-registers in `sample_result` is "
+    "deprecated and will be removed in a future release. Use `run` to retrieve "
+    "individual measurement results.";
+
+void cudaq::emitNamedMeasurementsWarning(const std::string &kernelName,
+                                         std::string_view detail) {
+  if (detail.empty())
+    detail = defaultNamedMeasurementsWarningDetail;
+
+  static std::once_flag warned;
+  std::call_once(warned, [&] {
+    CUDAQ_WARN("Kernel \"{}\" uses named measurement results but is {}",
+               kernelName, detail);
+  });
+}

--- a/runtime/common/SampleResult.h
+++ b/runtime/common/SampleResult.h
@@ -10,6 +10,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -293,5 +294,17 @@ public:
   /// @return
   static bool has_even_parity(std::string_view bitString);
 };
+
+/// @brief Emit a one-time deprecation warning that @p kernelName uses named
+/// measurement results in a context where named sub-registers are not
+/// preserved.
+///
+/// The warning is emitted once per process; every subsequent call is a no-op,
+/// regardless of the kernel name.
+///
+/// @param kernelName The name of the kernel that uses named measurements.
+/// @param detail Optional explanatory text for warning message.
+void emitNamedMeasurementsWarning(const std::string &kernelName,
+                                  std::string_view detail = "");
 
 } // namespace cudaq

--- a/runtime/cudaq/algorithms/sample/policy.h
+++ b/runtime/cudaq/algorithms/sample/policy.h
@@ -35,10 +35,6 @@ struct sample_policy {
   /// @brief The name of the kernel being executed.
   std::string kernelName;
 
-  /// @brief Flag to indicate that a warning about named measurement registers
-  /// in sampling context has already been emitted.
-  bool warnedNamedMeasurements = false;
-
   /// @brief A vector containing information about how to reorder the global
   /// register after execution. Empty means no reordering.
   mutable std::vector<std::size_t> reorderIdx;

--- a/runtime/cudaq/ptsbe/PTSBESample.cpp
+++ b/runtime/cudaq/ptsbe/PTSBESample.cpp
@@ -14,10 +14,8 @@
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/simulators.h"
 #include <algorithm>
-#include <iostream>
 #include <numeric>
 #include <span>
-#include <unordered_map>
 
 namespace cudaq::ptsbe::detail {
 
@@ -33,23 +31,20 @@ void validatePTSBEKernel(const std::string &kernelName,
   }
 }
 
-void warnNamedRegisters(const std::string &kernelName, ExecutionContext &ctx) {
-  if (ctx.warnedNamedMeasurements)
-    return;
+bool warnNamedRegisters(const std::string &kernelName,
+                        const ExecutionContext &ctx) {
   for (const auto &inst : ctx.kernelTrace) {
     if (inst.type == cudaq::TraceInstructionType::Measurement &&
         inst.register_name && *inst.register_name != "__global__") {
-      ctx.warnedNamedMeasurements = true;
-      std::cerr << "WARNING: Kernel \"" << kernelName
-                << "\" uses named measurement results but is invoked via "
-                   "ptsbe::sample (or ptsbe.sample). PTSBE outputs a single "
-                   "global register; "
-                   "named sub-registers are not preserved. Use `cudaq::run` "
-                   "to retrieve individual measurement results."
-                << std::endl;
-      return;
+      cudaq::emitNamedMeasurementsWarning(
+          kernelName,
+          "invoked via ptsbe::sample (or ptsbe.sample). PTSBE outputs a single "
+          "global register; named sub-registers are not preserved. Use "
+          "`cudaq::run` to retrieve individual measurement results.");
+      return true;
     }
   }
+  return false;
 }
 
 void validatePTSBEPreconditions(quantum_platform &platform,

--- a/runtime/cudaq/ptsbe/PTSBESample.h
+++ b/runtime/cudaq/ptsbe/PTSBESample.h
@@ -57,8 +57,10 @@ namespace cudaq::ptsbe::detail {
 void validatePTSBEKernel(const std::string &kernelName,
                          const ExecutionContext &ctx);
 
-/// @brief Warn if kernel uses named measurement registers. PTSBE outputs a
-void warnNamedRegisters(const std::string &kernelName, ExecutionContext &ctx);
+/// @brief Warn if the kernel uses named measurement registers. PTSBE outputs a
+/// single global register, so named sub-registers are not preserved.
+bool warnNamedRegisters(const std::string &kernelName,
+                        const ExecutionContext &ctx);
 
 /// @brief Validate platform preconditions for PTSBE execution
 void validatePTSBEPreconditions(

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -449,15 +449,8 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
         }
         return mlir::WalkResult::advance();
       });
-      if (hasNamedMeasurements) {
-        warnedNamedMeasurements = true;
-        std::cerr << "WARNING: Kernel \"" << kernelName
-                  << "\" uses named measurement results "
-                  << "but is invoked in sampling mode. Support for "
-                  << "sub-registers in `sample_result` is deprecated and will "
-                  << "be removed in a future release. Use `run` to retrieve "
-                  << "individual measurement results." << std::endl;
-      }
+      if (hasNamedMeasurements)
+        cudaq::emitNamedMeasurementsWarning(kernelName);
     }
   }
 

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -56,9 +56,6 @@ class Compiler {
   /// @brief Flag indicating whether we should print the IR.
   bool printIR = false;
 
-  /// Whether compilation emitted a named measurement warning.
-  bool warnedNamedMeasurements = false;
-
   mlir::ModuleOp lowerQuakeCodeBuildModule(const std::string &,
                                            mlir::ModuleOp module,
                                            mlir::MLIRContext *,
@@ -93,10 +90,6 @@ class Compiler {
       std::shared_ptr<mlir::MLIRContext> context);
 
 public:
-  /// Whether compilation emitted a warning about the presence of named
-  /// measurements.
-  bool hasWarnedNamedMeasurements() const { return warnedNamedMeasurements; }
-
   const cudaq::CompileTarget &getTarget() const { return *target; }
 
   static std::pair<const void *, std::shared_ptr<mlir::MLIRContext>>

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -772,17 +772,8 @@ protected:
     auto execResult = sample(sampleQubits, getNumShotsToExec());
 
     // Warn if there are named measurement registers beyond `__global__`
-    if (!executionContext->warnedNamedMeasurements &&
-        registerNameToMeasuredQubit.size() > 1) {
-      executionContext->warnedNamedMeasurements = true;
-      std::cerr
-          << "WARNING: Kernel \"" << executionContext->kernelName
-          << "\" uses named measurement results but is "
-             "invoked in sampling mode. Support for sub-registers in "
-             "`sample_result` is deprecated and will be removed in a future "
-             "release. Use `run` to retrieve individual measurement results."
-          << std::endl;
-    }
+    if (registerNameToMeasuredQubit.size() > 1)
+      cudaq::emitNamedMeasurementsWarning(executionContext->kernelName);
 
     if (registerNameToMeasuredQubit.empty()) {
       internalResult.append(execResult, executionContext->explicitMeasurements);

--- a/targettests/execution/sample_named_reg.cpp
+++ b/targettests/execution/sample_named_reg.cpp
@@ -25,4 +25,5 @@ int main() {
   return 0;
 }
 
-// CHECK: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK: [warning]
+// CHECK: Kernel "test_kernel" uses named measurement results

--- a/unittests/ptsbe/PTSBESampleTester.cpp
+++ b/unittests/ptsbe/PTSBESampleTester.cpp
@@ -143,21 +143,15 @@ CUDAQ_TEST(PTSBESampleTest, ValidateKernelNoThrowForValidContext) {
 }
 
 CUDAQ_TEST(PTSBESampleTest, WarnNamedRegisters) {
-  // __global__ only: no warning
+  // __global__ only: no named registers detected.
   cudaq::ExecutionContext globalCtx("tracer");
   globalCtx.kernelTrace.appendMeasurement("mz", {{2, 0}}, "__global__");
-  detail::warnNamedRegisters("testKernel", globalCtx);
-  EXPECT_FALSE(globalCtx.warnedNamedMeasurements);
+  EXPECT_FALSE(detail::warnNamedRegisters("testKernel", globalCtx));
 
-  // Named register: sets flag
+  // Named register: detected.
   cudaq::ExecutionContext namedCtx("tracer");
   namedCtx.kernelTrace.appendMeasurement("mz", {{2, 0}}, "my_register");
-  detail::warnNamedRegisters("testKernel", namedCtx);
-  EXPECT_TRUE(namedCtx.warnedNamedMeasurements);
-
-  // Second call is a no-op (flag already set)
-  detail::warnNamedRegisters("testKernel", namedCtx);
-  EXPECT_TRUE(namedCtx.warnedNamedMeasurements);
+  EXPECT_TRUE(detail::warnNamedRegisters("testKernel", namedCtx));
 }
 
 // ============================================================================


### PR DESCRIPTION
Currently, a warning gets emitted when using named measurements in a context that does not support it. This behaviour seems to be temporary in "sample" (as a deprecation measure), but permanent for PTSBE. It comes with a QOL feature in the runtime that ensures this warning is only emitted once per kernel launch.

As @Renaud-K and I were moving things out of the global execution context into policy objects, compiler flags etc, we've had to add a lot of logic just to track the status of whether this warning has been emitted yet. This seems overkill.

I suggest a simplification that tracks the `warnedNamedMeasurements` flag outside of the execution context, within a utiliy function called `emitNamedMeasurementsWarning`. This function keeps a static boolean flag to only emit the warning on its first call.

This changes the behaviour a bit: whereas before, the warning would get emitted _once per kernel launch_, it now gets emitted only once in the lifetime of the process. This change seems harmless to me but if anyone feels strongly about this change, please speak up!