### PR TITLE
[CI] Run Python test suite on nvidia GPU simulator in merge queue

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -483,6 +483,78 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
 
+  gpu_validation:
+    # Merge-queue gate: run the Python test suite against the GPU (nvidia)
+    # statevector simulator. Regressions that only manifest on the nvidia
+    # target pass on qpp-cpu and so escape per-PR CI, which has no GPU. This
+    # reuses the wheel built by build_wheel and runs a single representative
+    # config (amd64 / Python 3.11 / CUDA 12.6) to limit A100 runner cost.
+    name: Validate wheel on GPU (nvidia simulator)
+    needs: build_wheel
+    if: inputs.platform == 'linux/amd64' && inputs.python_version == '3.11' && inputs.cuda_version == '12.6'
+    runs-on: linux-amd64-gpu-a100-latest-1
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Log in to GitHub CR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Load cuda-quantum wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build_wheel.outputs.artifact_name }}
+
+      - name: Build wheel test image
+        run: |
+          # ubuntu:22.04 is the Python 3.11 validation image (see
+          # config/validation_config.json). Mirror the `validation` job and use
+          # the GHCR-mirrored base to limit pull rate on public registries.
+          repo_owner=${{ github.repository_owner }}
+          base_image=ghcr.io/${repo_owner,,}/ubuntu:22.04
+          wheelname=`echo cuda_quantum*-manylinux_*_$(uname -m).whl`
+          docker build --network host -t wheel_validation:local -f docker/test/wheels/ubuntu.Dockerfile . \
+            --build-arg base_image=$base_image \
+            --build-arg python_version=${{ inputs.python_version }} \
+            --build-arg cuda_quantum_wheel=$wheelname \
+            --build-arg preinstalled_modules="numpy pytest psutil" \
+            --build-arg pip_install_flags=
+
+      - name: Run Python tests on nvidia simulator
+        # On the A100 runner, run-in-docker auto-adds `--gpus all` (it detects
+        # nvidia-smi on the host), so the container can reach the GPU.
+        uses: ./.github/actions/run-in-docker
+        with:
+          image: wheel_validation:local
+          shell: bash
+          run: |
+            # Force the GPU statevector backend. Tests that set their own target
+            # override this; the rest run on nvidia instead of the qpp-cpu default.
+            export CUDAQ_DEFAULT_SIMULATOR=nvidia
+
+            # Fail loudly if the GPU / nvidia target is unavailable, so a missing
+            # GPU can't masquerade as a clean "everything skipped" run.
+            python${{ inputs.python_version }} -c "import cudaq; cudaq.set_target('nvidia'); k=cudaq.make_kernel(); q=k.qalloc(2); k.h(q[0]); k.cx(q[0], q[1]); c=cudaq.sample(k); assert c, 'nvidia target returned no samples'; print('nvidia target OK:', c)"
+
+            # Mirror the CPU suite selection: full python/tests minus backends
+            # (need mock QPUs) and contrib (needs qiskit).
+            python${{ inputs.python_version }} -m pytest -v --durations=0 /tmp/tests/ \
+              --ignore /tmp/tests/backends \
+              --ignore /tmp/tests/contrib
+            pytest_status=$?
+            if [ ! $pytest_status -eq 0 ]; then
+              echo "::error file=python_wheels.yml::Python tests on the nvidia simulator failed with status $pytest_status."
+              exit 1
+            fi
+
   staging:
     name: Staging
     needs: [build_wheel, validation]

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -379,8 +379,10 @@ jobs:
               echo "+ $line"
               # Fail loudly on the failing command. Without this a failed
               # `conda install` is swallowed and only surfaces ~60 lines later
-              # as a misleading "mpirun: command not found".
-              if ! eval "$line"; then
+              # as a misleading "mpirun: command not found". Retry to tolerate
+              # transient network drops mid-download (e.g. a "Connection reset
+              # by peer" while fetching a multi-hundred-MB CUDA package).
+              if ! retry eval "$line"; then
                 echo "::error file=python_wheel.yml::conda install step failed: $line"
                 exit 1
               fi
