### PR TITLE
Add target option for legacy SV simulator

### DIFF
--- a/cmake/modules/CUDAQConfig.cmake
+++ b/cmake/modules/CUDAQConfig.cmake
@@ -82,6 +82,13 @@ set_target_properties(cudaq::cudaq-nvidia-target PROPERTIES
   IMPORTED_SONAME "libnvqir-${__base_nvtarget_name}-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
 
+# NVIDIA Legacy Target
+add_library(cudaq::cudaq-nvidia-legacy-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-legacy-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+
 # NVIDIA FP64 Target
 add_library(cudaq::cudaq-nvidia-fp64-target SHARED IMPORTED)
 set_target_properties(cudaq::cudaq-nvidia-fp64-target PROPERTIES

--- a/docs/sphinx/using/backends/simulators.rst
+++ b/docs/sphinx/using/backends/simulators.rst
@@ -38,6 +38,12 @@ technical details and code examples for using each circuit simulator.
      - multi-GPU multi-node
      - single (default) / double
      - 33+
+   * - `nvidia-legacy`
+     - State Vector
+     - Legacy state vector simulator that does not support multi-GPU, gate fusion, or trajectory sampling. Can perform better at low qubit counts.
+     - Single GPU
+     - single (default) / double
+     - < 33 / 32 (64 GB)
    * - `tensornet` *
      - Tensor Network
      - Shallow-depth (low-entanglement) and high width circuits (exact)

--- a/python/tests/custom/test_custom_operations.py
+++ b/python/tests/custom/test_custom_operations.py
@@ -111,7 +111,7 @@ def test_three_qubit_op():
 
 # NOTE: Ref - https://github.com/NVIDIA/cuda-quantum/issues/1925
 @pytest.mark.parametrize("target", [
-    'density-matrix-cpu', 'nvidia', 'nvidia-fp64', 'nvidia-mqpu',
+    'density-matrix-cpu', 'nvidia', 'nvidia-legacy', 'nvidia-fp64', 'nvidia-mqpu',
     'nvidia-mqpu-fp64', 'qpp-cpu'
 ])
 def test_simulators(target):

--- a/python/tests/custom/test_custom_operations.py
+++ b/python/tests/custom/test_custom_operations.py
@@ -111,8 +111,8 @@ def test_three_qubit_op():
 
 # NOTE: Ref - https://github.com/NVIDIA/cuda-quantum/issues/1925
 @pytest.mark.parametrize("target", [
-    'density-matrix-cpu', 'nvidia', 'nvidia-legacy', 'nvidia-fp64', 'nvidia-mqpu',
-    'nvidia-mqpu-fp64', 'qpp-cpu'
+    'density-matrix-cpu', 'nvidia', 'nvidia-legacy', 'nvidia-fp64',
+    'nvidia-mqpu', 'nvidia-mqpu-fp64', 'qpp-cpu'
 ])
 def test_simulators(target):
     """Test simulation of custom operation on all available simulation targets."""

--- a/runtime/cudaq/platform/default/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/CMakeLists.txt
@@ -54,5 +54,6 @@ add_target_config(compiler-bench-ftqc-logical)
 
 if (cuStateVec_FOUND)
   add_target_config(nvidia)
+  add_target_config(nvidia-legacy)
   add_target_config(nvidia-fp64)
 endif()

--- a/runtime/cudaq/platform/default/nvidia-legacy.yml
+++ b/runtime/cudaq/platform/default/nvidia-legacy.yml
@@ -1,0 +1,44 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+description: "The NVIDIA Legacy Target provides a simulated QPU via cuStateVec (state-vector simulation) integration."
+
+name: nvidia-legacy
+
+gpu-requirements: true
+
+target-arguments:
+  - key: option
+    required: false
+    type: option-flags
+    help-string: "Specify the target options as a comma-separated list.\nSupported options are 'fp32', 'fp64', 'mqpu'.\nFor example, the 'fp32,mqpu' option combination will activate multi-QPU execution with single-precision. Not all option combinations are supported."
+
+configuration-matrix:
+  - name: single-gpu-fp32
+    option-flags: [fp32]
+    default: true
+    config:
+      nvqir-simulation-backend: custatevec-fp32
+      preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP32"]
+  - name: single-gpu-fp64
+    option-flags: [fp64]
+    config:
+      nvqir-simulation-backend: custatevec-fp64
+      preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
+  - name: multi-qpu-fp32
+    option-flags: [fp32, mqpu]
+    config:
+      nvqir-simulation-backend: custatevec-fp32
+      preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP32"]
+      platform-library: mqpu
+  - name: multi-qpu-fp64
+    option-flags: [fp64, mqpu]
+    config:
+      platform-library: mqpu
+      nvqir-simulation-backend: custatevec-fp64
+      preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]

--- a/scripts/validate_installation.sh
+++ b/scripts/validate_installation.sh
@@ -277,6 +277,7 @@ do
         get_target_options() {
             case "$1" in
                 nvidia) echo "fp32 fp64 fp32,mqpu fp64,mqpu fp32,mgpu fp64,mgpu" ;;
+                nvidia-legacy) echo "fp32 fp64 fp32,mqpu fp64,mqpu" ;;
                 tensornet) echo "fp32 fp64" ;;
                 tensornet-mps) echo "fp32 fp64" ;;
                 *) echo "" ;;

--- a/scripts/validate_pycudaq.sh
+++ b/scripts/validate_pycudaq.sh
@@ -188,7 +188,7 @@ requires_unavailable_gpu_target() {
     targets=$(awk -F'"' '/cudaq\.set_target/ {print $2}' "$file")
     for t in $targets; do
         case "$t" in
-            nvidia|nvidia-fp64|nvidia-mgpu|dynamics|tensornet)
+            nvidia|nvidia-legacy|nvidia-fp64|nvidia-mgpu|dynamics|tensornet)
                 echo "Skipping $file (requires GPU target '$t')" >&2
                 return 0
                 ;;
@@ -324,7 +324,7 @@ cd "$test_workdir"
 if $is_macos; then
     echo "Skipping GPU target verification on macOS (CPU-only)"
 else
-    for tgt in nvidia nvidia-fp64 nvidia-mgpu tensornet; do
+    for tgt in nvidia nvidia-legacy nvidia-fp64 nvidia-mgpu tensornet; do
         python3 -c "import cudaq; cudaq.set_target('${tgt}')"
         if [ $? -ne 0 ]; then
             echo -e "\e[01;31mPython trivial test for target ${tgt} failed.\e[0m" >&2


### PR DESCRIPTION
Currently, there are cases where custatevec significantly outperforms cusvsim at lower circuit widths. Adding explicit target for users to exploit (without editing .yml configs) as an interim solution.