### PR TITLE
fix(python): clarify bare tuple kernel argument annotations

### DIFF
--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -542,6 +542,13 @@ def mlirTypeFromAnnotation(annotation,
                 'list argument annotation must provide element type, e.g. list[float] instead of list.'
             )
 
+        if id == 'tuple' or id == 'Tuple':
+            localEmitFatalError(
+                'tuple argument annotation must provide element types, e.g. '
+                'tuple[int, int] or list[tuple[int, int]] instead of bare '
+                'tuple.'
+            )
+
         if id == 'int':
             return IntegerType.get_signless(64)
 

--- a/python/tests/kernel/test_list_tuple_kernel_arg.py
+++ b/python/tests/kernel/test_list_tuple_kernel_arg.py
@@ -7,6 +7,7 @@
 # ============================================================================ #
 
 import pytest
+from typing import Tuple
 
 import cudaq
 
@@ -15,6 +16,14 @@ import cudaq
 def run_and_clear_registries():
     yield
     cudaq.__clearKernelRegistries()
+
+
+def test_typed_tuple_as_kernel_argument():
+    @cudaq.kernel
+    def kernel(a: tuple[int, int]):
+        q = cudaq.qvector(2)
+
+    cudaq.sample(kernel, (1, 2))
 
 
 def test_list_of_typed_tuples_as_kernel_argument():
@@ -44,4 +53,14 @@ def test_bare_tuple_annotation_reports_helpful_error():
 
         @cudaq.kernel
         def kernel(a: tuple):
+            q = cudaq.qvector(2)
+
+
+def test_bare_tuple_capitalized_annotation_reports_helpful_error():
+    with pytest.raises(
+            cudaq.kernel.ast_bridge.CompilerError,
+            match="tuple argument annotation must provide element types"):
+
+        @cudaq.kernel
+        def kernel(a: Tuple):
             q = cudaq.qvector(2)

--- a/python/tests/kernel/test_list_tuple_kernel_arg.py
+++ b/python/tests/kernel/test_list_tuple_kernel_arg.py
@@ -1,0 +1,47 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import pytest
+
+import cudaq
+
+
+@pytest.fixture(autouse=True)
+def run_and_clear_registries():
+    yield
+    cudaq.__clearKernelRegistries()
+
+
+def test_list_of_typed_tuples_as_kernel_argument():
+    """Matches the original issue report once tuple element types are specified."""
+
+    @cudaq.kernel
+    def kernel(a: list[tuple[int, int]]):
+        q = cudaq.qvector(2)
+
+    cudaq.sample(kernel, [(1, 2)])
+
+
+def test_bare_list_tuple_annotation_reports_helpful_error():
+    with pytest.raises(
+            cudaq.kernel.ast_bridge.CompilerError,
+            match="tuple argument annotation must provide element types"):
+
+        @cudaq.kernel
+        def kernel(a: list[tuple]):
+            q = cudaq.qvector(2)
+
+
+def test_bare_tuple_annotation_reports_helpful_error():
+    with pytest.raises(
+            cudaq.kernel.ast_bridge.CompilerError,
+            match="tuple argument annotation must provide element types"):
+
+        @cudaq.kernel
+        def kernel(a: tuple):
+            q = cudaq.qvector(2)


### PR DESCRIPTION
## Summary
- Emit a helpful error when bare `tuple` appears in kernel annotations (e.g. `list[tuple]`), directing users to typed forms like `list[tuple[int, int]]`.
- Add regression tests for the typed form and the improved diagnostics.

Fixes #2560

## Test plan
- [x] `test_list_of_typed_tuples_as_kernel_argument`
- [x] `test_bare_list_tuple_annotation_reports_helpful_error`
- [x] `test_bare_tuple_annotation_reports_helpful_error`

Signed-off-by: Arth Jaiswal <contactarthj@gmail.com>

Made with [Cursor](https://cursor.com)