### PR TITLE
Follow-up to PR #4688: diagnose iterating an unbound `measure_handle` vector

### DIFF
--- a/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -648,7 +648,7 @@ private:
   /// Definite-assignment check for `for (bool b : v)` where `v` is a
   /// `std::vector<measure_handle>`. Returns false only when it can prove the
   /// vector was never bound to a measurement, and true for every shape it
-  /// cannot disprove. See: NVIDIA/cuda-quantum#4479.
+  /// cannot disprove. See: https://github.com/NVIDIA/cuda-quantum/issues/4479.
   bool isBoundHandleVector(mlir::Value, llvm::SmallPtrSetImpl<mlir::Value> &);
 
   /// Stack of Values built by the visitor. (right-to-left ordering)

--- a/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -645,6 +645,12 @@ private:
                                                    mlir::StringRef funcName,
                                                    mlir::FunctionType funcTy);
 
+  /// Definite-assignment check for `for (bool b : v)` where `v` is a
+  /// `std::vector<measure_handle>`. Returns false only when it can prove the
+  /// vector was never bound to a measurement, and true for every shape it
+  /// cannot disprove. See: NVIDIA/cuda-quantum#4479.
+  bool isBoundHandleVector(mlir::Value, llvm::SmallPtrSetImpl<mlir::Value> &);
+
   /// Stack of Values built by the visitor. (right-to-left ordering)
   mlir::SmallVector<mlir::Value> valueStack;
   clang::ASTContext *astContext;

--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -79,6 +79,46 @@ static bool storeDominatesLoad(cudaq::cc::StoreOp store,
          store.getOperation()->isBeforeInBlock(anchor);
 }
 
+// Follow a pointer back to the `cc.alloca` that owns its storage.  Returns null
+// if the chain does not bottom out at a local alloca (e.g. a function argument
+// or heap pointer).
+static cudaq::cc::AllocaOp getOwningAlloca(Value ptr) {
+  while (true) {
+    if (auto cp = ptr.getDefiningOp<cudaq::cc::ComputePtrOp>()) {
+      ptr = cp.getBase();
+      continue;
+    }
+    if (auto cs = ptr.getDefiningOp<cudaq::cc::CastOp>()) {
+      ptr = cs.getValue();
+      continue;
+    }
+    break;
+  }
+  return ptr.getDefiningOp<cudaq::cc::AllocaOp>();
+}
+
+// True if any `cc.store` into `alloca` satisfies `pred`. The bridge addresses a
+// slot's storage with a single indexing/retyping step before the store, so it
+// suffices to check stores directly on the alloca plus stores one hop away
+// through a `cc.compute_ptr` / `cc.cast` of it (e.g. brace-init writes elem 0
+// via a decay `cc.cast` and elem 1 via a `cc.compute_ptr`).
+static bool anyStoreInto(cudaq::cc::AllocaOp alloca,
+                         llvm::function_ref<bool(cudaq::cc::StoreOp)> pred) {
+  for (Operation *allocaUser : alloca->getUsers()) {
+    if (auto store = dyn_cast<cudaq::cc::StoreOp>(allocaUser)) {
+      if (pred(store))
+        return true;
+      continue;
+    }
+    if (isa<cudaq::cc::ComputePtrOp, cudaq::cc::CastOp>(allocaUser))
+      for (Operation *uu : allocaUser->getUsers())
+        if (auto store = dyn_cast<cudaq::cc::StoreOp>(uu))
+          if (store.getPtrvalue() == allocaUser->getResult(0) && pred(store))
+            return true;
+  }
+  return false;
+}
+
 // Walks the use-def chain back to the originating `mz`/`mx`/`my` so the bridge
 // can statically diagnose `bool b = h;` when `h` was default-constructed.
 //
