### PR TITLE
[python] Serialize MLIR pass manager runs for async compilation

### DIFF
--- a/python/runtime/cudaq/platform/PythonSignalCheck.cpp
+++ b/python/runtime/cudaq/platform/PythonSignalCheck.cpp
@@ -16,10 +16,16 @@
 #include "mlir/Pass/PassInstrumentation.h"
 #include "mlir/Pass/PassManager.h"
 #include <Python.h>
+#include <mutex>
 
 using namespace mlir;
 
 namespace {
+// Python kernels share MLIR contexts across async worker threads. MLIR pass
+// managers may append dependent dialect registries during `run`, which cannot
+// overlap with another pass manager executing on the same context.
+std::mutex passManagerMutex;
+
 class PythonSignalCheckInstrumentation : public PassInstrumentation {
   bool signalDetected = false;
 
@@ -51,10 +57,15 @@ void cudaq::addPythonSignalInstrumentation(PassManager &pm) {
 
 LogicalResult cudaq::runPassManagerReleasingGIL(PassManager &pm,
                                                 Operation *op) {
-  if (!PyGILState_Check())
+  auto runPassManager = [&]() {
+    std::lock_guard<std::mutex> lock(passManagerMutex);
     return pm.run(op);
+  };
+
+  if (!PyGILState_Check())
+    return runPassManager();
   PyThreadState *save = PyEval_SaveThread();
-  auto result = pm.run(op);
+  auto result = runPassManager();
   PyEval_RestoreThread(save);
   return result;
 }

--- a/python/tests/kernel/test_async_compile_threading.py
+++ b/python/tests/kernel/test_async_compile_threading.py
@@ -1,0 +1,41 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import concurrent.futures
+
+import cudaq
+import pytest
+from cudaq.mlir._mlir_libs._quakeDialects import cudaq_runtime
+
+
+@pytest.fixture(autouse=True)
+def run_and_clear_registries():
+    cudaq.reset_target()
+    yield
+    cudaq.__clearKernelRegistries()
+    cudaq.reset_target()
+
+
+@cudaq.kernel
+def threaded_compile_kernel(qubit_count: int):
+    qubits = cudaq.qvector(qubit_count)
+    h(qubits)
+    mz(qubits)
+
+
+def test_concurrent_compile_on_python_mlir_context():
+    threaded_compile_kernel.compile()
+
+    def compile_once(_):
+        args, module = threaded_compile_kernel.prepare_call(4)
+        cudaq_runtime.marshal_and_retain_module(
+            threaded_compile_kernel.uniqName, module, True, *args)
+
+    for _ in range(4):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            list(pool.map(compile_once, range(4)))


### PR DESCRIPTION
### Summary

- Serialize Python MLIR pass-manager execution to protect shared Python MLIR contexts during async compilation.
- Add a regression test that concurrently compiles a Python kernel from multiple host threads.
- Prevents `MLIRContext::appendDialectRegistry` assertions seen in `sample_async` / mqpu `observe` paths.

### Root Cause

Python async workers clone modules but share the originating `MLIRContext`. Since compilation releases the GIL, multiple worker threads can enter `PassManager::run()` concurrently. MLIR may append dependent dialect registries during pass-manager setup, which is not allowed while the same context is in a multi-threaded execution region.

