### PR TITLE
[python] Canonicalize InitialState in simulator evolve_async

### DIFF
--- a/python/cudaq/dynamics/evolution.py
+++ b/python/cudaq/dynamics/evolution.py
@@ -71,6 +71,28 @@ def _canonicalize_operator_to_dimensions(
     return system_operator
 
 
+def _canonicalize_initial_state(initial_state: InitialStateArgT,
+                                num_qubits: int) -> InitialStateArgT:
+    if not isinstance(initial_state, InitialState):
+        return initial_state
+
+    state_size = 2**num_qubits
+    if initial_state == InitialState.ZERO:
+        state_data = numpy.zeros(state_size, dtype=numpy.complex128)
+        state_data[0] = 1.0
+    elif initial_state == InitialState.UNIFORM:
+        state_data = (1. / numpy.sqrt(state_size)) * numpy.ones(
+            state_size, dtype=numpy.complex128)
+    else:
+        raise ValueError("Unsupported initial state type")
+
+    sim_name = cudaq_runtime.get_target().simulator.strip()
+    if sim_name == "dm":
+        return cudaq_runtime.State.from_data(
+            numpy.outer(state_data, numpy.conj(state_data)))
+    return cudaq_runtime.State.from_data(state_data)
+
+
 def _compute_step_matrix(hamiltonian: Operator,
                          dimensions: Mapping[int, int],
                          parameters: Mapping[str, NumericType],
@@ -289,24 +311,7 @@ def evolve_single(
         step_parameters, dt)
     if shots_count is None:
         shots_count = -1
-    if isinstance(initial_state, InitialState):
-        # This is an initial state enum, create concrete state.
-        state_size = 2**num_qubits
-        if initial_state == InitialState.ZERO:
-            state_data = numpy.zeros(state_size, dtype=numpy.complex128)
-            state_data[0] = 1.0
-        elif initial_state == InitialState.UNIFORM:
-            state_data = (1. / numpy.sqrt(state_size)) * numpy.ones(
-                state_size, dtype=numpy.complex128)
-        else:
-            raise ValueError("Unsupported initial state type")
-
-        sim_name = cudaq_runtime.get_target().simulator.strip()
-        if sim_name == "dm":
-            initial_state = cudaq_runtime.State.from_data(
-                numpy.outer(state_data, numpy.conj(state_data)))
-        else:
-            initial_state = cudaq_runtime.State.from_data(state_data)
+    initial_state = _canonicalize_initial_state(initial_state, num_qubits)
 
     if store_intermediate_results != IntermediateResultSave.NONE:
         evolution = _evolution_kernel(
@@ -612,6 +617,7 @@ def evolve_single_async(
         step_parameters, dt)
     if shots_count is None:
         shots_count = -1
+    initial_state = _canonicalize_initial_state(initial_state, num_qubits)
     if store_intermediate_results != IntermediateResultSave.NONE:
         evolution = _evolution_kernel(
             num_qubits,

--- a/python/tests/dynamics/test_evolve_simulators.py
+++ b/python/tests/dynamics/test_evolve_simulators.py
@@ -332,6 +332,27 @@ def test_evolve_async():
                                atol=0.15)
 
 
+@pytest.mark.parametrize("target", ["density-matrix-cpu", "qpp-cpu"])
+@pytest.mark.parametrize("initial_state",
+                         [InitialState.ZERO, InitialState.UNIFORM])
+def test_evolve_async_initial_state_enum(target, initial_state):
+    cudaq.set_target(target)
+
+    hamiltonian = 2 * np.pi * 0.1 * spin.x(0)
+    dimensions = {0: 2}
+    steps = np.linspace(0, 0.1, 3)
+
+    expected = cudaq.evolve(hamiltonian, dimensions, Schedule(steps, ["time"]),
+                            initial_state)
+    evolution_result = cudaq.evolve_async(hamiltonian, dimensions,
+                                          Schedule(steps, ["time"]),
+                                          initial_state).get()
+
+    np.testing.assert_allclose(np.array(evolution_result.final_state()),
+                               np.array(expected.final_state()),
+                               atol=1e-12)
+
+
 def test_evolve_no_intermediate_results():
     """Test evolve with store_intermediate_results=NONE 
     to verify the else branch in evolve_single is working."""


### PR DESCRIPTION
## Summary

- Reuse the simulator initial-state canonicalization logic for `evolve_async`.
- Fix `evolve_async` on simulator targets when `initial_state` is an `InitialState` enum.
- Add regression coverage for `InitialState.ZERO` and `InitialState.UNIFORM` on `density-matrix-cpu` and `qpp-cpu`.

## How To Reproduce

`evolve_async` advertises `InitialStateArgT` for `initial_state`, but the simulator async path did not canonicalize `InitialState` enum values before calling the runtime binding.

```python
import cudaq
from cudaq import operators, Schedule
from cudaq.dynamics import InitialState

cudaq.set_target("qpp-cpu")

hamiltonian = operators.number(0)
dimensions = {0: 2}
schedule = Schedule([0.0, 0.1], ["t"])

result = cudaq.evolve_async(
    hamiltonian,
    dimensions,
    schedule,
    InitialState.ZERO,
).get()

print(result.final_state())
```
Before this fix, the call fails with:
```
TypeError: evolve_async(): incompatible function arguments
Invoked with types: InitialStateType, PyKernel
```
The synchronous cudaq.evolve path already converted InitialState.ZERO / InitialState.UNIFORM into a concrete State, so this was a simulator async API consistency bug.