### PR TITLE
[macOS] Surface simulator kernel exceptions across the macOS JIT boundary

### DIFF
--- a/.github/pre-commit/spelling_allowlist_cxx.txt
+++ b/.github/pre-commit/spelling_allowlist_cxx.txt
@@ -3,3 +3,4 @@ gcc
 nullary
 pre
 typedef
+unwinder

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -170,6 +170,15 @@ public:
   /// above that boundary once the kernel returns. Callers therefore observe the
   /// same exception they would on platforms where direct unwinding works.
   std::exception_ptr deferredKernelException;
+
+  /// @brief True while a JIT/AOT-compiled kernel frame is executing on this
+  /// thread (set by the launcher around the kernel invocation; see
+  /// QPU::InKernelLaunchScope). The simulator only defers exceptions into
+  /// `deferredKernelException` while this is set. Outside the kernel frame
+  /// (for example, gate application during sample/observe finalization) there
+  /// is no JIT frame for an exception to unwind through, so it is thrown
+  /// directly, preserving the behavior callers see on all platforms.
+  bool inKernelLaunch = false;
 };
 
 //===----------------------------------------------------------------------===//

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -15,6 +15,7 @@
 #include "Trace.h"
 #include "cudaq/algorithms/optimizer.h"
 #include "cudaq/operators.h"
+#include <exception>
 #include <optional>
 #include <string_view>
 
@@ -159,6 +160,16 @@ public:
   /// @brief Slot for the detector error model, as `.dem` text.
   std::string dem_text;
   /// @endcond
+
+  /// @brief Captures an exception raised by the kernel while it runs on a
+  /// backend that cannot unwind C++ exceptions through JIT-compiled kernel
+  /// frames (notably macOS arm64, where the ORC-JIT'd kernel frame carries no
+  /// unwind info the system unwinder can use, so a throw escaping into it calls
+  /// `std::terminate`). The simulator stores the error here instead of throwing
+  /// across the JIT boundary, and the launcher re-throws it from a C++ frame
+  /// above that boundary once the kernel returns. Callers therefore observe the
+  /// same exception they would on platforms where direct unwinding works.
+  std::exception_ptr deferredKernelException;
 };
 
 //===----------------------------------------------------------------------===//

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -38,7 +38,11 @@ cudaq::DefaultQPU::unifiedLaunchModule(const cudaq::AnyModule &module,
 
   auto packed = args.getPacked();
   void *argData = packed ? packed->data.data() : nullptr;
-  return rawFn->getFn()(argData, /*isRemote=*/false);
+  auto result = rawFn->getFn()(argData, /*isRemote=*/false);
+  // Surface any error the kernel deferred rather than threw (see
+  // QPU::rethrowDeferredKernelException).
+  rethrowDeferredKernelException();
+  return result;
 }
 
 cudaq::sample_result

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -38,6 +38,10 @@ cudaq::DefaultQPU::unifiedLaunchModule(const cudaq::AnyModule &module,
 
   auto packed = args.getPacked();
   void *argData = packed ? packed->data.data() : nullptr;
+  // Mark the kernel frame so the simulator defers (rather than throws)
+  // exceptions while the JIT'd kernel runs; rethrowDeferredKernelException()
+  // below surfaces any such error from this C++ frame.
+  InKernelLaunchScope kernelFrame;
   auto result = rawFn->getFn()(argData, /*isRemote=*/false);
   // Surface any error the kernel deferred rather than threw (see
   // QPU::rethrowDeferredKernelException).

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -19,6 +19,7 @@
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <cstring>
+#include <exception>
 #include <stdexcept>
 
 using namespace cudaq_internal::compiler;
@@ -58,6 +59,14 @@ cudaq::QPU::launchKernel(const async_observe_policy &policy,
       "This QPU does not support launching the async_observe_policy.");
 }
 
+void cudaq::QPU::rethrowDeferredKernelException() {
+  if (auto *ctx = getExecutionContext(); ctx && ctx->deferredKernelException) {
+    auto deferred = ctx->deferredKernelException;
+    ctx->deferredKernelException = nullptr;
+    std::rethrow_exception(deferred);
+  }
+}
+
 cudaq::KernelThunkResultType
 cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
                                  KernelArgs args) {
@@ -92,17 +101,21 @@ cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
                   resultInfo.getBufferSize());
     }
     std::free(buff);
+    rethrowDeferredKernelException();
     return {nullptr, 0};
   }
   if (resultInfo.hasResult()) {
     // Fully specialized with result: rawArgs.back() is the pre-allocated
     // result buffer; pass it directly to the thunk.
     void *buff = const_cast<void *>(rawArgs.back());
-    return reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(funcPtr)(
-        buff, /*client_server=*/false);
+    auto result = reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(
+        funcPtr)(buff, /*client_server=*/false);
+    rethrowDeferredKernelException();
+    return result;
   }
   // Fully specialized, no result.
   funcPtr();
