### PR TITLE
[CI] Suppress unwanted ghcr deployment records in CI

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -110,6 +110,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
 
     steps:
       - name: Checkout repository
@@ -213,6 +214,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -110,7 +110,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
-      deployment: ${{ inputs.environment != 'ghcr-ci' }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' && inputs.update_registry_cache == '' }}
 
     steps:
       - name: Checkout repository
@@ -214,7 +214,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
-      deployment: ${{ inputs.environment != 'ghcr-ci' }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' && inputs.update_registry_cache == '' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/dev_environment_macos.yml
+++ b/.github/workflows/dev_environment_macos.yml
@@ -56,6 +56,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
 
     steps:
       - name: Checkout repository
@@ -133,6 +134,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -55,6 +55,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
 
     steps:
       - id: info
@@ -98,6 +99,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
   
     steps:
       - name: Checkout repository
@@ -228,6 +230,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
 
     # Needed for making local images available to the docker/build-push-action.
     # See also https://stackoverflow.com/a/63927832.
@@ -445,6 +448,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != 'ghcr-ci' }}
 
     # Needed for making local images available to the docker/build-push-action.
     # See also https://stackoverflow.com/a/63927832.


### PR DESCRIPTION
The ghcr-ci environment only gates CI secrets/access and is not a real deployment, but using it implicitly created a deployment record (and the "deployed to ghcr-ci" message on PRs). Set deployment: false for ghcr-ci in the shared dev_environment and docker_images workflows so the record is never created, while ghcr-deployment and other environments are unaffected.