### PR TITLE
fix(mqpu): localize device-resident cudaq.State for async launch

### DIFF
--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -21,6 +21,9 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
+#ifdef CUDAQ_ENABLE_CUDA
+#include "cuda_runtime_api.h"
+#endif
 
 using namespace cudaq;
 
@@ -71,6 +74,10 @@ static async_observe_result pyObserveAsync(const std::string &shortName,
   auto &platform = get_platform();
   args = simplifiedValidateInputArguments(args);
   auto fnOp = getKernelFuncOp(mod, shortName);
+#ifdef CUDAQ_ENABLE_CUDA
+  if (platform.num_qpus() > 1)
+    cudaSetDevice(static_cast<int>(qpu_id));
+#endif
   auto opaques = marshal_arguments_for_module_launch(mod, args, fnOp);
 
   // Launch the asynchronous execution.

--- a/python/runtime/cudaq/algorithms/py_sample_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample_async.cpp
@@ -18,6 +18,9 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
+#ifdef CUDAQ_ENABLE_CUDA
+#include "cuda_runtime_api.h"
+#endif
 
 using namespace cudaq;
 
@@ -37,6 +40,10 @@ static async_sample_result sample_async_impl(
         "Noise model is not supported on remote platforms.");
 
   auto fnOp = getKernelFuncOp(mod, shortName);
+#ifdef CUDAQ_ENABLE_CUDA
+  if (platform.num_qpus() > 1)
+    cudaSetDevice(static_cast<int>(qpu_id));
+#endif
   auto opaques = marshal_arguments_for_module_launch(mod, runtimeArgs, fnOp);
 
   // Should only have C++ going on here, safe to release the GIL

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -448,6 +448,14 @@ void cudaq::packArgs(
               argData.emplace_back(copyState, [](void *ptr) {
                 delete static_cast<state *>(ptr);
               });
+            } else if (simState->isDeviceData()) {
+              // MQPU launches may run on a different GPU than the one that owns
+              // device-resident state data (e.g. CuPy-backed cudaq.State).
+              state *localizedState =
+                  new state(stateArg->localized_to_current_device());
+              argData.emplace_back(localizedState, [](void *ptr) {
+                delete static_cast<state *>(ptr);
+              });
             } else {
               argData.emplace_back(
                   stateArg,

--- a/python/tests/parallel/test_mqpu_state_kernel.py
+++ b/python/tests/parallel/test_mqpu_state_kernel.py
@@ -1,0 +1,80 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import pytest
+
+import cudaq
+
+cp = pytest.importorskip('cupy')
+
+pytestmark = pytest.mark.skipif(
+    not (cudaq.num_available_gpus() > 1 and cudaq.has_target('nvidia')),
+    reason="nvidia mqpu target with multiple GPUs required")
+
+
+@pytest.fixture(autouse=True)
+def run_and_clear_registries():
+    yield
+    cudaq.__clearKernelRegistries()
+
+
+def test_mqpu_sample_async_state_on_different_qpus():
+    """Regression for #2628: cudaq.State must work across mqpu qpu_ids."""
+    cudaq.set_target('nvidia', option='mqpu')
+    assert cudaq.get_target().num_qpus() > 1
+
+    state_on_gpu0 = cudaq.State.from_data(
+        cp.array([0.0, 1.0], dtype=cp.complex64))
+    state_on_gpu1 = cudaq.State.from_data(
+        cp.array([1.0, 0.0], dtype=cp.complex64))
+
+    @cudaq.kernel
+    def kernel(state: cudaq.State):
+        ancilla = cudaq.qubit()
+        qubits = cudaq.qvector(state)
+        mz(ancilla)
+        mz(qubits)
+
+    result_0 = cudaq.sample_async(kernel, state_on_gpu0, qpu_id=0)
+    result_1 = cudaq.sample_async(kernel, state_on_gpu1, qpu_id=1)
+    assert result_0.get() is not None
+    assert result_1.get() is not None
+
+
+def test_mqpu_sample_async_two_independent_state_circuits():
+    """Matches the original issue report shape (two encodings, two qpu_ids)."""
+    cudaq.set_target('nvidia', option='mqpu')
+    assert cudaq.get_target().num_qpus() > 1
+
+    data = cp.array(
+        [[0, 0, 0, 0, 0, 0, 0, 0], [0, 1, 1, 1, 1, 1, 0, 0],
+         [0, 1, 1, 1, 1, 1, 1, 0], [0, 1, 1, 1, 1, 1, 1, 0],
+         [0, 1, 1, 1, 1, 1, 1, 0], [0, 0, 0, 1, 1, 1, 1, 0],
+         [0, 0, 0, 1, 1, 1, 1, 0], [0, 0, 0, 0, 0, 0, 0, 0]],
+        dtype=cp.float32)
+
+    def amplitude_encode(arr):
+        arr = cp.array(arr)
+        rms = cp.sqrt(cp.sum(arr**2))
+        flat = (arr / rms).flatten().astype(cp.complex64)
+        return flat
+
+    state_0 = cudaq.State.from_data(amplitude_encode(data))
+    state_1 = cudaq.State.from_data(amplitude_encode(data.T))
+
+    @cudaq.kernel
+    def kernel(state: cudaq.State):
+        ancilla = cudaq.qubit()
+        qubits = cudaq.qvector(state)
+        mz(ancilla)
+        mz(qubits)
+
+    result_0 = cudaq.sample_async(kernel, state_0, qpu_id=0)
+    result_1 = cudaq.sample_async(kernel, state_1, qpu_id=1)
+    assert result_0.get() is not None
+    assert result_1.get() is not None

--- a/python/tests/parallel/test_mqpu_state_kernel.py
+++ b/python/tests/parallel/test_mqpu_state_kernel.py
@@ -78,3 +78,25 @@ def test_mqpu_sample_async_two_independent_state_circuits():
     result_1 = cudaq.sample_async(kernel, state_1, qpu_id=1)
     assert result_0.get() is not None
     assert result_1.get() is not None
+
+
+def test_mqpu_observe_async_state_on_different_qpus():
+    cudaq.set_target('nvidia', option='mqpu')
+    assert cudaq.get_target().num_qpus() > 1
+
+    state_on_gpu0 = cudaq.State.from_data(
+        cp.array([0.0, 1.0], dtype=cp.complex64))
+    state_on_gpu1 = cudaq.State.from_data(
+        cp.array([1.0, 0.0], dtype=cp.complex64))
+
+    @cudaq.kernel
+    def kernel(state: cudaq.State):
+        qubits = cudaq.qvector(state)
+        mz(qubits)
+
+    h0 = cudaq.spin.z(0)
+    h1 = cudaq.spin.z(0)
+    result_0 = cudaq.observe_async(kernel, h0, state_on_gpu0, qpu_id=0)
+    result_1 = cudaq.observe_async(kernel, h1, state_on_gpu1, qpu_id=1)
+    assert result_0.get().expectation() is not None
+    assert result_1.get().expectation() is not None

--- a/runtime/cudaq/qis/state.cpp
+++ b/runtime/cudaq/qis/state.cpp
@@ -10,6 +10,9 @@
 #include "common/EigenDense.h"
 #include "cudaq/simulators.h"
 #include <iostream>
+#ifdef CUDAQ_ENABLE_CUDA
+#include "cuda_runtime_api.h"
+#endif
 
 namespace {
 /// Create a shared pointer that calls destroyState at destruction.
@@ -123,6 +126,42 @@ state &state::operator=(state &&other) {
   // Copy and swap idiom
   std::swap(internal, other.internal);
   return *this;
+}
+
+state state::localized_to_current_device() const {
+#ifdef CUDAQ_ENABLE_CUDA
+  if (!is_on_gpu())
+    return *this;
+
+  const auto tensor = get_tensor();
+  if (tensor.data == nullptr)
+    return *this;
+
+  cudaPointerAttributes attributes{};
+  if (cudaPointerGetAttributes(&attributes, tensor.data) != cudaSuccess)
+    return *this;
+
+  int currentDevice = 0;
+  if (cudaGetDevice(&currentDevice) != cudaSuccess)
+    return *this;
+
+  if (attributes.type != cudaMemoryTypeDevice ||
+      attributes.device == currentDevice)
+    return *this;
+
+  const auto numElements = tensor.get_num_elements();
+  if (get_precision() == SimulationState::precision::fp32) {
+    std::vector<std::complex<float>> host(numElements);
+    to_host(host.data(), numElements);
+    return state::from_data(host);
+  }
+
+  std::vector<std::complex<double>> host(numElements);
+  to_host(host.data(), numElements);
+  return state::from_data(host);
+#else
+  return *this;
+#endif
 }
 
 extern "C" {

--- a/runtime/cudaq/qis/state.h
+++ b/runtime/cudaq/qis/state.h
@@ -167,6 +167,11 @@ public:
     return state{}.initialize(data);
   }
 
+  /// @brief If this state lives on a GPU other than the active CUDA device,
+  /// return an equivalent state whose data is on the active device. Host states
+  /// are returned unchanged.
+  state localized_to_current_device() const;
+
 private:
   state() : internal{nullptr} {}
   state &initialize(const state_data &data);


### PR DESCRIPTION
## Summary
- Copy GPU-resident `cudaq.State` data onto the active CUDA device before marshaling kernel arguments, fixing `cudaErrorIllegalAddress` when using `sample_async` with different `qpu_id` values.
- Set the CUDA device before argument marshaling in async sample/observe paths on multi-QPU targets.

Fixes #2628

## Test plan
- [x] `test_mqpu_sample_async_state_on_different_qpus` (requires 2+ GPUs)
- [x] `test_mqpu_sample_async_two_independent_state_circuits` (requires 2+ GPUs)
- [ ] MQPU GPU CI

Signed-off-by: Arth Jaiswal <contactarthj@gmail.com>

Made with [Cursor](https://cursor.com)