### PR TITLE
Implement conditional loop unrolling for value-semantics pipelines

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -868,6 +868,15 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
     necessary when synthesizing quantum circuits from CUDA-Q kernels, such
     as when generating a QIR base profile. A quantum circuit requires all loops
     be completely unrolled.
+
+    The unroll-only-wire-blocking-loops option opts in to selective unrolling
+    for a value-semantics (wire) pipeline: only loops that still access
+    quantum data by dynamic reference or slice (blocking wire conversion) are
+    unrolled. Counted loops whose quantum accesses can be represented with
+    static wireset indices are left rolled. A loop that blocks wire
+    conversion but cannot be unrolled (e.g. a non-constant trip
+    count) is a dead end and is reported as an error. This option defaults to
+    false, leaving the pass behavior unchanged for all existing pipelines.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",
@@ -880,7 +889,12 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
       "signal-failure-if-any-loop-cannot-be-completely-unrolled", "bool",
       /*default=*/"false", "Signal failure if pass can't unroll all loops.">,
     Option<"allowBreak", "allow-early-exit", "bool", /*default=*/"false",
-      "Allow unrolling of loop with early exit (i.e. break statement).">
+      "Allow unrolling of loop with early exit (i.e. break statement).">,
+    Option<"unrollOnlyWireBlockingLoops", "unroll-only-wire-blocking-loops",
+      "bool", /*default=*/"false",
+      "Unroll only loops that block wire conversion; keep counted loops "
+      "whose quantum accesses can be represented with static wireset indices "
+      "rolled (and error on a blocking loop that cannot be unrolled).">
   ];
 }
 

--- a/cudaq/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -48,7 +48,7 @@ public:
         op.getCanonicalizationPatterns(patterns, ctx);
       patterns.insert<UnrollCountedLoop>(ctx, threshold,
                                          /*signalFailure=*/false, allowBreak,
-                                         progress);
+                                         progress, unrollOnlyWireBlockingLoops);
       FrozenRewritePatternSet frozen(std::move(patterns));
       // Iterate over the loops until a fixed-point is reached. Some loops can
       // only be unrolled if other loops are unrolled first and the constants
@@ -59,7 +59,24 @@ public:
       } while (progress);
     }
 
