### PR TITLE
Fix ORCA backend integration test

### DIFF
--- a/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
+++ b/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
@@ -70,10 +70,13 @@ public:
   bool supports_task_distribution() const override { return true; }
 
   void beginExecution() override {
-    // Set the current CUDA device for this thread based on the QPU ID in the
-    // execution context.
+    // Only set the CUDA device when GPU-backed QPUs are in use. When a
+    // non-GPU platform (e.g. ORCA) replaces the default QPUs via
+    // setTargetBackend.
     auto qid = cudaq::getCurrentQpuId();
-    cudaq::setCudaDevice(qid);
+    int nDevices = cudaq::getCudaDeviceCount();
+    if (nDevices > 0)
+      cudaq::setCudaDevice(qid);
     // Base implementation of beginExecution will be called after this.
     cudaq::quantum_platform::beginExecution();
   }

--- a/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
+++ b/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
@@ -70,9 +70,9 @@ public:
   bool supports_task_distribution() const override { return true; }
 
   void beginExecution() override {
-    // Only set the CUDA device when GPU-backed QPUs are in use. When a
-    // non-GPU platform (e.g. ORCA) replaces the default QPUs via
-    // setTargetBackend.
+    // Only set the CUDA device when GPU-backed QPUs are active.
+    // Non-GPU platforms (e.g. ORCA) that replace the default QPUs
+    // via setTargetBackend do not require a CUDA device assignment.
     auto qid = cudaq::getCurrentQpuId();
     int nDevices = cudaq::getCudaDeviceCount();
     if (nDevices > 0)


### PR DESCRIPTION
ORCA backend integration is failing with an "Failed to set CUDA device" error.
Error occurs when host machine does not have a GPU.
