### PR TITLE
Fix check-targets runtime library deps

### DIFF
--- a/targettests/CMakeLists.txt
+++ b/targettests/CMakeLists.txt
@@ -35,6 +35,21 @@ set(CUDAQ_TEST_DEPENDS
     FileCheck
     CustomPassPlugin
 )
+
+# Some runtime/plugin libraries used by target tests are optional and are not
+# registered in CUDAQ_RUNTIME_LIBS, so only add dependencies for targets that
+# are enabled in this build.
+foreach(_cudaq_targettest_runtime_dep IN ITEMS
+    cudaq-chemistry
+    cudaq-platform-mqpu
+    cudaq-py-utils
+    cudaq-rest-qpu
+)
+  if(TARGET ${_cudaq_targettest_runtime_dep})
+    list(APPEND CUDAQ_TEST_DEPENDS ${_cudaq_targettest_runtime_dep})
+  endif()
+endforeach()
+
 # We require split-file, which should be installed along with FileCheck, but
 # the CI doesn't do it. Comment this out and open a bug.
 #   split-file


### PR DESCRIPTION
## Summary

Closes #1571.

`check-targets` already depends on the global `CUDAQ_RUNTIME_LIBS` list, but a few runtime/plugin libraries used by target tests are not registered there. This adds an explicit guarded dependency list for the current targets that match the maintainer-provided missing-library list:

- `cudaq-chemistry`
- `cudaq-platform-mqpu`
- `cudaq-py-utils`
- `cudaq-rest-qpu`

The entries are wrapped in `if(TARGET ...)` so optional REST/Python/runtime plugin targets only become `check-targets` dependencies when that build actually defines them.

I did not add entries for `cudaq-simulator-qpu` or `rest-remote-platform-client` because I could not find current CMake targets or references with those names at HEAD; they appear to have been renamed or removed since the issue comment was written.

## Testing

- `git diff --check`
- repo-wide CMake target/name search for the listed libraries

I did not run a full CUDA-Q build locally; this host does not have the project toolchain/CUDA build environment set up.
