### PR TITLE
fix(packaging): include hatch_build.py in cudaq sdist metadata

### DIFF
--- a/python/metapackages/pyproject.toml
+++ b/python/metapackages/pyproject.toml
@@ -60,6 +60,7 @@ core-metadata-version = "2.3"
 include = [
   "_version.txt",
   "_deprecated.txt",
+  "hatch_build.py",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/python/metapackages/test_validate_sdist_metadata.py
+++ b/python/metapackages/test_validate_sdist_metadata.py
@@ -1,0 +1,72 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def test_cudaq_sdist_includes_hatch_build_hook():
+    """Regression for #3433: sdist must include hatch_build.py for metadata."""
+    metapackages = Path(__file__).resolve().parent
+    pyproject = metapackages / "pyproject.toml"
+    contents = pyproject.read_text(encoding="utf-8")
+    assert '"hatch_build.py"' in contents
+    assert (metapackages / "hatch_build.py").is_file()
+
+
+def test_cudaq_sdist_metadata_name_is_not_unknown():
+    """Build an sdist and verify pip can read project name cudaq (issue #3433)."""
+    metapackages = Path(__file__).resolve().parent
+    readme = metapackages / "README.md.in"
+    version_file = metapackages / "_version.txt"
+    readme_existed = readme.exists()
+    version_existed = version_file.exists()
+    readme_backup = readme.read_text(encoding="utf-8") if readme_existed else None
+    version_backup = version_file.read_text(encoding="utf-8") if version_existed else None
+
+    try:
+        if not readme_existed:
+            readme.write_text("# cudaq\n", encoding="utf-8")
+        version_file.write_text("0.0.0\n", encoding="utf-8")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dist_dir = Path(tmp_dir) / "dist"
+            dist_dir.mkdir()
+            env = os.environ.copy()
+            env["CUDAQ_META_SDIST_BUILD"] = "1"
+            subprocess.run(
+                [sys.executable, "-m", "build", str(metapackages), "--sdist",
+                 "-o", str(dist_dir)],
+                check=True,
+                env=env,
+            )
+            sdist = next(dist_dir.glob("cudaq-*.tar.gz"))
+
+            with tarfile.open(sdist, mode="r:gz") as archive:
+                names = archive.getnames()
+                assert any(n.endswith("hatch_build.py") for n in names), (
+                    "hatch_build.py missing from sdist")
+
+            subprocess.run(
+                [sys.executable, str(metapackages / "validate_sdist_metadata.py"),
+                 str(sdist)],
+                check=True,
+            )
+    finally:
+        if readme_existed and readme_backup is not None:
+            readme.write_text(readme_backup, encoding="utf-8")
+        elif not readme_existed and readme.exists():
+            readme.unlink()
+        if version_existed and version_backup is not None:
+            version_file.write_text(version_backup, encoding="utf-8")
+        elif not version_existed and version_file.exists():
+            version_file.unlink()

--- a/python/metapackages/validate_sdist_metadata.py
+++ b/python/metapackages/validate_sdist_metadata.py
@@ -1,0 +1,162 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+"""Regression checks for cudaq metapackage sdist metadata (issue #3433)."""
+
+from __future__ import annotations
+
+import argparse
+import email.parser
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def _read_pkg_info_from_sdist(sdist_path: Path) -> str:
+    with tarfile.open(sdist_path, mode="r:gz") as archive:
+        for member in archive.getmembers():
+            if member.name.endswith("/PKG-INFO"):
+                payload = archive.extractfile(member)
+                if payload is None:
+                    raise ValueError(f"Could not read {member.name} from {sdist_path}")
+                return payload.read().decode()
+
+    raise ValueError(f"No PKG-INFO found in {sdist_path}")
+
+
+def _metadata_name(metadata_text: str) -> str:
+    message = email.parser.Parser().parsestr(metadata_text)
+    name = message.get("Name")
+    if not name:
+        raise ValueError("Metadata is missing the Name field")
+    return name
+
+
+def _assert_no_legacy_setuptools_packaging(sdist_path: Path) -> None:
+    with tarfile.open(sdist_path, mode="r:gz") as archive:
+        names = {Path(member.name).name for member in archive.getmembers()}
+    legacy = {"setup.py", "setup.cfg"} & names
+    if legacy:
+        raise ValueError(
+            f"{sdist_path} still ships legacy packaging files: {sorted(legacy)}"
+        )
+
+
+def _assert_prepare_metadata_name(sdist_path: Path, expected_name: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        extract_dir = Path(tmp_dir) / "sdist"
+        with tarfile.open(sdist_path, mode="r:gz") as archive:
+            archive.extractall(extract_dir, filter="data")
+
+        source_dir = next(extract_dir.iterdir())
+        metadata_dir = Path(tmp_dir) / "metadata"
+        metadata_dir.mkdir()
+
+        env = os.environ.copy()
+        env.pop("CUDAQ_META_SDIST_BUILD", None)
+        env.pop("CUDAQ_META_WHEEL_BUILD", None)
+
+        script = f"""
+import glob
+import os
+import subprocess
+import sys
+
+def runner(cmd, cwd=None, extra_environ=None):
+    env = os.environ.copy()
+    if extra_environ:
+        env.update(extra_environ)
+    completed = subprocess.run(
+        cmd, cwd=cwd, env=env, capture_output=True, text=True, check=False
+    )
+    if completed.returncode != 0:
+        sys.stderr.write(completed.stdout)
+        sys.stderr.write(completed.stderr)
+        completed.check_returncode()
+    return completed
+
+from pyproject_hooks import BuildBackendHookCaller
+
+hook_caller = BuildBackendHookCaller(
+    source_dir={str(source_dir)!r},
+    build_backend="hatchling.build",
+    backend_path=None,
+    runner=runner,
+)
+hook_caller.prepare_metadata_for_build_wheel({str(metadata_dir)!r})
+
+for metadata_file in glob.glob({str(metadata_dir)!r} + "/**/*.dist-info/METADATA",
+                               recursive=True):
+    with open(metadata_file, encoding="utf-8") as handle:
+        for line in handle:
+            if line.startswith("Name:"):
+                print(line.strip().split(":", 1)[1].strip())
+                raise SystemExit(0)
+
+raise SystemExit("METADATA file with Name field was not generated")
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                "prepare_metadata_for_build_wheel failed:\n"
+                f"{completed.stdout}\n{completed.stderr}"
+            )
+
+        generated_name = completed.stdout.strip()
+        if generated_name.lower() == "unknown":
+            raise ValueError(
+                "prepare_metadata_for_build_wheel reported project name 'unknown'"
+            )
+        if generated_name != expected_name:
+            raise ValueError(
+                f"prepare_metadata_for_build_wheel reported name {generated_name!r}, "
+                f"expected {expected_name!r}"
+            )
+
+
+def validate_sdist_metadata(sdist_path: Path, expected_name: str) -> None:
+    pkg_info = _read_pkg_info_from_sdist(sdist_path)
+    pkg_info_name = _metadata_name(pkg_info)
+    if pkg_info_name.lower() == "unknown":
+        raise ValueError(f"PKG-INFO Name is 'unknown' in {sdist_path}")
+    if pkg_info_name != expected_name:
+        raise ValueError(
+            f"PKG-INFO Name is {pkg_info_name!r}, expected {expected_name!r}"
+        )
+
+    _assert_no_legacy_setuptools_packaging(sdist_path)
+    _assert_prepare_metadata_name(sdist_path, expected_name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate cudaq metapackage sdist metadata."
+    )
+    parser.add_argument("sdist", type=Path, help="Path to the cudaq sdist tarball")
+    parser.add_argument(
+        "--name",
+        default="cudaq",
+        help="Expected project name in sdist metadata (default: cudaq)",
+    )
+    args = parser.parse_args()
+
+    validate_sdist_metadata(args.sdist.resolve(), args.name)
+    print(f"Validated sdist metadata for {args.name!r} in {args.sdist}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Ship `hatch_build.py` in the cudaq sdist so `prepare_metadata_for_build_wheel` reports the correct project name on older pip (Ubuntu 22.04).
- Add `validate_sdist_metadata.py` and regression tests that build an sdist and verify metadata.

Fixes #3433

## Test plan
- [x] `pytest python/metapackages/test_validate_sdist_metadata.py`
- [ ] Metapackage CI on Ubuntu 22.04 system pip

Signed-off-by: Arth Jaiswal <contactarthj@gmail.com>

Made with [Cursor](https://cursor.com)