### PR TITLE
[CI] Retry submodule fetch on CI checkouts

### DIFF
--- a/.github/workflows/build_package_sources.yml
+++ b/.github/workflows/build_package_sources.yml
@@ -239,7 +239,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          submodules: recursive
+
+      - name: Initialize submodules (with retry)
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry git submodule update --init --recursive
 
       - name: Set base image
         id: base-image

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -120,8 +120,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          submodules: true
+
+      - name: Initialize submodules (with retry)
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry git submodule update --init --recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -214,8 +217,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          submodules: true
+
+      - name: Initialize submodules (with retry)
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry git submodule update --init --recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -368,8 +374,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          submodules: true
+
+      - name: Initialize submodules (with retry)
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry git submodule update --init --recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -219,7 +219,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: "${{ (inputs.pull_request_number != '' && (inputs.pull_request_commit || format('refs/pull/{0}/merge', inputs.pull_request_number))) || '' }}"
-          submodules: ${{ inputs.checkout_submodules }}
+
+      - name: Initialize submodules (with retry)
+        if: ${{ inputs.checkout_submodules }}
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry git submodule update --init --recursive
 
       - name: Set up context for buildx
         run: |

--- a/.github/workflows/dev_environment_macos.yml
+++ b/.github/workflows/dev_environment_macos.yml
@@ -206,7 +206,7 @@ jobs:
           # wheel jobs only change Python3_EXECUTABLE, which keeps ninja's
           # incremental rebuild scoped to the binding targets.
           # Initialize nanobind submodule which are needed for MLIR Python bindings
-          git submodule update --init --recursive tpls/nanobind
+          retry git submodule update --init --recursive tpls/nanobind
 
           source scripts/set_env_defaults.sh
           

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -60,8 +60,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          submodules: true
+
+      - name: Initialize submodules (with retry)
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry git submodule update --init --recursive
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
CI jobs intermittently fail during checkout when a runner briefly can't resolve github.com mid-clone (e.g. "Could not resolve host: github.com" while fetching tpls/nanobind). actions/checkout only makes one extra attempt for submodules, so a short DNS blip fails the whole job even though the rest of the clone succeeded. This shows up most on the hosted macOS runners but the same single-retry limitation applies everywhere.

Check out the repo without submodules and initialize them in a separate step wrapped in the same retry helper used elsewhere in these workflows, giving submodule fetches three attempts with backoff. Covers the macOS wheel/build/installer jobs plus the Linux paths that fetch submodules (dev_environment, prebuilt_binaries, build_package_sources). Also wrap the nanobind init in dev_environment_macos.yml, which already had the helper in scope but wasn't using it.

Closes #4739