### PR TITLE
[docs] Updated docs for `stim::ErrorAnalyzer::circuit_to_detector_error_model` flags in `dem_from_kernel`

### DIFF
--- a/.github/pre-commit/spelling_allowlist.txt
+++ b/.github/pre-commit/spelling_allowlist.txt
@@ -434,6 +434,7 @@ uccsd
 unary
 uncomputation
 uncompute
+undecomposed
 unitaries
 unitarity
 unitary

--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -339,6 +339,10 @@ Algorithms
 .. doxygenclass:: cudaq::gradients::forward_difference
     :members:
 
+.. doxygenstruct:: cudaq::dem_options
+    :members:
+
+.. doxygenfunction:: cudaq::dem_from_kernel(QuantumKernel &&kernel, const cudaq::noise_model *noise, const cudaq::dem_options &options, Args &&...args)
 .. doxygenfunction:: cudaq::dem_from_kernel(QuantumKernel &&kernel, const cudaq::noise_model *noise, Args &&...args)
 .. doxygenfunction:: cudaq::dem_from_kernel(QuantumKernel &&kernel, Args &&...args)
 

--- a/docs/sphinx/snippets/cpp/using/examples/dem/dem_from_kernel.cpp
+++ b/docs/sphinx/snippets/cpp/using/examples/dem/dem_from_kernel.cpp
@@ -48,5 +48,18 @@ int main() {
       cudaq::dem_from_kernel(memory_experiment, &noise, /*rounds=*/2);
   std::printf("%s\n", dem.c_str());
   // [End Generate]
+
+  // [Begin Options]
+  // Pass a cudaq::dem_options struct to control the Stim error analyzer.
+  // decompose_errors=true converts hyper-edge mechanisms into two-detector
+  // edges, which is required by most MWPM decoders.
+  cudaq::dem_options opts;
+  opts.decompose_errors = true;
+  opts.fold_loops = true;
+  std::string dem2 =
+      cudaq::dem_from_kernel(memory_experiment, &noise, opts, /*rounds=*/2);
+  std::printf("%s\n", dem2.c_str());
+  // [End Options]
+
   return 0;
 }

--- a/docs/sphinx/snippets/cpp/using/examples/dem/dem_from_kernel.cpp
+++ b/docs/sphinx/snippets/cpp/using/examples/dem/dem_from_kernel.cpp
@@ -37,6 +37,46 @@ __qpu__ void memory_experiment(int rounds) {
 }
 // [End Kernel]
 
