### PR TITLE
Cursor's fix for Python JIT compile pipeline regressions after runtime refactor (#4636)

### DIFF
--- a/cudaq/lib/Target/CompileTarget.cpp
+++ b/cudaq/lib/Target/CompileTarget.cpp
@@ -52,10 +52,6 @@ cudaq::CompileTarget::CompileTarget(
     return;
 
   const auto &backendConfig = *targetConfig.BackendConfig;
-  if (!backendConfig.hasPassPipeline()) {
-    pipelineConfig.skipTargetLoweringPipeline = true;
-  }
-
   auto prepPipeline = [&](const std::string &stage,
                           const std::string &stageName) {
     std::string pipeline = stage;

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -112,6 +112,8 @@ getDefaultPythonCompileTargetImpl() {
   }
 
   bool isLocalSimulator = !(platform->is_remote() || platform->is_emulated());
+  if (isLocalSimulator && ct->pipelineConfig.midLevelPipeline.empty())
+    ct->pipelineConfig.skipTargetLoweringPipeline = true;
 
   ct->fullySpecialize = !isLocalSimulator;
   ct->supportDeviceCalls = true;

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -207,11 +207,16 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
   bool isFullySpecialized = true;
   auto rawArgs = args.getTypeErased();
   auto packed = args.getPacked();
-  if (!args.empty()) {
+  const bool runKernelSpecialization =
+      !args.empty() || (isPython && isEntryPoint);
+  if (runKernelSpecialization) {
     mlir::PassManager pm(contextPtr);
-    if (isPython && rawArgs)
+    if (isPython) {
+      std::span<void *const> mergeArgs =
+          rawArgs ? *rawArgs : std::span<void *const>{};
       cudaq_internal::compiler::mergeAllCallableClosures(moduleOp, kernelName,
-                                                         *rawArgs);
+                                                         mergeArgs);
+    }
 
     // Mark all newly merged kernels private, and leave the entry point alone.
     for (auto &op : moduleOp)
@@ -219,7 +224,7 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
         if (f != epFunc)
           f.setPrivate();
 
-    if (rawArgs) {
+    if (rawArgs || (isPython && isEntryPoint && !packed)) {
       CUDAQ_INFO("Run Argument Synth.\n");
       // For quantum devices, we generate a collection of `init` and
       // `num_qubits` functions and their substitutions created
@@ -230,12 +235,15 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
       if (cudaq::opt::factory::isFullySynthesized(epFunc)) {
         // Already fully specialized, nothing to do.
         isFullySpecialized = true;
-      } else if (isEntryPoint && !target->fullySpecialize) {
+      } else if (isEntryPoint && !target->fullySpecialize && rawArgs) {
         // We disable specialization by erasing args that should not be inlined
         isFullySpecialized =
             eraseNonCallableArguments(*rawArgs, closureArgs, epFunc);
       }
-      argCon.gen(*rawArgs);
+      if (rawArgs)
+        argCon.gen(*rawArgs);
+      else
+        argCon.gen(std::span<void *const>{});
 
       // Store kernel and substitution strings on the stack.
       // We pass string references to the `createArgumentSynthesisPass`.


### PR DESCRIPTION
# Cursor's fix for Python JIT compile pipeline regressions after runtime refactor (#4636)

## Summary

PR #4636 disturbed three related behaviors in the Python JIT path:

1. **When** the target lowering pipeline runs
2. **Whether** kernel specialization runs for nullary Python builder kernels
3. **How** `CompileTarget` decides to skip lowering for backends without an explicit pass pipeline in YAML

Together these caused `cudaq.draw` to print over-lowered circuits and broke resource counting on targets that depend on mid-level passes (DQE, qubit mapping).

This PR restores the pre-refactor semantics with three targeted fixes across `CompileTarget.cpp`, `Compiler.cpp`, and `quantum_platform.cpp`.

## Context

After #4636, all Python JIT compilation flows through `getDefaultPythonCompileTarget()` → `Compiler::runPassPipeline()`. The old Python QPU path had implicit rules that were not fully carried over:

| Old behavior | Lost after #4636 |
|---|---|
| Local simulators skipped target lowering for Python JIT | Full hw-jit-prep / deploy / finalize ran on `nvidia`, changing `cudaq.draw` output |
| Nullary Python builder kernels went through apply-specialization | `prepareModule` gated on `!args.empty()`, skipping specialization for `make_kernel()` entry points |
| Targets without YAML pass pipelines still ran default lowering stages | `CompileTarget` set `skipTargetLoweringPipeline = true` when `!hasPassPipeline()` |
# Why the draw regression appeared on GPU but not CPU

The draw regression originated in PR #4636 (`d6e40ae0` — [python] Use Compiler class within PythonLauncher, Luca Mondada). That change routed Python JIT through the shared `Compiler` / `CompileTarget` path instead of the older PythonLauncher-specific behavior. The issue persists on current tree (#4660 moved compile-target setup out of `PythonLauncher` into `quantum_platform.cpp`, but did not introduce it).

`test_draw` fails on machines with a GPU but passes on CPU-only setups. **This is not a CPU-vs-GPU execution difference.** It is a **default-target difference** exposed by an inconsistency in how target YAML is wired into the Python JIT compile path.

## What people observe

| Environment | Default target | `test_draw` since #4636 (no fix) |
|---------------|----------------|-------------------------------|
| GPU present   | `nvidia`       | **FAIL** — circuit ~2113 chars, over-lowered |
| No GPU        | `qpp-cpu`      | **PASS** — circuit ~1262 chars, expected output |

Default target selection is in `LinkedLibraryHolder::resolveDefaultTarget()`:

- GPUs available + `cusvsim` installed → `nvidia`
- Otherwise → `qpp-cpu`

So “GPU box” really means “running as **`nvidia`**”; “CPU box” means “running as **`qpp-cpu`**”.

## Root cause: YAML shape → `BackendConfig` → skip flag

Python JIT builds a `CompileTarget` in `getDefaultPythonCompileTargetImpl()` from `platform->get_runtime_target()->config`.

`CompileTarget`’s constructor (`cudaq/lib/Target/CompileTarget.cpp`) does this on tree since #4636 **without** the draw-fix:

```cpp
if (!targetConfig.BackendConfig.has_value())
  return;  // skipTargetLoweringPipeline stays false (default)

const auto &backendConfig = *targetConfig.BackendConfig;
if (!backendConfig.hasPassPipeline()) {
  pipelineConfig.skipTargetLoweringPipeline = true;
}
```

The two default simulator targets are structured differently in YAML:

### `qpp-cpu.yml` — top-level `config:`

```yaml
name: qpp-cpu
config:
  nvqir-simulation-backend: qpp
  preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
```

- `TargetConfig.BackendConfig` is **set**
- No JIT pass pipelines are configured → `hasPassPipeline()` is false
- `skipTargetLoweringPipeline = true`
- `cudaq.draw` does **not** run hw-jit-prep / deploy / finalize
- Draw sees the lightly optimized Quake IR the test expects

### `nvidia.yml` — `configuration-matrix` only (no top-level `config:`)

```yaml
name: nvidia
gpu-requirements: true
configuration-matrix:
  - name: single-gpu-fp32
    default: true
    config:
      nvqir-simulation-backend: cusvsim-fp32, custatevec-fp32
      ...
```

- `TargetConfig.BackendConfig` at the **top level** is **unset** (`std::nullopt`)
- The per-matrix `config:` blocks are used for **simulator/backend selection** via `processRuntimeArgs()`, but they are **not** copied into `rt->config.BackendConfig` when constructing `CompileTarget`
- Constructor returns early → `skipTargetLoweringPipeline` stays **false**
- Full target lowering runs:

  ```
  canonicalize, hw-jit-prep-pipeline{...}, jit-deploy-pipeline, jit-finalize-pipeline{...}
  ```

- `cudaq.draw` traces over-lowered IR → assertion failure

## Runtime evidence (upstream, no fix)

Measured on a GPU machine at `cbaf15f4` (top of tree; includes #4660 on top of #4636) with draw-fix reverted:

| Target    | `hasBackendConfig` | `skipTargetLoweringPipeline` | `Pass pipeline for` logged? | `test_draw` exact match |
|-----------|--------------------|------------------------------|----------------------------|-------------------------|
| `qpp-cpu` | true               | true                         | No                         | **true**                |
| `nvidia`  | false              | false                        | Yes                        | **false**               |

Logs from `CUDAQ_LOG_LEVEL=INFO` on `cudaq.draw`:

- **`qpp-cpu`:** no `Pass pipeline for ...` line
- **`nvidia`:** `Pass pipeline for ... = canonicalize,hw-jit-prep-pipeline{...},jit-deploy-pipeline,jit-finalize-pipeline{...}`

Circuit string length:

- `qpp-cpu`: 1262 characters (matches expected)
- `nvidia`: 2113 characters (fails full string compare)

## Why #4636 made this visible

Before #4636, `PythonLauncher` owned Python JIT compilation with target-specific behavior that did not go through the shared `Compiler::runPassPipeline()` / `CompileTarget` constructor in the same way.

#4636 unified Python JIT on the `Compiler` class. Combined with `CompileTarget`’s `!hasPassPipeline()` skip logic, that accidentally skipped target lowering only when top-level `BackendConfig` is present — which `qpp-cpu` has and `nvidia` does not.

#4660 subsequently moved compile-target setup from `PythonLauncher` / `DefaultQPU` into `getDefaultPythonCompileTargetImpl()` in `quantum_platform.cpp` **without** restoring an explicit local-simulator skip. The accidental protection for `qpp-cpu` still worked via `CompileTarget` + top-level `config:`. **`nvidia` had no such protection** because its YAML never populates top-level `BackendConfig`.

## Fix (draw-fix PR)

The durable fix is in `quantum_platform.cpp`, not in making GPU simulators special:

```cpp
if (isLocalSimulator && ct->pipelineConfig.midLevelPipeline.empty())
    ct->pipelineConfig.skipTargetLoweringPipeline = true;
```

This applies the same rule to **all** local simulators with no mid-level pipeline — including `nvidia` — regardless of YAML layout. Targets that **do** define a mid-level pipeline (e.g. `compiler-bench-nisq` for DQE / routing) still run lowering for resource counting.

Removing the `!hasPassPipeline()` auto-skip from `CompileTarget.cpp` avoids encoding policy in a way that depends on whether a target author used top-level `config:` vs `configuration-matrix`.

## Optional follow-up (not required for draw-fix)

Adding an empty top-level `config:` to `nvidia.yml` would also populate `BackendConfig` and recreate the old accidental skip since #4636, but that duplicates policy in YAML shape and does not help targets that use only `configuration-matrix`. The platform-level skip is the intentional, consistent policy.

## Changes

### 1. `cudaq/lib/Target/CompileTarget.cpp` — do not auto-skip lowering

**Removed:**

```cpp
if (!backendConfig.hasPassPipeline()) {
  pipelineConfig.skipTargetLoweringPipeline = true;
}
```

**Why:** `hasPassPipeline()` only checks whether the YAML defines explicit pipeline strings. Targets that rely on the default stages assembled by `getPassPipeline()` (hw-jit-prep, deploy, finalize) were incorrectly marked to skip lowering entirely. `skipTargetLoweringPipeline` should be an explicit policy decision at the compile-target setup site, not inferred from missing YAML fields.

### 2. `runtime/internal/compiler/Compiler.cpp` — specialize nullary Python entry points

**Problem:** `prepareModule` only ran the specialization pipeline when `!args.empty()`. Python builder kernels launched with no arguments (`make_kernel()` + `cudaq.draw` / `sample`) never ran apply-specialization, lambda lifting, or device-call lowering.

**Fix:** Run kernel specialization when `!args.empty()` **or** when the module is a Python entry point:

```cpp
const bool runKernelSpecialization =
    !args.empty() || (isPython && isEntryPoint);
```

For nullary Python kernels, callable-closure merging and argument synthesis now use empty spans instead of being skipped entirely. `eraseNonCallableArguments` remains guarded on `rawArgs` so remote partial-specialization behavior is unchanged.

### 3. `runtime/cudaq/platform/quantum_platform.cpp` — restore selective local-simulator skip

**Problem:** #4636 dropped the old local-simulator rule that skipped target lowering for Python JIT. Running hw-jit-prep/finalize on default simulators (e.g. `nvidia`, which has no mid-level pipeline) changes the IR that `cudaq.draw` traces, producing a larger circuit with different gate decomposition and trace layout (`test_draw`).

A naive restore (`skipTargetLoweringPipeline = true` for all local simulators) fixes draw but breaks `estimate_resources` on `compiler-bench-nisq`, which **does** configure a mid-level pipeline with DQE and qubit mapping. Skipping lowering there leaves `num_qubits` at the raw allocation size (5) instead of the post-DQE count (2).

**Fix:** Skip target lowering on local simulators only when the target has no mid-level pipeline:

```cpp
if (isLocalSimulator && ct->pipelineConfig.midLevelPipeline.empty())
    ct->pipelineConfig.skipTargetLoweringPipeline = true;
```

| Target | Mid-level pipeline | Skip? | Path |
|---|---|---|---|
| `nvidia` (draw / sample) | empty | yes | Lightly optimized Quake IR for tracing |
| `compiler-bench-nisq` (resource count) | DQE, routing, … | no | DQE shrinks allocation before `countResourcesFromIR` |
| Remote / emulated | target-specific | no | unchanged |

This replaces the old `PythonLauncher` / `QPU.cpp` local-simulator skip now that compile-target setup lives in `quantum_platform.cpp`.

## How the fixes interact

The three changes address different layers of the same JIT pipeline:

```
getDefaultPythonCompileTargetImpl()     ← (3) when to skip target lowering
        ↓
Compiler::prepareModule()               ← (2) nullary Python specialization
        ↓
Compiler::executeMainPipeline()         ← (1) + (3) whether YAML/default stages run
        ↓
countResourcesFromIR() / JIT / draw
```

- **(3)** alone is sufficient for `test_draw` on default simulators.
- **(3)** with a blanket skip breaks `test_num_qubits_and_used_qubits`; the mid-level-pipeline guard resolves that.
- **(1)** and **(2)** fix correctness gaps exposed by the refactor for other Python JIT paths (nullary kernels, backends without explicit YAML pipelines).

## Tests fixed

- `python/tests/builder/test_kernel_builder.py::test_draw` — circuit trace matches expected optimized output
- `python/tests/builder/test_resource_metrics.py::test_num_qubits_and_used_qubits` — `num_qubits == 2` after DQE on `compiler-bench-nisq` with `device='path(5)'`

