### PR TITLE
[fix] Skip compilation in the absence of BackendConfig

### DIFF
--- a/cudaq/lib/Target/CompileTarget.cpp
+++ b/cudaq/lib/Target/CompileTarget.cpp
@@ -48,8 +48,10 @@ cudaq::CompileTarget::CompileTarget(
     config::TargetConfig targetConfig,
     std::map<std::string, std::string> runtimeConfig, bool emulate_)
     : emulate(emulate_) {
-  if (!targetConfig.BackendConfig.has_value())
+  if (!targetConfig.BackendConfig.has_value()) {
+    pipelineConfig.skipTargetLoweringPipeline = true;
     return;
+  }
 
   const auto &backendConfig = *targetConfig.BackendConfig;
   if (!backendConfig.hasPassPipeline()) {

--- a/cudaq/test/CMakeLists.txt
+++ b/cudaq/test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(CUDAQ_TEST_DEPENDS
     FileCheck
     nvq++
     test_argument_conversion
+    test_compile_target
 )
 
 if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME AND NOT CUDAQ_DISABLE_CPP_FRONTEND AND

--- a/cudaq/test/CompileTarget/test_compile_target.cpp
+++ b/cudaq/test/CompileTarget/test_compile_target.cpp
@@ -1,0 +1,1 @@
+../../../runtime/test/test_compile_target.cpp

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -6,25 +6,28 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# Hybrid test. Build the executable like any of the other tools, but
+# Hybrid tests. Build the executable like any of the other tools, but
 # run it like it was a lit test.
-set(TEST_NAME test_argument_conversion)
-
-add_llvm_executable(${TEST_NAME} test_argument_conversion.cpp)
-
-target_compile_options(${TEST_NAME} PUBLIC -Wno-type-limits -fexceptions -DCUDAQ_RTTI_DISABLED)
-
-target_include_directories(${TEST_NAME}
-  PUBLIC
-    ${CMAKE_SOURCE_DIR}/runtime
-)
-
 link_directories(${CMAKE_BINARY_DIR}/lib)
 
-target_link_libraries(${TEST_NAME}
-  PUBLIC
-    cudaq-mlir-runtime
-    cudaq
-    cudaq-platform-default)
+function(add_cudaq_hybrid_test TEST_NAME)
+  add_llvm_executable(${TEST_NAME} ${TEST_NAME}.cpp PARTIAL_SOURCES_INTENDED)
 
-set_property(TARGET ${TEST_NAME} PROPERTY FOLDER test)
+  target_compile_options(${TEST_NAME} PUBLIC -Wno-type-limits -fexceptions -DCUDAQ_RTTI_DISABLED)
+
+  target_include_directories(${TEST_NAME}
+    PUBLIC
+      ${CMAKE_SOURCE_DIR}/runtime
+  )
+
+  target_link_libraries(${TEST_NAME}
+    PUBLIC
+      cudaq-mlir-runtime
+      cudaq
+      cudaq-platform-default)
+
+  set_property(TARGET ${TEST_NAME} PROPERTY FOLDER test)
+endfunction()
+
+add_cudaq_hybrid_test(test_argument_conversion)
+add_cudaq_hybrid_test(test_compile_target)

--- a/runtime/test/test_compile_target.cpp
+++ b/runtime/test/test_compile_target.cpp
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// This test is compiled inside the runtime directory tree. We include it as a
+// regression test and use FileCheck to verify the output.
+
+// RUN: test_compile_target | FileCheck %s
+
+#include "common/KernelArgs.h"
+#include "cudaq_internal/compiler/CompiledModuleHelper.h"
+#include "cudaq_internal/compiler/Compiler.h"
+#include "cudaq_internal/compiler/RuntimeMLIR.h"
+#include "cudaq/Target/CompileTarget.h"
+#include "cudaq/Target/TargetConfig.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+#include <cstdint>
+#include <memory>
+#include <span>
+
+using namespace cudaq_internal::compiler;
+
+/// Compile \p quake and print the resulting MLIR module to stdout.
+static void compileAndDump(mlir::MLIRContext *ctx,
+                           const std::string &kernelName,
+                           const std::string &quake,
+                           std::unique_ptr<cudaq::CompileTarget> target,
+                           cudaq::KernelArgs args = {}) {
+  auto mod = mlir::parseSourceString<mlir::ModuleOp>(quake, ctx);
+  if (!mod) {
+    llvm::outs() << "FAILED TO PARSE\n";
+    return;
+  }
+
+  Compiler compiler(std::move(target));
+  auto compiled = compiler.runPassPipeline(
+      kernelName, mod.release().getAsOpaquePointer(), args, /*isEntryPoint=*/
+      true);
+
+  auto mlirArtifact = compiled.getMlir();
+  if (!mlirArtifact) {
+    llvm::outs() << "NO MLIR ARTIFACT\n";
+    return;
+  }
+  auto moduleOp = CompiledModuleHelper::getMlirModuleOp(*mlirArtifact);
+  llvm::outs() << "Compiled module:\n" << moduleOp << "\n";
+}
+
+/// Build a CompileTarget with no backend configuration
+static std::unique_ptr<cudaq::CompileTarget> noBackendTarget() {
+  cudaq::config::TargetConfig cfg;
+  return std::make_unique<cudaq::CompileTarget>(
+      cfg, /*runtimeConfig=*/
+      std::map<std::string, std::string>{},
+      /*emulate=*/false);
+}
+
+/// Build a CompileTarget with a backend configuration with an empty pass
+/// pipeline
+static std::unique_ptr<cudaq::CompileTarget> emptyPipelineTarget() {
+  cudaq::config::TargetConfig cfg;
+  cfg.BackendConfig = cudaq::config::BackendEndConfigEntry{};
+  return std::make_unique<cudaq::CompileTarget>(
+      cfg, std::map<std::string, std::string>{},
+      /*emulate=*/false);
+}
+
+/// Build a CompileTarget with a backend configuration with a non-empty pass
+/// pipeline
+static std::unique_ptr<cudaq::CompileTarget>
+nonEmptyPipelineTarget(const std::string &pipeline) {
+  cudaq::config::TargetConfig cfg;
+  cudaq::config::BackendEndConfigEntry backend;
+  backend.TargetPassPipeline = pipeline;
+  cfg.BackendConfig = backend;
+  return std::make_unique<cudaq::CompileTarget>(
+      cfg, std::map<std::string, std::string>{},
+      /*emulate=*/false);
+}
+
+/// Kernel with statically-sized qubit register
+static const char *quantumKernel = R"#(
+func.func @__nvqpp__mlirgen__foo() -> i64 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.veq_size %0 : (!quake.veq<2>) -> i64
+  return %1 : i64
+}
+)#";
+
+/// Kernel with a device call
+static const char *deviceCallKernel = R"#(
+func.func @__nvqpp__mlirgen__devKernel(%arg0: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  cc.device_call @consume(%arg0) : (i64) -> ()
+  return
+}
+func.func private @consume(i64) attributes {"cudaq-devicecall"}
+)#";
+
+void test_device_calls_supported(mlir::MLIRContext *ctx) {
+  std::int64_t arg = 42;
+  std::vector<void *> v = {static_cast<void *>(&arg)};
+  cudaq::KernelArgs args(std::span<void *const>(v.data(), v.size()));
+
+  auto target = std::make_unique<cudaq::CompileTarget>();
+  target->supportDeviceCalls = true;
+  // Isolate the device-call lowering performed during argument synthesis from
+  // the rest of the target lowering pipeline.
+  target->pipelineConfig.skipTargetLoweringPipeline = true;
+  compileAndDump(ctx, "devKernel", deviceCallKernel, std::move(target), args);
+}
+
+// clang-format off
+// CHECK-LABEL: Compiled module:
+// CHECK:         func.func @__nvqpp__mlirgen__devKernel()
+// CHECK:           %[[VAL_0:.*]] = arith.constant 42 : i64
+// CHECK:           call @consume(%[[VAL_0]]) : (i64) -> ()
+// CHECK-NOT:       cc.device_call
+// CHECK:         func.func private @consume(i64) attributes {{.*}}cudaq-devicecall
+// clang-format on
+
+void test_device_calls_unsupported(mlir::MLIRContext *ctx) {
+  std::int64_t arg = 42;
+  std::vector<void *> v = {static_cast<void *>(&arg)};
+  cudaq::KernelArgs args(std::span<void *const>(v.data(), v.size()));
+
+  auto target = std::make_unique<cudaq::CompileTarget>();
+  target->supportDeviceCalls = false;
+  target->pipelineConfig.skipTargetLoweringPipeline = true;
+  compileAndDump(ctx, "devKernel", deviceCallKernel, std::move(target), args);
+}
+
+// CHECK-LABEL: Compiled module:
+// CHECK:         func.func @__nvqpp__mlirgen__devKernel()
+// CHECK:           cc.device_call @consume
+
+void test_no_backend_config(mlir::MLIRContext *ctx) {
+  compileAndDump(ctx, "foo", quantumKernel, noBackendTarget());
+}
+
+// CHECK-LABEL: Compiled module:
+// CHECK:         func.func @__nvqpp__mlirgen__foo()
+// CHECK:           quake.veq_size
+// CHECK:           return
+
+void test_empty_pipeline(mlir::MLIRContext *ctx) {
+  compileAndDump(ctx, "foo", quantumKernel, emptyPipelineTarget());
+}
+
+// CHECK-LABEL: Compiled module:
+// CHECK:         func.func @__nvqpp__mlirgen__foo()
+// CHECK:           quake.veq_size
+// CHECK:           return
+
+void test_non_empty_pipeline(mlir::MLIRContext *ctx) {
+  compileAndDump(ctx, "foo", quantumKernel,
+                 nonEmptyPipelineTarget("canonicalize"));
+}
+
+// CHECK-LABEL: Compiled module:
+// CHECK:         func.func @__nvqpp__mlirgen__foo()
+// CHECK-NOT:       quake.veq_size
+// CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
+// CHECK:           return %[[VAL_0]] : i64
+
+int main() {
+  auto context = cudaq_internal::compiler::getOwningMLIRContext();
+
+  test_device_calls_supported(context.get());
+  test_device_calls_unsupported(context.get());
+  test_no_backend_config(context.get());
+  test_empty_pipeline(context.get());
+  test_non_empty_pipeline(context.get());
+  return 0;
+}


### PR DESCRIPTION
I suggest this fix over #4718, it correctly fixes my omission from #4636. It preserves the old behavior that if no optimization pipeline is defined, none is run.

I'm writing some tests that I will push in a minute. EDIT: done.

Having had to go again through the details of this logic, this could definitely use a good cleanup. I'll create a jira task for this.