### PR TITLE
[ci] add multi-GPU MPI validation on 2-GPU runners

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1082,9 +1082,9 @@ jobs:
         image_hash: ${{ fromJson(needs.image_validation_config.outputs.docker_images) }}
         include:
           - arch: amd64
-            runner: nv-gpu-amd64-rtxpro6000-2gpu
+            runner: linux-amd64-gpu-rtxpro6000-latest-2
           - arch: arm64
-            runner: nv-gpu-arm64-l4-2gpu
+            runner: linux-arm64-gpu-l4-latest-2
       fail-fast: false
 
     container:

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1064,6 +1064,80 @@ jobs:
             exit $status_sum
           fi
 
+  multi_gpu_mpi_validation:
+    name: Multi-GPU MPI validation
+    needs: [assets, cudaq_images, image_validation_config]
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+
+    environment:
+      name: ghcr-deployment
+      url: ${{ vars.deployment_url }}
+
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        image_hash: ${{ fromJson(needs.image_validation_config.outputs.docker_images) }}
+        include:
+          - arch: amd64
+            runner: nv-gpu-amd64-rtxpro6000-2gpu
+          - arch: arm64
+            runner: nv-gpu-arm64-l4-2gpu
+      fail-fast: false
+
+    container:
+      image: ${{ matrix.image_hash }}
+      credentials:
+        username: ${{ needs.cudaq_images.outputs.push_to_ngc != 'true' && github.actor || '$oauthtoken' }}
+        password: ${{ needs.cudaq_images.outputs.push_to_ngc != 'true' && github.token || secrets.NGC_CREDENTIALS  }}
+      options: --user root # otherwise step summary doesn't work
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+        TERM: xterm
+
+    steps:
+      - name: Require two visible GPUs
+        shell: bash
+        run: |
+          gpu_count=$(nvidia-smi -L | wc -l)
+          echo "Visible GPUs: $gpu_count"
+          nvidia-smi -L
+          if [ "$gpu_count" -lt 2 ]; then
+            echo "::error::Multi-GPU MPI validation requires >=2 GPUs; found $gpu_count."
+            exit 1
+          fi
+
+      - name: MPI validation (2 GPUs)
+        shell: bash
+        run: |
+          # The distributed examples run one MPI rank per GPU on the
+          # nvidia-mgpu backend; -np 2 exercises real cross-GPU distribution.
+          status_sum=0 && set +e # Allow script to keep going through errors
+          for ex in `find /home/cudaq/examples/other/distributed/ -name '*.cpp'`; do
+            filename=$(basename -- "$ex")
+            # Set CUDAQ_ENABLE_MPI_EXAMPLE to activate these examples.
+            nvq++ -DCUDAQ_ENABLE_MPI_EXAMPLE=1 "$ex"
+            if [ $? -ne 0 ]; then
+              echo ":x: Compilation failed for $filename." >> $GITHUB_STEP_SUMMARY
+              status_sum=$((status_sum+1))
+              continue
+            fi
+            mpiexec --allow-run-as-root -np 2 ./a.out
+            if [ $? -eq 0 ]; then
+              echo ":white_check_mark: Ran $filename across 2 GPUs." >> $GITHUB_STEP_SUMMARY
+            else
+              echo ":x: Failed to execute $filename." >> $GITHUB_STEP_SUMMARY
+              status_sum=$((status_sum+1))
+            fi
+          done
+          set -e # Re-enable exit code error checking
+          if [ ! $status_sum -eq 0 ]; then
+            echo "::error::$status_sum example(s) failed; see step summary for a list of failures."
+            exit $status_sum
+          fi
+
   installer_validation:
     name: Installer validation
     needs: [assets, cudaq_installers]
@@ -1563,7 +1637,7 @@ jobs:
 
   clean_up:
     name: Clean up
-    needs: [assets, cudaq_images, cudaq_installers, cudaq_wheels, cudaq_metapackages, macos_artifacts, cudaq_realtime_installers, image_validation, installer_validation, metapackage_validation_conda, metapackage_validation_macos, wheel_validation_piponly, create_release]
+    needs: [assets, cudaq_images, cudaq_installers, cudaq_wheels, cudaq_metapackages, macos_artifacts, cudaq_realtime_installers, image_validation, multi_gpu_mpi_validation, installer_validation, metapackage_validation_conda, metapackage_validation_macos, wheel_validation_piponly, create_release]
     # Force this job to run even when some of the dependencies above are skipped.
     if: always() && !cancelled() && needs.assets.result != 'skipped' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Publishing only exercised nvidia-mgpu/MPI on a single GPU (mpiexec -np 4, oversubscribed).

Add a job that runs the distributed examples with -np 2 (one rank per GPU) on real 2-GPU runners (nv-gpu-amd64-rtxpro6000-2gpu / nv-gpu-arm64-l4-2gpu), using the published multi-arch image.

It checks that two GPUs are visible and gates the release via clean_up.