### PR TITLE
[python] Fix dynamics target evolve_async regression

### DIFF
--- a/python/runtime/cudaq/algorithms/py_evolve.cpp
+++ b/python/runtime/cudaq/algorithms/py_evolve.cpp
@@ -281,6 +281,15 @@ pyEvolveAsync(state initial_state, std::vector<nanobind::object> kernels,
       nanobind::arg("noise_model") = std::nullopt,                             \
       nanobind::arg("shots_count") = -1);
 
+#define DEFINE_ASYNC_CALLABLE_OVERLOAD(pyMod)                                  \
+  pyMod.def(                                                                   \
+      "evolve_async",                                                          \
+      [](std::function<evolve_result()> evolveFunctor, std::size_t qpu_id) {   \
+        return detail::evolve_async(std::move(evolveFunctor), qpu_id);         \
+      },                                                                       \
+      "Asynchronously execute a callable that returns an evolution result.",   \
+      nanobind::arg("evolve_function"), nanobind::arg("qpu_id") = 0);
+
 /// @brief Bind the evolve cudaq function for circuit simulator
 void bindPyEvolve(nanobind::module_ &mod) {
   // Sync evolve overloads
@@ -298,6 +307,7 @@ void bindPyEvolve(nanobind::module_ &mod) {
   DEFINE_ASYNC_PARAM_TYPE_OVERLOAD(long, mod);
   DEFINE_ASYNC_PARAM_TYPE_OVERLOAD(double, mod);
   DEFINE_ASYNC_PARAM_TYPE_OVERLOAD(std::complex<double>, mod);
+  DEFINE_ASYNC_CALLABLE_OVERLOAD(mod);
 }
 
 } // namespace cudaq

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -84,6 +84,84 @@ def test_euler_integrator():
     np.testing.assert_allclose(expected_answer, expt, 1e-3)
 
 