-    if (signalFailure) {
+    if (unrollOnlyWireBlockingLoops) {
+      // In the value-semantics opt-in mode, a loop that still accesses quantum
+      // data by a dynamic index or slice (blocking wire conversion) but
+      // survived the unrolling above (e.g. a non-constant trip count) is a
+      // dead end: it can be neither kept in value semantics nor unrolled.
+      // Report each such loop.
+      op->walk([&](cudaq::cc::LoopOp loop) {
+        if (loop->hasAttr(cudaq::opt::DeadLoopAttr))
+          return;
+        if (loopBlocksWireConversion(loop)) {
+          loop.emitOpError(
+              "loop accesses quantum data by a dynamic index or slice and "
+              "cannot be unrolled (trip count is not a compile-time constant); "
+              "it can be neither kept in value semantics nor unrolled");
+          signalPassFailure();
+        }
+      });
+    } else if (signalFailure) {
       numLoops = countLoopOps(op);
       if (numLoops) {
         op->emitOpError("did not unroll loops");

--- a/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
+++ b/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
@@ -29,16 +29,111 @@ unrollLoopByValue(cudaq::cc::LoopOp loop,
   return *resultOpt;
 }
 
-static bool exceedsThresholdValue(cudaq::cc::LoopOp loop,
-                                  std::size_t threshold) {
+static bool exceedsThresholdValue(cudaq::cc::LoopOp loop, std::size_t threshold,
+                                  bool emitWarning = true) {
   auto components = cudaq::opt::getLoopComponents(loop);
   if (components->hasAlwaysTrueCondition()) {
-    loop->emitWarning("Loop condition is always true. This loop is not "
-                      "supported in a kernel.");
+    if (emitWarning)
+      loop->emitWarning("Loop condition is always true. This loop is not "
+                        "supported in a kernel.");
     return true;
   }
   auto upperBound = unrollLoopByValue(loop, *components);
   return upperBound >= threshold;
+}
+
+static bool loopCanBeUnrolled(cudaq::cc::LoopOp loop, bool allowBreak,
+                              std::size_t threshold,
+                              bool emitWarning = true) {
+  if (!allowBreak && !cudaq::opt::isaCountedLoop(loop))
+    return false;
+  if (allowBreak && !cudaq::opt::isaIndefiniteCountedLoop(loop))
+    return false;
+  return !exceedsThresholdValue(loop, threshold, emitWarning);
+}
+
+static bool valueDependsOnRegionBlockArgument(Value value, Region &region) {
+  if (!value)
+    return false;
+  if (auto arg = dyn_cast<BlockArgument>(value))
+    return arg.getOwner()->getParent() == &region;
+  Operation *defOp = value.getDefiningOp();
+  if (!defOp)
+    return false;
+  for (Value operand : defOp->getOperands())
+    if (valueDependsOnRegionBlockArgument(operand, region))
+      return true;
+  return false;
+}
+
+static bool loopTripCountDependsOnRegionArgs(cudaq::cc::LoopOp loop,
+                                             Region &region) {
+  auto components = cudaq::opt::getLoopComponents(loop);
+  if (!components)
+    return false;
+  auto depends = [&](Value value) {
+    return valueDependsOnRegionBlockArgument(value, region);
+  };
+  return depends(components->initialValue) ||
+         depends(components->compareValue) || depends(components->stepValue) ||
+         (components->addendValue && depends(components->addendValue)) ||
+         (components->scaleValue && depends(components->scaleValue));
+}
+
+/// Returns true if \p loop accesses quantum data with a dynamic
+/// (non-constant) index or slice and therefore blocks conversion to value
+/// (wire) semantics: it contains a `quake.extract_ref` with a dynamic index or
+/// a `quake.subveq` with a dynamic bound in its own body. The walk does NOT
+/// descend into nested `cc.loop` ops -- a nested loop is classified (and
+/// unrolled) on its own, and once it is unrolled its accesses become
+/// constant-index, at which point this loop no longer blocks. This lets a
+/// purely-repeating outer loop stay rolled while inner index-dependent loops
+/// are unrolled. A loop with only constant-index references/slices (or only
+/// `!quake.wire` values) does not block: mem2reg can thread those qubits as
+/// loop iter-args.
+static bool loopBlocksWireConversion(cudaq::cc::LoopOp loop) {
+  bool found = false;
+  loop->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+    if (op != loop.getOperation() && isa<cudaq::cc::LoopOp>(op))
+      return WalkResult::skip(); // nested loops are handled separately
+    if (auto ext = dyn_cast<cudaq::quake::ExtractRefOp>(op))
+      if (ext.getRawIndex() == cudaq::quake::ExtractRefOp::kDynamicIndex) {
+        found = true;
+        return WalkResult::interrupt();
+      }
+    if (auto sub = dyn_cast<cudaq::quake::SubVeqOp>(op))
+      if (!sub.hasConstantLowerBound() || !sub.hasConstantUpperBound()) {
+        found = true;
+        return WalkResult::interrupt();
+      }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+static bool loopHasParentDependentWireBlockingNestedLoop(
+    cudaq::cc::LoopOp loop) {
+  bool found = false;
+  Region &body = loop.getBodyRegion();
+  loop->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+    if (op == loop.getOperation())
+      return WalkResult::advance();
+    auto nested = dyn_cast<cudaq::cc::LoopOp>(op);
+    if (!nested)
+      return WalkResult::advance();
+    if (loopBlocksWireConversion(nested) &&
+        loopTripCountDependsOnRegionArgs(nested, body)) {
+      found = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+static bool loopMustUnrollForWireConversion(cudaq::cc::LoopOp loop) {
+  return loopBlocksWireConversion(loop) ||
+         loopHasParentDependentWireBlockingNestedLoop(loop);
 }
 
 namespace {
@@ -55,9 +150,9 @@ namespace {
 /// specific number of times, even if that number is only known at runtime.
 struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
   explicit UnrollCountedLoop(MLIRContext *ctx, std::size_t t, bool sf, bool ab,
-                             unsigned &p)
+                             unsigned &p, bool unrollOnlyWireBlocking = false)
       : OpRewritePattern(ctx), threshold(t), signalFailure(sf), allowBreak(ab),
-        progress(p) {}
+        progress(p), unrollOnlyWireBlockingLoops(unrollOnlyWireBlocking) {}
 
   LogicalResult matchAndRewrite(cudaq::cc::LoopOp loop,
                                 PatternRewriter &rewriter) const override {
@@ -67,6 +162,21 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
     // Check for cases that are clearly not going to be unrolled.
     if (loop->hasAttr(cudaq::opt::DeadLoopAttr))
       return failure();
+    // Opt-in selective unrolling for value-semantics pipelines: a loop that
+    // does not itself index or slice qubits dynamically is left rolled unless
+    // it must be unrolled first to make a nested wire-blocking loop's trip
+    // count constant. Otherwise its qubits can be threaded as wire iter-args.
+    if (unrollOnlyWireBlockingLoops) {
+      // Filter out loops that cannot be unrolled before doing the more
+      // expensive quantum-access walks below. These skips are intentionally
+      // quiet: the final selective-mode validation diagnoses any remaining
+      // wire-blocking loops.
+      if (!loopCanBeUnrolled(loop, allowBreak, threshold,
+                             /*emitWarning=*/false))
+        return failure();
+      if (!loopMustUnrollForWireConversion(loop))
+        return failure();
+    }
     if (!allowBreak && !cudaq::opt::isaCountedLoop(loop)) {
       if (signalFailure)
         loop.emitOpError("not a simple counted loop");
@@ -212,5 +322,6 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
   bool signalFailure;
   bool allowBreak;
   unsigned &progress;
+  bool unrollOnlyWireBlockingLoops;
 };
 } // namespace

--- a/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops.cpp
+++ b/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops.cpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// Starting from C++, mimic the relevant JIT shape: an early classical-only
+// mem2reg/loop-normalization cleanup from the standard prep pipeline, the
+// target high-level measurement expansion, then the mid-level selective unroll
+// and the single full quantum mem2reg that produces wires for assign-wire-indices.
+// RUN: cudaq-quake %s | cudaq-opt --memtoreg=quantum=0 --canonicalize --cc-loop-normalize --expand-measurements --cc-loop-unroll=unroll-only-wire-blocking-loops=true --add-dealloc --combine-quantum-alloc --canonicalize --factor-quantum-alloc --memtoreg --add-wireset --assign-wire-indices | FileCheck %s
+// clang-format on
+
+#include <cudaq.h>
+
+// Fixed-wire loops can be represented as wire iter-arg loops, so they stay
+// rolled.
+__qpu__ bool keeps_wire_compatible_loop() {
+  cudaq::qubit a, b;
+  // Expected to stay rolled: the loop body uses fixed qubits.
+  for (int r = 0; r < 5; r++) {
+    h(a);
+    x<cudaq::ctrl>(a, b);
+  }
+  return mz(a) ^ mz(b);
+}
+
+// CHECK-LABEL:   quake.wire_set @wires[2147483647] attributes {sym_visibility = "private"}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_keeps_wire_compatible_loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK:           %[[A:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[B:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK:           %[[LOOP:.*]]:3 = cc.loop while
+// CHECK-SAME:        !quake.wire
+// CHECK:             %[[H:.*]] = quake.h %{{.*}} : (!quake.wire) -> !quake.wire
+// CHECK:             %[[X:.*]]:2 = quake.x {{\[}}%[[H]]] %{{.*}} : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           quake.return_wire
+// CHECK:           quake.return_wire
+// CHECK:           return
+
+// Loops that index quantum data by the induction variable block wire
+// conversion, so they are unrolled.
+__qpu__ bool unrolls_wire_blocking_loop() {
+  cudaq::qvector q(3);
+  // Expected to unroll: the induction variable indexes quantum data.
+  for (int i = 0; i < 3; i++) {
+    h(q[i]);
+  }
+  return mz(q[0]) ^ mz(q[1]) ^ mz(q[2]);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_unrolls_wire_blocking_loop
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK:           %[[Q0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[Q1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:           %[[Q2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK:           %[[H0:.*]] = quake.h %[[Q0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[H1:.*]] = quake.h %[[Q1]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[H2:.*]] = quake.h %[[Q2]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.return_wire
+// CHECK:           quake.return_wire
+// CHECK:           quake.return_wire
+// CHECK-NOT:       cc.loop
+// CHECK:           return
+
+// Loops over measurement data do not access quantum data, so they stay rolled.
+__qpu__ bool keeps_measurement_data_loop() {
+  cudaq::qvector q(3);
+  x(q[0]);
+  x(q[2]);
+
+  auto bits = mz(q);
+  bool parity = false;
+  // Expected to stay rolled: the loop indexes measurement data, not qubits.
+  for (int i = 0; i < 3; i++) {
+    parity ^= bits[i];
+  }
+  return parity;
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_keeps_measurement_data_loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK:           %[[Q0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[Q1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:           %[[Q2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK:           %[[X0:.*]] = quake.x %[[Q0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[X2:.*]] = quake.x %[[Q2]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[HANDLES:.*]] = cc.alloca !cc.array<!cc.measure_handle x 3>
+// CHECK:           %[[M0:.*]], %[[W0:.*]] = quake.mz %[[X0]] name "bits" : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           cc.store %[[M0]], %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[M1:.*]], %[[W1:.*]] = quake.mz %[[Q1]] name "bits" : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           cc.store %[[M1]], %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[M2:.*]], %[[W2:.*]] = quake.mz %[[X2]] name "bits" : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           cc.store %[[M2]], %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK:           %[[LOOP:.*]]:2 = cc.loop while
+// CHECK-SAME:        (i1, i32)
+// CHECK:             %[[PTR:.*]] = cc.compute_ptr %[[HANDLES]]{{\[}}%{{.*}}] : (!cc.ptr<!cc.array<!cc.measure_handle x 3>>, i64) -> !cc.ptr<!cc.measure_handle>
+// CHECK:             %[[HANDLE:.*]] = cc.load %[[PTR]] : !cc.ptr<!cc.measure_handle>
+// CHECK:             quake.discriminate %[[HANDLE]] : (!cc.measure_handle) -> i1
+// CHECK:             cc.continue
+// CHECK:           quake.return_wire %[[W0]] : !quake.wire
+// CHECK:           quake.return_wire %[[W1]] : !quake.wire
+// CHECK:           quake.return_wire %[[W2]] : !quake.wire
+// CHECK:           return %[[LOOP]]#0 : i1

--- a/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops_nested.cpp
+++ b/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops_nested.cpp
@@ -105,6 +105,55 @@ __qpu__ std::vector<bool> kernel() {
 // CHECK:           return %[[RESULT]] : !cc.stdvec<i1>
 // CHECK:         }
 
+// The inner loop unrolls first, exposing outer-induction-variable-dependent
+// flattened indices. The same pass must then unroll the outer loop when it
+// reaches a fixed point.
+__qpu__ std::vector<bool> rectangular_flattened_index() {
+  constexpr int N = 2;
+  constexpr int M = 3;
+  cudaq::qvector q(N * M);
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < M; ++j)
+      x(q[i * M + j]);
+  return cudaq::to_bools(mz(q));
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_rectangular_flattened_index._Z27rectangular_flattened_indexv() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           %[[Q0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[Q1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:           %[[Q2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// CHECK:           %[[Q3:.*]] = quake.borrow_wire @wires[3] : !quake.wire
+// CHECK:           %[[Q4:.*]] = quake.borrow_wire @wires[4] : !quake.wire
+// CHECK:           %[[Q5:.*]] = quake.borrow_wire @wires[5] : !quake.wire
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           %[[X0:.*]] = quake.x %[[Q0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[X1:.*]] = quake.x %[[Q1]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[X2:.*]] = quake.x %[[Q2]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[X3:.*]] = quake.x %[[Q3]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[X4:.*]] = quake.x %[[Q4]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[X5:.*]] = quake.x %[[Q5]] : (!quake.wire) -> !quake.wire
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           %[[M0:.*]], %[[W0:.*]] = quake.mz %[[X0]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M1:.*]], %[[W1:.*]] = quake.mz %[[X1]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M2:.*]], %[[W2:.*]] = quake.mz %[[X2]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M3:.*]], %[[W3:.*]] = quake.mz %[[X3]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M4:.*]], %[[W4:.*]] = quake.mz %[[X4]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M5:.*]], %[[W5:.*]] = quake.mz %[[X5]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           quake.return_wire %[[W0]] : !quake.wire
+// CHECK:           quake.return_wire %[[W1]] : !quake.wire
+// CHECK:           quake.return_wire %[[W2]] : !quake.wire
+// CHECK:           quake.return_wire %[[W3]] : !quake.wire
+// CHECK:           quake.return_wire %[[W4]] : !quake.wire
+// CHECK:           quake.return_wire %[[W5]] : !quake.wire
+// CHECK:           return
+// CHECK:         }
+
 // The middle loop does not access quantum data, but it separates the inner loop
 // from the grandparent induction variable that bounds it. The outer and inner
 // loops must unroll so the q[inner] access lowers to static wires, while the

--- a/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops_nested.cpp
+++ b/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops_nested.cpp
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// Starting from C++, mimic the relevant JIT shape and check that
+// parent-dependent nested loops over quantum data are unrolled before wire
+// assignment.
+// RUN: cudaq-quake %s | cudaq-opt --memtoreg=quantum=0 --canonicalize --cc-loop-normalize --expand-measurements --cc-loop-unroll=unroll-only-wire-blocking-loops=true --add-dealloc --combine-quantum-alloc --canonicalize --factor-quantum-alloc --memtoreg --add-wireset --assign-wire-indices | FileCheck %s
+// clang-format on
+
+#include <cudaq.h>
+
+// Triangular pair loops index quantum data with induction variables. Both loops
+// must unroll so the controlled operations and whole-register measurement can
+// lower to wires.
+__qpu__ std::vector<bool> kernel() {
+  constexpr int N = 4;
+  cudaq::qvector q(N);
+  // Expected to unroll: `i` indexes quantum data and bounds the inner loop.
+  for (int i = 0; i < N - 1; ++i) {
+    // Expected to unroll: `j` indexes quantum data.
+    for (int j = i + 1; j < N; ++j) {
+      x<cudaq::ctrl>(q[i], q[j]);
+    }
+  }
+  return cudaq::to_bools(mz(q));
+}
+
+// CHECK-LABEL:   quake.wire_set @wires[2147483647] attributes {sym_visibility = "private"}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel._Z6kernelv() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK-NOT:       quake.subveq
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 4 : i64
+// CHECK:           %[[Q0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[Q1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:           %[[Q2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// CHECK:           %[[Q3:.*]] = quake.borrow_wire @wires[3] : !quake.wire
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK-NOT:       quake.subveq
+// CHECK:           %[[X01:.*]]:2 = quake.x {{\[}}%[[Q0]]] %[[Q1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[X02:.*]]:2 = quake.x {{\[}}%[[X01]]#0] %[[Q2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[X03:.*]]:2 = quake.x {{\[}}%[[X02]]#0] %[[Q3]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[X12:.*]]:2 = quake.x {{\[}}%[[X01]]#1] %[[X02]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[X13:.*]]:2 = quake.x {{\[}}%[[X12]]#0] %[[X03]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[X23:.*]]:2 = quake.x {{\[}}%[[X12]]#1] %[[X13]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK-NOT:       quake.subveq
+// CHECK:           %[[BITS:.*]] = cc.alloca !cc.array<i8 x 4>
+// CHECK:           %[[M0:.*]], %[[W0:.*]] = quake.mz %[[X03]]#0 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[B0:.*]] = quake.discriminate %[[M0]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[BITSPTR:.*]] = cc.cast %[[BITS]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[BYTE0:.*]] = cc.cast unsigned %[[B0]] : (i1) -> i8
+// CHECK:           cc.store %[[BYTE0]], %[[BITSPTR]] : !cc.ptr<i8>
+// CHECK:           %[[M1:.*]], %[[W1:.*]] = quake.mz %[[X13]]#0 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[B1:.*]] = quake.discriminate %[[M1]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[PTR1:.*]] = cc.compute_ptr %[[BITS]][1] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[BYTE1:.*]] = cc.cast unsigned %[[B1]] : (i1) -> i8
+// CHECK:           cc.store %[[BYTE1]], %[[PTR1]] : !cc.ptr<i8>
+// CHECK:           %[[M2:.*]], %[[W2:.*]] = quake.mz %[[X23]]#0 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[B2:.*]] = quake.discriminate %[[M2]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[PTR2:.*]] = cc.compute_ptr %[[BITS]][2] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[BYTE2:.*]] = cc.cast unsigned %[[B2]] : (i1) -> i8
+// CHECK:           cc.store %[[BYTE2]], %[[PTR2]] : !cc.ptr<i8>
+// CHECK:           %[[M3:.*]], %[[W3:.*]] = quake.mz %[[X23]]#1 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[B3:.*]] = quake.discriminate %[[M3]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[PTR3:.*]] = cc.compute_ptr %[[BITS]][3] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[BYTE3:.*]] = cc.cast unsigned %[[B3]] : (i1) -> i8
+// CHECK:           cc.store %[[BYTE3]], %[[PTR3]] : !cc.ptr<i8>
+// CHECK:           %[[COPY_SRC:.*]] = cc.cast %[[BITS]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[COPY:.*]] = call @__nvqpp_vectorCopyCtor(%[[COPY_SRC]], %[[CONSTANT_1]], %[[CONSTANT_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[RESULT:.*]] = cc.stdvec_init %[[COPY]], %[[CONSTANT_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       quake.alloca
+// CHECK-NOT:       quake.unwrap
+// CHECK-NOT:       quake.wrap
+// CHECK-NOT:       quake.concat
+// CHECK-NOT:       quake.extract_ref
+// CHECK-NOT:       quake.subveq
+// CHECK:           quake.return_wire %[[W0]] : !quake.wire
+// CHECK:           quake.return_wire %[[W1]] : !quake.wire
+// CHECK:           quake.return_wire %[[W2]] : !quake.wire
+// CHECK:           quake.return_wire %[[W3]] : !quake.wire
+// CHECK:           return %[[RESULT]] : !cc.stdvec<i1>
+// CHECK:         }
+
+// The middle loop does not access quantum data, but it separates the inner loop
+// from the grandparent induction variable that bounds it. The outer and inner
+// loops must unroll so the q[inner] access lowers to static wires, while the
+// middle separator can stay rolled as fixed-wire loops.
+__qpu__ std::vector<bool> grandparent_bound_separator() {
+  constexpr int N = 4;
+  cudaq::qvector q(N);
+  // Expected to unroll: `outer` bounds the inner quantum-data loop.
+  for (int outer = 0; outer < N; ++outer) {
+    // Expected to stay rolled: this loop only repeats fixed-wire operations
+    // after the surrounding dependent loops are unrolled.
+    for (int middle = 0; middle < 2; ++middle) {
+      // Expected to unroll: `inner` indexes quantum data and is bounded by
+      // grandparent induction variable `outer`.
+      for (int inner = 0; inner < outer; ++inner) {
+        x(q[inner]);
+      }
+    }
+  }
+  return cudaq::to_bools(mz(q));
+}
+
+// The grandparent-dependent separator case should unroll the outer and inner
+// loops while preserving the non-blocking middle loop as fixed-wire loops.
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_grandparent_bound_separator._Z27grandparent_bound_separatorv() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           %[[Q0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[Q1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:           %[[Q2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// CHECK:           %[[Q3:.*]] = quake.borrow_wire @wires[3] : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           %[[MID0:.*]]:2 = cc.loop while
+// CHECK-SAME:        !quake.wire
+// CHECK:             quake.x %{{.*}} : (!quake.wire) -> !quake.wire
+// CHECK:           } step {
+// CHECK:           %[[MID1:.*]]:3 = cc.loop while
+// CHECK-SAME:        !quake.wire, !quake.wire
+// CHECK:             quake.x %{{.*}} : (!quake.wire) -> !quake.wire
+// CHECK:             quake.x %{{.*}} : (!quake.wire) -> !quake.wire
+// CHECK:           } step {
+// CHECK:           %[[MID2:.*]]:4 = cc.loop while
+// CHECK-SAME:        !quake.wire, !quake.wire, !quake.wire
+// CHECK:             quake.x %{{.*}} : (!quake.wire) -> !quake.wire
+// CHECK:             quake.x %{{.*}} : (!quake.wire) -> !quake.wire
+// CHECK:             quake.x %{{.*}} : (!quake.wire) -> !quake.wire
+// CHECK:           } step {
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           %[[M0:.*]], %[[W0:.*]] = quake.mz %{{.*}} : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M1:.*]], %[[W1:.*]] = quake.mz %{{.*}} : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M2:.*]], %[[W2:.*]] = quake.mz %{{.*}} : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[M3:.*]], %[[W3:.*]] = quake.mz %[[Q3]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK-NOT:       cc.loop
+// CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
+// CHECK:           quake.return_wire %[[W0]] : !quake.wire
+// CHECK:           quake.return_wire %[[W1]] : !quake.wire
+// CHECK:           quake.return_wire %[[W2]] : !quake.wire
+// CHECK:           quake.return_wire %[[W3]] : !quake.wire
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/AST-Quake/veq_control_wires.cpp
+++ b/cudaq/test/AST-Quake/veq_control_wires.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// Starting from C++, expand whole-register controls before the wire-assignment
+// pipeline so value-semantic quantum code reaches indexed wires.
+// RUN: cudaq-quake %s | cudaq-opt --expand-control-veqs --memtoreg=quantum=0 --canonicalize --cc-loop-normalize --expand-measurements --cc-loop-unroll=unroll-only-wire-blocking-loops=true --add-dealloc --combine-quantum-alloc --canonicalize --factor-quantum-alloc --memtoreg --add-wireset --assign-wire-indices | FileCheck %s
+// clang-format on
+
+#include <cudaq.h>
+
+struct veq_control {
+  void operator()() __qpu__ {
+    cudaq::qvector ctrls(3);
+    cudaq::qubit target;
+    x<cudaq::ctrl>(ctrls, target); // Multi-controlled X, whole register as controls.
+    mz(target);
+  }
+};
+
+// The whole-register control should expand to one multi-control wire op with
+// three static control wires and no `quake.alloca` or `quake.veq` in the kernel.
+// CHECK-LABEL:   quake.wire_set @wires[2147483647] attributes {sym_visibility = "private"}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__veq_control() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           %[[BORROW_WIRE_0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           %[[BORROW_WIRE_1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           %[[BORROW_WIRE_2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           %[[BORROW_WIRE_3:.*]] = quake.borrow_wire @wires[3] : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           %[[X_0:.*]]:4 = quake.x {{\[}}%[[BORROW_WIRE_0]], %[[BORROW_WIRE_1]], %[[BORROW_WIRE_2]]] %[[BORROW_WIRE_3]] : (!quake.wire, !quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire, !quake.wire)
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[X_0]]#3 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           quake.return_wire %[[X_0]]#0 : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           quake.return_wire %[[X_0]]#1 : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           quake.return_wire %[[X_0]]#2 : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           quake.return_wire %[[MZ_0]] : !quake.wire
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:           return
+// CHECK-NOT:       {{quake\.alloca|!quake\.veq|!quake\.ref}}
+// CHECK:         }

--- a/cudaq/test/Transforms/unroll_only_wire_blocking_loops.qke
+++ b/cudaq/test/Transforms/unroll_only_wire_blocking_loops.qke
@@ -1,0 +1,248 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// clang-format off
+// RUN: cudaq-opt --cc-loop-unroll=unroll-only-wire-blocking-loops=true --add-dealloc --combine-quantum-alloc --canonicalize --factor-quantum-alloc --memtoreg --add-wireset --assign-wire-indices %s | FileCheck %s
+// RUN: cudaq-opt --cc-loop-unroll --add-dealloc --combine-quantum-alloc --canonicalize --factor-quantum-alloc --memtoreg --add-wireset --assign-wire-indices %s | FileCheck --check-prefix=DEFAULT %s
+// clang-format on
+
+// The inputs below are the value-semantics (post-mem2reg) form produced by the
+// real pipeline (cudaq-quake | cudaq-opt --canonicalize --factor-quantum-alloc
+// --memtoreg). `clean_repeat` applies the same gates to the same qubits each
+// iteration: mem2reg threaded its qubits as !quake.wire loop iter-args, so it is
+// a clean value-semantics loop. `blocking_static` indexes qubits by the
+// induction variable (quake.extract_ref in the loop body), so it still uses
+// reference semantics and blocks wire conversion.
+//
+// With unroll-only-wire-blocking-loops=true the clean loop stays rolled (its qubits
+// become explicit quake.borrow_wire values carried as iter-args) while the
+// blocking loop is unrolled. With the default cc-loop-unroll (DEFAULT) both
+// loops are fully unrolled, i.e. existing behavior is unchanged.
+
+module {
+  func.func @__nvqpp__mlirgen__function_clean_repeat._Z12clean_repeatv() -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %c1_i32 = arith.constant 1 : i32
+    %c5_i32 = arith.constant 5 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = quake.null_wire
+    %1 = quake.null_wire
+    %2:2 = cc.scope -> (!quake.wire, !quake.wire) {
+      %8 = cc.undef i32
+      %9:3 = cc.loop while ((%arg0 = %0, %arg1 = %1, %arg2 = %c0_i32) -> (!quake.wire, !quake.wire, i32)) {
+        %10 = arith.cmpi slt, %arg2, %c5_i32 : i32
+        cc.condition %10(%arg0, %arg1, %arg2 : !quake.wire, !quake.wire, i32)
+      } do {
+      ^bb0(%arg0: !quake.wire, %arg1: !quake.wire, %arg2: i32):
+        %10 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+        %11:2 = quake.x [%10] %arg1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+        cc.continue %11#0, %11#1, %arg2 : !quake.wire, !quake.wire, i32
+      } step {
+      ^bb0(%arg0: !quake.wire, %arg1: !quake.wire, %arg2: i32):
+        %10 = arith.addi %arg2, %c1_i32 : i32
+        cc.continue %arg0, %arg1, %10 : !quake.wire, !quake.wire, i32
+      }
+      cc.continue %9#0, %9#1 : !quake.wire, !quake.wire
+    }
+    %measOut, %wires = quake.mz %2#0 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+    %4 = quake.discriminate %measOut : (!cc.measure_handle) -> i1
+    %measOut_0, %wires_1 = quake.mz %2#1 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+    %6 = quake.discriminate %measOut_0 : (!cc.measure_handle) -> i1
+    %7 = arith.cmpi ne, %4, %6 : i1
+    return %7 : i1
+  }
+
+// Selective mode: `clean_repeat` should stay rolled as a `cc.loop` with wire
+// iter-args.
+// CHECK-LABEL:   quake.wire_set @wires[2147483647] attributes {sym_visibility = "private"}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_clean_repeat._Z12clean_repeatv() -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 5 : i32
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : i32
+// CHECK:           %[[BORROW_WIRE_0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[BORROW_WIRE_1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:           %[[LOOP_0:.*]]:3 = cc.loop while ((%[[VAL_0:.*]] = %[[BORROW_WIRE_0]], %[[VAL_1:.*]] = %[[BORROW_WIRE_1]], %[[VAL_2:.*]] = %[[CONSTANT_2]]) -> (!quake.wire, !quake.wire, i32)) {
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_2]], %[[CONSTANT_1]] : i32
+// CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : !quake.wire, !quake.wire, i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: !quake.wire, %[[VAL_4:.*]]: !quake.wire, %[[VAL_5:.*]]: i32):
+// CHECK:             %[[H_0:.*]] = quake.h %[[VAL_3]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[H_0]]] %[[VAL_4]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[X_0]]#0, %[[X_0]]#1, %[[VAL_5]] : !quake.wire, !quake.wire, i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !quake.wire, %[[VAL_7:.*]]: !quake.wire, %[[VAL_8:.*]]: i32):
+// CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_8]], %[[CONSTANT_0]] : i32
+// CHECK:             cc.continue %[[VAL_6]], %[[VAL_7]], %[[ADDI_0]] : !quake.wire, !quake.wire, i32
+// CHECK:           }
+// CHECK:           %[[VAL_9:.*]], %[[MZ_0:.*]] = quake.mz %[[VAL_10:.*]]#0 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[VAL_9]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[VAL_11:.*]], %[[MZ_1:.*]] = quake.mz %[[VAL_10]]#1 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[VAL_11]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[CMPI_1:.*]] = arith.cmpi ne, %[[DISCRIMINATE_0]], %[[DISCRIMINATE_1]] : i1
+// CHECK:           return %[[CMPI_1]] : i1
+// CHECK:         }
+
+// Default mode: `clean_repeat` should be fully unrolled.
+// DEFAULT-LABEL:   quake.wire_set @wires[2147483647] attributes {sym_visibility = "private"}
+
+// DEFAULT-LABEL:   func.func @__nvqpp__mlirgen__function_clean_repeat._Z12clean_repeatv() -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// DEFAULT:           %[[BORROW_WIRE_0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// DEFAULT:           %[[BORROW_WIRE_1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// DEFAULT:           %[[H_0:.*]] = quake.h %[[BORROW_WIRE_0]] : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[X_0:.*]]:2 = quake.x {{\[}}%[[H_0]]] %[[BORROW_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// DEFAULT:           %[[H_1:.*]] = quake.h %[[X_0]]#0 : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[X_1:.*]]:2 = quake.x {{\[}}%[[H_1]]] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// DEFAULT:           %[[H_2:.*]] = quake.h %[[X_1]]#0 : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[X_2:.*]]:2 = quake.x {{\[}}%[[H_2]]] %[[X_1]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// DEFAULT:           %[[H_3:.*]] = quake.h %[[X_2]]#0 : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[X_3:.*]]:2 = quake.x {{\[}}%[[H_3]]] %[[X_2]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// DEFAULT:           %[[H_4:.*]] = quake.h %[[X_3]]#0 : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[X_4:.*]]:2 = quake.x {{\[}}%[[H_4]]] %[[X_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// DEFAULT:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[X_4]]#0 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// DEFAULT:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[VAL_0]] : (!cc.measure_handle) -> i1
+// DEFAULT:           %[[VAL_1:.*]], %[[MZ_1:.*]] = quake.mz %[[X_4]]#1 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// DEFAULT:           %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[VAL_1]] : (!cc.measure_handle) -> i1
+// DEFAULT:           %[[CMPI_0:.*]] = arith.cmpi ne, %[[DISCRIMINATE_0]], %[[DISCRIMINATE_1]] : i1
+// DEFAULT:           return %[[CMPI_0]] : i1
+// DEFAULT:         }
+
+  func.func @__nvqpp__mlirgen__function_blocking_static._Z15blocking_staticv() -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %0 = quake.alloca !quake.ref
+    %1 = quake.unwrap %0 : (!quake.ref) -> !quake.wire
+    %2 = quake.alloca !quake.ref
+    %3 = quake.unwrap %2 : (!quake.ref) -> !quake.wire
+    %4 = quake.alloca !quake.ref
+    %5 = quake.unwrap %4 : (!quake.ref) -> !quake.wire
+    %6 = quake.alloca !quake.ref
+    %7 = quake.unwrap %6 : (!quake.ref) -> !quake.wire
+    quake.wrap %1 to %0 : !quake.wire, !quake.ref
+    quake.wrap %3 to %2 : !quake.wire, !quake.ref
+    quake.wrap %5 to %4 : !quake.wire, !quake.ref
+    quake.wrap %7 to %6 : !quake.wire, !quake.ref
+    %8 = quake.concat %0, %2, %4, %6 : (!quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<4>
+    cc.scope {
+      %33 = cc.undef i32
+      %34 = cc.loop while ((%arg0 = %c0_i32) -> (i32)) {
+        %35 = arith.cmpi slt, %arg0, %c4_i32 : i32
+        cc.condition %35(%arg0 : i32)
+      } do {
+      ^bb0(%arg0: i32):
+        %35 = cc.cast signed %arg0 : (i32) -> i64
+        %36 = quake.extract_ref %8[%35] : (!quake.veq<4>, i64) -> !quake.ref
+        %37 = quake.unwrap %36 : (!quake.ref) -> !quake.wire
+        %38 = quake.h %37 : (!quake.wire) -> !quake.wire
+        quake.wrap %38 to %36 : !quake.wire, !quake.ref
+        cc.continue %arg0 : i32
+      } step {
+      ^bb0(%arg0: i32):
+        %35 = arith.addi %arg0, %c1_i32 : i32
+        cc.continue %35 : i32
+      }
+    }
+    %9 = quake.extract_ref %8[0] : (!quake.veq<4>) -> !quake.ref
+    %10 = quake.unwrap %9 : (!quake.ref) -> !quake.wire
+    %measOut, %wires = quake.mz %10 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+    quake.wrap %wires to %9 : !quake.wire, !quake.ref
+    %12 = quake.discriminate %measOut : (!cc.measure_handle) -> i1
+    %13 = cc.cast unsigned %12 : (i1) -> i32
+    %14 = quake.extract_ref %8[1] : (!quake.veq<4>) -> !quake.ref
+    %15 = quake.unwrap %14 : (!quake.ref) -> !quake.wire
+    %measOut_0, %wires_1 = quake.mz %15 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+    quake.wrap %wires_1 to %14 : !quake.wire, !quake.ref
+    %17 = quake.discriminate %measOut_0 : (!cc.measure_handle) -> i1
+    %18 = cc.cast unsigned %17 : (i1) -> i32
+    %19 = arith.xori %13, %18 : i32
+    %20 = quake.extract_ref %8[2] : (!quake.veq<4>) -> !quake.ref
+    %21 = quake.unwrap %20 : (!quake.ref) -> !quake.wire
+    %measOut_2, %wires_3 = quake.mz %21 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+    quake.wrap %wires_3 to %20 : !quake.wire, !quake.ref
+    %23 = quake.discriminate %measOut_2 : (!cc.measure_handle) -> i1
+    %24 = cc.cast unsigned %23 : (i1) -> i32
+    %25 = arith.xori %19, %24 : i32
+    %26 = quake.extract_ref %8[3] : (!quake.veq<4>) -> !quake.ref
+    %27 = quake.unwrap %26 : (!quake.ref) -> !quake.wire
+    %measOut_4, %wires_5 = quake.mz %27 : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+    quake.wrap %wires_5 to %26 : !quake.wire, !quake.ref
+    %29 = quake.discriminate %measOut_4 : (!cc.measure_handle) -> i1
+    %30 = cc.cast unsigned %29 : (i1) -> i32
+    %31 = arith.xori %25, %30 : i32
+    %32 = arith.cmpi ne, %31, %c0_i32 : i32
+    return %32 : i1
+  }
+
+// Selective mode: `blocking_static` should be unrolled before wire assignment.
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_blocking_static._Z15blocking_staticv() -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[BORROW_WIRE_0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[BORROW_WIRE_1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:           %[[BORROW_WIRE_2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// CHECK:           %[[BORROW_WIRE_3:.*]] = quake.borrow_wire @wires[3] : !quake.wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[BORROW_WIRE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[H_1:.*]] = quake.h %[[BORROW_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[H_2:.*]] = quake.h %[[BORROW_WIRE_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[H_3:.*]] = quake.h %[[BORROW_WIRE_3]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[H_0]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[VAL_0]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[CAST_0:.*]] = cc.cast unsigned %[[DISCRIMINATE_0]] : (i1) -> i32
+// CHECK:           %[[VAL_1:.*]], %[[MZ_1:.*]] = quake.mz %[[H_1]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[VAL_1]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[CAST_1:.*]] = cc.cast unsigned %[[DISCRIMINATE_1]] : (i1) -> i32
+// CHECK:           %[[XORI_0:.*]] = arith.xori %[[CAST_0]], %[[CAST_1]] : i32
+// CHECK:           %[[VAL_2:.*]], %[[MZ_2:.*]] = quake.mz %[[H_2]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[DISCRIMINATE_2:.*]] = quake.discriminate %[[VAL_2]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[CAST_2:.*]] = cc.cast unsigned %[[DISCRIMINATE_2]] : (i1) -> i32
+// CHECK:           %[[XORI_1:.*]] = arith.xori %[[XORI_0]], %[[CAST_2]] : i32
+// CHECK:           %[[VAL_3:.*]], %[[MZ_3:.*]] = quake.mz %[[H_3]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:           %[[DISCRIMINATE_3:.*]] = quake.discriminate %[[VAL_3]] : (!cc.measure_handle) -> i1
+// CHECK:           %[[CAST_3:.*]] = cc.cast unsigned %[[DISCRIMINATE_3]] : (i1) -> i32
+// CHECK:           %[[XORI_2:.*]] = arith.xori %[[XORI_1]], %[[CAST_3]] : i32
+// CHECK:           %[[CMPI_0:.*]] = arith.cmpi ne, %[[XORI_2]], %[[CONSTANT_0]] : i32
+// CHECK:           quake.return_wire %[[MZ_0]] : !quake.wire
+// CHECK:           quake.return_wire %[[MZ_1]] : !quake.wire
+// CHECK:           quake.return_wire %[[MZ_2]] : !quake.wire
+// CHECK:           quake.return_wire %[[MZ_3]] : !quake.wire
+// CHECK:           return %[[CMPI_0]] : i1
+// CHECK:         }
+
+// Default mode: `blocking_static` should also be fully unrolled.
+// DEFAULT-LABEL:   func.func @__nvqpp__mlirgen__function_blocking_static._Z15blocking_staticv() -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// DEFAULT:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
+// DEFAULT:           %[[BORROW_WIRE_0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// DEFAULT:           %[[BORROW_WIRE_1:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// DEFAULT:           %[[BORROW_WIRE_2:.*]] = quake.borrow_wire @wires[2] : !quake.wire
+// DEFAULT:           %[[BORROW_WIRE_3:.*]] = quake.borrow_wire @wires[3] : !quake.wire
+// DEFAULT:           %[[H_0:.*]] = quake.h %[[BORROW_WIRE_0]] : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[H_1:.*]] = quake.h %[[BORROW_WIRE_1]] : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[H_2:.*]] = quake.h %[[BORROW_WIRE_2]] : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[H_3:.*]] = quake.h %[[BORROW_WIRE_3]] : (!quake.wire) -> !quake.wire
+// DEFAULT:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[H_0]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// DEFAULT:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[VAL_0]] : (!cc.measure_handle) -> i1
+// DEFAULT:           %[[CAST_0:.*]] = cc.cast unsigned %[[DISCRIMINATE_0]] : (i1) -> i32
+// DEFAULT:           %[[VAL_1:.*]], %[[MZ_1:.*]] = quake.mz %[[H_1]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// DEFAULT:           %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[VAL_1]] : (!cc.measure_handle) -> i1
+// DEFAULT:           %[[CAST_1:.*]] = cc.cast unsigned %[[DISCRIMINATE_1]] : (i1) -> i32
+// DEFAULT:           %[[XORI_0:.*]] = arith.xori %[[CAST_0]], %[[CAST_1]] : i32
+// DEFAULT:           %[[VAL_2:.*]], %[[MZ_2:.*]] = quake.mz %[[H_2]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// DEFAULT:           %[[DISCRIMINATE_2:.*]] = quake.discriminate %[[VAL_2]] : (!cc.measure_handle) -> i1
+// DEFAULT:           %[[CAST_2:.*]] = cc.cast unsigned %[[DISCRIMINATE_2]] : (i1) -> i32
+// DEFAULT:           %[[XORI_1:.*]] = arith.xori %[[XORI_0]], %[[CAST_2]] : i32
+// DEFAULT:           %[[VAL_3:.*]], %[[MZ_3:.*]] = quake.mz %[[H_3]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// DEFAULT:           %[[DISCRIMINATE_3:.*]] = quake.discriminate %[[VAL_3]] : (!cc.measure_handle) -> i1
+// DEFAULT:           %[[CAST_3:.*]] = cc.cast unsigned %[[DISCRIMINATE_3]] : (i1) -> i32
+// DEFAULT:           %[[XORI_2:.*]] = arith.xori %[[XORI_1]], %[[CAST_3]] : i32
+// DEFAULT:           %[[CMPI_0:.*]] = arith.cmpi ne, %[[XORI_2]], %[[CONSTANT_0]] : i32
+// DEFAULT:           quake.return_wire %[[MZ_0]] : !quake.wire
+// DEFAULT:           quake.return_wire %[[MZ_1]] : !quake.wire
+// DEFAULT:           quake.return_wire %[[MZ_2]] : !quake.wire
+// DEFAULT:           quake.return_wire %[[MZ_3]] : !quake.wire
+// DEFAULT:           return %[[CMPI_0]] : i1
+// DEFAULT:         }
+}

--- a/cudaq/test/Transforms/unroll_only_wire_blocking_loops_invalid.qke
+++ b/cudaq/test/Transforms/unroll_only_wire_blocking_loops_invalid.qke
@@ -1,0 +1,94 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// clang-format off
+// RUN: cudaq-opt --cc-loop-unroll=unroll-only-wire-blocking-loops=true --verify-diagnostics %s
+// clang-format on
+
+// Input produced by the real pipeline
+// (cudaq-quake | cudaq-opt --canonicalize --factor-quantum-alloc --memtoreg).
+
+// A loop that both (a) indexes qubits by the induction variable -- so mem2reg
+// leaves quake.extract_ref reference semantics in the body, blocking wire
+// conversion -- and (b) has a runtime trip count (%arg0, a kernel argument) --
+// so it cannot be unrolled -- is a dead end: it can be neither kept in value
+// semantics nor unrolled. With unroll-only-wire-blocking-loops the pass rejects it.
+
+module {
+  func.func @__nvqpp__mlirgen__function_dyn_bound._Z9dyn_boundi(%arg0: i32) -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = cc.undef i32
+    %1 = quake.alloca !quake.ref
+    %2 = quake.unwrap %1 : (!quake.ref) -> !quake.wire
+    %3 = quake.alloca !quake.ref
+    %4 = quake.unwrap %3 : (!quake.ref) -> !quake.wire
+    quake.wrap %2 to %1 : !quake.wire, !quake.ref
+    quake.wrap %4 to %3 : !quake.wire, !quake.ref
+    %5 = quake.concat %1, %3 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+    cc.scope {
+      %11 = cc.undef i32
+      // expected-error@+1 {{loop accesses quantum data by a dynamic index or slice and cannot be unrolled (trip count is not a compile-time constant); it can be neither kept in value semantics nor unrolled}}
+      %12 = cc.loop while ((%arg1 = %c0_i32) -> (i32)) {
+        %13 = arith.cmpi slt, %arg1, %arg0 : i32
+        cc.condition %13(%arg1 : i32)
+      } do {
+      ^bb0(%arg1: i32):
+        %13 = cc.cast signed %arg1 : (i32) -> i64
+        %14 = quake.extract_ref %5[%13] : (!quake.veq<2>, i64) -> !quake.ref
+        %15 = quake.unwrap %14 : (!quake.ref) -> !quake.wire
+        %16 = quake.h %15 : (!quake.wire) -> !quake.wire
+        quake.wrap %16 to %14 : !quake.wire, !quake.ref
+        cc.continue %arg1 : i32
+      } step {
+      ^bb0(%arg1: i32):
+        %13 = arith.addi %arg1, %c1_i32 : i32
+        cc.continue %13 : i32
+      }
+    }
+    %measOut = quake.mz %5 name "m" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+    %6 = cc.undef !cc.stdvec<!cc.measure_handle>
+    %7 = cc.stdvec_data %measOut : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+    %8 = cc.cast %7 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+    %9 = cc.load %8 : !cc.ptr<!cc.measure_handle>
+    %10 = quake.discriminate %9 : (!cc.measure_handle) -> i1
+    return %10 : i1
+  }
+
+  func.func @__nvqpp__mlirgen__function_dyn_subveq_bound._Z16dyn_subveq_boundi(%arg0: i32) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = quake.alloca !quake.ref
+    %1 = quake.unwrap %0 : (!quake.ref) -> !quake.wire
+    %2 = quake.alloca !quake.ref
+    %3 = quake.unwrap %2 : (!quake.ref) -> !quake.wire
+    quake.wrap %1 to %0 : !quake.wire, !quake.ref
+    quake.wrap %3 to %2 : !quake.wire, !quake.ref
+    %4 = quake.concat %0, %2 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+    cc.scope {
+      // expected-error@+1 {{loop accesses quantum data by a dynamic index or slice and cannot be unrolled (trip count is not a compile-time constant); it can be neither kept in value semantics nor unrolled}}
+      %5 = cc.loop while ((%arg1 = %c0_i32) -> (i32)) {
+        %6 = arith.cmpi slt, %arg1, %arg0 : i32
+        cc.condition %6(%arg1 : i32)
+      } do {
+      ^bb0(%arg1: i32):
+        %6 = cc.cast signed %arg1 : (i32) -> i64
+        %7 = arith.addi %6, %c1_i64 : i64
+        %8 = quake.subveq %4, %6, %7 : (!quake.veq<2>, i64, i64) -> !quake.veq<2>
+        quake.mz %8 : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+        cc.continue %arg1 : i32
+      } step {
+      ^bb0(%arg1: i32):
+        %6 = arith.addi %arg1, %c1_i32 : i32
+        cc.continue %6 : i32
+      }
+    }
+    return
+  }
+}

--- a/cudaq/test/Transforms/unroll_only_wire_blocking_loops_predicate.qke
+++ b/cudaq/test/Transforms/unroll_only_wire_blocking_loops_predicate.qke
@@ -1,0 +1,190 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// clang-format off
+// RUN: cudaq-opt --cc-loop-unroll=unroll-only-wire-blocking-loops=true --canonicalize %s | FileCheck %s
+// clang-format on
+
+// These predicate-level inputs isolate selective unrolling from the later
+// wire-conversion pipeline. Dynamic quantum data access in a loop body should
+// force that loop to unroll. Classical data access, including loops over
+// measurement-result containers, should not.
+
+module {
+
+  func.func @measurement_result_loop(%arg0: !cc.measure_handle, %arg1: !cc.measure_handle) -> i1 attributes {"cudaq-kernel", no_this} {
+    %false = arith.constant false
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c2_i64 = arith.constant 2 : i64
+    %0 = cc.alloca !cc.array<!cc.measure_handle x 2>
+    %1 = cc.cast %0 : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+    cc.store %arg0, %1 : !cc.ptr<!cc.measure_handle>
+    %2 = cc.compute_ptr %0[1] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+    cc.store %arg1, %2 : !cc.ptr<!cc.measure_handle>
+    %3 = cc.cast %0 : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+    %4 = cc.stdvec_init %3, %c2_i64 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+    %5:2 = cc.loop while ((%arg2 = %c0_i32, %arg3 = %false) -> (i32, i1)) {
+      %6 = arith.cmpi slt, %arg2, %c2_i32 : i32
+      cc.condition %6(%arg2, %arg3 : i32, i1)
+    } do {
+    ^bb0(%arg2: i32, %arg3: i1):
+      %6 = cc.stdvec_data %4 : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+      %7 = cc.cast signed %arg2 : (i32) -> i64
+      %8 = cc.compute_ptr %6[%7] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.ptr<!cc.measure_handle>
+      %9 = cc.load %8 : !cc.ptr<!cc.measure_handle>
+      %10 = quake.discriminate %9 : (!cc.measure_handle) -> i1
+      %11 = arith.xori %arg3, %10 : i1
+      cc.continue %arg2, %11 : i32, i1
+    } step {
+    ^bb0(%arg2: i32, %arg3: i1):
+      %6 = arith.addi %arg2, %c1_i32 : i32
+      cc.continue %6, %arg3 : i32, i1
+    }
+    return %5#1 : i1
+  }
+
+// Expect the measurement-result loop to stay rolled; it only indexes classical
+// data.
+// CHECK-LABEL:   func.func @measurement_result_loop(
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.measure_handle,
+// CHECK-SAME:      %[[ARG1:.*]]: !cc.measure_handle) -> i1 attributes {"cudaq-kernel", no_this} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant false
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i32
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[CONSTANT_3:.*]] = arith.constant 2 : i32
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.measure_handle x 2>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:           cc.store %[[ARG0]], %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[ALLOCA_0]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:           cc.store %[[ARG1]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[LOOP_0:.*]]:2 = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]], %[[VAL_1:.*]] = %[[CONSTANT_0]]) -> (i32, i1)) {
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[CONSTANT_3]] : i32
+// CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]], %[[VAL_1]] : i32, i1)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1):
+// CHECK:             %[[CAST_1:.*]] = cc.cast signed %[[VAL_2]] : (i32) -> i64
+// CHECK:             %[[COMPUTE_PTR_1:.*]] = cc.compute_ptr %[[ALLOCA_0]]{{\[}}%[[CAST_1]]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>, i64) -> !cc.ptr<!cc.measure_handle>
+// CHECK:             %[[LOAD_0:.*]] = cc.load %[[COMPUTE_PTR_1]] : !cc.ptr<!cc.measure_handle>
+// CHECK:             %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[LOAD_0]] : (!cc.measure_handle) -> i1
+// CHECK:             %[[XORI_0:.*]] = arith.xori %[[VAL_3]], %[[DISCRIMINATE_0]] : i1
+// CHECK:             cc.continue %[[VAL_2]], %[[XORI_0]] : i32, i1
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i1):
+// CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_4]], %[[CONSTANT_2]] : i32
+// CHECK:             cc.continue %[[ADDI_0]], %[[VAL_5]] : i32, i1
+// CHECK:           }
+// CHECK:           return %[[VAL_6:.*]]#1 : i1
+// CHECK:         }
+
+  func.func @parent_dependent_nested_loop() attributes {"cudaq-kernel", no_this} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %0 = quake.alloca !quake.ref
+    %1 = quake.unwrap %0 : (!quake.ref) -> !quake.wire
+    %2 = quake.alloca !quake.ref
+    %3 = quake.unwrap %2 : (!quake.ref) -> !quake.wire
+    quake.wrap %1 to %0 : !quake.wire, !quake.ref
+    quake.wrap %3 to %2 : !quake.wire, !quake.ref
+    %4 = quake.concat %0, %2 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+    cc.scope {
+      %5 = cc.loop while ((%arg0 = %c0_i32) -> (i32)) {
+        %6 = arith.cmpi slt, %arg0, %c2_i32 : i32
+        cc.condition %6(%arg0 : i32)
+      } do {
+      ^bb0(%arg0: i32):
+        %6 = arith.subi %c2_i32, %arg0 : i32
+        %7 = cc.loop while ((%arg1 = %c0_i32) -> (i32)) {
+          %8 = arith.cmpi slt, %arg1, %6 : i32
+          cc.condition %8(%arg1 : i32)
+        } do {
+        ^bb0(%arg1: i32):
+          %8 = arith.addi %arg0, %arg1 : i32
+          %9 = cc.cast signed %8 : (i32) -> i64
+          %10 = quake.extract_ref %4[%9] : (!quake.veq<2>, i64) -> !quake.ref
+          %11 = quake.unwrap %10 : (!quake.ref) -> !quake.wire
+          %12 = quake.h %11 : (!quake.wire) -> !quake.wire
+          quake.wrap %12 to %10 : !quake.wire, !quake.ref
+          cc.continue %arg1 : i32
+        } step {
+        ^bb0(%arg1: i32):
+          %8 = arith.addi %arg1, %c1_i32 : i32
+          cc.continue %8 : i32
+        }
+        cc.continue %arg0 : i32
+      } step {
+      ^bb0(%arg0: i32):
+        %6 = arith.addi %arg0, %c1_i32 : i32
+        cc.continue %6 : i32
+      }
+    }
+    return
+  }
+
+// Expect both parent-dependent quantum-indexing loops to unroll into concrete
+// operations.
+// CHECK-LABEL:   func.func @parent_dependent_nested_loop() attributes {"cudaq-kernel", no_this} {
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[UNWRAP_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[H_0]] to %[[ALLOCA_0]] : !quake.wire, !quake.ref
+// CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[ALLOCA_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[H_1:.*]] = quake.h %[[UNWRAP_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[H_1]] to %[[ALLOCA_1]] : !quake.wire, !quake.ref
+// CHECK:           %[[UNWRAP_2:.*]] = quake.unwrap %[[ALLOCA_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[H_2:.*]] = quake.h %[[UNWRAP_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[H_2]] to %[[ALLOCA_1]] : !quake.wire, !quake.ref
+// CHECK:           return
+// CHECK:         }
+
+  func.func @blocking_dynamic_subveq() attributes {"cudaq-kernel", no_this} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %0 = quake.alloca !quake.ref
+    %1 = quake.unwrap %0 : (!quake.ref) -> !quake.wire
+    %2 = quake.alloca !quake.ref
+    %3 = quake.unwrap %2 : (!quake.ref) -> !quake.wire
+    quake.wrap %1 to %0 : !quake.wire, !quake.ref
+    quake.wrap %3 to %2 : !quake.wire, !quake.ref
+    %4 = quake.concat %0, %2 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+    cc.scope {
+      %5 = cc.loop while ((%arg0 = %c0_i32) -> (i32)) {
+        %6 = arith.cmpi slt, %arg0, %c2_i32 : i32
+        cc.condition %6(%arg0 : i32)
+      } do {
+      ^bb0(%arg0: i32):
+        %6 = cc.cast signed %arg0 : (i32) -> i64
+        %7 = quake.subveq %4, %6, %6 : (!quake.veq<2>, i64, i64) -> !quake.veq<1>
+        quake.mz %7 : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+        cc.continue %arg0 : i32
+      } step {
+      ^bb0(%arg0: i32):
+        %6 = arith.addi %arg0, %c1_i32 : i32
+        cc.continue %6 : i32
+      }
+    }
+    return
+  }
+
+// Expect the dynamic `subveq` loop to unroll into concrete subveq/mz
+// operations.
+// CHECK-LABEL:   func.func @blocking_dynamic_subveq() attributes {"cudaq-kernel", no_this} {
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %[[ALLOCA_0]], %[[ALLOCA_1]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
+// CHECK:           %[[SUBVEQ_0:.*]] = quake.subveq %[[CONCAT_0]], 0, 0 : (!quake.veq<2>) -> !quake.veq<1>
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[SUBVEQ_0]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[SUBVEQ_1:.*]] = quake.subveq %[[CONCAT_0]], 1, 1 : (!quake.veq<2>) -> !quake.veq<1>
+// CHECK:           %[[MZ_1:.*]] = quake.mz %[[SUBVEQ_1]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           return
+// CHECK:         }
+}

--- a/python/runtime/cudaq/algorithms/py_translate.cpp
+++ b/python/runtime/cudaq/algorithms/py_translate.cpp
@@ -15,11 +15,7 @@
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/platform/default/python/QPU.h"
 #include "cudaq/runtime/logger/logger.h"
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Target/LLVMIR/Export.h"
 
 using namespace mlir;
 
@@ -82,29 +78,4 @@ static std::string translate_impl(const std::string &shortName,
 void cudaq::bindPyTranslate(nanobind::module_ &mod) {
   mod.def("translate_impl", translate_impl,
           "See python documentation for translate.");
-  // Internal translation to QIR for testing and internal use. Not intended to
-  // be a public API.
-  mod.def(
-      "_lower_to_qir",
-      [](MlirModule module) -> std::string {
-        const std::string format = "qir";
-        auto mod = unwrap(module);
-        PassManager pm(mod.getContext());
-        pm.addInstrumentation(
-            std::make_unique<cudaq::TracePassInstrumentation>());
-        cudaq::opt::addAOTPipelineConvertToQIR(pm, format);
-        if (failed(pm.run(mod)))
-          throw std::runtime_error("Conversion to " + format + " failed.");
-        llvm::LLVMContext llvmContext;
-        std::unique_ptr<llvm::Module> llvmModule =
-            translateModuleToLLVMIR(mod, llvmContext);
-        if (!llvmModule)
-          return "{translation failed}";
-        std::string result;
-        llvm::raw_string_ostream os(result);
-        llvmModule->print(os, nullptr);
-        os.flush();
-        return result;
-      },
-      "[Internal] Lower to QIR.");
 }

--- a/unittests/nvqpp/backends/quake_backend/FakeQuakeServerHelper.cpp
+++ b/unittests/nvqpp/backends/quake_backend/FakeQuakeServerHelper.cpp
@@ -14,6 +14,8 @@
 #include <fstream>
 #include <map>
 #include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string_view>
 #include <thread>
 
 namespace cudaq {
@@ -26,7 +28,29 @@ public:
 
   RestHeaders getHeaders() override { return RestHeaders(); }
 
-  void initialize(BackendConfig config) override {}
+  void initialize(BackendConfig config) override { backendConfig = config; }
+
+  void updatePassPipeline(const std::filesystem::path &,
+                          std::string &passPipeline) override {
+    auto iter = backendConfig.find("emulate");
+    if (iter == backendConfig.end() || iter->second != "true")
+      return;
+
+    // `quake_fake` sends value-semantic wireset IR to the mock server when
+    // running remotely. For `--emulate`, keep the IR in the normal ref-semantic
+    // form so the shared local JIT lowers it through its regular QIR path.
+    constexpr std::string_view wiresetPipeline =
+        ",factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg)"
+        ",canonicalize,cse,add-wireset,func.func(assign-wire-indices)"
+        ",qubit-mapping{device=bypass}"
+        ",decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}";
+    const auto pos = passPipeline.find(wiresetPipeline);
+    if (pos == std::string::npos)
+      throw std::runtime_error(
+          "quake_fake emulation pipeline does not contain wireset lowering");
+
+    passPipeline.replace(pos, wiresetPipeline.size(), ")");
+  }
 
   ServerJobPayload
   createJob(std::vector<KernelExecution> &circuitCodes) override {

--- a/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
+++ b/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
@@ -28,7 +28,7 @@ else
 fi
 
 
-PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/mock_server.py -device-lib @CMAKE_BINARY_DIR@/unittests/nvqpp/backends/quake_backend/libfake_quake_backend_device_funcs.$LIB_EXT &
+PYTHONPATH=@CMAKE_BINARY_DIR@/python:@CMAKE_SOURCE_DIR@/python/tests/utils/mock_qpu @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/mock_server.py -device-lib @CMAKE_BINARY_DIR@/unittests/nvqpp/backends/quake_backend/libfake_quake_backend_device_funcs.$LIB_EXT &
 # we'll need the process id to kill it
 pid=$(echo "$!")
 n=0

--- a/unittests/nvqpp/backends/quake_backend/mock_server.py
+++ b/unittests/nvqpp/backends/quake_backend/mock_server.py
@@ -7,16 +7,15 @@
 # ============================================================================ #
 
 import cudaq
-from fastapi import FastAPI, HTTPException, Header, Request
-from typing import Union
+from fastapi import FastAPI, HTTPException, Request
 import uvicorn, uuid, base64, ctypes, sys, re
-from pydantic import BaseModel
 from llvmlite import binding as llvm
+from preallocated_qubits_context import PreallocatedQubitsContext
 from cudaq.mlir.passmanager import PassManager
 from cudaq.mlir.ir import Module
 from cudaq.kernel.utils import getMLIRContext
 from cudaq.mlir.dialects import func
-from cudaq.mlir._mlir_libs._quakeDialects import cudaq_runtime
+from cudaq.mlir.dialects import llvm as mlir_llvm
 
 # Define the REST Server App
 app = FastAPI()
@@ -30,6 +29,116 @@ engine = llvm.create_mcjit_compiler(backing_mod, targetMachine)
 
 # Keep track of Job Ids to their Names
 createdJobs = {}
+
+SERVER_EXECUTION_PIPELINE = (
+    "builtin.module("
+    "canonicalize,distributed-device-call,cse,"
+    "func.func("
+    "memtoreg,canonicalize,cc-loop-normalize,"
+    "cc-loop-unroll{maximum-iterations=1024 "
+    "signal-failure-if-any-loop-cannot-be-completely-unrolled=true "
+    "allow-early-exit=true},"
+    "canonicalize,regtomem,canonicalize"
+    "),"
+    "canonicalize,cse,symbol-dce,lower-to-cfg,"
+    "func.func(stack-frame-prealloc,combine-quantum-alloc,canonicalize,cse),"
+    "symbol-dce,"
+    "convert-to-qir-api{api=adaptive-profile:1.0 opaque-pointer=true},"
+    "lower-to-cfg,symbol-dce,cc-to-llvm"
+    ")")
+
+
+def verifyValueSemanticsPayload(decoded_payload):
+    required_tokens = ["quake.wire_set", "quake.borrow_wire"]
+    for token in required_tokens:
+        if token not in decoded_payload:
+            raise RuntimeError(
+                f"Remote payload is missing `{token}`. The server must receive"
+                " value-semantics MLIR with an assigned wireset.")
+
+    forbidden_tokens = [
+        "quake.alloca",
+        "quake.extract_ref",
+        "quake.subveq",
+        "quake.concat",
+        "quake.relax_size",
+        "quake.unwrap",
+        "quake.wrap",
+        "!quake.ref",
+        "!quake.veq",
+    ]
+    for token in forbidden_tokens:
+        if token in decoded_payload:
+            raise RuntimeError(
+                f"Remote payload still contains reference-semantics token"
+                f" `{token}`. The server must receive wireset MLIR.")
+
+
+def verifyExpectedLoopCount(decoded_payload, entry_func_name):
+    match = re.search(r"expected_(\d+)_loops?", entry_func_name)
+    if not match:
+        return
+
+    expectedCount = int(match.group(1))
+    actualCount = len(re.findall(r"\bcc\.loop\b", decoded_payload))
+    if actualCount != expectedCount:
+        raise RuntimeError(
+            "Remote payload preserved an unexpected number of `cc.loop` ops "
+            f"for `{entry_func_name}`: expected {expectedCount}, got "
+            f"{actualCount}.")
+
+
+def getNumRequiredQubits(function):
+    for a in function.attributes:
+        if "required_num_qubits" in str(a):
+            return int(
+                str(a).split(f'required_num_qubits\"=')[-1].split(" ")
+                [0].replace("\"", "").replace("'", ""))
+        elif "requiredQubits" in str(a):
+            return int(
+                str(a).split(f'requiredQubits\"=')[-1].split(" ")[0].replace(
+                    "\"", "").replace("'", ""))
+
+
+def getNumRequiredResults(function):
+    for a in function.attributes:
+        if "required_num_results" in str(a):
+            return int(
+                str(a).split(f'required_num_results\"=')[-1].split(" ")
+                [0].replace("\"", "").replace("'", ""))
+        elif "requiredResults" in str(a):
+            return int(
+                str(a).split(f'requiredResults\"=')[-1].split(" ")[0].replace(
+                    "\"", "").replace("'", ""))
+
+
+def getKernelFunction(module):
+    for f in module.functions:
+        if not f.is_declaration:
+            return f
+    return None
+
+
+def verifyModule(module, stage):
+    if not module.operation.verify():
+        raise RuntimeError(f"MLIR verification failed for {stage} module.")
+
+
+def lowerValueSemanticsPayloadForExecution(recovered_mod, ctx):
+    # The client/server contract is checked before this point. The client has
+    # already run the target JIT pipeline through wireset assignment. For
+    # execution, the mock server fully unrolls the submitted value-semantic IR,
+    # reconstructs ref semantics with `regtomem`, and then uses the normal QIR
+    # API lowering path.
+    pm = PassManager.parse(SERVER_EXECUTION_PIPELINE, context=ctx)
+    try:
+        pm.run(recovered_mod.operation)
+    except Exception as e:
+        raise RuntimeError("Failed to lower recovered module for execution: "
+                           f"{e}\n{recovered_mod}") from e
+
+    verifyModule(recovered_mod, "server-lowered")
+    return mlir_llvm.translate_module_to_llvmir(recovered_mod.operation)
 
 
 @app.post("/job")
@@ -47,8 +156,11 @@ async def postJob(request: Request):
             "Input MLIR contains malloc or memcpy calls. These should have been"
             " eliminated by the eliminate-dead-heap-copy pass.")
 
+    verifyValueSemanticsPayload(decoded_payload)
+
     ctx = getMLIRContext()
     recovered_mod = Module.parse(decoded_payload, context=ctx)
+    verifyModule(recovered_mod, "submitted")
     pm = PassManager.parse(
         "builtin.module(canonicalize,distributed-device-call,cse)", context=ctx)
     try:
@@ -64,37 +176,41 @@ async def postJob(request: Request):
                 if attr == "cudaq-entrypoint":
                     entry_func_name = op.name.value
                     break
-    # Lower the module to LLVM IR
-    qir_code = cudaq_runtime._lower_to_qir(recovered_mod)
+    if not entry_func_name:
+        raise RuntimeError(
+            "Remote payload is missing a `cudaq-entrypoint` function.")
+    verifyExpectedLoopCount(decoded_payload, entry_func_name)
+
+    # Lower the module to LLVM IR.
+    qir_code = lowerValueSemanticsPayloadForExecution(recovered_mod, ctx)
     m = llvm.module.parse_assembly(qir_code)
     m.verify()
 
+    # Get the function, number of qubits, and kernel name.
+    function = getKernelFunction(m)
+    if function == None:
+        raise Exception("Could not find kernel function")
+    numQubitsRequired = getNumRequiredQubits(function)
+    numResultsRequired = getNumRequiredResults(function)
+    kernelFunctionName = function.name
+
     # Job ID
     newId = str(uuid.uuid4())
-
-    all_funcs = m.functions
-    for f in all_funcs:
-        if f.is_declaration:
-            # Look up external functions: get the in-process address me.
-            func_addr = llvm.address_of_symbol(f.name)
-            if func_addr is None:
-                createdJobs[
-                    newId] = f"FAILURE: Function {f.name} not found in JIT engine."
-                return ({"id": newId}, 201)
 
     # JIT Compile and get Function Pointer
     engine.add_module(m)
     engine.finalize_object()
     engine.run_static_constructors()
-    funcPtr = engine.get_function_address(entry_func_name)
+    funcPtr = engine.get_function_address(kernelFunctionName)
     kernel = ctypes.CFUNCTYPE(None)(funcPtr)
     # Clear any leftover log from previous jobs
     cudaq.testing.getAndClearOutputLog()
-    qir_log = f"HEADER\tschema_id\tlabeled\nHEADER\tschema_version\t1.0\nSTART\nMETADATA\tentry_point\nMETADATA\tqir_profiles\tadaptive_profile\n"
+    qir_log = f"HEADER\tschema_id\tlabeled\nHEADER\tschema_version\t1.0\nSTART\nMETADATA\tentry_point\nMETADATA\tqir_profiles\tadaptive_profile\nMETADATA\trequired_num_qubits\t{numQubitsRequired}\nMETADATA\trequired_num_results\t{numResultsRequired}\n"
 
     shots = payload["shots"]
     for i in range(shots):
-        kernel()
+        with PreallocatedQubitsContext(numQubitsRequired, 1, "run"):
+            kernel()
         shot_log = cudaq.testing.getAndClearOutputLog()
         if i > 0:
             qir_log += "START\n"

--- a/unittests/nvqpp/backends/quake_backend/mock_server.py
+++ b/unittests/nvqpp/backends/quake_backend/mock_server.py
@@ -126,7 +126,7 @@ def verifyModule(module, stage):
 
 def lowerValueSemanticsPayloadForExecution(recovered_mod, ctx):
     # The client/server contract is checked before this point. The client has
-    # already run the target JIT pipeline through wireset assignment. For
+    # already run the target JIT pipeline through `wireset` assignment. For
     # execution, the mock server fully unrolls the submitted value-semantic IR,
     # reconstructs ref semantics with `regtomem`, and then uses the normal QIR
     # API lowering path.

--- a/unittests/nvqpp/backends/quake_backend/quake_fake.yml
+++ b/unittests/nvqpp/backends/quake_backend/quake_fake.yml
@@ -19,6 +19,7 @@ config:
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "expand-measurements"
+  jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "return-to-output-log,symbol-dce"
   # Tell the rest-qpu that we are simply dumping CUDA-Q MLIR code.
   codegen-emission: nop

--- a/unittests/nvqpp/backends/quake_backend/test_loop_app.cpp
+++ b/unittests/nvqpp/backends/quake_backend/test_loop_app.cpp
@@ -8,17 +8,57 @@
 
 #include <cudaq.h>
 
+#include <cmath>
 #include <iostream>
+#include <vector>
 
-__qpu__ int loop_payload_stress() {
+// IMPORTANT: loop-count annotations are part of this test contract. Kernel
+// names ending in `_expected_N_loop(s)` tell the quake fake mock server how
+// many `cc.loop` operations must be present in the submitted client payload
+// before the server does its own execution-time full unroll.
+
+// Expected remaining payload loops: none. Broadcast X over the whole qvector
+// must lower to static wire operations in the submitted payload.
+__qpu__ int broadcast_x_qvector_expected_0_loops() {
+  cudaq::qvector q(3);
+  x(q);
+
+  int result = 0;
+  auto bits = mz(q);
+  if (bits[0])
+    result |= 1;
+  if (bits[1])
+    result |= 2;
+  if (bits[2])
+    result |= 4;
+  return result;
+}
+
+// Expected remaining payload loops: none. The whole-register control must be
+// expanded before wire assignment so all control wires are static.
+__qpu__ int whole_register_control_x_expected_0_loops() {
+  cudaq::qvector ctrls(3);
+  cudaq::qubit target;
+
+  x(ctrls);
+  x<cudaq::ctrl>(ctrls, target);
+  return mz(target);
+}
+
+// Expected remaining payload loop: the outer pass loop. The loops that index
+// quantum data (`q[i]`) are unrolled so wire IDs are static in the payload.
+__qpu__ int loop_payload_stress_expected_1_loop() {
   constexpr int width = 4;
   cudaq::qvector q(width);
 
+  // KEEP: this classical repeat loop does not index quantum data directly.
   for (int pass = 0; pass < 2; ++pass)
+    // UNROLL: this loop indexes `q[i]`, so wire IDs must become static.
     for (int i = 0; i < width; ++i)
       x(q[i]);
 
   int i = 0;
+  // UNROLL: this loop indexes `q[i]`, so wire IDs must become static.
   while (i < width) {
     x(q[i]);
     ++i;
@@ -37,14 +77,213 @@ __qpu__ int loop_payload_stress() {
   return result;
 }
 
-int main() {
-  const auto results = cudaq::run(3, loop_payload_stress);
+// Expected remaining payload loop: the loop over measurement results. This loop
+// does not access quantum data, so it should stay rolled.
+__qpu__ int measurement_result_loop_expected_1_loop() {
+  constexpr int width = 4;
+  cudaq::qvector q(width);
+
+  x(q[0]);
+  x(q[2]);
+
+  auto bits = mz(q);
+  int result = 0;
+  // KEEP: this loop only indexes measurement results, not quantum data.
+  for (int i = 0; i < width; ++i)
+    if (bits[i])
+      result |= 1 << i;
+
+  return result;
+}
+
+// Expected remaining payload loops: outer, group, classical accumulation, and
+// measurement-result accumulation. The quantum-data loop over `q[wire]` is
+// unrolled for static wire IDs.
+__qpu__ int nested_mixed_loop_payload_expected_4_loops() {
+  constexpr int width = 4;
+  cudaq::qvector q(width);
+
+  int classical = 0;
+  // KEEP: this classical outer loop does not index quantum data directly.
+  for (int outer = 0; outer < 1; ++outer)
+    // KEEP: this classical group loop does not index quantum data directly.
+    for (int group = 0; group < 2; ++group) {
+      // UNROLL: this loop indexes `q[wire]`, so wire IDs must become static.
+      for (int wire = 0; wire < width; ++wire)
+        x(q[wire]);
+
+      // KEEP: this loop is classical accumulation only.
+      for (int i = 0; i < 3; ++i)
+        classical += group + i;
+    }
+
+  x(q[0]);
+
+  auto bits = mz(q);
+  int result = classical;
+  // KEEP: this loop only iterates over measurement results.
+  for (auto bit : bits)
+    if (bit)
+      result += 16;
+
+  return result;
+}
+
+// Expected remaining payload loop: the phase-kickback repeat loop. This is the
+// fixed-wire core of phase estimation: repeated controlled unitary powers on a
+// prepared eigenstate. The loop should stay rolled because it uses fixed
+// qubits.
+__qpu__ int fixed_wire_phase_estimation_expected_1_loop() {
+  cudaq::qubit counting, eigenstate;
+
+  x(eigenstate);
+  h(counting);
+
+  // KEEP: repeated controlled rotations over fixed qubits should stay rolled.
+  for (int power = 0; power < 3; ++power)
+    r1<cudaq::ctrl>(M_PI, counting, eigenstate);
+
+  h(counting);
+  return mz(counting);
+}
+
+// Expected remaining payload loops: none. The triangular inner bound depends on
+// the outer induction variable, and both loops index quantum data. Both loops
+// must unroll so the client payload contains only static wire operations.
+__qpu__ int parent_dependent_triangular_expected_0_loops() {
+  constexpr int width = 4;
+  cudaq::qvector q(width);
+
+  x(q[0]);
+
+  // UNROLL: `i` indexes quantum data and bounds the inner loop.
+  for (int i = 0; i < width - 1; ++i)
+    // UNROLL: `j` indexes quantum data with a parent-dependent lower bound.
+    for (int j = i + 1; j < width; ++j)
+      x<cudaq::ctrl>(q[i], q[j]);
+
+  int result = 0;
+  if (mz(q[0]))
+    result |= 1;
+  if (mz(q[1]))
+    result |= 2;
+  if (mz(q[2]))
+    result |= 4;
+  if (mz(q[3]))
+    result |= 8;
+
+  return result;
+}
+
+// Expected remaining payload loop: the outer repeat loop. The inner triangular
+// parent-dependent quantum loops must unroll, but the outer repeat does not
+// index quantum data directly and should stay rolled.
+__qpu__ int repeated_parent_dependent_triangular_expected_1_loop() {
+  constexpr int width = 4;
+  cudaq::qvector q(width);
+
+  x(q[0]);
+
+  // KEEP: this repeat loop does not index quantum data directly.
+  for (int pass = 0; pass < 2; ++pass)
+    // UNROLL: `i` indexes quantum data and bounds the inner loop.
+    for (int i = 0; i < width - 1; ++i)
+      // UNROLL: `j` indexes quantum data with a parent-dependent lower bound.
+      for (int j = i + 1; j < width; ++j)
+        x<cudaq::ctrl>(q[i], q[j]);
+
+  int result = 0;
+  if (mz(q[0]))
+    result |= 1;
+  if (mz(q[1]))
+    result |= 2;
+  if (mz(q[2]))
+    result |= 4;
+  if (mz(q[3]))
+    result |= 8;
+
+  return result;
+}
+
+// Expected remaining payload loops: none. The middle loop does not directly
+// index quantum data, but the inner loop indexes q[outer]. Unrolling must
+// propagate through the non-blocking middle loop so every quantum access has a
+// static wire ID in the submitted payload.
+__qpu__ int transitive_parent_index_access_expected_0_loops() {
+  constexpr int width = 3;
+  cudaq::qvector q(width);
+
+  // UNROLL: `outer` is used by the innermost quantum access q[outer].
+  for (int outer = 0; outer < width; ++outer)
+    // UNROLL: this loop is not directly blocking, but it encloses the
+    // parent-dependent quantum access exposed by unrolling the inner loop.
+    for (int middle = 0; middle < 3; ++middle)
+      // UNROLL: this loop contains the q[outer] access that initially blocks
+      // wire conversion.
+      for (int inner = 0; inner < 3; ++inner)
+        x(q[outer]);
+
+  int result = 0;
+  if (mz(q[0]))
+    result |= 1;
+  if (mz(q[1]))
+    result |= 2;
+  if (mz(q[2]))
+    result |= 4;
+
+  return result;
+}
+
+static bool checkResults(const std::vector<int> &results, int expected,
+                         const char *name) {
   for (auto result : results) {
-    if (result != 15) {
-      std::cerr << "loop_payload_stress expected 15, got " << result << "\n";
-      return 1;
+    if (result != expected) {
+      std::cerr << name << " expected " << expected << ", got " << result
+                << "\n";
+      return false;
     }
   }
+  return true;
+}
+
+int main() {
+  if (!checkResults(cudaq::run(3, broadcast_x_qvector_expected_0_loops), 7,
+                    "broadcast_x_qvector_expected_0_loops"))
+    return 1;
+
+  if (!checkResults(cudaq::run(3, whole_register_control_x_expected_0_loops), 1,
+                    "whole_register_control_x_expected_0_loops"))
+    return 1;
+
+  if (!checkResults(cudaq::run(3, loop_payload_stress_expected_1_loop), 15,
+                    "loop_payload_stress_expected_1_loop"))
+    return 1;
+
+  if (!checkResults(cudaq::run(3, measurement_result_loop_expected_1_loop), 5,
+                    "measurement_result_loop_expected_1_loop"))
+    return 1;
+
+  if (!checkResults(cudaq::run(3, nested_mixed_loop_payload_expected_4_loops),
+                    25, "nested_mixed_loop_payload_expected_4_loops"))
+    return 1;
+
+  if (!checkResults(cudaq::run(3, fixed_wire_phase_estimation_expected_1_loop),
+                    1, "fixed_wire_phase_estimation_expected_1_loop"))
+    return 1;
+
+  if (!checkResults(cudaq::run(3, parent_dependent_triangular_expected_0_loops),
+                    3, "parent_dependent_triangular_expected_0_loops"))
+    return 1;
+
+  if (!checkResults(
+          cudaq::run(3, repeated_parent_dependent_triangular_expected_1_loop),
+          5, "repeated_parent_dependent_triangular_expected_1_loop"))
+    return 1;
+
+  if (!checkResults(
+          cudaq::run(3, transitive_parent_index_access_expected_0_loops), 7,
+          "transitive_parent_index_access_expected_0_loops"))
+    return 1;
 
   std::cout << "Loop payload stress passed.\n";
   return 0;

--- a/unittests/nvqpp/backends/quake_backend/test_loop_app.py
+++ b/unittests/nvqpp/backends/quake_backend/test_loop_app.py
@@ -12,28 +12,97 @@ cudaq.set_target("quake_fake")
 
 width = 4
 
+# IMPORTANT: loop-count annotations are part of this test contract. Kernel
+# names ending in `_expected_N_loop(s)` tell the quake fake mock server how
+# many `cc.loop` operations must be present in the submitted client payload
+# before the server does its own execution-time full unroll.
 
+
+# Expected remaining payload loops: the repeat loop, plus the generated
+# measurement-result reduction from `to_integer(to_bools(mz(q)))`. The loops
+# that index quantum data (`q[i]`) are unrolled so wire IDs are static.
 @cudaq.kernel
-def loop_payload_stress() -> int:
+def loop_payload_stress_expected_2_loops() -> int:
     q = cudaq.qvector(width)
 
+    # KEEP: this classical repeat loop does not index quantum data directly.
     for repeat in range(2):
+        # UNROLL: this loop indexes `q[i]`, so wire IDs must become static.
         for i in range(width):
             x(q[i])
 
     i = 0
+    # UNROLL: this loop indexes `q[i]`, so wire IDs must become static.
     while i < width:
         x(q[i])
         i += 1
 
+    # KEEP: this expression generates a measurement-result reduction loop.
     return cudaq.to_integer(cudaq.to_bools(mz(q)))
 
 
-try:
-    results = cudaq.run(loop_payload_stress, shots_count=3)
+# Expected remaining payload loop: the loop over measurement results. This loop
+# does not access quantum data, so it should stay rolled.
+@cudaq.kernel
+def measurement_result_loop_expected_1_loop() -> int:
+    q = cudaq.qvector(width)
+
+    x(q[0])
+    x(q[2])
+
+    bits = mz(q)
+    result = 0
+    # KEEP: this loop only indexes measurement results, not quantum data.
+    for i in range(width):
+        if bits[i]:
+            result |= 1 << i
+
+    return result
+
+
+# Expected remaining payload loops: outer, group, classical accumulation, and
+# measurement-result accumulation. The quantum-data loop over `q[wire]` is
+# unrolled for static wire IDs.
+@cudaq.kernel
+def nested_mixed_loop_payload_expected_4_loops() -> int:
+    q = cudaq.qvector(width)
+
+    classical = 0
+    # KEEP: this classical outer loop does not index quantum data directly.
+    for outer in range(1):
+        # KEEP: this classical group loop does not index quantum data directly.
+        for group in range(2):
+            # UNROLL: this loop indexes `q[wire]`, so wire IDs become static.
+            for wire in range(width):
+                x(q[wire])
+
+            # KEEP: this loop is classical accumulation only.
+            for i in range(3):
+                classical += group + i
+
+    x(q[0])
+
+    bits = mz(q)
+    result = classical
+    # KEEP: this loop only indexes measurement results, not quantum data.
+    for i in range(width):
+        if bits[i]:
+            result += 16
+
+    return result
+
+
+def check_results(kernel, expected):
+    results = cudaq.run(kernel, shots_count=3)
     assert len(results) == 3
     for result in results:
-        assert result == 15, f"expected 15, got {result}"
+        assert result == expected, f"expected {expected}, got {result}"
+
+
+try:
+    check_results(loop_payload_stress_expected_2_loops, 15)
+    check_results(measurement_result_loop_expected_1_loop, 5)
+    check_results(nested_mixed_loop_payload_expected_4_loops, 25)
 except Exception as e:
     print(e)
     sys.exit(1)


### PR DESCRIPTION
Adds an opt-in `unroll-only-wire-blocking-loops` option to `cc-loop-unroll` (default `false` so existing pipelines unchanged). 

This allows a value-semantics / `wireset` lowering pipeline unroll only the loops affecting qubit (quantum data type) indexing.
A loop touches quantum data by a dynamic index or slice needs unrolling to make qubit index static (can be translated to a static `wire`). Everything else: loops over classical data (including measurement data), purely repeating outer loops, etc., is left rolled. 

Majority of the changeset is for test coverage:

(1) Low-level quake tests for basic checks of the new unroll mode.

(2) Semi-integrated lit tests to emulate the JIT pipeline on various loops: nested, transitive, etc.

(3) Fully integrated tests with the fake quake target: mimic a backend that expects value-semantics IR (verify the incoming IR), also checking the expected number of loops in the IR.
