### PR TITLE
fix(runtime): validate state vector size is a power of 2

### DIFF
--- a/python/tests/kernel/test_observe_kernel.py
+++ b/python/tests/kernel/test_observe_kernel.py
@@ -408,3 +408,30 @@ def test_observe_list_multi_term_operators():
     results_id = cudaq.observe(simple_kernel, [op_with_id])
     result_id = cudaq.observe(simple_kernel, op_with_id)
     assert np.isclose(results_id[0].expectation(), result_id.expectation())
+
+
+def test_observe_rejects_non_power_of_two_state_size():
+    """Regression for #2490: non-power-of-2 state must error, not segfault."""
+    cudaq.set_target('qpp-cpu')
+
+    n_size = 7
+
+    @cudaq.kernel
+    def initial_state(vec: list[float]):
+        q = cudaq.qvector(vec)
+
+    x = np.random.randn(n_size)
+    x = x / np.linalg.norm(x)
+
+    H = -5.0 + 2.5 * spin.x(0) * spin.y(1) + 0.23 * spin.z(1) + 0.11 * spin.z(0)
+
+    with pytest.raises(RuntimeError, match="power of 2"):
+        cudaq.observe(initial_state, H, x).expectation()
+
+
+def test_state_from_data_rejects_non_power_of_two():
+    """Regression for #2490: direct state construction must also validate size."""
+    cudaq.set_target('qpp-cpu')
+    bad = np.ones(7, dtype=np.complex128) / np.sqrt(7)
+    with pytest.raises(RuntimeError, match="power of 2"):
+        cudaq.State.from_data(bad)

--- a/python/tests/kernel/test_observe_kernel.py
+++ b/python/tests/kernel/test_observe_kernel.py
@@ -435,3 +435,15 @@ def test_state_from_data_rejects_non_power_of_two():
     bad = np.ones(7, dtype=np.complex128) / np.sqrt(7)
     with pytest.raises(RuntimeError, match="power of 2"):
         cudaq.State.from_data(bad)
+
+
+def test_state_from_data_rejects_empty_vector():
+    cudaq.set_target('qpp-cpu')
+    with pytest.raises(RuntimeError, match="power of 2"):
+        cudaq.State.from_data(np.array([], dtype=np.complex128))
+
+
+def test_state_from_data_accepts_power_of_two():
+    cudaq.set_target('qpp-cpu')
+    good = np.ones(4, dtype=np.complex128) / 2.0
+    assert cudaq.State.from_data(good) is not None

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -10,6 +10,7 @@
 
 #include "cudaq/operators/matrix.h"
 #include <algorithm>
+#include <bit>
 #include <bitset>
 #include <complex>
 #include <memory>
@@ -144,12 +145,23 @@ public:
     // Check the precision first. Get the size and
     // data pointer from the input data.
 
+    const auto validateStateVectorSize = [](std::size_t size) {
+      if (size == 0 || !std::has_single_bit(size))
+        throw std::runtime_error(
+            "State vector size must be a power of 2, but is " +
+            std::to_string(size));
+    };
+
     if (getPrecision() == precision::fp32) {
       auto [size, ptr] = getSizeAndPtr<float>(data);
+      if (isArrayLike())
+        validateStateVectorSize(size);
       return createFromSizeAndPtr(size, ptr, data.index());
     }
 
     auto [size, ptr] = getSizeAndPtr(data);
+    if (isArrayLike())
+      validateStateVectorSize(size);
     return createFromSizeAndPtr(size, ptr, data.index());
   }
 

--- a/unittests/nvqpp/integration/get_state_tester.cpp
+++ b/unittests/nvqpp/integration/get_state_tester.cpp
@@ -227,4 +227,14 @@ CUDAQ_TEST(GetStateTester, checkKron) {
             "0" + std::string(num_qubits_input_state, '1'));
 }
 
+#ifndef CUDAQ_BACKEND_DM
+CUDAQ_TEST(GetStateTester, rejectNonPowerOfTwoStateData) {
+  std::vector<std::complex<double>> invalid(7);
+  const double norm = 1.0 / std::sqrt(7.0);
+  for (auto &val : invalid)
+    val = {norm, 0.0};
+  EXPECT_THROW(cudaq::state::from_data(invalid), std::runtime_error);
+}
+#endif
+
 #endif


### PR DESCRIPTION
## Summary
- Reject non-power-of-2 state vector sizes in `SimulationState::createFromData` with a clear error instead of segfaulting during observe/get_state paths.
- Add C++ and Python regression tests.

Fixes #2490

## Test plan
- [x] `GetStateTester.rejectNonPowerOfTwoStateData` (C++)
- [x] `test_observe_rejects_non_power_of_two_state_size` (Python)
- [x] `test_state_from_data_rejects_non_power_of_two` (Python)

Signed-off-by: Arth Jaiswal <contactarthj@gmail.com>

Made with [Cursor](https://cursor.com)