### PR TITLE
[ci] read-only ccache on PRs, larger dev-env runners

### DIFF
--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -27,7 +27,7 @@ name: Run CI within the dev environment container
 jobs:
   build_and_test:
     name: Dev environment (Debug)
-    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu8') || 'linux-amd64-cpu8' }}
+    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu16') || 'linux-amd64-cpu16' }}
     permissions:
       contents: read
       packages: write
@@ -134,6 +134,9 @@ jobs:
             --target test-mpi
 
       - name: Extract ccache from build
+        # Write cache only on merge-queue/scheduled runs; PRs (event 'push' =
+        # pull-request/*) are read-only, skipping the ~6-7 min extract+push.
+        if: github.event_name != 'push'
         timeout-minutes: 15
         continue-on-error: true
         run: |
@@ -154,6 +157,7 @@ jobs:
           fi
 
       - name: Push ccache to GHCR
+        if: github.event_name != 'push'
         uses: ./.github/actions/ccache-push
         with:
           cache-key: ${{ steps.platform_meta.outputs.platform_id }}-devenv
@@ -194,7 +198,7 @@ jobs:
 
   build_and_test_python:
     name: Dev environment (Python)
-    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu8') || 'linux-amd64-cpu8' }}
+    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu16') || 'linux-amd64-cpu16' }}
     permissions:
       contents: read
       packages: write
@@ -330,6 +334,7 @@ jobs:
             fi
 
       - name: Extract ccache from container
+        if: github.event_name != 'push'
         timeout-minutes: 15
         continue-on-error: true
         run: |
@@ -342,6 +347,7 @@ jobs:
           fi
 
       - name: Push ccache to GHCR
+        if: github.event_name != 'push'
         uses: ./.github/actions/ccache-push
         with:
           cache-key: ${{ steps.platform_meta.outputs.platform_id }}-devenv-python


### PR DESCRIPTION
PR runs spend ~7 min extracting and pushing the ccache tarball through the build context and GHCR. Skip those steps on PRs (push to pull-request/*); only the merge queue writes the cache now. Reads are unchanged and the cache stays warm from merge-queue runs.

Also move the Debug and Python dev-env jobs to cpu16 runners.