### PR TITLE
fix: correct sdist metadata name for cudaq metapackage — closes #3433

### DIFF
--- a/.github/required-checks.yml
+++ b/.github/required-checks.yml
@@ -31,6 +31,7 @@ merge_group: &full_matrix
 - Create Docker images (amd64) / Validation
 - Create Docker images (arm64) / Validation
 - Create Python metapackages / Build Python metapackages
+- Create Python metapackages / Validate sdist metadata (Ubuntu 22.04 system pip)
 - Create Python metapackages / Test Python metapackages (3.11)
 - Create Python metapackages / Test Python metapackages (3.13)
 - Create Python metapackages / Test Python metapackages (12.6, 3.11)

--- a/.github/workflows/python_metapackages.yml
+++ b/.github/workflows/python_metapackages.yml
@@ -76,6 +76,7 @@ jobs:
             cd python/metapackages && echo ${{ inputs.cudaq_version }} > _version.txt
             CUDAQ_META_SDIST_BUILD=1 python3 -m build . --sdist
             mkdir /tmp/packages && mv dist/cudaq-* /tmp/packages/
+            python3 validate_sdist_metadata.py /tmp/packages/cudaq-*.tar.gz
             rm -rf dist
 
             echo "Creating README.md for cuda-quantum package"
@@ -98,6 +99,43 @@ jobs:
           path: /tmp/packages/
           retention-days: 1
           if-no-files-found: error
+
+  validate_sdist_metadata_old_pip:
+    name: Validate sdist metadata (Ubuntu 22.04 system pip)
+    needs: build_metapackages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    container:
+      image: ubuntu:22.04
+
+    steps:
+      - name: Load metapackages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build_metapackages.outputs.artifact_name }}
+          path: /tmp/metapackages/
+          merge-multiple: true
+
+      - name: Validate metadata with system pip
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -qq
+          apt-get install -y -qq python3 python3-pip > /dev/null
+          echo "Using $(pip3 --version)"
+          set +e
+          pip3 install /tmp/metapackages/cudaq-*.tar.gz 2>&1 | tee /tmp/install.log
+          install_status=$?
+          set -e
+          if grep -Eiq "metadata has 'unknown'|inconsistent name: filename has 'cudaq', but metadata has 'unknown'" /tmp/install.log; then
+            echo "::error file=python_metapackages.yml::cudaq sdist metadata name mismatch on Ubuntu 22.04 system pip."
+            exit 1
+          fi
+          if [ "$install_status" -ne 0 ] && ! grep -q "No matching distribution found for cuda-quantum" /tmp/install.log; then
+            echo "::error file=python_metapackages.yml::Unexpected pip failure while validating cudaq sdist metadata."
+            exit 1
+          fi
 
   test_metapackages:
     name: Test Python metapackages

