### PR TITLE
Support dumping IR between passes during specialization only

### DIFF
--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -1098,8 +1098,8 @@ static MlirModule synthesizeKernel(nanobind::object kernel,
   // Get additional debug values
   auto disableMLIRthreading =
       cudaq::getEnvBool("CUDAQ_MLIR_DISABLE_THREADING", false);
-  auto enablePrintMLIREachPass =
-      cudaq::getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", false);
+  auto printEachPass =
+      cudaq::getEnvPrintEachPassMode("CUDAQ_MLIR_PRINT_EACH_PASS");
 
   auto &platform = cudaq::get_platform();
   auto isLocalSimulator = platform.is_simulator() && !platform.is_emulated();
@@ -1166,9 +1166,9 @@ static MlirModule synthesizeKernel(nanobind::object kernel,
   tm.setEnabled(cudaq::isTimingTagEnabled(cudaq::TIMING_JIT_PASSES));
   auto timingScope = tm.getRootScope(); // starts the timer
   pm.enableTiming(timingScope);         // do this right before pm.run
-  if (disableMLIRthreading || enablePrintMLIREachPass)
+  if (disableMLIRthreading || printEachPass == cudaq::PrintEachPassMode::All)
     context->disableMultithreading();
-  if (enablePrintMLIREachPass)
+  if (printEachPass == cudaq::PrintEachPassMode::All)
     pm.enableIRPrinting();
   bool pmFailed = failed(cudaq::runPassManagerReleasingGIL(pm, cloned));
   timingScope.stop();
@@ -1180,10 +1180,10 @@ static MlirModule synthesizeKernel(nanobind::object kernel,
 }
 
 static void executeMLIRPassManager(ModuleOp mod, PassManager &pm) {
-  auto enablePrintMLIREachPass =
-      cudaq::getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", false);
+  auto printEachPass =
+      cudaq::getEnvPrintEachPassMode("CUDAQ_MLIR_PRINT_EACH_PASS");
   auto context = mod.getContext();
-  if (enablePrintMLIREachPass) {
+  if (printEachPass == cudaq::PrintEachPassMode::All) {
     context->disableMultithreading();
     pm.enableIRPrinting();
   }

--- a/runtime/common/Environment.cpp
+++ b/runtime/common/Environment.cpp
@@ -10,32 +10,33 @@
 #include <algorithm>
 #include <string>
 
-namespace cudaq {
+static std::string toLower(const std::string &str) {
+  std::string tmp(str);
+  std::transform(tmp.begin(), tmp.end(), tmp.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return tmp;
+}
+
+static bool isTruthy(const std::string &str) {
+  return str == "1" || str == "on" || str == "true" || str[0] == 'y';
+}
 
 /// @brief Helper function to get boolean environment variable
-bool getEnvBool(const char *envName, bool defaultVal = false) {
+bool cudaq::getEnvBool(const char *envName, bool defaultVal = false) {
   if (auto envVal = std::getenv(envName)) {
-    std::string tmp(envVal);
-    std::transform(tmp.begin(), tmp.end(), tmp.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    return (tmp == "1" || tmp == "on" || tmp == "true" || tmp == "y" ||
-            tmp == "yes");
+    return isTruthy(toLower(envVal));
   }
   return defaultVal;
 }
 
-PrintEachPassMode getEnvPrintEachPassMode(const char *envName) {
+cudaq::PrintEachPassMode cudaq::getEnvPrintEachPassMode(const char *envName) {
   if (auto envVal = std::getenv(envName)) {
-    std::string tmp(envVal);
-    std::transform(tmp.begin(), tmp.end(), tmp.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    if (tmp == "specialize")
-      return PrintEachPassMode::Specialize;
-    if (tmp == "1" || tmp == "on" || tmp == "true" || tmp == "y" ||
-        tmp == "yes")
+    auto tmp = toLower(envVal);
+    if (tmp == "specialize" || tmp.starts_with("arg-synth") ||
+        tmp.starts_with("argsynth"))
+      return PrintEachPassMode::ArgSynthesis;
+    if (isTruthy(tmp))
       return PrintEachPassMode::All;
   }
   return PrintEachPassMode::None;
 }
-
-} // namespace cudaq

--- a/runtime/common/Environment.cpp
+++ b/runtime/common/Environment.cpp
@@ -24,4 +24,18 @@ bool getEnvBool(const char *envName, bool defaultVal = false) {
   return defaultVal;
 }
 
+PrintEachPassMode getEnvPrintEachPassMode(const char *envName) {
+  if (auto envVal = std::getenv(envName)) {
+    std::string tmp(envVal);
+    std::transform(tmp.begin(), tmp.end(), tmp.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (tmp == "specialize")
+      return PrintEachPassMode::Specialize;
+    if (tmp == "1" || tmp == "on" || tmp == "true" || tmp == "y" ||
+        tmp == "yes")
+      return PrintEachPassMode::All;
+  }
+  return PrintEachPassMode::None;
+}
+
 } // namespace cudaq

--- a/runtime/common/Environment.h
+++ b/runtime/common/Environment.h
@@ -13,4 +13,11 @@ namespace cudaq {
 /// @brief Helper function to get boolean environment variable
 bool getEnvBool(const char *envName, bool defaultVal);
 
+/// Valid options for `CUDAQ_MLIR_PRINT_EACH_PASS` environment variable.
+enum class PrintEachPassMode { None = 0, Specialize = 1, All = 2 };
+
+/// @brief Parse the environment variable into a PrintEachPassMode.
+PrintEachPassMode
+getEnvPrintEachPassMode(const char *envName = "CUDAQ_MLIR_PRINT_EACH_PASS");
+
 } // namespace cudaq

--- a/runtime/common/Environment.h
+++ b/runtime/common/Environment.h
@@ -14,7 +14,14 @@ namespace cudaq {
 bool getEnvBool(const char *envName, bool defaultVal);
 
 /// Valid options for `CUDAQ_MLIR_PRINT_EACH_PASS` environment variable.
-enum class PrintEachPassMode { None = 0, Specialize = 1, All = 2 };
+enum class PrintEachPassMode {
+  /// Never dump the IR (default)
+  None = 0,
+  /// Dump the IR for passes during argument synthesis
+  ArgSynthesis = 1,
+  /// Dump the IR for all passes
+  All = 2
+};
 
 /// @brief Parse the environment variable into a PrintEachPassMode.
 PrintEachPassMode

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -1038,13 +1038,13 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
     pm.addPass(cudaq::opt::createCCToLLVM());
     pm.addPass(createCanonicalizerPass());
 
-    auto enablePrintMLIREachPass =
-        cudaq::getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", false);
+    auto printEachPass =
+        cudaq::getEnvPrintEachPassMode("CUDAQ_MLIR_PRINT_EACH_PASS");
     auto disableThreading =
         cudaq::getEnvBool("CUDAQ_MLIR_DISABLE_THREADING", false);
-    if (enablePrintMLIREachPass || disableThreading) {
+    if (printEachPass != cudaq::PrintEachPassMode::None || disableThreading) {
       module->getContext()->disableMultithreading();
-      if (enablePrintMLIREachPass)
+      if (printEachPass == cudaq::PrintEachPassMode::All)
         pm.enableIRPrinting();
     }
 

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -106,12 +106,6 @@ std::string cudaq::detail::lower_to_openqasm(const std::string &name,
   }
   cudaq::opt::createPipelineTransformsForPythonToOpenQASM(pm);
   cudaq::opt::addPipelineTranslateToOpenQASM(pm);
-  const bool enablePrintMLIRBeforeAndAfterEachPass =
-      cudaq::getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", false);
-  if (enablePrintMLIRBeforeAndAfterEachPass) {
-    ctx->disableMultithreading();
-    pm.enableIRPrinting();
-  }
   if (failed(cudaq_internal::compiler::runPassManager(pm, compiled_module)))
     throw std::runtime_error("Pass pipeline failed.");
   std::string result;

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -98,8 +98,8 @@ getDefaultPythonCompileTargetImpl() {
   const bool enablePythonCodegenDump =
       cudaq::getEnvBool("CUDAQ_PYTHON_CODEGEN_DUMP", false);
   if (enablePythonCodegenDump) {
-    CUDAQ_WARN("CUDAQ_PYTHON_CODEGEN_DUMP is no longer supported and will be "
-               "ignored. Use CUDAQ_MLIR_PRINT_EACH_PASS instead.");
+    CUDAQ_WARN("CUDAQ_PYTHON_CODEGEN_DUMP is no longer supported. Use "
+               "CUDAQ_MLIR_PRINT_EACH_PASS=specialize instead.");
   }
   std::unique_ptr<cudaq::CompileTarget> ct;
   auto *rt = platform->get_runtime_target();

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -99,7 +99,7 @@ getDefaultPythonCompileTargetImpl() {
       cudaq::getEnvBool("CUDAQ_PYTHON_CODEGEN_DUMP", false);
   if (enablePythonCodegenDump) {
     CUDAQ_WARN("CUDAQ_PYTHON_CODEGEN_DUMP is no longer supported. Use "
-               "CUDAQ_MLIR_PRINT_EACH_PASS=specialize instead.");
+               "CUDAQ_MLIR_PRINT_EACH_PASS=argsynth instead.");
   }
   std::unique_ptr<cudaq::CompileTarget> ct;
   auto *rt = platform->get_runtime_target();

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -136,14 +136,12 @@ cudaq_internal::compiler::Compiler::Compiler(
   // Get additional debug values
   disableMLIRthreading =
       cudaq::getEnvBool("CUDAQ_MLIR_DISABLE_THREADING", disableMLIRthreading);
-  enablePrintMLIREachPass =
-      cudaq::getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", enablePrintMLIREachPass);
+  printEachPass = cudaq::getEnvPrintEachPassMode("CUDAQ_MLIR_PRINT_EACH_PASS");
   enablePassStatistics =
       cudaq::getEnvBool("CUDAQ_MLIR_PASS_STATISTICS", enablePassStatistics);
 
-  // If the very verbose enablePrintMLIREachPass flag is set, then
-  // multi-threading must be disabled.
-  if (enablePrintMLIREachPass) {
+  // Ensure pass debug output is ordered and readable.
+  if (printEachPass != cudaq::PrintEachPassMode::None) {
     disableMLIRthreading = true;
   }
 }
@@ -209,6 +207,8 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
   auto packed = args.getPacked();
   if (!args.empty()) {
     mlir::PassManager pm(contextPtr);
+    if (printEachPass != cudaq::PrintEachPassMode::None)
+      moduleOp.dump();
     if (isPython && rawArgs)
       cudaq_internal::compiler::mergeAllCallableClosures(moduleOp, kernelName,
                                                          *rawArgs);
@@ -300,6 +300,13 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
           cudaq::opt::createQuakeSynthesizer(kernelName, packed->data.data()));
     }
     pm.addPass(mlir::createCanonicalizerPass());
+    if (printEachPass != cudaq::PrintEachPassMode::None)
+      moduleOp.dump();
+    // For Specialize mode, enable per-pass IR printing on this pipeline only.
+    // The ::All variant is handled by configurePassManagerFromEnv (called by
+    // runPassManager).
+    if (printEachPass == cudaq::PrintEachPassMode::Specialize)
+      pm.enableIRPrinting();
     if (failed(cudaq_internal::compiler::runPassManager(
             pm, moduleOp.getOperation())))
       throw std::runtime_error(

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -557,12 +557,14 @@ cudaq_internal::compiler::Compiler::emitKernelExecutions(
       if (codegenTranslation.starts_with("qir")) {
         if (failed(translation(*compiled_module, codegenTranslation, outStr,
                                postCodeGenPasses, printIR,
-                               enablePrintMLIREachPass, enablePassStatistics)))
+                               printEachPass == cudaq::PrintEachPassMode::All,
+                               enablePassStatistics)))
           throw std::runtime_error("Could not successfully translate to " +
                                    codegenTranslation + ".");
       } else {
         if (failed(translation(*compiled_module, outStr, postCodeGenPasses,
-                               printIR, enablePrintMLIREachPass,
+                               printIR,
+                               printEachPass == cudaq::PrintEachPassMode::All,
                                enablePassStatistics)))
           throw std::runtime_error("Could not successfully translate to " +
                                    codegenTranslation + ".");

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -302,10 +302,10 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
     pm.addPass(mlir::createCanonicalizerPass());
     if (printEachPass != cudaq::PrintEachPassMode::None)
       moduleOp.dump();
-    // For Specialize mode, enable per-pass IR printing on this pipeline only.
+    // For ArgSynthesis mode, enable per-pass IR printing on this pipeline only.
     // The ::All variant is handled by configurePassManagerFromEnv (called by
     // runPassManager).
-    if (printEachPass == cudaq::PrintEachPassMode::Specialize)
+    if (printEachPass == cudaq::PrintEachPassMode::ArgSynthesis)
       pm.enableIRPrinting();
     if (failed(cudaq_internal::compiler::runPassManager(
             pm, moduleOp.getOperation())))

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -206,16 +206,6 @@ cudaq_internal::compiler::createJITEngine(ModuleOp &moduleOp,
       cudaq::opt::addAOTPipelineConvertToQIR(pm);
     }
 
-    auto enablePrintMLIREachPass =
-        cudaq::getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", false);
-    auto disableThreading =
-        cudaq::getEnvBool("CUDAQ_MLIR_DISABLE_THREADING", false);
-    if (enablePrintMLIREachPass || disableThreading) {
-      module->getContext()->disableMultithreading();
-      if (enablePrintMLIREachPass)
-        pm.enableIRPrinting();
-    }
-
     std::string error_msg;
     DiagnosticEngine &engine = context->getDiagEngine();
     auto handlerId =

--- a/runtime/internal/compiler/RuntimeMLIR.cpp
+++ b/runtime/internal/compiler/RuntimeMLIR.cpp
@@ -755,12 +755,13 @@ cudaq_internal::compiler::getEntryPointName(OwningOpRef<ModuleOp> &module) {
 
 void cudaq_internal::compiler::configurePassManagerFromEnv(PassManager &pm) {
   auto *ctx = pm.getContext();
-  auto enablePrintEachPass =
-      cudaq::getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", false);
+  auto printMode = cudaq::getEnvPrintEachPassMode("CUDAQ_MLIR_PRINT_EACH_PASS");
   auto disableThreading =
       cudaq::getEnvBool("CUDAQ_MLIR_DISABLE_THREADING", false);
-  if (enablePrintEachPass || disableThreading)
+  if (printMode != cudaq::PrintEachPassMode::None || disableThreading)
     ctx->disableMultithreading();
-  if (enablePrintEachPass)
+  // Enable IR printing indiscriminately. ::Specialize variant is handled in
+  // Compiler::prepareModule.
+  if (printMode == cudaq::PrintEachPassMode::All)
     pm.enableIRPrinting();
 }

--- a/runtime/internal/compiler/RuntimeMLIR.cpp
+++ b/runtime/internal/compiler/RuntimeMLIR.cpp
@@ -755,13 +755,14 @@ cudaq_internal::compiler::getEntryPointName(OwningOpRef<ModuleOp> &module) {
 
 void cudaq_internal::compiler::configurePassManagerFromEnv(PassManager &pm) {
   auto *ctx = pm.getContext();
-  auto printMode = cudaq::getEnvPrintEachPassMode("CUDAQ_MLIR_PRINT_EACH_PASS");
+  auto printEachPass =
+      cudaq::getEnvPrintEachPassMode("CUDAQ_MLIR_PRINT_EACH_PASS");
   auto disableThreading =
       cudaq::getEnvBool("CUDAQ_MLIR_DISABLE_THREADING", false);
-  if (printMode != cudaq::PrintEachPassMode::None || disableThreading)
+  if (printEachPass != cudaq::PrintEachPassMode::None || disableThreading)
     ctx->disableMultithreading();
   // Enable IR printing indiscriminately. ::Specialize variant is handled in
   // Compiler::prepareModule.
-  if (printMode == cudaq::PrintEachPassMode::All)
+  if (printEachPass == cudaq::PrintEachPassMode::All)
     pm.enableIRPrinting();
 }

--- a/runtime/internal/compiler/RuntimeMLIR.cpp
+++ b/runtime/internal/compiler/RuntimeMLIR.cpp
@@ -761,7 +761,7 @@ void cudaq_internal::compiler::configurePassManagerFromEnv(PassManager &pm) {
       cudaq::getEnvBool("CUDAQ_MLIR_DISABLE_THREADING", false);
   if (printEachPass != cudaq::PrintEachPassMode::None || disableThreading)
     ctx->disableMultithreading();
-  // Enable IR printing indiscriminately. ::Specialize variant is handled in
+  // Enable IR printing indiscriminately. ::ArgSynthesis variant is handled in
   // Compiler::prepareModule.
   if (printEachPass == cudaq::PrintEachPassMode::All)
     pm.enableIRPrinting();

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "common/CompiledModule.h"
+#include "common/Environment.h"
 #include "common/KernelArgs.h"
 #include "cudaq_internal/compiler/CompiledModuleHelper.h"
 #include "cudaq/Target/CompileTarget.h"
@@ -39,10 +40,12 @@ class Compiler {
   /// `-mlir-disable-threading` for `cudaq-opt`.
   bool disableMLIRthreading = false;
 
-  /// @brief Flag indicating whether we should enable MLIR printing before and
-  /// after each pass. This is similar to `-mlir-print-ir-before-all` and
-  /// `-mlir-print-ir-after-all` in `cudaq-opt`.
-  bool enablePrintMLIREachPass = false;
+  /// @brief Whether to enable MLIR printing before and after each pass.
+  ///
+  /// This is similar to `-mlir-print-ir-before-all` and
+  /// `-mlir-print-ir-after-all` in `cudaq-opt`. Printing can be enabled for all
+  /// passes or just during specialization.
+  cudaq::PrintEachPassMode printEachPass = cudaq::PrintEachPassMode::None;
 
   /// @brief Flag indicating whether we should enable MLIR pass statistics
   /// to be printed. This is similar to `-mlir-pass-statistics` in `cudaq-opt`


### PR DESCRIPTION
#4636 removed support for the `CUDAQ_PYTHON_CODEGEN_DUMP` environment variable in favour of `CUDAQ_MLIR_PRINT_EACH_PASS`. The reasoning was that
- the flag was needlessly Python specific (it is also useful for C++ JIT compilation)
- it overlapped with functionality of `CUDAQ_MLIR_PRINT_EACH_PASS`
- its name was confusing as "codegen" referred to kernel specialization, rather than codegen in the sense of lowering to target-specific output format

However, in doing so, we lost the option to dump IR between MLIR passes during specialization only.

This PR introduces support for `CUDAQ_MLIR_PRINT_EACH_PASS=specialize` (on top of the already accepted ON/OFF settings) to turn on IR dumping for that phase of compilation only. Setting this env variable reproduces the old behaviour of `CUDAQ_PYTHON_CODEGEN_DUMP=1`.

drive-by: IR printing instrumentation was often registered twice (once in `Compiler.cpp` and once in `runPassManager`), causing duplicate outputs. I've removed this duplication where it was easy.

@schweitzpgi is this a good solution for you?