### PR TITLE
Fix mqpu and mpi test interactions

### DIFF
--- a/python/tests/parallel/test_mpi_dynamics.py
+++ b/python/tests/parallel/test_mpi_dynamics.py
@@ -19,6 +19,8 @@ skipIfUnsupported = pytest.mark.skipif(
 def setup_mpi():
     """Setup and teardown MPI and dynamics target for the module."""
     cudaq.mpi.initialize()
+    if cudaq.mpi.num_ranks() <= 1:
+        pytest.skip("MPI dynamics tests require more than one MPI rank")
     cudaq.set_target('dynamics')
     yield
     cudaq.reset_target()

--- a/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
+++ b/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
@@ -37,35 +37,7 @@ public:
     platformQPUs.clear();
   }
 
-  MultiQPUQuantumPlatform() {
-    int nDevices = cudaq::getCudaDeviceCount();
-    // Skipped if CUDA-Q was built with CUDA but no devices present at
-    // runtime.
-    if (nDevices > 0) {
-      const char *envVal = std::getenv("CUDAQ_MQPU_NGPUS");
-      if (envVal != nullptr) {
-        int specifiedNDevices = 0;
-        try {
-          specifiedNDevices = std::stoi(envVal);
-        } catch (...) {
-          throw std::runtime_error("Invalid CUDAQ_MQPU_NGPUS environment "
-                                   "variable, must be integer.");
-        }
-
-        if (specifiedNDevices < nDevices)
-          nDevices = specifiedNDevices;
-      }
-
-      if (nDevices == 0)
-        throw std::runtime_error("No GPUs available to instantiate platform.");
-
-      // Add a QPU for each GPU.
-      for (int i = 0; i < nDevices; i++) {
-        platformQPUs.emplace_back(std::make_unique<cudaq::DefaultQPU>());
-        platformQPUs.back()->setId(i);
-      }
-    }
-  }
+  MultiQPUQuantumPlatform() { populateDefaultQPUs(); }
 
   bool supports_task_distribution() const override { return true; }
 
@@ -82,6 +54,8 @@ public:
   }
 
 private:
+  void populateDefaultQPUs();
+
   static std::string getTargetName(const std::string &description) {
     // Target name is the first one in the target config string
     // or the whole string if this is the only config.
@@ -183,15 +157,50 @@ private:
                         "target config. Currently only 'orca' is supported.",
                         qpuSubType));
       }
-    } else if (platformQPUs.empty()) {
-      // No QPU (GPU simulator nor specified platform QPU) was able to be
-      // initialized, so we can't run.
-      throw std::runtime_error(
-          "No platform QPU implementations available. Please check your "
-          "installation and target configuration.");
+    } else {
+      populateDefaultQPUs();
+
+      if (platformQPUs.empty()) {
+        // No QPU (GPU simulator nor specified platform QPU) was able to be
+        // initialized, so we can't run.
+        throw std::runtime_error(
+            "No platform QPU implementations available. Please check your "
+            "installation and target configuration.");
+      }
     }
   }
 };
+
+void MultiQPUQuantumPlatform::populateDefaultQPUs() {
+  platformQPUs.clear();
+  int nDevices = cudaq::getCudaDeviceCount();
+  // Skipped if CUDA-Q was built with CUDA but no devices present at
+  // runtime.
+  if (nDevices > 0) {
+    const char *envVal = std::getenv("CUDAQ_MQPU_NGPUS");
+    if (envVal != nullptr) {
+      int specifiedNDevices = 0;
+      try {
+        specifiedNDevices = std::stoi(envVal);
+      } catch (...) {
+        throw std::runtime_error("Invalid CUDAQ_MQPU_NGPUS environment "
+                                 "variable, must be integer.");
+      }
+
+      if (specifiedNDevices < nDevices)
+        nDevices = specifiedNDevices;
+    }
+
+    if (nDevices == 0)
+      throw std::runtime_error("No GPUs available to instantiate platform.");
+
+    // Add a QPU for each GPU.
+    for (int i = 0; i < nDevices; i++) {
+      platformQPUs.emplace_back(std::make_unique<cudaq::DefaultQPU>());
+      platformQPUs.back()->setId(i);
+    }
+  }
+}
 } // namespace
 
 CUDAQ_REGISTER_PLATFORM(MultiQPUQuantumPlatform, mqpu)


### PR DESCRIPTION
We got `No platform QPU implementations available` errors when running the full test suite but not individual test files.

This is due to test interaction b/w `test_unsupported_targets_0` which set `orca` target (no URL, hence clearing the QPUs) and later multi-qpu tests.

Fixes by refactoring the default QPU assignment into a helper and repeat the procedure on target set, not just constructor (we have a static instance).

Also, add a proper MPI rank check for `test_mpi_dynamics.py`, which is intended to be launched with multiple MPI ranks, e.g.  via the test driver in `python/tests/parallel/CMakeLists.txt`.