### PR TITLE
fix(nvqpp): insert quake.discriminate for `for (bool b : mz(reg))`

### DIFF
--- a/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -226,9 +226,27 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
             }
             auto iterVar = popValue();
             Value atOffset = cc::LoadOp::create(builder, loc, addr);
-            if (isBool)
+            if (isBool) {
               atOffset = cc::CastOp::create(builder, loc, builder.getI1Type(),
                                             atOffset);
+            } else if (isa<cc::MeasureHandleType>(atOffset.getType())) {
+              // `for (bool b : mz(reg))` binds an `i1` loop variable to a
+              // container of `!cc.measure_handle`. Mirror
+              // `measure_handle::operator bool()` and lower the handle through
+              // `quake.discriminate` before storing into the `i1` slot.
+              // Without it the `cc.store` value type (`!cc.measure_handle`) and
+              // pointer element type (`i1`) disagree and the verifier rejects
+              // the module. A `measure_handle` loop variable
+              // (`for (auto b : mz(reg))`) keeps the handle and is unaffected.
+              //
+              // TODO(NVIDIA/cuda-quantum#4479): this does not diagnose
+              // discriminating an unbound handle. Definite-assignment analysis
+              // for `measure_handle` is tracked there.
+              if (auto iterPtrTy = dyn_cast<cc::PointerType>(iterVar.getType()))
+                if (iterPtrTy.getElementType() == builder.getI1Type())
+                  atOffset = cudaq::quake::DiscriminateOp::create(
+                      builder, loc, builder.getI1Type(), atOffset);
+            }
             cc::StoreOp::create(builder, loc, atOffset, iterVar);
           }
         }

--- a/cudaq/test/AST-Quake/range_for_measure.cpp
+++ b/cudaq/test/AST-Quake/range_for_measure.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | FileCheck %s
+
+#include <cudaq.h>
+
+// A range-based for loop with a `bool` loop variable over the result of a
+// multi-qubit `mz` iterates a container of `!cc.measure_handle`. The bridge
+// must lower each per-iteration handle through `quake.discriminate` before
+// storing it into the `i1` slot of the loop variable. Without it the bridge
+// emitted `cc.store %handle, %i1ptr`, whose value/pointer types disagree, and
+// the verifier crashed `cudaq-quake`.
+
+struct range_for_measure_bool {
+  bool operator()() __qpu__ {
+    cudaq::qarray<2> reg;
+    bool any = false;
+    for (bool b : mz(reg)) {
+      any = any || b;
+    }
+    return any;
+  }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_bool()
+// CHECK:           quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[HANDLE:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[BIT:.*]] = quake.discriminate %[[HANDLE]] : (!cc.measure_handle) -> i1
+// CHECK:           cc.store %[[BIT]], %{{.*}} : !cc.ptr<i1>
+// clang-format on
+
+// A `measure_handle` loop variable (`auto`) keeps the handle and must NOT have
+// a discriminate inserted at bind time; the discriminate happens at the
+// `operator bool()` use site instead.
+
+struct range_for_measure_auto {
+  bool operator()() __qpu__ {
+    cudaq::qarray<2> reg;
+    bool any = false;
+    for (auto b : mz(reg)) {
+      any = any || b;
+    }
+    return any;
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_auto()
+// CHECK:           quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %{{.*}}, %{{.*}} : !cc.ptr<!cc.measure_handle>


### PR DESCRIPTION
### Summary

Fixes #4562.

A range-based `for` loop with a `bool` loop variable over a multi-qubit `mz` result crashes `cudaq-quake` in the verifier:

```
'cc.store' op failed to verify that type of value matches element type of pointer
```

### Root cause

In `QuakeBridgeVisitor::TraverseCXXForRangeStmt` (`lib/Frontend/nvqpp/ConvertStmt.cpp`), `mz(reg)` lowers to `!cc.stdvec<!cc.measure_handle>`, so the container element type is `!cc.measure_handle`, not `i1`. The non-reference / non-const "create a local copy" path loads the element and stores it into the loop variable's slot:

```cpp
Value atOffset = cc::LoadOp::create(builder, loc, addr);   // !cc.measure_handle
if (isBool)                                                // false: eleTy is measure_handle, not i1
  atOffset = cc::CastOp::create(..., builder.getI1Type(), atOffset);
cc::StoreOp::create(builder, loc, atOffset, iterVar);      // store measure_handle into !cc.ptr<i1>
```

For `for (bool b : mz(reg))` the loop variable slot is `!cc.ptr<i1>`, so the store has mismatched value/pointer types and the verifier rejects the module. `for (auto b : mz(reg))` works because the slot is `!cc.ptr<!cc.measure_handle>` and the discriminate is inserted later at the `operator bool()` use site.

### Fix

When the loaded value is a `!cc.measure_handle` and the loop variable slot is `i1`, lower the handle through `quake.discriminate` before the store, mirroring the single sanctioned coercion in `measure_handle::operator bool()` (`ConvertExpr.cpp`). The `auto` (handle-typed) binding is unchanged.

### Test

Adds `test/AST-Quake/range_for_measure.cpp` covering both the `bool` binding (discriminate inserted, stores `i1`) and the `auto` binding (handle retained). Pre-fix, `cudaq-quake` crashes on the `bool` case, so the `CHECK-LABEL` alone fails without the fix.