--- a/python/metapackages/pyproject.toml
+++ b/python/metapackages/pyproject.toml
@@ -60,6 +60,7 @@ core-metadata-version = "2.3"
 include = [
   "_version.txt",
   "_deprecated.txt",
+  "hatch_build.py",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/python/metapackages/validate_sdist_metadata.py
+++ b/python/metapackages/validate_sdist_metadata.py
@@ -1,0 +1,163 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+"""Regression checks for cudaq metapackage sdist metadata (issue #3433)."""
+
+from __future__ import annotations
+
+import argparse
+import email.parser
+import os
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def _read_pkg_info_from_sdist(sdist_path: Path) -> str:
+    with tarfile.open(sdist_path, mode="r:gz") as archive:
+        for member in archive.getmembers():
+            if member.name.endswith("/PKG-INFO"):
+                payload = archive.extractfile(member)
+                if payload is None:
+                    raise ValueError(f"Could not read {member.name} from {sdist_path}")
+                return payload.read().decode()
+
+    raise ValueError(f"No PKG-INFO found in {sdist_path}")
+
+
+def _metadata_name(metadata_text: str) -> str:
+    message = email.parser.Parser().parsestr(metadata_text)
+    name = message.get("Name")
+    if not name:
+        raise ValueError("Metadata is missing the Name field")
+    return name
+
+
+def _assert_no_legacy_setuptools_packaging(sdist_path: Path) -> None:
+    with tarfile.open(sdist_path, mode="r:gz") as archive:
+        names = {Path(member.name).name for member in archive.getmembers()}
+    legacy = {"setup.py", "setup.cfg"} & names
+    if legacy:
+        raise ValueError(
+            f"{sdist_path} still ships legacy packaging files: {sorted(legacy)}"
+        )
+
+
+def _assert_prepare_metadata_name(sdist_path: Path, expected_name: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        extract_dir = Path(tmp_dir) / "sdist"
+        with tarfile.open(sdist_path, mode="r:gz") as archive:
+            archive.extractall(extract_dir, filter="data")
+
+        source_dir = next(extract_dir.iterdir())
+        metadata_dir = Path(tmp_dir) / "metadata"
+        metadata_dir.mkdir()
+
+        env = os.environ.copy()
+        env.pop("CUDAQ_META_SDIST_BUILD", None)
+        env.pop("CUDAQ_META_WHEEL_BUILD", None)
+
+        script = f"""
+import glob
+import os
+import subprocess
+import sys
+
+def runner(cmd, cwd=None, extra_environ=None):
+    env = os.environ.copy()
+    if extra_environ:
+        env.update(extra_environ)
+    completed = subprocess.run(
+        cmd, cwd=cwd, env=env, capture_output=True, text=True, check=False
+    )
+    if completed.returncode != 0:
+        sys.stderr.write(completed.stdout)
+        sys.stderr.write(completed.stderr)
+        completed.check_returncode()
+    return completed
+
+from pyproject_hooks import BuildBackendHookCaller
+
+hook_caller = BuildBackendHookCaller(
+    source_dir={str(source_dir)!r},
+    build_backend="hatchling.build",
+    backend_path=None,
+    runner=runner,
+)
+hook_caller.prepare_metadata_for_build_wheel({str(metadata_dir)!r})
+
+for metadata_file in glob.glob({str(metadata_dir)!r} + "/**/*.dist-info/METADATA",
+                               recursive=True):
+    with open(metadata_file, encoding="utf-8") as handle:
+        for line in handle:
+            if line.startswith("Name:"):
+                print(line.strip().split(":", 1)[1].strip())
+                raise SystemExit(0)
+
+raise SystemExit("METADATA file with Name field was not generated")
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                "prepare_metadata_for_build_wheel failed:\n"
+                f"{completed.stdout}\n{completed.stderr}"
+            )
+
+        generated_name = completed.stdout.strip()
+        if generated_name.lower() == "unknown":
+            raise ValueError(
+                "prepare_metadata_for_build_wheel reported project name 'unknown'"
+            )
+        if generated_name != expected_name:
+            raise ValueError(
+                f"prepare_metadata_for_build_wheel reported name {generated_name!r}, "
+                f"expected {expected_name!r}"
+            )
+
+
+def validate_sdist_metadata(sdist_path: Path, expected_name: str) -> None:
+    pkg_info = _read_pkg_info_from_sdist(sdist_path)
+    pkg_info_name = _metadata_name(pkg_info)
+    if pkg_info_name.lower() == "unknown":
+        raise ValueError(f"PKG-INFO Name is 'unknown' in {sdist_path}")
+    if pkg_info_name != expected_name:
+        raise ValueError(
+            f"PKG-INFO Name is {pkg_info_name!r}, expected {expected_name!r}"
+        )
+
+    _assert_no_legacy_setuptools_packaging(sdist_path)
+    _assert_prepare_metadata_name(sdist_path, expected_name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate cudaq metapackage sdist metadata."
+    )
+    parser.add_argument("sdist", type=Path, help="Path to the cudaq sdist tarball")
+    parser.add_argument(
+        "--name",
+        default="cudaq",
+        help="Expected project name in sdist metadata (default: cudaq)",
+    )
+    args = parser.parse_args()
+
+    validate_sdist_metadata(args.sdist.resolve(), args.name)
+    print(f"Validated sdist metadata for {args.name!r} in {args.sdist}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`pip3 install cudaq` breaks on a fresh Ubuntu 22.04 box with the system pip. Pip downloads the sdist, tries to read its metadata, gets project name `unknown` instead of `cudaq`, and throws the package away. Upgrading pip works around it, but the sdist metadata is actually wrong on that platform.

The published sdists were built with setuptools and no minimum version pin. On Ubuntu 22.04, pip 22.0.2's build isolation can still pick up the distro's setuptools 59.x, which doesn't handle PEP 621 metadata from `pyproject.toml` properly. `prepare_metadata_for_build_wheel` then reports `unknown`, and pip rejects the sdist.

## What this changes

`main` already moved the metapackage to hatchling. This PR adds guardrails so we don't ship broken metadata again:

- include `hatch_build.py` explicitly in the sdist
- add `python/metapackages/validate_sdist_metadata.py` to check `PKG-INFO` / `METADATA` name, block legacy `setup.py` / `setup.cfg` in the sdist, and verify `prepare_metadata_for_build_wheel` without `CUDAQ_META_SDIST_BUILD`
- run that validator in the metapackage build step
- add a Ubuntu 22.04 job that installs the built sdist with system pip and fails on the `unknown` metadata mismatch

## Verification

Reproduced the failure on `ubuntu:22.04` with pip 22.0.2 against PyPI cudaq sdists.

Built a hatchling sdist locally — `validate_sdist_metadata.py` passes, and `pip3 install` on Ubuntu 22.04 gets past metadata generation (it then fails on missing wheel deps, which is expected in that environment).

Closes #3433

## Test plan

- [x] Build cudaq metapackage sdist locally and run `validate_sdist_metadata.py`
- [x] Reproduce original failure on Ubuntu 22.04 with PyPI sdist + system pip
- [x] Confirm hatchling sdist passes metadata validation on Ubuntu 22.04 with system pip
- [ ] CI: `Create Python metapackages / Build Python metapackages`
- [ ] CI: `Create Python metapackages / Validate sdist metadata (Ubuntu 22.04 system pip)`
