### PR TITLE
Harden the verifier for custom ops

### DIFF
--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -1240,7 +1240,41 @@ LogicalResult cudaq::quake::CustomUnitaryConstantOp::verify() {
   auto fn =
       SymbolTable::lookupNearestSymbolFrom<cudaq::cc::GlobalOp>(*this, mat);
   if (!fn)
-    return emitOpError("symbol must be a cc.global");
+    return emitOpError("Invalid matrix symbol, must reference a `cc.global`");
+  auto attr = fn.getValue();
+  if (!attr)
+    return emitOpError("Invalid matrix symbol, must have a constant value");
+  auto elementsAttr = dyn_cast<mlir::ElementsAttr>(*attr);
+  if (!elementsAttr)
+    return emitOpError("Invalid matrix symbol, must be an elements attribute");
+  auto complex64Ty = ComplexType::get(Float64Type::get(getContext()));
+  if (elementsAttr.getElementType() != complex64Ty)
+    return emitOpError("Invalid matrix element type, required `complex<f64>`");
+
+  size_t numQubits = 0;
+  bool sizeKnown = true;
+  for (auto target : getTargets()) {
+    if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(target.getType())) {
+      if (!veqTy.hasSpecifiedSize()) {
+        sizeKnown = false;
+        break;
+      }
+      numQubits += veqTy.getSize();
+    } else {
+      ++numQubits;
+    }
+  }
+  if (numQubits >= 32)
+    return emitOpError("Too many qubits (>=32), not supported");
+  if (sizeKnown) {
+    const size_t numEntries =
+        static_cast<size_t>(elementsAttr.getNumElements());
+    const size_t expectedDim = size_t{1} << numQubits;
+    if (numEntries != expectedDim * expectedDim)
+      return emitOpError(
+          "Invalid matrix size, required 2^N * 2^N for N-qubit operation");
+  }
+
   return verifyWireResultsAreLinear(getOperation());
 }
 

--- a/cudaq/test/Transforms/invalid.qke
+++ b/cudaq/test/Transforms/invalid.qke
@@ -234,3 +234,77 @@ func.func @mz_handle_register_scalar_result(%v: !quake.veq<?>) {
   %m = quake.mz %v : (!quake.veq<?>) -> !cc.measure_handle
   return
 }
+
+// -----
+
+module {
+  func.func @test_custom_unitary_non_square() {
+    %0 = quake.alloca !quake.ref
+    // expected-error@+1 {{Invalid matrix size, required 2^N * 2^N for N-qubit operation}}
+    quake.custom_unitary_constant @nonsquare_3_mat %0 : (!quake.ref) -> ()
+    return
+  }
+  cc.global constant private @nonsquare_3_mat (dense<[(0.0,0.0), (1.0,0.0), (1.0,0.0)]> : tensor<3xcomplex<f64>>) : !cc.array<complex<f64> x 3>
+}
+
+// -----
+
+module {
+  func.func @test_custom_unitary_target_mismatch_too_small() {
+    %0 = quake.alloca !quake.veq<2>
+    %1 = quake.extract_ref %0[0] : (!quake.veq<2>) -> !quake.ref
+    %2 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
+    // expected-error@+1 {{Invalid matrix size, required 2^N * 2^N for N-qubit operation}}
+    quake.custom_unitary_constant @one_q_mat %1, %2 : (!quake.ref, !quake.ref) -> ()
+    return
+  }
+  cc.global constant private @one_q_mat (dense<[(0.0,0.0), (1.0,0.0), (1.0,0.0), (0.0,0.0)]> : tensor<4xcomplex<f64>>) : !cc.array<complex<f64> x 4>
+}
+
+// -----
+
+module {
+  func.func @test_custom_unitary_target_mismatch_too_large() {
+    %0 = quake.alloca !quake.ref
+    // expected-error@+1 {{Invalid matrix size, required 2^N * 2^N for N-qubit operation}}
+    quake.custom_unitary_constant @two_q_mat %0 : (!quake.ref) -> ()
+    return
+  }
+  cc.global constant private @two_q_mat (dense<[(1.0,0.0), (0.0,0.0), (0.0,0.0), (0.0,0.0), (0.0,0.0), (1.0,0.0), (0.0,0.0), (0.0,0.0), (0.0,0.0), (0.0,0.0), (1.0,0.0), (0.0,0.0), (0.0,0.0), (0.0,0.0), (0.0,0.0), (1.0,0.0)]> : tensor<16xcomplex<f64>>) : !cc.array<complex<f64> x 16>
+}
+
+// -----
+
+module {
+  func.func @test_custom_unitary_extern_matrix() {
+    %0 = quake.alloca !quake.ref
+    // expected-error@+1 {{Invalid matrix symbol, must have a constant value}}
+    quake.custom_unitary_constant @extern_mat %0 : (!quake.ref) -> ()
+    return
+  }
+  cc.global extern private @extern_mat : !cc.array<complex<f64> x 4>
+}
+
+// -----
+
+module {
+  func.func @test_custom_unitary_non_elements_matrix() {
+    %0 = quake.alloca !quake.ref
+    // expected-error@+1 {{Invalid matrix symbol, must be an elements attribute}}
+    quake.custom_unitary_constant @str_mat %0 : (!quake.ref) -> ()
+    return
+  }
+  cc.global constant private @str_mat ("hello") : !cc.array<i8 x 5>
+}
+
+// -----
+
+module {
+  func.func @test_custom_unitary_integer_elements() {
+    %0 = quake.alloca !quake.ref
+    // expected-error@+1 {{Invalid matrix element type, required `complex<f64>`}}
+    quake.custom_unitary_constant @int_mat %0 : (!quake.ref) -> ()
+    return
+  }
+  cc.global constant private @int_mat (dense<[0, 1, 1, 0]> : tensor<4xi64>) : !cc.array<i64 x 4>
+}

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -1069,8 +1069,9 @@ void __quantum__qis__custom_unitary(std::complex<double> *unitary,
   auto ctrlsVec = safeArrayToVectorSizeT(controls);
   auto tgtsVec = arrayToVectorSizeT(targets);
   auto numQubits = tgtsVec.size();
-  if (numQubits >= 64)
-    throw std::invalid_argument("Too many qubits (>=64), not supported");
+  // 4^N matrix entries must fit in size_t; 4^32 == 2^64 overflows.
+  if (numQubits >= 32)
+    throw std::invalid_argument("Too many qubits (>=32), not supported");
   auto nToPowTwo = (1ULL << numQubits);
   auto numElements = nToPowTwo * nToPowTwo;
   std::vector<std::complex<double>> unitaryMatrix(unitary,
@@ -1085,8 +1086,9 @@ void __quantum__qis__custom_unitary__adj(std::complex<double> *unitary,
   auto ctrlsVec = safeArrayToVectorSizeT(controls);
   auto tgtsVec = arrayToVectorSizeT(targets);
   auto numQubits = tgtsVec.size();
-  if (numQubits >= 64)
-    throw std::invalid_argument("Too many qubits (>=64), not supported");
+  // 4^N matrix entries must fit in size_t; 4^32 == 2^64 overflows.
+  if (numQubits >= 32)
+    throw std::invalid_argument("Too many qubits (>=32), not supported");
   auto nToPowTwo = (1ULL << numQubits);
 
   std::vector<std::vector<std::complex<double>>> unitaryConj2D;


### PR DESCRIPTION
This PR adds stronger validation for `quake.custom_unitary_constant` matrix operands and aligns the NVQIR runtime guard with the actual 4^N matrix-size overflow boundary.

Note that the Python frontend already had most of these checks in place, but they escaped C++ frontend.