### PR TITLE
Removing warnedNamedMeasurements from ExecutionContext

### DIFF
--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -299,10 +299,6 @@ public:
 
       compiled = compiler.runPassPipeline(kernelName, moduleOp, args, true,
                                           std::move(context));
-      if constexpr (std::is_same_v<Policy, sample_policy>) {
-        if (compiler.hasWarnedNamedMeasurements())
-          policy.warnedNamedMeasurements = true;
-      }
     } else {
       compiled = std::get<CompiledModule>(module);
       kernelName = compiled->getName();

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -263,7 +263,6 @@ public:
   getCompileTarget(const sample_policy &policy) override {
     auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
         serverHelper.get(), targetConfig, backendConfig, emulate);
-    target->warnNamedMeasurements = !policy.warnedNamedMeasurements;
     target->supportConditionalsOnMeasureResults = !emulate;
     target->pipelineConfig.addMeasurements = true;
     target->storeReorderIdx = true;
@@ -493,7 +492,6 @@ public:
     for (std::size_t i = 0; i < codes.size(); i++) {
       cudaq::ExecutionContext context("sample", localShots);
       // Avoid emitting the warning again during execution
-      context.warnedNamedMeasurements = policy.warnedNamedMeasurements;
       sample_policy localPolicy;
       localPolicy.options.shots = localShots;
       localPolicy.reorderIdx = std::move(codes[i].mapping_reorder_idx);
@@ -552,7 +550,6 @@ public:
     std::vector<cudaq::ExecutionResult> results;
     for (std::size_t i = 0; i < codes.size(); i++) {
       cudaq::ExecutionContext context("sample", localShots);
-      // Avoid emitting the warning again during execution
       sample_policy localPolicy;
       localPolicy.options.shots = localShots;
       localPolicy.reorderIdx = std::move(codes[i].mapping_reorder_idx);

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -487,7 +487,6 @@ public:
     // observe) one time each.
     for (std::size_t i = 0; i < codes.size(); i++) {
       cudaq::ExecutionContext context("sample", localShots);
-      // Avoid emitting the warning again during execution
       sample_policy localPolicy;
       localPolicy.options.shots = localShots;
       localPolicy.reorderIdx = std::move(codes[i].mapping_reorder_idx);

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -124,10 +124,6 @@ public:
   /// order.
   bool explicitMeasurements = false;
 
-  /// @brief Flag to indicate that a warning about named measurement registers
-  /// in sampling context has already been emitted.
-  bool warnedNamedMeasurements = false;
-
   /// @brief Probability of occurrence of each error mechanism (column) in
   /// Measurement Syndrome Matrix (0-1 range).
   std::optional<std::vector<double>> msm_probabilities;

--- a/runtime/cudaq/algorithms/sample/policy.h
+++ b/runtime/cudaq/algorithms/sample/policy.h
@@ -35,10 +35,6 @@ struct sample_policy {
   /// @brief The name of the kernel being executed.
   std::string kernelName;
 
-  /// @brief Flag to indicate that a warning about named measurement registers
-  /// in sampling context has already been emitted.
-  bool warnedNamedMeasurements = false;
-
   /// @brief A vector containing information about how to reorder the global
   /// register after execution. Empty means no reordering.
   mutable std::vector<std::size_t> reorderIdx;

--- a/runtime/cudaq/ptsbe/PTSBESample.cpp
+++ b/runtime/cudaq/ptsbe/PTSBESample.cpp
@@ -33,13 +33,10 @@ void validatePTSBEKernel(const std::string &kernelName,
   }
 }
 
-void warnNamedRegisters(const std::string &kernelName, ExecutionContext &ctx) {
-  if (ctx.warnedNamedMeasurements)
-    return;
+bool warnNamedRegisters(const std::string &kernelName, ExecutionContext &ctx) {
   for (const auto &inst : ctx.kernelTrace) {
     if (inst.type == cudaq::TraceInstructionType::Measurement &&
         inst.register_name && *inst.register_name != "__global__") {
-      ctx.warnedNamedMeasurements = true;
       std::cerr << "WARNING: Kernel \"" << kernelName
                 << "\" uses named measurement results but is invoked via "
                    "ptsbe::sample (or ptsbe.sample). PTSBE outputs a single "
@@ -47,9 +44,10 @@ void warnNamedRegisters(const std::string &kernelName, ExecutionContext &ctx) {
                    "named sub-registers are not preserved. Use `cudaq::run` "
                    "to retrieve individual measurement results."
                 << std::endl;
-      return;
+      return true;
     }
   }
+  return false;
 }
 
 void validatePTSBEPreconditions(quantum_platform &platform,

--- a/runtime/cudaq/ptsbe/PTSBESample.h
+++ b/runtime/cudaq/ptsbe/PTSBESample.h
@@ -57,8 +57,11 @@ namespace cudaq::ptsbe::detail {
 void validatePTSBEKernel(const std::string &kernelName,
                          const ExecutionContext &ctx);
 
-/// @brief Warn if kernel uses named measurement registers. PTSBE outputs a
-void warnNamedRegisters(const std::string &kernelName, ExecutionContext &ctx);
+/// @brief Warn if kernel uses named measurement registers.
+/// @param kernelName Name of the kernel being validated
+/// @param ctx ExecutionContext populated after kernel tracing
+/// @return True if a warning was emitted, false otherwise
+bool warnNamedRegisters(const std::string &kernelName, ExecutionContext &ctx);
 
 /// @brief Validate platform preconditions for PTSBE execution
 void validatePTSBEPreconditions(

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -455,7 +455,6 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
         return mlir::WalkResult::advance();
       });
       if (hasNamedMeasurements) {
-        warnedNamedMeasurements = true;
         std::cerr << "WARNING: Kernel \"" << kernelName
                   << "\" uses named measurement results "
                   << "but is invoked in sampling mode. Support for "

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -151,10 +151,6 @@ compileModule(const Policy &policy,
   auto compiled =
       compiler.runPassPipeline(kernelName, modulePtr, args, isEntryPoint);
 
-  if constexpr (std::is_same_v<Policy, cudaq::sample_policy>) {
-    if (compiler.hasWarnedNamedMeasurements())
-      policy.warnedNamedMeasurements = true;
-  }
   return compiled;
 }
 

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -57,9 +57,6 @@ class Compiler {
   /// @brief Flag indicating whether we should print the IR.
   bool printIR = false;
 
-  /// Whether compilation emitted a named measurement warning.
-  bool warnedNamedMeasurements = false;
-
   mlir::ModuleOp lowerQuakeCodeBuildModule(const std::string &,
                                            mlir::ModuleOp module,
                                            mlir::MLIRContext *,
@@ -94,10 +91,6 @@ class Compiler {
       std::shared_ptr<mlir::MLIRContext> context);
 
 public:
-  /// Whether compilation emitted a warning about the presence of named
-  /// measurements.
-  bool hasWarnedNamedMeasurements() const { return warnedNamedMeasurements; }
-
   const cudaq::CompileTarget &getTarget() const { return *target; }
 
   static std::pair<const void *, std::shared_ptr<mlir::MLIRContext>>

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -120,6 +120,10 @@ protected:
   /// @brief Noise model to apply to the current execution.
   const cudaq::noise_model *noiseModel = nullptr;
 
+  /// @brief Flag to indicate that a warning about named measurement registers
+  /// should be emitted.
+  bool warnAboutNamedMeasurements = false;
+
 public:
   /// @brief The constructor
   CircuitSimulator() = default;
@@ -303,6 +307,7 @@ public:
 
   /// @brief Set the execution context
   void configureExecutionContext(const cudaq::sample_policy &policy) {
+    warnAboutNamedMeasurements = true;
     noiseModel = policy.noiseModel;
     currentCircuitName = policy.kernelName;
     CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
@@ -779,11 +784,10 @@ protected:
     auto execResult = sample(sampleQubits, getNumShotsToExec());
 
     // Warn if there are named measurement registers beyond `__global__`
-    if (!executionContext->warnedNamedMeasurements &&
-        registerNameToMeasuredQubit.size() > 1) {
-      executionContext->warnedNamedMeasurements = true;
+    if (warnAboutNamedMeasurements && registerNameToMeasuredQubit.size() > 1) {
+      warnAboutNamedMeasurements = false;
       std::cerr
-          << "WARNING: Kernel \"" << executionContext->kernelName
+          << "WARNING: Kernel \"" << currentCircuitName
           << "\" uses named measurement results but is "
              "invoked in sampling mode. Support for sub-registers in "
              "`sample_result` is deprecated and will be removed in a future "
@@ -1182,6 +1186,9 @@ protected:
 public:
   /// @brief Clean up state after execution ends
   void endExecution() override {
+    internalResult = {};
+    noiseModel = nullptr;
+
     if (nQubitsAllocated == 0) {
       tracker = {};
       return;
@@ -1203,7 +1210,6 @@ public:
     }
 
     tracker = {};
-    internalResult = {};
   }
 
   /// @brief Apply a pre-constructed gate task to the simulator state.

--- a/targettests/execution/sample_named_reg.cpp
+++ b/targettests/execution/sample_named_reg.cpp
@@ -6,10 +6,12 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ %s -o %t && %t 2>&1 | FileCheck %s
-// RUN: nvq++ --target quantinuum --emulate %s -o %t && %t 2>&1 | FileCheck %s
+// RUN: nvq++ %s -o %t && %t 2>&1 | FileCheck --check-prefix=CHECK-SIM %s
+// RUN: nvq++ --target qci --emulate %s -o %t && %t 2>&1 | FileCheck --check-prefix=CHECK-EMUL %s
 
 #include <cudaq.h>
+#include <cudaq/ptsbe/PTSBESample.h>
+#include <iostream>
 
 struct test_kernel {
   auto operator()() __qpu__ {
@@ -19,10 +21,40 @@ struct test_kernel {
   }
 };
 
+__qpu__ bool test_run_kernel() {
+  cudaq::qubit q;
+  h(q);
+  auto res = mz(q);
+  return res;
+}
+
 int main() {
   auto counts = cudaq::sample(test_kernel{});
   counts.dump();
+
+  std::cout << " before cudaq::run" << std::endl;
+  auto run_results = cudaq::run(1000, test_run_kernel);
+
+  std::cout << " before cudaq::ptsbe::sample" << std::endl;
+  cudaq::ptsbe::sample_options options;
+  options.shots = 100;
+  options.ptsbe.return_execution_data = true;
+
+  auto result = cudaq::ptsbe::sample(options, test_kernel{});
   return 0;
 }
 
-// CHECK: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-SIM: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-SIM-NOT: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-SIM: before cudaq::run
+// CHECK-SIM-NOT: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-SIM: before cudaq::ptsbe::sample
+// CHECK-SIM: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-SIM-NOT: WARNING: Kernel "test_kernel" uses named measurement results
+
+
+// CHECK-EMUL: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-EMUL-NOT: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-EMUL: before cudaq::run
+// CHECK-EMUL-NOT: WARNING: Kernel "test_kernel" uses named measurement results
+// CHECK-EMUL: before cudaq::ptsbe::sample

--- a/unittests/nvqpp/ptsbe/PTSBESampleTester.cpp
+++ b/unittests/nvqpp/ptsbe/PTSBESampleTester.cpp
@@ -146,18 +146,14 @@ CUDAQ_TEST(PTSBESampleTest, WarnNamedRegisters) {
   // __global__ only: no warning
   cudaq::ExecutionContext globalCtx("tracer");
   globalCtx.kernelTrace.appendMeasurement("mz", {{2, 0}}, "__global__");
-  detail::warnNamedRegisters("testKernel", globalCtx);
-  EXPECT_FALSE(globalCtx.warnedNamedMeasurements);
+  bool warned = detail::warnNamedRegisters("testKernel", globalCtx);
+  EXPECT_FALSE(warned);
 
   // Named register: sets flag
   cudaq::ExecutionContext namedCtx("tracer");
   namedCtx.kernelTrace.appendMeasurement("mz", {{2, 0}}, "my_register");
-  detail::warnNamedRegisters("testKernel", namedCtx);
-  EXPECT_TRUE(namedCtx.warnedNamedMeasurements);
-
-  // Second call is a no-op (flag already set)
-  detail::warnNamedRegisters("testKernel", namedCtx);
-  EXPECT_TRUE(namedCtx.warnedNamedMeasurements);
+  warned = detail::warnNamedRegisters("testKernel", namedCtx);
+  EXPECT_TRUE(warned);
 }
 
 // ============================================================================


### PR DESCRIPTION
We do not really need the flag on the executionContext or the policy. In the worse case we issue the warning once during JIT compilation and once during simulation but I don't think that we should be trying too hard to carry the information over from one to the next just so the warning is only issue once. I feel that it is unnecessary churn. 

The simulator already holds state, so it keeps track of whether the warning was issued or not. What we really need is only to make sure that it is not issued for every operation of every iteration. The test has been improved to check for that. 