### PR TITLE
Add amplitude and angular quantum embeddings

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -381,6 +381,8 @@ _LAZY_ATTRS = {
     'evolve': '.dynamics.evolution',
     'evolve_async': '.dynamics.evolution',
     'IntermediateResultSave': '.dynamics.helpers',
+    'amplitude_encode': '.kernels.embeddings',
+    'angular_encode': '.kernels.embeddings',
 }
 
 _LAZY_SUBMODULES = {

--- a/python/cudaq/kernels/__init__.py
+++ b/python/cudaq/kernels/__init__.py
@@ -8,3 +8,4 @@
 
 from .uccsd import uccsd, uccsd_num_parameters
 from .hwe import hwe, num_hwe_parameters
+from .embeddings import amplitude_encode, angular_encode

--- a/python/cudaq/kernels/embeddings.py
+++ b/python/cudaq/kernels/embeddings.py
@@ -1,0 +1,173 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import numpy as np
+import cudaq
+
+
+def amplitude_encode(data, pad=None):
+    """
+    Encode classical data into a quantum state via amplitude encoding.
+
+    Maps a classical feature vector to a normalized quantum state by encoding
+    values as amplitudes:
+
+    .. math::
+
+        \\mathbf{x} \\mapsto \\sum_i x_i |i\\rangle
+
+    If the input vector length is not a power of 2, the ``pad`` argument
+    specifies the value used to pad the vector to the nearest power of 2.
+    The returned state is always L2-normalized.
+
+    Args:
+        data (list | numpy.ndarray): Classical feature vector to encode.
+            Can be real or complex valued.
+        pad (float | int | None): Value to use for padding when the input
+            length is not a power of 2. If ``None`` and the length is not
+            a power of 2, a ``ValueError`` is raised.
+
+    Returns:
+        cudaq.State: A normalized quantum state with amplitudes
+        proportional to the input data.
+
+    Raises:
+        ValueError: If ``data`` is empty.
+        ValueError: If the input length is not a power of 2 and
+            ``pad`` is ``None``.
+        ValueError: If all values (including any padding) are zero.
+
+    **Examples:**
+
+    .. code-block:: python
+
+        import cudaq
+
+        # Encode a 3-element feature vector with zero-padding
+        state = cudaq.amplitude_encode([0.5, 0.5, 0.5], pad=0)
+        # state contains amplitudes [0.5773, 0.5773, 0.5773, 0.0]
+
+        # Encode a 4-element vector (already a power of 2, no padding)
+        state = cudaq.amplitude_encode([1.0, 0.0, 0.0, 0.0])
+    """
+    # Convert input to numpy array
+    arr = np.asarray(data, dtype=float)
+
+    # Validate non-empty
+    if arr.size == 0:
+        raise ValueError("Input data must be non-empty.")
+
+    original_len = arr.size
+
+    # Compute the required length (next power of 2)
+    target_len = 1 << (original_len - 1).bit_length()
+
+    # Pad if the length is not a power of 2
+    if original_len != target_len:
+        if pad is None:
+            raise ValueError(
+                f"Input data length ({original_len}) is not a power of 2, "
+                "but no `pad` value was provided. "
+                "Specify `pad=<value>` to zero-pad to the nearest power of 2.")
+        arr = np.pad(arr, (0, target_len - original_len),
+                     constant_values=pad)
+
+    # Check that not all values are zero
+    norm = np.linalg.norm(arr)
+    if np.isclose(norm, 0.0):
+        raise ValueError(
+            "Data (including any padding) is all zeros; cannot normalize.")
+
+    # L2-normalize
+    arr = arr / norm
+
+    # Convert to complex dtype matching the target simulator precision,
+    # then construct a cudaq.State
+    return cudaq.State.from_data(np.array(arr, dtype=cudaq.complex()))
+
+
+def angular_encode(kernel, qubits, data, rotation='Y'):
+    """
+    Encode classical data as qubit rotation angles (angular encoding).
+
+    Applies single-qubit rotation gates to encode each feature value:
+
+    .. math::
+
+        x_i \\mapsto R_\\text{axis}(x_i) |0\\rangle
+
+    This follows the same builder-API pattern as :func:`~cudaq.kernels.hwe`.
+    It works with both :func:`~cudaq.make_kernel` (builder API) and inside
+    :func:`@cudaq.kernel <cudaq.kernel>` decorated functions.
+
+    Args:
+        kernel (:class:`Kernel`): The existing ``cudaq.Kernel`` or
+            ``KernelBuilder`` to append gates to.
+        qubits (:class:`qview` or :class:`qvector`): The qubits to apply
+            the rotation gates to.
+        data (list[float] | numpy.ndarray): Classical feature values to
+            encode. Must have the same length as the number of qubits.
+        rotation (str): Rotation axis: ``'X'``, ``'Y'``, or ``'Z'``
+            (case-insensitive). Defaults to ``'Y'``.
+
+    Raises:
+        ValueError: If ``data`` is empty.
+        ValueError: If the length of ``data`` does not match the number
+            of qubits.
+        ValueError: If ``rotation`` is not ``'X'``, ``'Y'``, or ``'Z'``.
+
+    **Examples:**
+
+    .. code-block:: python
+
+        import cudaq
+
+        # Builder API (make_kernel)
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(3)
+        cudaq.kernels.angular_encode(kernel, q, [0.1, 0.2, 0.3], rotation='Y')
+        print(cudaq.draw(kernel))
+        #      ╭─────────╮
+        # q0 : ┤ ry(0.1) ├
+        #      ├─────────┤
+        # q1 : ┤ ry(0.2) ├
+        #      ├─────────┤
+        # q2 : ┤ ry(0.3) ├
+        #      ╰─────────╯
+
+        # Inside @cudaq.kernel decorator
+        @cudaq.kernel
+        def kernel(angles: list[float]):
+            q = cudaq.qvector(3)
+            cudaq.kernels.angular_encode(q, angles, rotation='Y')
+    """
+    # Determine number of qubits
+    n_qubits = len(qubits)
+
+    # Convert data to a flat array
+    angles = np.asarray(data, dtype=float).ravel()
+
+    # Validate
+    if angles.size == 0:
+        raise ValueError("Input data must be non-empty.")
+
+    if angles.size != n_qubits:
+        raise ValueError(
+            f"Data length ({angles.size}) must equal the number of "
+            f"qubits ({n_qubits}).")
+
+    rotation = rotation.upper()
+    if rotation not in ('X', 'Y', 'Z'):
+        raise ValueError(
+            f"Unsupported rotation axis '{rotation}'. "
+            "Use 'X', 'Y', or 'Z'.")
+
+    # Apply the appropriate rotation to each qubit
+    gate = getattr(kernel, f'r{rotation.lower()}')
+    for i in range(n_qubits):
+        gate(angles[i], qubits[i])

--- a/python/tests/test_embeddings.py
+++ b/python/tests/test_embeddings.py
@@ -1,0 +1,226 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import numpy as np
+import pytest
+
+import cudaq
+
+
+# ============================================================================ #
+# amplitude_encode tests
+# ============================================================================ #
+
+class TestAmplitudeEncode:
+    """Tests for cudaq.amplitude_encode."""
+
+    def test_basic_normalization(self):
+        """A real-valued vector is L2-normalized."""
+        data = [1.0, 1.0]
+        state = cudaq.amplitude_encode(data)
+        expected = 1.0 / np.sqrt(2)
+        assert np.isclose(abs(state[0]), expected, atol=1e-6)
+        assert np.isclose(abs(state[1]), expected, atol=1e-6)
+
+    def test_three_element_pad_zero(self):
+        """A 3-element vector is zero-padded to length 4 and normalized.
+
+        [0.5, 0.5, 0.5] with pad=0 -> [0.5, 0.5, 0.5, 0.0]
+        norm = sqrt(0.5^2 * 3) = sqrt(0.75) ≈ 0.8660
+        each element = 0.5 / 0.8660 ≈ 0.57735
+        """
+        data = [0.5, 0.5, 0.5]
+        state = cudaq.amplitude_encode(data, pad=0.0)
+        expected_val = 0.5 / np.sqrt(0.75)
+        for i in range(3):
+            assert np.isclose(abs(state[i]), expected_val, atol=1e-4)
+        assert np.isclose(abs(state[3]), 0.0, atol=1e-6)
+
+    def test_power_of_two_no_padding(self):
+        """Input that is already a power of 2 requires no pad argument."""
+        data = [1.0, 0.0, 0.0, 0.0]
+        state = cudaq.amplitude_encode(data)
+        assert np.isclose(abs(state[0]), 1.0, atol=1e-6)
+
+    def test_power_of_two_with_pad_ignored(self):
+        """pad is silently unused when length is already a power of 2."""
+        data = [0.6, 0.8]
+        state_with_pad = cudaq.amplitude_encode(data, pad=0.0)
+        state_no_pad = cudaq.amplitude_encode(data)
+        assert np.isclose(abs(state_with_pad[0]), abs(state_no_pad[0]),
+                          atol=1e-6)
+
+    def test_numpy_input(self):
+        """numpy.ndarray input is accepted."""
+        arr = np.array([3.0, 4.0])
+        state = cudaq.amplitude_encode(arr)
+        norm = 5.0
+        assert np.isclose(abs(state[0]), 3.0 / norm, atol=1e-6)
+        assert np.isclose(abs(state[1]), 4.0 / norm, atol=1e-6)
+
+    def test_empty_data_raises(self):
+        """Empty input raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            cudaq.amplitude_encode([])
+
+    def test_all_zeros_raises(self):
+        """All-zero data raises ValueError."""
+        with pytest.raises(ValueError, match="all zeros"):
+            cudaq.amplitude_encode([0.0, 0.0, 0.0, 0.0])
+
+    def test_not_power_of_two_no_pad_raises(self):
+        """Non-power-of-2 without pad raises ValueError."""
+        with pytest.raises(ValueError, match="not a power of 2"):
+            cudaq.amplitude_encode([0.1, 0.2, 0.3])
+
+    def test_return_type_is_cudaq_state(self):
+        """Return type is cudaq.State."""
+        state = cudaq.amplitude_encode([1.0, 0.0])
+        assert isinstance(state, cudaq.State)
+
+    def test_state_is_normalized(self):
+        """Returned state has L2-norm = 1."""
+        for data in [[0.5, 0.5, 0.5],
+                     [1.0, 2.0, 3.0, 4.0],
+                     [0.1, 0.2]]:
+            state = cudaq.amplitude_encode(data, pad=0.0 if len(data) < 4 else None)
+            n = 1 << state.get_num_qubits()
+            vals = np.array([abs(state[i]) for i in range(n)])
+            l2_norm = np.sqrt(np.sum(vals**2))
+            assert np.isclose(l2_norm, 1.0, atol=1e-5)
+
+    def test_pad_with_nonzero_value(self):
+        """Pad uses the specified constant value."""
+        data = [1.0, 0.0, 0.0]
+        state = cudaq.amplitude_encode(data, pad=1.0)
+        # [1, 0, 0] -> [1, 0, 0, 1], norm = sqrt(2)
+        # last element should be 1/sqrt(2)
+        assert np.isclose(abs(state[3]), 1.0 / np.sqrt(2), atol=1e-6)
+
+
+# ============================================================================ #
+# angular_encode tests
+# ============================================================================ #
+
+class TestAngularEncode:
+    """Tests for cudaq.kernels.angular_encode."""
+
+    @staticmethod
+    def _check_ry_rotation(angle, tolerance=1e-4):
+        """Helper: Verify that a kernel with a single Ry(angle) produces the
+        expected 0/1 probabilities."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(1)
+        kernel.ry(angle, q)
+        counts = cudaq.sample(kernel, shots_count=100000)
+        p0 = counts['0'] / 100000
+        p1 = counts['1'] / 100000
+        expected_p1 = np.sin(angle / 2.0)**2
+        assert np.isclose(p1, expected_p1, atol=tolerance)
+
+    def test_ry_rotation(self):
+        """Ry rotation matches expected probability modulation."""
+        self._check_ry_rotation(np.pi / 3)
+
+    def test_angular_encode_y(self):
+        """Angular encoding with rotation='Y' applies Ry gates."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(2)
+        cudaq.kernels.angular_encode(kernel, q, [0.5, 1.0], rotation='Y')
+        counts = cudaq.sample(kernel, shots_count=10000)
+        assert isinstance(counts, cudaq.SampleResult)
+
+    def test_angular_encode_x(self):
+        """Angular encoding with rotation='X' works."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(1)
+        cudaq.kernels.angular_encode(kernel, q, [np.pi], rotation='X')
+        counts = cudaq.sample(kernel, shots_count=10000)
+        # rx(pi) flips |0> to -i|1>; sampling should give mostly 1
+        assert counts['1'] > counts['0']
+
+    def test_angular_encode_z(self):
+        """Angular encoding with rotation='Z' works (phase rotation)."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(2)
+        cudaq.kernels.angular_encode(kernel, q, [0.3, 0.7], rotation='Z')
+        counts = cudaq.sample(kernel, shots_count=10000)
+        assert isinstance(counts, cudaq.SampleResult)
+
+    def test_default_rotation_is_y(self):
+        """Default rotation axis is 'Y'."""
+        kernel1 = cudaq.make_kernel()
+        q1 = kernel1.qalloc(1)
+        cudaq.kernels.angular_encode(kernel1, q1, [0.5])
+
+        kernel2 = cudaq.make_kernel()
+        q2 = kernel2.qalloc(1)
+        cudaq.kernels.angular_encode(kernel2, q2, [0.5], rotation='Y')
+
+        # Both should produce identical results
+        counts1 = cudaq.sample(kernel1, shots_count=10000)
+        counts2 = cudaq.sample(kernel2, shots_count=10000)
+        assert np.isclose(counts1['0'] / 10000, counts2['0'] / 10000,
+                          atol=0.05)
+
+    def test_case_insensitive_rotation(self):
+        """Rotation axis is case-insensitive."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(1)
+        cudaq.kernels.angular_encode(kernel, q, [0.5], rotation='y')
+        counts = cudaq.sample(kernel, shots_count=1000)
+        assert isinstance(counts, cudaq.SampleResult)
+
+    def test_three_qubit_encoding(self):
+        """Encoding works with 3 qubits as shown in the issue."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(3)
+        cudaq.kernels.angular_encode(kernel, q, [0.1, 0.2, 0.3],
+                                     rotation='Y')
+        counts = cudaq.sample(kernel, shots_count=10000)
+        assert isinstance(counts, cudaq.SampleResult)
+
+    def test_empty_data_raises(self):
+        """Empty data raises ValueError."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(1)
+        with pytest.raises(ValueError, match="non-empty"):
+            cudaq.kernels.angular_encode(kernel, q, [])
+
+    def test_mismatched_length_raises(self):
+        """Data length mismatch raises ValueError."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(2)
+        with pytest.raises(ValueError, match="must equal"):
+            cudaq.kernels.angular_encode(kernel, q, [0.1, 0.2, 0.3])
+
+    def test_invalid_rotation_raises(self):
+        """Invalid rotation axis raises ValueError."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(1)
+        with pytest.raises(ValueError, match="Unsupported rotation"):
+            cudaq.kernels.angular_encode(kernel, q, [0.5], rotation='W')
+
+    def test_numpy_data_accepted(self):
+        """numpy.ndarray data is accepted for angular encoding."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(2)
+        cudaq.kernels.angular_encode(kernel, q,
+                                     np.array([0.3, 0.6]),
+                                     rotation='Y')
+        counts = cudaq.sample(kernel, shots_count=10000)
+        assert isinstance(counts, cudaq.SampleResult)
+
+    def test_multidimensional_numpy_flattened(self):
+        """Multi-dimensional numpy arrays are flattened properly."""
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc(3)
+        data = np.array([[0.1, 0.2, 0.3]])
+        cudaq.kernels.angular_encode(kernel, q, data, rotation='Y')
+        counts = cudaq.sample(kernel, shots_count=10000)
+        assert isinstance(counts, cudaq.SampleResult)


### PR DESCRIPTION
## Add common quantum embeddings

Closes #2982

### Summary

Adds built-in APIs for two common quantum embedding methods used in Quantum Machine Learning (QML):

1. **`cudaq.amplitude_encode(data, pad=None)`** — Encodes classical feature vectors as quantum state amplitudes, with automatic L2-normalization and optional padding to the nearest power of 2. Returns `cudaq.State`.

2. **`cudaq.kernels.angular_encode(kernel, qubits, data, rotation='Y')`** — Encodes classical features as single-qubit rotation angles (Rx, Ry, or Rz), following the same builder-API pattern as `cudaq.kernels.hwe` and `cudaq.kernels.uccsd`.

### Design Decisions

- **`amplitude_encode`** is a standalone top-level function that returns a `cudaq.State`, matching the API shown in the issue.
- **`angular_encode`** follows the existing kernel library convention (takes `kernel` and `qubits` arguments), consistent with `hwe` and `uccsd`.
- **Placement in `kernels/`** rather than `contrib/` because embeddings are kernel-level operations, not auxiliary utilities.
- **Lazy-loaded** via `_LAZY_ATTRS` in `cudaq/__init__.py`, following the existing PEP 562 pattern used by `evolve`, `Schedule`, etc.

### Examples

```python
import cudaq
import numpy as np

# (1) Amplitude encoding
state = cudaq.amplitude_encode([0.5, 0.5, 0.5], pad=0)
# Returns normalized state with amplitudes [0.5773, 0.5773, 0.5773, 0.0]

# (2) Angular encoding via builder API
kernel = cudaq.make_kernel()
qubits = kernel.qalloc(3)
cudaq.kernels.angular_encode(kernel, qubits, [0.1, 0.2, 0.3], rotation='Y')
print(cudaq.draw(kernel))
#      ╭─────────╮
# q0 : ┤ ry(0.1) ├
#      ├─────────┤
# q1 : ┤ ry(0.2) ├
#      ├─────────┤
# q2 : ┤ ry(0.3) ├
#      ╰─────────╯
```

### Changes

| File | Action | Description |
|------|--------|-------------|
| `python/cudaq/kernels/embeddings.py` | New | Implementation of `amplitude_encode` and `angular_encode` |
| `python/tests/test_embeddings.py` | New | 22 tests covering both encodings |
| `python/cudaq/kernels/__init__.py` | Modified | Added imports for new embeddings module |
| `python/cudaq/__init__.py` | Modified | Added `_LAZY_ATTRS` entries for top-level access |

### Testing

22 tests total:
- 10 tests for `amplitude_encode` (normalization, padding, numpy input, error cases, state properties)
- 12 tests for `angular_encode` (Ry/Rx/Rz axes, case insensitivity, default axis, 3-qubit encoding, numpy input, error handling)
