### PR TITLE
fix(opt): diagnose adjoint of forward-declared kernel instead of crashing

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -405,6 +405,25 @@ public:
       assert(func && "global must be a FuncOp");
       auto &variant = variantIter->second;
 
+      // We cannot synthesize variants if only a declaration is available.
+      if ((variant.needsAdjointVariant || variant.needsAdjointControlVariant ||
+           variant.needsControlVariant) &&
+          func.isDeclaration()) {
+        if (variant.needsAdjointVariant || variant.needsAdjointControlVariant) {
+          func.emitOpError()
+              << "cannot create adjoint variant for forward-declared kernel '"
+              << func.getName()
+              << "' (kernel body is unavailable in this translation unit)";
+        } else {
+          func.emitOpError()
+              << "cannot create control variant for forward-declared kernel '"
+              << func.getName()
+              << "' (kernel body is unavailable in this translation unit)";
+        }
+        signalPassFailure();
+        return failure();
+      }
+
       if (variant.needsControlVariant)
         createControlVariantOf(func);
       if (variant.needsAdjointVariant) {

--- a/cudaq/test/Transforms/apply_op_specialization_forward_declared_adjoint.qke
+++ b/cudaq/test/Transforms/apply_op_specialization_forward_declared_adjoint.qke
@@ -1,0 +1,21 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: not cudaq-opt %s --apply-op-specialization 2>&1 | FileCheck %s
+
+module {
+  func.func private @prep(!quake.ref)
+
+  func.func @kernel() {
+    %q = quake.alloca !quake.ref
+    quake.apply<adj> @prep %q : (!quake.ref) -> ()
+    return
+  }
+}
+
+// CHECK: error: 'func.func' op cannot create adjoint variant for forward-declared kernel 'prep' (kernel body is unavailable in this translation unit)


### PR DESCRIPTION
## Summary
- Reject adjoint/control specialization for forward-declared kernels with a clear compiler diagnostic instead of asserting on an empty function body.
- Add MLIR regression test for the `apply-op-specialization` pass.

Fixes #4268

## Test plan
- [x] `not cudaq-opt apply_op_specialization_forward_declared_adjoint.qke --apply-op-specialization`
- [ ] Full `ctest` on CI

Signed-off-by: Arth Jaiswal <contactarthj@gmail.com>

Made with [Cursor](https://cursor.com)