@@ -388,7 +390,7 @@ jobs:
             ompi_script="$(awk '/(Begin ompi setup)/{flag=1;next}/(End ompi setup)/{flag=0}flag' $metadata | grep . | sed '/^```/d')"
             while IFS= read -r line; do
                 echo "+ $line"
-                if ! eval "$line"; then
+                if ! retry eval "$line"; then
                   echo "::error file=python_wheel.yml::ompi setup step failed: $line"
                   exit 1
                 fi

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -547,10 +547,14 @@ jobs:
             python${{ inputs.python_version }} -c "import cudaq; cudaq.set_target('nvidia'); k=cudaq.make_kernel(); q=k.qalloc(2); k.h(q[0]); k.cx(q[0], q[1]); c=cudaq.sample(k); assert c, 'nvidia target returned no samples'; print('nvidia target OK:', c)"
 
             # Mirror the CPU suite selection: full python/tests minus backends
-            # (need mock QPUs) and contrib (needs qiskit).
+            # (need mock QPUs) and contrib (needs qiskit). Also skip parallel
+            # (needs MPI and the multi-QPU mqpu platform, neither of which this
+            # single-GPU validation container provides; MPI is covered by the
+            # dedicated conda/OpenMPI step in the wheel validation job).
             python${{ inputs.python_version }} -m pytest -v --durations=0 /tmp/tests/ \
               --ignore /tmp/tests/backends \
-              --ignore /tmp/tests/contrib
+              --ignore /tmp/tests/contrib \
+              --ignore /tmp/tests/parallel
             pytest_status=$?
             if [ ! $pytest_status -eq 0 ]; then
               echo "::error file=python_wheels.yml::Python tests on the nvidia simulator failed with status $pytest_status."

--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -100,6 +100,11 @@ public:
   /// Whether to fully specialize the kernel.
   bool fullySpecialize = true;
 
+  /// Whether this target is a local simulator (not remote, not emulated). On
+  /// this path `i1` vector arguments are packed as bit-packed
+  /// `std::vector<bool>`.
+  bool isLocalSimulator = false;
+
   /// Set the `changeSemantics` flag for the argument synthesis pass.
   bool argumentSynthChangeSemantics = true;
 

--- a/docker/test/installer/runtime_dependencies.sh
+++ b/docker/test/installer/runtime_dependencies.sh
@@ -16,6 +16,19 @@ if [ -d /etc/apt/apt.conf.d ]; then
         sudo sh -c 'echo "Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries' 2>/dev/null || true
 fi
 
+# Retry dnf operations to tolerate transient CDN/mirror races. NVIDIA's CUDA
+# repo rotates its repodata, and if the hashed *-primary.xml.gz referenced by a
+# just-fetched repomd.xml is replaced before dnf downloads it, the install dies
+# with a 404 on metadata. Refreshing metadata between attempts re-fetches the
+# current repomd so the retry sees consistent files.
+dnf_retry() {
+    for n in 1 2 3 4 5; do
+        dnf "$@" && return 0
+        [ $n -lt 5 ] && { dnf clean all >/dev/null 2>&1 || true; sleep $((5*n)); }
+    done
+    return 1
+}
+
 case $1 in
     *ubuntu*)
         pkg_manager=apt-get
@@ -71,24 +84,24 @@ if [ "$pkg_manager" == "apt-get" ]; then
 
 elif [ "$pkg_manager" == "dnf" ]; then
     ## [Prerequisites]
-    dnf install -y --nobest --setopt=install_weak_deps=False \
+    dnf_retry install -y --nobest --setopt=install_weak_deps=False \
         sudo 'dnf-command(config-manager)'
     echo "dnf install -y --nobest --setopt=install_weak_deps=False openssh-clients" > install_sshclient.sh
 
     ## [C development headers]
     if [ -n "${LIBCDEV_PACKAGE}" ]; then
-        dnf install -y --nobest --setopt=install_weak_deps=False ${LIBCDEV_PACKAGE}
+        dnf_retry install -y --nobest --setopt=install_weak_deps=False ${LIBCDEV_PACKAGE}
     fi
 
     ## [CUDA runtime libraries]
     if [ -n "${CUDA_DISTRIBUTION}" ]; then
         dnf config-manager --add-repo "${CUDA_DOWNLOAD_URL}/${CUDA_DISTRIBUTION}/${CUDA_ARCH_FOLDER}/cuda-${CUDA_DISTRIBUTION}.repo"