+def test_evolve_async_dynamics_target():
+    """Test async evolution on the dynamics target."""
+    steps = np.linspace(0, 0.1, 3)
+    hamiltonian = operators.number(0)
+    dimensions = {0: 2}
+    save_all = cudaq.IntermediateResultSave.ALL
+    save_expectations = cudaq.IntermediateResultSave.EXPECTATION_VALUE
+    psi0_ = cp.zeros(2, dtype=cp.complex128)
+    psi0_[1] = 1.0
+    psi0 = cudaq.State.from_data(psi0_)
+
+    expected = cudaq.evolve(hamiltonian, dimensions, Schedule(steps, ["t"]),
+                            psi0)
+    evolution_result = cudaq.evolve_async(hamiltonian, dimensions,
+                                          Schedule(steps, ["t"]), psi0).get()
+
+    assert len(evolution_result.intermediate_states()) == 1
+    np.testing.assert_allclose(np.array(evolution_result.final_state()),
+                               np.array(expected.final_state()),
+                               atol=1e-12)
+
+    expected = cudaq.evolve(hamiltonian,
+                            dimensions,
+                            Schedule(steps, ["t"]),
+                            psi0,
+                            store_intermediate_results=save_all)
+    evolution_result = cudaq.evolve_async(
+        hamiltonian,
+        dimensions,
+        Schedule(steps, ["t"]),
+        psi0,
+        store_intermediate_results=save_all).get()
+
+    assert len(evolution_result.intermediate_states()) == len(steps)
+    np.testing.assert_allclose(np.array(evolution_result.final_state()),
+                               np.array(expected.final_state()),
+                               atol=1e-12)
+
+    expected = cudaq.evolve(hamiltonian,
+                            dimensions,
+                            Schedule(steps, ["t"]),
+                            psi0,
+                            observables=[hamiltonian],
+                            store_intermediate_results=save_expectations)
+    evolution_result = cudaq.evolve_async(
+        hamiltonian,
+        dimensions,
+        Schedule(steps, ["t"]),
+        psi0,
+        observables=[hamiltonian],
+        store_intermediate_results=save_expectations).get()
+
+    assert len(evolution_result.intermediate_states()) == 1
+    assert len(evolution_result.expectation_values()) == len(steps)
+    expected_values = [[obs.expectation()
+                        for obs in step]
+                       for step in expected.expectation_values()]
+    actual_values = [[obs.expectation()
+                      for obs in step]
+                     for step in evolution_result.expectation_values()]
+    np.testing.assert_allclose(actual_values, expected_values, atol=1e-12)
+
+
+def test_evolve_async_dynamics_target_propagates_errors():
+    """Test async dynamics errors are reported through get()."""
+    steps = np.linspace(0, 0.1, 3)
+    schedule = Schedule(steps, ["t"])
+    hamiltonian = operators.number(0)
+    psi0_ = cp.zeros(2, dtype=cp.complex128)
+    psi0_[1] = 1.0
+    psi0 = cudaq.State.from_data(psi0_)
+
+    result = cudaq.evolve_async(hamiltonian, {1: 2}, schedule, psi0)
+
+    with pytest.raises(Exception):
+        result.get()
+
+
 def test_save_all_intermediate_states():
     """
     Test save all option for intermediate states

--- a/runtime/cudaq/algorithms/evolve_internal.h
+++ b/runtime/cudaq/algorithms/evolve_internal.h
@@ -109,13 +109,19 @@ evolve_async(state initial_state, QuantumKernel &&kernel,
       [p = std::move(promise), func = std::forward<QuantumKernel>(kernel),
        initial_state, observables, noise_model, shots_count,
        &platform]() mutable {
-        if (noise_model.has_value())
-          platform.set_noise(&noise_model.value());
-        with_platform_in_library_mode libraryMode(platform);
-        auto result = evolve(initial_state, func, observables, shots_count);
-        if (noise_model.has_value())
-          platform.set_noise(nullptr);
-        p.set_value(std::move(result));
+        try {
+          if (noise_model.has_value())
+            platform.set_noise(&noise_model.value());
+          with_platform_in_library_mode libraryMode(platform);
+          auto result = evolve(initial_state, func, observables, shots_count);
+          if (noise_model.has_value())
+            platform.set_noise(nullptr);
+          p.set_value(std::move(result));
+        } catch (...) {
+          if (noise_model.has_value())
+            platform.set_noise(nullptr);
+          p.set_exception(std::current_exception());
+        }
       });
 
   platform.enqueueAsyncTask(qpu_id, wrapped);
@@ -136,14 +142,20 @@ evolve_async(state initial_state, std::vector<QuantumKernel> kernels,
   QuantumTask wrapped = detail::make_copyable_function(
       [p = std::move(promise), kernels, initial_state, observables, noise_model,
        shots_count, &platform, save_intermediate_states]() mutable {
-        if (noise_model.has_value())
-          platform.set_noise(&noise_model.value());
-        with_platform_in_library_mode libraryMode(platform);
-        auto result = evolve(initial_state, kernels, observables, shots_count,
-                             save_intermediate_states);
-        if (noise_model.has_value())
-          platform.set_noise(nullptr);
-        p.set_value(std::move(result));
+        try {
+          if (noise_model.has_value())
+            platform.set_noise(&noise_model.value());
+          with_platform_in_library_mode libraryMode(platform);
+          auto result = evolve(initial_state, kernels, observables, shots_count,
+                               save_intermediate_states);
+          if (noise_model.has_value())
+            platform.set_noise(nullptr);
+          p.set_value(std::move(result));
+        } catch (...) {
+          if (noise_model.has_value())
+            platform.set_noise(nullptr);
+          p.set_exception(std::current_exception());
+        }
       });
 
   platform.enqueueAsyncTask(qpu_id, wrapped);

--- a/runtime/cudaq/algorithms/evolve_internal.h
+++ b/runtime/cudaq/algorithms/evolve_internal.h
@@ -16,6 +16,7 @@
 #include "cudaq/platform.h"
 #include "cudaq/platform/QuantumExecutionQueue.h"
 #include "cudaq/schedule.h"
+#include <exception>
 
 namespace cudaq {
 class base_integrator;
@@ -164,7 +165,11 @@ evolve_async(std::function<evolve_result()> evolveFunctor,
 
   QuantumTask wrapped = detail::make_copyable_function(
       [p = std::move(promise), evolveFunctor]() mutable {
-        p.set_value(evolveFunctor());
+        try {
+          p.set_value(evolveFunctor());
+        } catch (...) {
+          p.set_exception(std::current_exception());
+        }
       });
 
   platform.enqueueAsyncTask(qpu_id, wrapped);


### PR DESCRIPTION
## Summary

- Add the missing Python binding for the callable `evolve_async` overload used by the `dynamics` target.
- Propagate callable failures through the async evolution future so `AsyncEvolveResult.get()` raises instead of terminating the worker.
- Add regression coverage for successful dynamics async evolution, intermediate result modes, observable expectation values, and async error propagation.

## How To Reproduce

This is a regression. The sample below works with CUDA-Q `0.13.0`, but fails with CUDA-Q `0.14.0`.

```python
import cupy as cp
import cudaq
from cudaq import operators, Schedule

cudaq.set_target("dynamics")

steps = [0.0, 0.1]
schedule = Schedule(steps, ["t"])
hamiltonian = operators.number(0)
dimensions = {0: 2}

state = cp.zeros(2, dtype=cp.complex128)
state[1] = 1.0
initial_state = cudaq.State.from_data(state)

result = cudaq.evolve_async(
    hamiltonian,
    dimensions,
    schedule,
    initial_state,
).get()

print(result.final_state())
```

The dynamics target dispatches cudaq.evolve_async() by passing a Python callable to cudaq_runtime.evolve_async():
```
cudaq_runtime.evolve_async(lambda: evolve_dynamics(...))
```
The runtime bindings already covered the kernel-based async overloads, but did not expose the callable overload to Python. This caused dynamics target async evolution to fail with an incompatible function arguments error.

This PR adds a callable overload binding and updates the callable async implementation to catch exceptions from the queued callable and store them on the promise. With this behavior, failures in evolve_dynamics() are reported when users call .get(), matching normal future semantics.