### PR TITLE
[CI] Retry prerequisite package installs on transient repo failures

### DIFF
--- a/scripts/bootstrap_prerequisites.sh
+++ b/scripts/bootstrap_prerequisites.sh
@@ -205,13 +205,31 @@ echo "Building prerequisites in $PREREQS_BUILD_DIR"
 # Remove below if you wish to debug pre-req build failures
 trap "rm -rf $PREREQS_BUILD_DIR" EXIT
 
+# Retry a command, clearing package-manager metadata between attempts. The CUDA
+# yum repo CDN intermittently serves a stale repomd.xml that points at rotated
+# repodata files, producing 404s; clearing metadata forces a fresh fetch.
+function retry {
+  local n=0 max=5 delay=15
+  until "$@"; do
+    n=$((n+1))
+    if [ "$n" -ge "$max" ]; then
+      echo "Command failed after $max attempts: $*" >&2
+      return 1
+    fi
+    echo "Attempt $n/$max failed; clearing repo metadata and retrying in ${delay}s..." >&2
+    if [ -x "$(command -v dnf)" ]; then dnf clean all || true
+    elif [ -x "$(command -v apt-get)" ]; then apt-get clean || true; fi
+    sleep "$delay"
+  done
+}
+
 function temp_install_if_command_unknown {
   if [ ! -x "$(command -v $1)" ]; then
     if [ -x "$(command -v apt-get)" ]; then
-      if [ -z "$PKG_UNINSTALL" ]; then apt-get update; fi
-      apt-get install -y --no-install-recommends $2
+      if [ -z "$PKG_UNINSTALL" ]; then retry apt-get update; fi
+      retry apt-get install -y --no-install-recommends $2
     elif [ -x "$(command -v dnf)" ]; then
-      dnf install -y --nobest --setopt=install_weak_deps=False $2
+      retry dnf install -y --nobest --setopt=install_weak_deps=False $2
     elif [ -x "$(command -v brew)" ]; then
       HOMEBREW_NO_AUTO_UPDATE=1 brew install $2
     else

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -205,13 +205,31 @@ echo "Building prerequisites in $PREREQS_BUILD_DIR"
 # Remove below if you wish to debug pre-req build failures
 trap "rm -rf $PREREQS_BUILD_DIR" EXIT
 
+# Retry a command, clearing package-manager metadata between attempts. The CUDA
+# yum repo CDN intermittently serves a stale repomd.xml that points at rotated
+# repodata files, producing 404s; clearing metadata forces a fresh fetch.
+function retry {
+  local n=0 max=5 delay=15
+  until "$@"; do
+    n=$((n+1))
+    if [ "$n" -ge "$max" ]; then
+      echo "Command failed after $max attempts: $*" >&2
+      return 1
+    fi
+    echo "Attempt $n/$max failed; clearing repo metadata and retrying in ${delay}s..." >&2
+    if [ -x "$(command -v dnf)" ]; then dnf clean all || true
+    elif [ -x "$(command -v apt-get)" ]; then apt-get clean || true; fi
+    sleep "$delay"
+  done
+}
+
 function temp_install_if_command_unknown {
   if [ ! -x "$(command -v $1)" ]; then
     if [ -x "$(command -v apt-get)" ]; then
-      if [ -z "$PKG_UNINSTALL" ]; then apt-get update; fi
-      apt-get install -y --no-install-recommends $2
+      if [ -z "$PKG_UNINSTALL" ]; then retry apt-get update; fi
+      retry apt-get install -y --no-install-recommends $2
     elif [ -x "$(command -v dnf)" ]; then
-      dnf install -y --nobest --setopt=install_weak_deps=False $2
+      retry dnf install -y --nobest --setopt=install_weak_deps=False $2
     elif [ -x "$(command -v brew)" ]; then
       HOMEBREW_NO_AUTO_UPDATE=1 brew install $2
     else


### PR DESCRIPTION
The CUDA yum repo CDN intermittently serves a stale repomd.xml that references rotated repodata files, producing 404s during dnf metadata refresh and failing the prerequisites build.

Wrap the package-manager calls in temp_install_if_command_unknown with a retry helper that clears metadata between attempts so a fresh repomd.xml is fetched, rather than reusing the stale cached one.

See https://github.com/NVIDIA/cuda-quantum/actions/runs/27975416710/job/82791913916