+  rethrowDeferredKernelException();
   return {nullptr, 0};
 }
 

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -67,6 +67,16 @@ void cudaq::QPU::rethrowDeferredKernelException() {
   }
 }
 
+cudaq::QPU::InKernelLaunchScope::InKernelLaunchScope() {
+  if (auto *ctx = getExecutionContext())
+    ctx->inKernelLaunch = true;
+}
+
+cudaq::QPU::InKernelLaunchScope::~InKernelLaunchScope() {
+  if (auto *ctx = getExecutionContext())
+    ctx->inKernelLaunch = false;
+}
+
 cudaq::KernelThunkResultType
 cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
                                  KernelArgs args) {
@@ -86,6 +96,10 @@ cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
   auto rawArgs = args.getTypeErased().value_or(std::span<void *const>{});
   auto funcPtr = compiled.getJit()->getFn();
   const auto &resultInfo = compiled.getResultInfo();
+  // Mark the kernel frame so the simulator defers (rather than throws)
+  // exceptions while the JIT'd kernel runs; rethrowDeferredKernelException()
+  // below surfaces any such error from this C++ frame.
+  InKernelLaunchScope kernelFrame;
   if (!compiled.isFullySpecialized()) {
     // Pack args at runtime via argsCreator, then call the thunk.
     auto argsCreator = compiled.getArgsCreator();

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -57,6 +57,16 @@ protected:
   [[nodiscard]] static KernelThunkResultType
   runJITCompiledModule(const CompiledModule &compiled, KernelArgs args);
 
+  /// @brief Re-throw an exception the kernel deferred during execution, if any.
+  /// Subclasses must call this immediately after invoking a kernel, from the
+  /// C++ frame above the JIT/AOT boundary. It exists because on some platforms
+  /// (macOS arm64) a C++ exception cannot unwind through a JIT-compiled kernel
+  /// frame; the simulator records the error on the execution context instead of
+  /// throwing across that boundary (see
+  /// ExecutionContext::deferredKernelException). No-op when nothing was
+  /// deferred.
+  static void rethrowDeferredKernelException();
+
 public:
   /// The constructor, initializes the execution queue
   QPU() : execution_queue(std::make_unique<QuantumExecutionQueue>()) {}

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -67,6 +67,19 @@ protected:
   /// deferred.
   static void rethrowDeferredKernelException();
 
+  /// @brief RAII marker for the window in which a JIT/AOT-compiled kernel frame
+  /// is executing. While alive it sets `ExecutionContext::inKernelLaunch` on
+  /// the active context, so the simulator defers (rather than throws)
+  /// exceptions that would otherwise have to unwind through the kernel frame.
+  /// Launchers wrap the raw kernel invocation in this scope and call
+  /// rethrowDeferredKernelException() immediately afterwards.
+  struct InKernelLaunchScope {
+    InKernelLaunchScope();
+    ~InKernelLaunchScope();
+    InKernelLaunchScope(const InKernelLaunchScope &) = delete;
+    InKernelLaunchScope &operator=(const InKernelLaunchScope &) = delete;
+  };
+
 public:
   /// The constructor, initializes the execution queue
   QPU() : execution_queue(std::make_unique<QuantumExecutionQueue>()) {}

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -838,6 +838,10 @@ protected:
                    const std::vector<std::size_t> &controls,
                    const std::vector<std::size_t> &targets,
                    const std::vector<ScalarType> &params) {
+    // Once a kernel run has failed (error deferred for the launcher to
+    // re-throw), stop accumulating further gates.
+    if (kernelExecutionDeferred())
+      return;
     if (cudaq::isInTracerMode()) {
       std::vector<cudaq::QuditInfo> controlsInfo, targetsInfo;
       for (auto &c : controls)
@@ -903,9 +907,43 @@ protected:
     CUDAQ_WARN("Applying noise is not supported on {} simulator.", name());
   }
 
+  /// @brief Record a fatal kernel error. When an execution context is active
+  /// the exception is stashed on it (`deferredKernelException`) so the launcher
+  /// can re-throw it from a C++ frame above the JIT boundary; this is required
+  /// on platforms such as macOS arm64 where a C++ exception cannot unwind
+  /// through a JIT-compiled kernel frame and would otherwise call
+  /// `std::terminate`. Without a context to carry the error there is no JIT
+  /// frame to escape, so throw directly. Only the first error per kernel run is
+  /// retained; later ones are suppressed since the kernel result is discarded.
+  static void deferOrThrowKernelException(const std::string &msg) {
+    auto *ctx = cudaq::getExecutionContext();
+    if (!ctx)
+      throw std::runtime_error(msg);
+    if (!ctx->deferredKernelException)
+      ctx->deferredKernelException =
+          std::make_exception_ptr(std::runtime_error(msg));
+  }
+
+  /// @brief True once the current kernel run has recorded a deferred error.
+  /// Gate enqueue and queue flushing become no-ops in this state so the
+  /// simulator is not mutated after the failure and no re-entrant throw occurs.
+  static bool kernelExecutionDeferred() {
+    auto *ctx = cudaq::getExecutionContext();
+    return ctx && ctx->deferredKernelException;
+  }
+
   /// @brief Flush the gate queue, run all queued gate
   /// application tasks.
   void flushGateQueueImpl() override {
+
+    // If an earlier operation in this kernel run already failed, drop any
+    // queued gates without applying them. The recorded error is re-thrown by
+    // the launcher once the kernel returns (see deferOrThrowKernelException).
+    if (kernelExecutionDeferred()) {
+      while (!gateQueue.empty())
+        gateQueue.pop();
+      return;
+    }
 
     while (!gateQueue.empty()) {
       auto &next = gateQueue.front();
@@ -918,12 +956,14 @@ protected:
       } catch (std::exception &e) {
         while (!gateQueue.empty())
           gateQueue.pop();
-        throw std::runtime_error(std::string("Exception in applyGate: ") +
-                                 e.what());
+        deferOrThrowKernelException(std::string("Exception in applyGate: ") +
+                                    e.what());
+        return;
       } catch (...) {
         while (!gateQueue.empty())
           gateQueue.pop();
-        throw std::runtime_error("Unknown exception in applyGate");
+        deferOrThrowKernelException("Unknown exception in applyGate");
+        return;
       }
       if (getNoiseModel() && !getNoiseModel()->empty()) {
         std::vector<double> params(next.parameters.begin(),

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -907,17 +907,20 @@ protected:
     CUDAQ_WARN("Applying noise is not supported on {} simulator.", name());
   }
 
-  /// @brief Record a fatal kernel error. When an execution context is active
-  /// the exception is stashed on it (`deferredKernelException`) so the launcher
-  /// can re-throw it from a C++ frame above the JIT boundary; this is required
-  /// on platforms such as macOS arm64 where a C++ exception cannot unwind
-  /// through a JIT-compiled kernel frame and would otherwise call
-  /// `std::terminate`. Without a context to carry the error there is no JIT
-  /// frame to escape, so throw directly. Only the first error per kernel run is
-  /// retained; later ones are suppressed since the kernel result is discarded.
+  /// @brief Record a fatal kernel error. While a JIT/AOT-compiled kernel frame
+  /// is executing (`ExecutionContext::inKernelLaunch`) the exception is stashed
+  /// on the context (`deferredKernelException`) so the launcher can re-throw it
+  /// from a C++ frame above the JIT boundary; this is required on platforms
+  /// such as macOS arm64 where a C++ exception cannot unwind through a
+  /// JIT-compiled kernel frame and would otherwise call `std::terminate`.
+  /// Outside such a frame (for example, gate application during sample/observe
+  /// finalization, or with no active context) there is no JIT frame to escape,
+  /// so throw directly, exactly as callers expect on every platform. Only the
+  /// first error per kernel run is retained; later ones are suppressed since
+  /// the kernel result is discarded.
   static void deferOrThrowKernelException(const std::string &msg) {
     auto *ctx = cudaq::getExecutionContext();
-    if (!ctx)
+    if (!ctx || !ctx->inKernelLaunch)
       throw std::runtime_error(msg);
     if (!ctx->deferredKernelException)
       ctx->deferredKernelException =


### PR DESCRIPTION
On macOS arm64, a C++ exception thrown by the simulator inside a
JIT-compiled kernel frame cannot be unwound by the system unwinder and
calls `std::terminate`, crashing the process instead of raising a catchable
error (e.g. Stim rejecting a non-Clifford gate, or dem_from_kernel on a
non-Clifford kernel).

This defers such exceptions onto the ExecutionContext while a kernel frame
is executing and re-throws them from the C++ launcher frame above the JIT
boundary, so callers observe the same exception as on platforms where
direct unwinding works. The deferral is scoped to the kernel frame via an
RAII guard (`ExecutionContext::inKernelLaunch`); outside it - e.g. gate
application during sample/observe finalization - exceptions throw directly,
preserving existing behavior on all platforms.

This was merged into the release branch for 0.15 to unblock the publishing piepline, which is fully green now - https://github.com/NVIDIA/cuda-quantum/actions/runs/28160514270