### PR TITLE
Accept np.floor in Python kernels

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -857,7 +857,7 @@ class PyASTBridge(ast.NodeVisitor):
     def __isSupportedNumpyFunction(self, id):
         return id in [
             'sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'arcsin', 'arccos',
-            'arctan', 'sqrt', 'ceil', 'exp', 'log'
+            'arctan', 'sqrt', 'ceil', 'floor', 'exp', 'log'
         ]
 
     def __isSupportedVectorFunction(self, id):
@@ -3704,6 +3704,14 @@ class PyASTBridge(ast.NodeVisitor):
                                 f"supported for complex numbers", node)
                             return
                         self.pushValue(math.CeilOp(value).result)
+                        return
+                    if node.func.attr == 'floor':
+                        if ComplexType.isinstance(value.type):
+                            self.emitFatalError(
+                                f"numpy call ({node.func.attr}) is not "
+                                f"supported for complex numbers", node)
+                            return
+                        self.pushValue(math.FloorOp(value).result)
                         return
 
                     self.emitFatalError(

--- a/python/tests/kernel/test_kernel_float.py
+++ b/python/tests/kernel/test_kernel_float.py
@@ -183,6 +183,14 @@ def test_float64_use():
     t = np.ceil(np.float64(np.pi / 2 + 1))
     assert is_close(t, float_np_use())
 
+    # Use a float inside np in a kernel (floor)
+    @cudaq.kernel
+    def float_np_use() -> np.float64:
+        return np.floor(np.float64(np.pi / 2 + 1))
+
+    t = np.floor(np.float64(np.pi / 2 + 1))
+    assert is_close(t, float_np_use())
+
     # Use a float inside np in a kernel (exp)
     @cudaq.kernel
     def float_np_use() -> np.float64:
@@ -310,6 +318,14 @@ def test_float32_use():
         return np.ceil(np.float32(np.pi / 2 + 1))
 
     t = np.ceil(np.float32(np.pi / 2 + 1))
+    assert is_close(t, float_np_use())
+
+    # Use a float inside np in a kernel (floor)
+    @cudaq.kernel
+    def float_np_use() -> np.float32:
+        return np.floor(np.float32(np.pi / 2 + 1))
+
+    t = np.floor(np.float32(np.pi / 2 + 1))
     assert is_close(t, float_np_use())
 
     # Use a float inside np in a kernel (exp)


### PR DESCRIPTION
Fixes #4780.

## Problem
The Python AST bridge accepts `np.ceil` but not `np.floor`, even though the C++ frontend already lowers `std::floor`. Calling `np.floor` inside a `@cudaq.kernel` hits the `unsupported NumPy call` fatal error. This is a pre-existing Python/C++ coverage gap (not a regression from the math-function work in #4680), surfaced in #4780.

## Fix
Mirror the existing `ceil` path exactly in `python/cudaq/kernel/ast_bridge.py`:
- add `floor` to `__isSupportedNumpyFunction`;
- add a `floor` dispatch handler that rejects complex inputs (same as `ceil`) and emits `math.FloorOp`.

`math.FloorOp` is the MLIR Math dialect analog of `math.CeilOp` (both are defined in the dialect), so this needs no C++ changes.

## Tests
Extended `python/tests/kernel/test_kernel_float.py` with `np.floor` cases for both `np.float64` and `np.float32`, mirroring the existing `np.ceil` checks.

## Validation
- `python -m py_compile` passes on both changed files.
- Confirmed `FloorOp` and `CeilOp` are both defined in the MLIR Math dialect (`mlir/Dialect/Math/IR/MathOps.h.inc`), so `math.FloorOp` resolves the same way `math.CeilOp` does.
- Full kernel execution requires a source build; the change is a line-for-line mirror of the verified `ceil` path, so CI on this PR exercises the new tests end to end.