### PR TITLE
disable MPI tests with TODO to enable again later.

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -316,7 +316,10 @@ jobs:
             fi
 
       - name: Run Python MPI tests
-        if: matrix.os_image == 'redhat/ubi9:9.6'
+        # TODO: temporarily disabled due to flaky conda CUDA downloads
+        # (ConnectionResetError / ChecksumMismatchError). Re-enable once the
+        # conda install is hardened against transient network failures.
+        if: false && matrix.os_image == 'redhat/ubi9:9.6'
         uses: ./.github/actions/run-in-docker
         with:
           image: wheel_validation:local


### PR DESCRIPTION
I am attempting to fix transient network failures in https://github.com/NVIDIA/cuda-quantum/pull/4704, but the workflow is currently blocking CI. Disable for now so CI can go through, with a TODO to enable again later.