@@ -98,21 +138,8 @@ static bool isBoundHandle(Value v, llvm::SmallPtrSetImpl<Value> &visited) {
   auto load = v.getDefiningOp<cudaq::cc::LoadOp>();
   if (!load)
     return true;
-  // Walk through `cc.compute_ptr` and `cc.cast` to reach the alloca that owns
-  // the storage being loaded.
   Value ptr = load.getPtrvalue();
-  while (true) {
-    if (auto cp = ptr.getDefiningOp<cudaq::cc::ComputePtrOp>()) {
-      ptr = cp.getBase();
-      continue;
-    }
-    if (auto cs = ptr.getDefiningOp<cudaq::cc::CastOp>()) {
-      ptr = cs.getValue();
-      continue;
-    }
-    break;
-  }
-  auto alloca = ptr.getDefiningOp<cudaq::cc::AllocaOp>();
+  auto alloca = getOwningAlloca(ptr);
   if (!alloca)
     return true;
   auto eleTy = alloca.getElementType();
@@ -128,18 +155,8 @@ static bool isBoundHandle(Value v, llvm::SmallPtrSetImpl<Value> &visited) {
       return false;
     return isBoundHandle(store.getValue(), visited);
   };
-  for (Operation *u : alloca->getUsers()) {
-    if (auto store = dyn_cast<cudaq::cc::StoreOp>(u)) {
-      if (checkStore(store))
-        return true;
-      continue;
-    }
-    if (isa<cudaq::cc::ComputePtrOp, cudaq::cc::CastOp>(u))
-      for (Operation *uu : u->getUsers())
-        if (auto store = dyn_cast<cudaq::cc::StoreOp>(uu))
-          if (store.getPtrvalue() == u->getResult(0) && checkStore(store))
-            return true;
-  }
+  if (anyStoreInto(alloca, checkStore))
+    return true;
   return false;
 }
 
@@ -3815,6 +3832,54 @@ bool QuakeBridgeVisitor::VisitStringLiteral(clang::StringLiteral *x) {
       builder.getContext(), builder.getI8Type(), x->getString().size() + 1));
   return pushValue(cc::CreateStringLiteralOp::create(
       builder, toLocation(x), strLitTy, builder.getStringAttr(x->getString())));
+}
+
+// This walk is lenient: it returns `false` (unbound) only when it can prove no
+// measurement reached the vector, and `true` (bound) for every shape it cannot
+// disprove. It proves "unbound" through exactly one shape: a local descriptor
+// slot initialized from a `cc.stdvec_init` whose backing array never receives a
+// bound element store.
+//
+// Limitation: `anyStoreInto` is satisfied by the first bound element, so a
+// partially-bound vector (some elements measured, some not) reads as bound.
+// Per-element / per-index resolution is deferred (NVIDIA/cuda-quantum#4479),
+// the same coarseness `isBoundHandle` carries on aggregates.
+bool QuakeBridgeVisitor::isBoundHandleVector(
+    mlir::Value v, llvm::SmallPtrSetImpl<mlir::Value> &visited) {
+  if (!visited.insert(v).second)
+    return false;
+  if (v.getDefiningOp<cudaq::quake::MeasurementInterface>())
+    return true;
+  // The vector is a named local; trace its descriptor slot to the store that
+  // initialized it. Anything we cannot trace is assumed bound.
+  auto load = v.getDefiningOp<cc::LoadOp>();
+  if (!load)
+    return true;
+  mlir::Value slotPtr = load.getPtrvalue();
+  auto slot = slotPtr.getDefiningOp<cc::AllocaOp>();
+  if (!slot)
+    return true;
+  for (Operation *u : slot->getUsers()) {
+    auto store = dyn_cast<cc::StoreOp>(u);
+    if (!store || store.getPtrvalue() != slotPtr ||
+        !storeDominatesLoad(store, load))
+      continue;
+    mlir::Value stored = store.getValue();
+    if (stored.getDefiningOp<cudaq::quake::MeasurementInterface>())
+      return true;
+    // Bound iff some element was stored from a bound handle; an empty backing
+    // array is the only provable "unbound".
+    if (auto init = stored.getDefiningOp<cc::StdvecInitOp>()) {
+      auto arr = getOwningAlloca(init.getBuffer());
+      if (!arr)
+        return true;
+      return anyStoreInto(arr, [&](cc::StoreOp st) {
+        return isBoundHandle(st.getValue(), visited);
+      });
+    }
+    return true;
+  }
+  return true;
 }
 
 } // namespace cudaq::detail

--- a/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -238,16 +238,23 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
               // pointer element type (`i1`) disagree and the verifier rejects
               // the module. A `measure_handle` loop variable
               // (`for (auto b : mz(reg))`) keeps the handle and is unaffected.
-              //
-              // TODO(NVIDIA/cuda-quantum#4479): this does not diagnose
-              // discriminating an unbound handle. Definite-assignment analysis
-              // for `measure_handle` is tracked there.
               if (auto iterPtrTy = dyn_cast<cc::PointerType>(iterVar.getType()))