-        dnf install -y --nobest --setopt=install_weak_deps=False ${CUDA_PACKAGES}
+        dnf_retry install -y --nobest --setopt=install_weak_deps=False ${CUDA_PACKAGES}
     fi
 
     ## [Extra validation packages]
     if [ -n "${VALIDATION_PACKAGES}" ]; then
-        dnf install -y --nobest --setopt=install_weak_deps=False ${VALIDATION_PACKAGES}
+        dnf_retry install -y --nobest --setopt=install_weak_deps=False ${VALIDATION_PACKAGES}
     fi
 
 elif [ "$pkg_manager" == "zypper" ]; then

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -13,6 +13,8 @@ import pytest
 import random
 import numpy as np
 import os
+import subprocess
+import sys
 from typing import List
 
 import cudaq
@@ -1533,6 +1535,41 @@ def test_call_invalid_attribute_on_a_kernel():
         kernel.op(q[0])
         result = cudaq.sample(kernel, cudaq.pauli_word("X"))
     assert "not supported on PyKernel" in str(e.value)
+
+
+def test_repeated_builder_launch_no_segfault():
+    """A ``list[bool]`` arg used to corrupt the heap during argument synthesis,
+    crashing a repeated ``make_kernel`` + ``sample`` loop at a random iteration.
+
+    The crash only surfaces when the bit-packed ``std::vector<bool>`` padding is
+    nonzero, so run under ``MALLOC_PERTURB_`` (set before the process starts) in
+    a subprocess. See ``runtime/test/test_argument_conversion.cpp`` for the
+    unit-level regression.
+    """
+    script = (
+        "import cudaq\n"
+        "from typing import List\n"
+        "cudaq.set_target('qpp-cpu')\n"
+        "for _ in range(512):\n"
+        "    kernel, *_ = cudaq.make_kernel(bool, list[bool], List[int], list[float])\n"
+        "    kernel.qalloc(1)\n"
+        "    cudaq.sample(kernel, False, [False], [3], [3.5])\n"
+        "    cudaq.sample(kernel, False, [], [], [])\n"
+        "print('OK')\n")
+    env = dict(os.environ)
+    # Dirty fresh allocations so the std::vector<bool> padding is never zero,
+    # otherwise the corruption stays latent and the test passes with the bug.
+    env["MALLOC_PERTURB_"] = "165"
+    proc = subprocess.run([sys.executable, "-c", script],
+                          env=env,
+                          capture_output=True,
+                          text=True,
+                          timeout=900)
+    assert proc.returncode == 0, ("repeated make_kernel/sample crashed "
+                                  f"(returncode={proc.returncode}).\n"
+                                  f"stdout:\n{proc.stdout}\n"
+                                  f"stderr (tail):\n{proc.stderr[-3000:]}")
+    assert "OK" in proc.stdout
 
 
 # leave for gdb debugging

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -114,6 +114,7 @@ getDefaultPythonCompileTargetImpl() {
   bool isLocalSimulator = !(platform->is_remote() || platform->is_emulated());
 
   ct->fullySpecialize = !isLocalSimulator;
+  ct->isLocalSimulator = isLocalSimulator;
   ct->supportDeviceCalls = true;
   ct->argumentSynthChangeSemantics = false;
   ct->pipelineConfig.codegenTranslation = "qir:";

--- a/runtime/internal/compiler/ArgumentConversion.cpp
+++ b/runtime/internal/compiler/ArgumentConversion.cpp
@@ -97,15 +97,15 @@ static Value genConstant(OpBuilder &builder, const std::string &v,
 
 // Forward declare aggregate type builder as they can be recursive.
 static Value genRecursiveSpan(OpBuilder &, cudaq::cc::StdvecType, void *,
-                              ModuleOp, llvm::DataLayout &);
+                              ModuleOp, llvm::DataLayout &, bool);
 static Value genConstant(OpBuilder &, cudaq::cc::StdvecType, void *, ModuleOp,
-                         llvm::DataLayout &);
+                         llvm::DataLayout &, bool);
 static Value genConstant(OpBuilder &, cudaq::cc::StructType, void *, ModuleOp,
-                         llvm::DataLayout &);
+                         llvm::DataLayout &, bool);
 static Value genConstant(OpBuilder &, cudaq::cc::ArrayType, void *, ModuleOp,
-                         llvm::DataLayout &);
+                         llvm::DataLayout &, bool);
 static Value genConstant(OpBuilder &, cudaq::cc::CallableType, void *, ModuleOp,
-                         llvm::DataLayout &);
+                         llvm::DataLayout &, bool);
 
 /// Create callee.init_N that initializes the state
 ///
