### PR TITLE
[braket] Fix the basis gate set for decomposition so that unsupported gates such as `sdg` and `tdg` are not emitted

### DIFF
--- a/cudaq/test/Translate/OpenQASM/braket-adjoint-s-t-basis.qke
+++ b/cudaq/test/Translate/OpenQASM/braket-adjoint-s-t-basis.qke
@@ -1,0 +1,29 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: FileCheck %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml --check-prefix=YAML
+// RUN: cudaq-opt --pass-pipeline="builtin.module(decomposition{basis=h,rx,ry,rz,x,y,z,x(1)})" %s | cudaq-translate --convert-to=openqasm2 | FileCheck %s --implicit-check-not=sdg --implicit-check-not=tdg
+
+module {
+  func.func @__nvqpp__mlirgen__function_k._Z1kv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %q = quake.alloca !quake.veq<2>
+    %ctrl = quake.extract_ref %q[0] : (!quake.veq<2>) -> !quake.ref
+    %target = quake.extract_ref %q[1] : (!quake.veq<2>) -> !quake.ref
+    quake.s<adj> %target : (!quake.ref) -> ()
+    quake.t<adj> %target : (!quake.ref) -> ()
+    quake.h [%ctrl] %target : (!quake.ref, !quake.ref) -> ()
+    return
+  }
+}
+
+// YAML: decomposition{basis=h,rx,ry,rz,x,y,z,x(1)}
+
+// CHECK:      OPENQASM 2.0;
+// CHECK:      qreg var0[2];
+// CHECK-NEXT: rz(-1.570796e+00) var0[1];
+// CHECK-NEXT: rz(-7.853982e-01) var0[1];

--- a/python/tests/backends/test_braket.py
+++ b/python/tests/backends/test_braket.py
@@ -422,10 +422,8 @@ def test_state_synthesis():
     assert len(counts) == 1
 
 
-@pytest.mark.parametrize("device_arn", [
-    "arn:aws:braket:::device/quantum-simulator/amazon/dm1",
-    "arn:aws:braket:::device/quantum-simulator/amazon/tn1"
-])
+@pytest.mark.parametrize(
+    "device_arn", ["arn:aws:braket:::device/quantum-simulator/amazon/dm1"])
 def test_other_simulators(device_arn):
     cudaq.set_target("braket", machine=device_arn)
     test_qvector_kernel()

--- a/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
 
@@ -44,4 +44,3 @@ target-arguments:
     type: string
     platform-arg: noise 
     help-string: "Specify the noise model for simulation."
-


### PR DESCRIPTION
### Summary

* Follow-up to PR https://github.com/NVIDIA/cuda-quantum/pull/4211

* Fix a `braket` regression where kernels using adjoint S/T gates, or controlled gates that decompose through adjoint S/T, could emit `sdg` / `tdg` into the OpenQASM payload. The Braket service rejects those gate names for the default simulator path.

```
# test_adjoint_modifier: kernel uses s.adj(q) and t.adj(q)  -> sdg / tdg
>   cudaq.sample(single_qubit_gates, shots_count=100).dump()
E   RuntimeError: [line 11] uses a gate: sdg which is either not supported by the device,
    not defined via a defcal, or not used in the right scope
    (e.g., when a device does not support using native gates outside of verbatim)

# test_control_modifier: kernel uses s.ctrl / t.ctrl  -> tdg
E   RuntimeError: [line 10] uses a gate: tdg which is either not supported by the device, ...
```

* This removes native `s,t` from the Braket decomposition basis so CUDA-Q lowers S/T and S†/T† through supported rotation gates. 

* It also removes the retired TN1 simulator from the live Braket backend test matrix since it reports to be `RETIRED`.
```
RuntimeError: Device is not available because it is retired. Please try another device.
```