-                if (iterPtrTy.getElementType() == builder.getI1Type())
-                  atOffset = cudaq::quake::DiscriminateOp::create(
-                      builder, loc, builder.getI1Type(), atOffset);
+                if (iterPtrTy.getElementType() == builder.getI1Type()) {
+                  llvm::SmallPtrSet<Value, 4> visited;
+                  if (isBoundHandleVector(buffer, visited)) {
+                    atOffset = cudaq::quake::DiscriminateOp::create(
+                        builder, loc, builder.getI1Type(), atOffset);
+                  } else {
+                    reportClangError(
+                        x, mangler, "discriminating an unbound measure_handle");
+                    // Substitute a well-typed `i1` so the shared store below
+                    // stays valid, and let traversal succeed.
+                    atOffset = arith::ConstantIntOp::create(
+                        builder, loc, builder.getI1Type(), /*value=*/0);
+                  }
+                }
+              cc::StoreOp::create(builder, loc, atOffset, iterVar);
             }
-            cc::StoreOp::create(builder, loc, atOffset, iterVar);
           }
         }
         if (!TraverseStmt(static_cast<clang::Stmt *>(body))) {

--- a/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -253,8 +253,8 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
                         builder, loc, builder.getI1Type(), /*value=*/0);
                   }
                 }
-              cc::StoreOp::create(builder, loc, atOffset, iterVar);
             }
+            cc::StoreOp::create(builder, loc, atOffset, iterVar);
           }
         }
         if (!TraverseStmt(static_cast<clang::Stmt *>(body))) {

--- a/cudaq/test/AST-Quake/range_for_measure.cpp
+++ b/cudaq/test/AST-Quake/range_for_measure.cpp
@@ -9,6 +9,7 @@
 // RUN: cudaq-quake %s | FileCheck %s
 
 #include <cudaq.h>
+#include <vector>
 
 // A range-based for loop with a `bool` loop variable over the result of a
 // multi-qubit `mz` iterates a container of `!cc.measure_handle`. The bridge
@@ -54,3 +55,57 @@ struct range_for_measure_auto {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_auto()
 // CHECK:           quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
 // CHECK:           cc.store %{{.*}}, %{{.*}} : !cc.ptr<!cc.measure_handle>
+
+// A named `std::vector<measure_handle>` bound straight from a multi-qubit `mz`.
+// The descriptor slot stores the `mz` result, so the vector is bound and the
+// per-iteration `quake.discriminate` is still emitted for the `bool` loop
+// variable (regression guard against over-diagnosing a bound vector).
+
+struct range_for_measure_named_vector {
+  bool operator()() __qpu__ {
+    cudaq::qarray<2> reg;
+    auto handles = mz(reg);
+    bool any = false;
+    for (bool b : handles) {
+      any = any || b;
+    }
+    return any;
+  }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_named_vector()
+// CHECK:           quake.mz %{{.*}} name "handles" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %{{.*}}, %{{.*}} : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[HANDLE:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[BIT:.*]] = quake.discriminate %[[HANDLE]] : (!cc.measure_handle) -> i1
+// CHECK:           cc.store %[[BIT]], %{{.*}} : !cc.ptr<i1>
+// clang-format on
+
+// A list-initialized `std::vector<measure_handle>` whose backing array receives
+// the individual `mz` results one hop away -- element 0 through a decay
+// `cc.cast`, element 1 through a `cc.compute_ptr`. The vector is bound, so the
+// loop discriminates rather than diagnosing (regression guard for the
+// cast-reached backing-store path).
+
+struct range_for_measure_list_init {
+  bool operator()() __qpu__ {
+    cudaq::qubit q0, q1;
+    std::vector<cudaq::measure_handle> handles{mz(q0), mz(q1)};
+    bool any = false;
+    for (bool b : handles) {
+      any = any || b;
+    }
+    return any;
+  }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_list_init()
+// CHECK:           quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
+// CHECK:           quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
+// CHECK:           cc.stdvec_init %{{.*}}, %{{.*}} : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[HANDLE:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[BIT:.*]] = quake.discriminate %[[HANDLE]] : (!cc.measure_handle) -> i1
+// CHECK:           cc.store %[[BIT]], %{{.*}} : !cc.ptr<i1>
+// clang-format on

--- a/cudaq/test/AST-error/measure_handle.cpp
+++ b/cudaq/test/AST-error/measure_handle.cpp
@@ -159,3 +159,12 @@ struct ConditionalStoreUnbound {
     return b;
   }
 };
+
+struct RangeForUnboundVector {
+  void operator()() __qpu__ {
+    std::vector<cudaq::measure_handle> handles(2);
+    // expected-error@+1{{discriminating an unbound measure_handle}}
+    for (bool b : handles)
+      (void)b;
+  }
+};


### PR DESCRIPTION
### Summary

* Follow-up to PR #4688

* Diagnose `for (bool b : v)` over a `std::vector<measure_handle>` whose handles were never measured. The loop discriminates each element, so an unbound vector lowers `quake.discriminate` onto a `cc.undef` and reads a result that never existed.