@@ -524,7 +524,7 @@ static bool isSupportedRecursiveSpan(cudaq::cc::StdvecType ty) {
 
 // Recursive step processing of aggregates.
 Value dispatchSubtype(OpBuilder &builder, Type ty, void *p, ModuleOp substMod,
-                      llvm::DataLayout &layout) {
+                      llvm::DataLayout &layout, bool boolVecBitPacked = false) {
   auto *ctx = builder.getContext();
   return TypeSwitch<Type, Value>(ty)
       .Case([&](IntegerType intTy) -> Value {
@@ -567,16 +567,16 @@ Value dispatchSubtype(OpBuilder &builder, Type ty, void *p, ModuleOp substMod,
                            substMod);
       })
       .Case([&](cudaq::cc::StdvecType ty) {
-        return genConstant(builder, ty, p, substMod, layout);
+        return genConstant(builder, ty, p, substMod, layout, boolVecBitPacked);
       })
       .Case([&](cudaq::cc::StructType ty) {
-        return genConstant(builder, ty, p, substMod, layout);
+        return genConstant(builder, ty, p, substMod, layout, boolVecBitPacked);
       })
       .Case([&](cudaq::cc::ArrayType ty) {
-        return genConstant(builder, ty, p, substMod, layout);
+        return genConstant(builder, ty, p, substMod, layout, boolVecBitPacked);
       })
       .Case([&](cudaq::cc::CallableType ty) {
-        return genConstant(builder, ty, p, substMod, layout);
+        return genConstant(builder, ty, p, substMod, layout, boolVecBitPacked);
       })
       .Default({});
 }
@@ -597,21 +597,40 @@ static std::size_t getHostSideElementSize(Type eleTy,
 }
 
 /// Recursively builds an `ArrayAttr` containing the constants.
+///
+/// Set \p boolVecBitPacked when an `i1` vector arg is a host
+/// `std::vector<bool>` (bit-packed; not the `{begin, end, capacity}` triple).
 ArrayAttr genRecursiveConstantArray(OpBuilder &builder,
                                     cudaq::cc::StdvecType vecTy, void *p,
-                                    llvm::DataLayout &layout) {
+                                    llvm::DataLayout &layout,
+                                    bool boolVecBitPacked = false) {
+  auto eleTy = vecTy.getElementType();
+
+  // Bit-packed `std::vector<bool>`: read via the container API, not a triple.
+  if (boolVecBitPacked && eleTy.isInteger(1)) {
+    auto *boolVec = reinterpret_cast<const std::vector<bool> *>(p);
+    if (boolVec->empty())
+      return {};
+    auto intTy = cast<IntegerType>(eleTy);
+    SmallVector<Attribute> members;
+    members.reserve(boolVec->size());
+    for (bool bit : *boolVec)
+      members.push_back(IntegerAttr::get(intTy, bit ? 1 : 0));
+    return ArrayAttr::get(builder.getContext(), members);
+  }
+
   typedef const char *VectorType[3];
   VectorType *vecPtr = static_cast<VectorType *>(p);
   auto delta = (*vecPtr)[1] - (*vecPtr)[0];
   if (!delta)
     return {};
-  auto eleTy = vecTy.getElementType();
   unsigned stepBy = 0;
   std::function<Attribute(char *)> genAttr;
   if (auto innerTy = dyn_cast<cudaq::cc::StdvecType>(eleTy)) {
     stepBy = sizeof(VectorType);
     genAttr = [&, innerTy](char *p) -> Attribute {
-      return genRecursiveConstantArray(builder, innerTy, p, layout);
+      return genRecursiveConstantArray(builder, innerTy, p, layout,
+                                       boolVecBitPacked);
     };
   } else if (auto stringTy = dyn_cast<cudaq::cc::CharspanType>(eleTy)) {
     stepBy = sizeof(std::string);
@@ -688,8 +707,10 @@ static Type convertRecursiveSpanType(Type ty) {
 /// constant propagation through the recursive span structure. The reify
 /// operation will be lowered to more primitive ops on an as-needed basis.
 Value genRecursiveSpan(OpBuilder &builder, cudaq::cc::StdvecType ty, void *p,
-                       ModuleOp substMod, llvm::DataLayout &layout) {
-  ArrayAttr constants = genRecursiveConstantArray(builder, ty, p, layout);
+                       ModuleOp substMod, llvm::DataLayout &layout,
+                       bool boolVecBitPacked = false) {
+  ArrayAttr constants =
+      genRecursiveConstantArray(builder, ty, p, layout, boolVecBitPacked);
   auto loc = builder.getUnknownLoc();
   if (!constants) {
     // Empty vector. Not much to contemplate here.
@@ -705,9 +726,11 @@ Value genRecursiveSpan(OpBuilder &builder, cudaq::cc::StdvecType ty, void *p,
 }
 
 Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
-                  ModuleOp substMod, llvm::DataLayout &layout) {
+                  ModuleOp substMod, llvm::DataLayout &layout,
+                  bool boolVecBitPacked = false) {
   if (isSupportedRecursiveSpan(vecTy))
-    return genRecursiveSpan(builder, vecTy, p, substMod, layout);
+    return genRecursiveSpan(builder, vecTy, p, substMod, layout,
+                            boolVecBitPacked);
   typedef const char *VectorType[3];
   VectorType *vecPtr = static_cast<VectorType *>(p);
   auto delta = (*vecPtr)[1] - (*vecPtr)[0];
@@ -727,7 +750,7 @@ Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
   for (std::int32_t i = 0; i < vecSize; ++i) {
     if (Value val = dispatchSubtype(
             builder, eleTy, static_cast<void *>(const_cast<char *>(cursor)),
-            substMod, layout)) {
+            substMod, layout, boolVecBitPacked)) {
       auto atLoc = cudaq::cc::ComputePtrOp::create(
           builder, loc, elePtrTy, buffer,
           ArrayRef<cudaq::cc::ComputePtrArg>{i});
@@ -740,7 +763,8 @@ Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
 }
 
 Value genConstant(OpBuilder &builder, cudaq::cc::StructType strTy, void *p,
-                  ModuleOp substMod, llvm::DataLayout &layout) {
+                  ModuleOp substMod, llvm::DataLayout &layout,
+                  bool boolVecBitPacked = false) {
   if (strTy.getMembers().empty())
     return {};
   const char *cursor = static_cast<const char *>(p);
@@ -752,7 +776,7 @@ Value genConstant(OpBuilder &builder, cudaq::cc::StructType strTy, void *p,
             builder, iter.value(),
             static_cast<void *>(const_cast<char *>(
                 cursor + cudaq::opt::getDataOffset(layout, strTy, i))),
-            substMod, layout))
+            substMod, layout, boolVecBitPacked))
       aggie =
           cudaq::cc::InsertValueOp::create(builder, loc, strTy, aggie, v, i);
   }
@@ -760,7 +784,8 @@ Value genConstant(OpBuilder &builder, cudaq::cc::StructType strTy, void *p,
 }
 
 Value genConstant(OpBuilder &builder, cudaq::cc::CallableType callTy, void *p,
-                  ModuleOp substMod, llvm::DataLayout &layout) {
+                  ModuleOp substMod, llvm::DataLayout &layout,
+                  bool boolVecBitPacked = false) {
   if (!p)
     return {};
   auto loc = builder.getUnknownLoc();
@@ -787,7 +812,7 @@ Value genConstant(OpBuilder &builder, cudaq::cc::CallableType callTy, void *p,
         if (hasLiftedArgs) {
           for (unsigned i = liftedPos, j = 0; i < liftedArity; ++i, ++j) {
             Value v = dispatchSubtype(builder, calleeInpTys[i], closureArgs[j],
-                                      substMod, layout);
+                                      substMod, layout, boolVecBitPacked);
             assert(v && "lifted argument must be handled");
             args.push_back(v);
           }
@@ -806,7 +831,8 @@ Value genConstant(OpBuilder &builder, cudaq::cc::CallableType callTy, void *p,
 }
 
 Value genConstant(OpBuilder &builder, cudaq::cc::ArrayType arrTy, void *p,
-                  ModuleOp substMod, llvm::DataLayout &layout) {
+                  ModuleOp substMod, llvm::DataLayout &layout,
+                  bool boolVecBitPacked = false) {
   if (arrTy.isUnknownSize())
     return {};
   auto eleTy = arrTy.getElementType();
@@ -818,7 +844,7 @@ Value genConstant(OpBuilder &builder, cudaq::cc::ArrayType arrTy, void *p,
   for (std::size_t i = 0; i < arrSize; ++i) {
     if (Value v = dispatchSubtype(
             builder, eleTy, static_cast<void *>(const_cast<char *>(cursor)),
-            substMod, layout))
+            substMod, layout, boolVecBitPacked))
       aggie =
           cudaq::cc::InsertValueOp::create(builder, loc, arrTy, aggie, v, i);
     cursor += eleSize;
@@ -854,8 +880,9 @@ Value genConstant(OpBuilder &builder, cudaq::cc::IndirectCallableType indCallTy,
 //===----------------------------------------------------------------------===//
 
 cudaq_internal::compiler::ArgumentConverter::ArgumentConverter(
-    StringRef kernelName, ModuleOp sourceModule)
-    : sourceModule(sourceModule), kernelName(kernelName) {}
+    StringRef kernelName, ModuleOp sourceModule, bool boolVecBitPacked)
+    : sourceModule(sourceModule), kernelName(kernelName),
+      boolVecBitPacked(boolVecBitPacked) {}
 
 void cudaq_internal::compiler::ArgumentConverter::gen(
     std::span<void *const> arguments) {
@@ -954,19 +981,23 @@ void cudaq_internal::compiler::ArgumentConverter::gen(
               return {};
             })
             .Case([&](cudaq::cc::StdvecType ty) {
-              return buildSubst(ty, argPtr, substModule, dataLayout);
+              return buildSubst(ty, argPtr, substModule, dataLayout,
+                                boolVecBitPacked);
             })
             .Case([&](cudaq::cc::StructType ty) {
-              return buildSubst(ty, argPtr, substModule, dataLayout);
+              return buildSubst(ty, argPtr, substModule, dataLayout,
+                                boolVecBitPacked);
             })
             .Case([&](cudaq::cc::ArrayType ty) {
-              return buildSubst(ty, argPtr, substModule, dataLayout);
+              return buildSubst(ty, argPtr, substModule, dataLayout,
+                                boolVecBitPacked);
             })
             .Case([&](cudaq::cc::IndirectCallableType ty) {
               return buildSubst(ty, argPtr, substModule, dataLayout);
             })
             .Case([&](cudaq::cc::CallableType ty) {
-              return buildSubst(ty, argPtr, substModule, dataLayout);
+              return buildSubst(ty, argPtr, substModule, dataLayout,
+                                boolVecBitPacked);
             })
             .Default({});
     if (subst)

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -224,7 +224,11 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
       // For quantum devices, we generate a collection of `init` and
       // `num_qubits` functions and their substitutions created
       // from a kernel and arguments that generated a state argument.
-      cudaq_internal::compiler::ArgumentConverter argCon(kernelName, moduleOp);
+      // Local simulators marshal `i1` vectors as bit-packed `std::vector<bool>`
+      // (argsCreator); remote/emulated targets use `std::vector<char>`.
+      const bool boolVecBitPacked = target->isLocalSimulator;
+      cudaq_internal::compiler::ArgumentConverter argCon(kernelName, moduleOp,
+                                                         boolVecBitPacked);
       // Must stay in scope as `eraseNonCallableArguments` may populate it
       std::vector<void *> closureArgs;
       if (cudaq::opt::factory::isFullySynthesized(epFunc)) {

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/ArgumentConversion.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/ArgumentConversion.h
@@ -51,7 +51,12 @@ class ArgumentConverter {
 public:
   /// Build an instance to create argument substitutions for a specified \p
   /// kernelName in \p sourceModule.
-  ArgumentConverter(mlir::StringRef kernelName, mlir::ModuleOp sourceModule);
+  ///
+  /// Set \p boolVecBitPacked when `i1` vector arguments are host
+  /// `std::vector<bool>` (local-simulator launch path), not
+  /// `std::vector<char>`.
+  ArgumentConverter(mlir::StringRef kernelName, mlir::ModuleOp sourceModule,
+                    bool boolVecBitPacked = false);
 
   ~ArgumentConverter() {
     for (auto *kInfo : kernelSubstitutions) {
@@ -110,6 +115,10 @@ private:
 
   /// Kernel we are substituting the arguments for.
   mlir::StringRef kernelName;
+
+  /// Whether `i1` vector arguments are bit-packed `std::vector<bool>` (vs
+  /// `std::vector<char>`). See the constructor.
+  bool boolVecBitPacked;
 };
 
 /// Merge modules from any CallableClosureArgument arguments into \p intoModule.

--- a/runtime/test/test_argument_conversion.cpp
+++ b/runtime/test/test_argument_conversion.cpp
@@ -152,7 +152,8 @@ void dumpSubstitutionModules(ArgumentConverter &con) {
 
 void doSimpleTest(mlir::MLIRContext *ctx, const std::string &typeName,
                   std::vector<void *> args,
-                  const std::string &additionalCode = "") {
+                  const std::string &additionalCode = "",
+                  bool boolVecBitPacked = false) {
   std::string code = additionalCode + R"#(
 func.func private @callee(%0: )#" +
                      typeName + R"#()
@@ -166,7 +167,7 @@ func.func @__nvqpp__mlirgen__testy(%0: )#" +
   // Create the Module
   auto mod = mlir::parseSourceString<mlir::ModuleOp>(code, ctx);
   llvm::outs() << "Source module:\n" << *mod << '\n';
-  ArgumentConverter ab{"testy", *mod};
+  ArgumentConverter ab{"testy", *mod, boolVecBitPacked};
   // Create the argument conversions
   ab.gen(args);
   // Dump all conversions
@@ -396,6 +397,22 @@ void test_vectors(mlir::MLIRContext *ctx) {
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array [true, false] : !cc.array<i1 x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i1 x ?>) -> !cc.stdvec<i1>
+ // CHECK:         }
+  // clang-format on
+
+  {
+    // Real bit-packed `std::vector<bool>`, as the local-simulator launch path
+    // passes it. Reading this as a `{begin, end, capacity}` triple corrupts the
+    // heap; `boolVecBitPacked` selects the correct reader.
+    std::vector<bool> x = {true, false, true, true};
+    std::vector<void *> v = {static_cast<void *>(&x)};
+    doSimpleTest(ctx, "!cc.stdvec<i1>", v, /*additionalCode=*/"",
+                 /*boolVecBitPacked=*/true);
+  }
+  // clang-format off
+// CHECK-LABEL:   cc.arg_subst[0] {
+// CHECK: %[[VAL_0:.*]] = cc.const_array [true, false, true, true] : !cc.array<i1 x ?>
 // CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i1 x ?>) -> !cc.stdvec<i1>
  // CHECK:         }
   // clang-format on


### PR DESCRIPTION
Per-PR CI runs python/tests only on qpp-cpu, so regressions that fail only on the nvidia (GPU) simulator slip through to publishing.

Add a gpu_validation job to python_wheels.yml that reuses the wheel from build_wheel and runs python/tests (minus backends/contrib) under CUDAQ_DEFAULT_SIMULATOR=nvidia on an A100 runner. Gated to a single config (amd64/py3.11/cu12.6) and, via python_wheels, to merge_group, schedule, and workflow_dispatch only (not per-PR push).