+// [Begin Options Kernel]
+// A hyperedge arises naturally when one fault trips both an
+// X-type and a Z-type parity check. This circuit prepares a Bell pair |Phi+>,
+// the +1 eigenstate of both XX and ZZ, and measures each stabilizer with its
+// own ancilla. A Y error anticommutes with both checks and flips the data
+// readout, lighting up three detectors at once. Because Y = X * Z, that
+// hyperedge decomposes into the separate X and Z edges seeded by the
+// accompanying single-qubit errors.
+__qpu__ void correlated_checks() {
+  cudaq::qvector data(2);
+  cudaq::qubit z_anc;
+  cudaq::qubit x_anc;
+
+  // Prepare |00> + |11>
+  h(data[0]);
+  x<cudaq::ctrl>(data[0], data[1]);
+
+  cudaq::apply_noise<cudaq::x_error>(0.01, data[0]);
+  cudaq::apply_noise<cudaq::z_error>(0.01, data[0]);
+  cudaq::apply_noise<cudaq::y_error>(0.02, data[0]);
+
+  // ZZ parity check: the data qubits control the ancilla.
+  x<cudaq::ctrl>(data[0], z_anc);
+  x<cudaq::ctrl>(data[1], z_anc);
+  auto z_syndrome = mz(z_anc);
+
+  // XX parity check: the ancilla controls the data, read out in the X basis.
+  h(x_anc);
+  x<cudaq::ctrl>(x_anc, data[0]);
+  x<cudaq::ctrl>(x_anc, data[1]);
+  h(x_anc);
+  auto x_syndrome = mz(x_anc);
+
+  auto final = mz(data);
+  cudaq::detector(z_syndrome);
+  cudaq::detector(x_syndrome);
+  cudaq::detector(final[0], final[1]);
+}
+// [End Options Kernel]
+
 int main() {
   // [Begin Generate]
   // Generate the detector error model as Stim `.dem` text. A noise model must
@@ -46,19 +86,20 @@ int main() {
   cudaq::noise_model noise;
   std::string dem =
       cudaq::dem_from_kernel(memory_experiment, &noise, /*rounds=*/2);
-  std::printf("%s\n", dem.c_str());
+  std::printf("Memory experiment DEM:\n%s\n", dem.c_str());
   // [End Generate]
 
   // [Begin Options]
   // Pass a cudaq::dem_options struct to control the Stim error analyzer.
-  // decompose_errors=true converts hyper-edge mechanisms into two-detector
-  // edges, which is required by most MWPM decoders.
+  // decompose_errors=true splits hyperedge mechanisms (three or more detectors)
+  // into pairs of graphlike edges, which is required by most MWPM decoders.
+  std::string dem_raw = cudaq::dem_from_kernel(correlated_checks, &noise);
   cudaq::dem_options opts;
   opts.decompose_errors = true;
-  opts.fold_loops = true;
-  std::string dem2 =
-      cudaq::dem_from_kernel(memory_experiment, &noise, opts, /*rounds=*/2);
-  std::printf("%s\n", dem2.c_str());
+  std::string dem_decomposed =
+      cudaq::dem_from_kernel(correlated_checks, &noise, opts);
+  std::printf("Raw DEM:\n%s\n", dem_raw.c_str());
+  std::printf("Decomposed DEM:\n%s\n", dem_decomposed.c_str());
   // [End Options]
 
   return 0;

--- a/docs/sphinx/snippets/python/using/examples/dem/dem_from_kernel.py
+++ b/docs/sphinx/snippets/python/using/examples/dem/dem_from_kernel.py
@@ -44,3 +44,17 @@ noise = cudaq.NoiseModel()
 dem = cudaq.dem_from_kernel(memory_experiment, 2, noise_model=noise)
 print(dem)
 # [End Generate]
+
+# [Begin Options]
+# Pass DEM options as keyword arguments to control the Stim error analyzer.
+# decompose_errors=True converts hyper-edge mechanisms into two-detector edges,
+# which is required by most MWPM decoders.
+dem2 = cudaq.dem_from_kernel(
+    memory_experiment,
+    2,
+    noise_model=noise,
+    decompose_errors=True,
+    fold_loops=True,
+)
+print(dem2)
+# [End Options]

--- a/docs/sphinx/snippets/python/using/examples/dem/dem_from_kernel.py
+++ b/docs/sphinx/snippets/python/using/examples/dem/dem_from_kernel.py
@@ -36,25 +36,69 @@ def memory_experiment(rounds: int):
 
 # [End Kernel]
 
+
+# [Begin Options Kernel]
+# A hyper-edge arises naturally when one fault trips both an
+# X-type and a Z-type parity check. This circuit prepares a Bell pair |Phi+>,
+# the +1 eigenstate of both XX and ZZ, and measures each stabilizer with its
+# own ancilla. A Y error anti-commutes with both checks and flips the data
+# readout, lighting up three detectors at once. Because Y = X * Z, that
+# hyper-edge decomposes into the separate X and Z edges seeded by the
+# accompanying single-qubit errors.
+@cudaq.kernel
+def correlated_checks():
+    data = cudaq.qvector(2)
+    z_anc = cudaq.qubit()
+    x_anc = cudaq.qubit()
+
+    # Prepare |00> + |11>
+    h(data[0])
+    x.ctrl(data[0], data[1])
+
+    cudaq.apply_noise(cudaq.XError, 0.01, data[0])
+    cudaq.apply_noise(cudaq.ZError, 0.01, data[0])
+    cudaq.apply_noise(cudaq.YError, 0.02, data[0])
+
+    # ZZ parity check: the data qubits control the ancilla.
+    x.ctrl(data[0], z_anc)
+    x.ctrl(data[1], z_anc)
+    z_syndrome = mz(z_anc)
+
+    # XX parity check: the ancilla controls the data, read out in the X basis.
+    h(x_anc)
+    x.ctrl(x_anc, data[0])
+    x.ctrl(x_anc, data[1])
+    h(x_anc)
+    x_syndrome = mz(x_anc)
+
+    final = mz(data)
+    cudaq.detector(z_syndrome)
+    cudaq.detector(x_syndrome)
+    cudaq.detector(final[0], final[1])
+
+
+# [End Options Kernel]
+
 # [Begin Generate]
 # Generate the detector error model as Stim `.dem` text. A noise model must be
 # supplied for the in-kernel `apply_noise` mechanisms to take effect. Parse the
 # text with `stim.DetectorErrorModel(dem)` to drive a decoder.
 noise = cudaq.NoiseModel()
 dem = cudaq.dem_from_kernel(memory_experiment, 2, noise_model=noise)
-print(dem)
+print(f"Memory experiment DEM:\n{dem}")
 # [End Generate]
 
+print()
 # [Begin Options]
 # Pass DEM options as keyword arguments to control the Stim error analyzer.
-# decompose_errors=True converts hyper-edge mechanisms into two-detector edges,
-# which is required by most MWPM decoders.
-dem2 = cudaq.dem_from_kernel(
-    memory_experiment,
-    2,
+# decompose_errors=True splits hyper-edge mechanisms (three or more detectors)
+# into pairs of graph-like edges, which is required by most MWPM decoders.
+dem_raw = cudaq.dem_from_kernel(correlated_checks, noise_model=noise)
+dem_decomposed = cudaq.dem_from_kernel(
+    correlated_checks,
     noise_model=noise,
     decompose_errors=True,
-    fold_loops=True,
 )
-print(dem2)
+print(f"Raw DEM:\n{dem_raw}")
+print(f"Decomposed DEM:\n{dem_decomposed}")
 # [End Options]

--- a/docs/sphinx/using/examples/dem_from_kernel.rst
+++ b/docs/sphinx/using/examples/dem_from_kernel.rst
@@ -117,6 +117,30 @@ All options default to ``False`` / ``0``.
      - Prevent the decomposer from introducing remnant edges that would
        otherwise be needed to satisfy the decomposition.
 
+Hyper-edges appear when a single fault trips both an ``X``-type and a ``Z``-type parity
+check. The circuit below prepares a Bell pair (the ``+1`` eigenstate of both
+``XX`` and ``ZZ``) and measures each stabilizer with its own ancilla. A ``Y``
+error on a data qubit anti-commutes with both checks and flips the data
+readout, so one mechanism flips three detectors at once. The accompanying
+single-qubit ``X`` and ``Z`` errors seed the graph-like edges that the
+hyper-edge decomposes into (since ``Y = X · Z``):
+
+.. tab:: Python
+
+   .. literalinclude:: ../../snippets/python/using/examples/dem/dem_from_kernel.py
+        :language: python
+        :start-after: [Begin Options Kernel]
+        :end-before: [End Options Kernel]
+
+.. tab:: C++
+
+   .. literalinclude:: ../../snippets/cpp/using/examples/dem/dem_from_kernel.cpp
+        :language: cpp
+        :start-after: [Begin Options Kernel]
+        :end-before: [End Options Kernel]
+
+Generate the DEM with and without ``decompose_errors``:
+
 .. tab:: Python
 
    Pass any option as a keyword argument after the kernel arguments:
@@ -135,6 +159,25 @@ All options default to ``False`` / ``0``.
         :language: cpp
         :start-after: [Begin Options]
         :end-before: [End Options]
+
+Without decomposition the ``Y`` error is a single three-detector hyper-edge
+(``D0 D1 D2``), printed alongside the graph-like ``X`` edge (``D0 D2``) and
+``Z`` edge (``D1``):
+
+.. code-block:: text
+
+    error(0.02000000000000000042) D0 D1 D2
+    error(0.01000000000000000021) D0 D2
+    error(0.01000000000000000021) D1
+
+With ``decompose_errors=True`` the hyper-edge is written as the product of
+two graph-like components, separated by ``^``:
+
+.. code-block:: text
+
+    error(0.01000000000000000021) D0 D2
+    error(0.02000000000000000042) D0 D2 ^ D1
+    error(0.01000000000000000021) D1
 
 Limitations
 ------------

--- a/docs/sphinx/using/examples/dem_from_kernel.rst
+++ b/docs/sphinx/using/examples/dem_from_kernel.rst
@@ -84,6 +84,58 @@ flips one detector together with the logical observable ``L0``:
     error(0.01000000000000000021) D4 L0
     error(0.01000000000000000021) D5 L0
 
+DEM Options
+-----------
+
+``dem_from_kernel`` accepts optional parameters that are forwarded to the Stim
+error analyzer (C++: ``cudaq::dem_options`` struct; Python: keyword arguments).
+All options default to ``False`` / ``0``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 44 56
+
+   * - Option
+     - Description
+   * - ``decompose_errors``
+     - Decompose hyper-edge error mechanisms into pairs of two-detector edges.
+       Required when feeding the DEM to minimum-weight perfect matching decoders.
+   * - ``fold_loops``
+     - Fold loop bodies in the circuit for a more compact DEM. CUDA-Q kernels
+       are compiled to a flat (loop-free) Stim circuit, so this option has no
+       effect in practice. 
+   * - ``allow_gauge_detectors``
+     - Allow detectors whose parity is not determined by the circuit.
+   * - ``approximate_disjoint_errors_threshold``
+     - Threshold in [0, 1] for approximating disjoint-error products.
+       Set to ``0.0`` (the default) to disable approximation.
+   * - ``ignore_decomposition_failures``
+     - When decomposition fails for an error mechanism, insert it into the DEM
+       undecomposed (as a hyper-edge) instead of raising an exception. Only
+       relevant when ``decompose_errors`` is ``True``.
+   * - ``block_decomposition_from_introducing_remnant_edges``
+     - Prevent the decomposer from introducing remnant edges that would
+       otherwise be needed to satisfy the decomposition.
+
+.. tab:: Python
+
+   Pass any option as a keyword argument after the kernel arguments:
+
+   .. literalinclude:: ../../snippets/python/using/examples/dem/dem_from_kernel.py
+        :language: python
+        :start-after: [Begin Options]
+        :end-before: [End Options]
+
+.. tab:: C++
+
+   Construct a ``cudaq::dem_options`` value and pass it as the third
+   argument (after the noise model):
+
+   .. literalinclude:: ../../snippets/cpp/using/examples/dem/dem_from_kernel.cpp
+        :language: cpp
+        :start-after: [Begin Options]
+        :end-before: [End Options]
+
 Limitations
 ------------
 
@@ -93,6 +145,6 @@ Limitations
 * **No measurement-conditional control flow.** Branching on a measurement result
   changes the measurement count shot-to-shot and breaks the detector matrix
   model; such kernels are rejected.
-* **Independent Pauli noise.** Each error mechanism is assumed independent..
+* **Independent Pauli noise.** Each error mechanism is assumed independent.
 * **Pre-decomposition.** The DEM reflects the abstract kernel circuit, not the
   hardware-decomposed circuit.

--- a/python/cudaq/runtime/dem.py
+++ b/python/cudaq/runtime/dem.py
@@ -55,9 +55,10 @@ def dem_from_kernel(kernel, *args, noise_model=None, **dem_kwargs):
       approximate_disjoint_errors_threshold (float, optional): Threshold
           for approximating disjoint-error products; set to ``0`` to
           disable. Default ``0.0``.
-      ignore_decomposition_failures (bool, optional): Skip error mechanisms
-          that cannot be decomposed instead of raising an exception.
-          Default ``False``.
+      ignore_decomposition_failures (bool, optional): When decomposition
+          fails for an error mechanism, insert it into the DEM undecomposed
+          (as a hyper-edge) instead of raising an exception. Only relevant
+          when ``decompose_errors`` is ``True``. Default ``False``.
       block_decomposition_from_introducing_remnant_edges (bool, optional):
           Prevent the decomposer from introducing remnant edges.
           Default ``False``.

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -38,8 +38,9 @@ struct dem_options {
   /// Threshold (in [0,1]) for approximating disjoint-error products.
   /// Set to 0 to disable approximation.
   double approximate_disjoint_errors_threshold = 0.0;
-  /// Silently skip error mechanisms that cannot be decomposed instead of
-  /// raising an exception.
+  /// When decomposition fails for an error mechanism, insert it into the DEM
+  /// undecomposed (as a hyper-edge) instead of raising an exception.
+  /// Only relevant when decompose_errors is true.
   bool ignore_decomposition_failures = false;
   /// Prevent the decomposer from introducing remnant edges that would otherwise
   /// be needed to satisfy the decomposition.


### PR DESCRIPTION
This PR adds documentation for the changes made by https://github.com/NVIDIA/cuda-quantum/pull/4756.