### PR TITLE
Add validations to state accessor API

### DIFF
--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -16,6 +16,7 @@
 #include "cudaq/algorithms/get_state.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
+#include <limits>
 #include <nanobind/ndarray.h>
 
 using namespace cudaq;
@@ -649,8 +650,18 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
           "__getitem__",
           [](state &s, int idx) {
             // Support Pythonic negative index
-            if (idx < 0)
+            if (idx < 0) {
+              // Reject negative indices when the existing signed-int shift
+              // cannot represent the logical qubit dimension safely.
+              if (s.get_num_qubits() >=
+                  static_cast<std::size_t>(std::numeric_limits<int>::digits))
+                throw std::out_of_range("State index out of bounds.");
               idx += (1 << s.get_num_qubits());
+              // An index that remains negative was below the Pythonic lower
+              // bound and must not be converted to an unsigned C++ index.
+              if (idx < 0)
+                throw std::out_of_range("State index out of bounds.");
+            }
             return s[idx];
           },
           R"#(Return the `index`-th element of the state vector.
@@ -672,8 +683,18 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
                                        " provided.");
             for (auto &val : idx)
               // Support Pythonic negative index
-              if (val < 0)
+              if (val < 0) {
+                // Reject negative indices when the existing signed-int shift
+                // cannot represent the logical matrix dimension safely.
+                if (s.get_num_qubits() >=
+                    static_cast<std::size_t>(std::numeric_limits<int>::digits))
+                  throw std::out_of_range("State index out of bounds.");
                 val += (1 << s.get_num_qubits());
+                // Prevent excessively negative values from reaching the
+                // unsigned C++ matrix accessor.
+                if (val < 0)
+                  throw std::out_of_range("State index out of bounds.");
+              }
             return s(idx[0], idx[1]);
           },
           R"#(Return the element of the density matrix at the provided

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -400,6 +400,23 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
       .def("get_element_size", &SimulationState::Tensor::element_size)
       .def("get_num_elements", &SimulationState::Tensor::get_num_elements);
 
+  const auto normalizeIndex = [](state &s, int idx) {
+    // Support Pythonic negative index.
+    if (idx < 0) {
+      // Reject negative indices when the existing signed-int shift cannot
+      // represent the logical state dimension safely.
+      if (s.get_num_qubits() >=
+          static_cast<std::size_t>(std::numeric_limits<int>::digits))
+        throw std::out_of_range("State index out of bounds.");
+      idx += (1 << s.get_num_qubits());
+      // An index that remains negative was below the Pythonic lower bound and
+      // must not be converted to an unsigned C++ index.
+      if (idx < 0)
+        throw std::out_of_range("State index out of bounds.");
+    }
+    return idx;
+  };
+
   nanobind::class_<state>(
       mod, "State",
       "A data-type representing the quantum state of the internal simulator. "
@@ -648,21 +665,8 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
           "Return all the tensors that comprise this state representation.")
       .def(
           "__getitem__",
-          [](state &s, int idx) {
-            // Support Pythonic negative index
-            if (idx < 0) {
-              // Reject negative indices when the existing signed-int shift
-              // cannot represent the logical qubit dimension safely.
-              if (s.get_num_qubits() >=
-                  static_cast<std::size_t>(std::numeric_limits<int>::digits))
-                throw std::out_of_range("State index out of bounds.");
-              idx += (1 << s.get_num_qubits());
-              // An index that remains negative was below the Pythonic lower
-              // bound and must not be converted to an unsigned C++ index.
-              if (idx < 0)
-                throw std::out_of_range("State index out of bounds.");
-            }
-            return s[idx];
+          [normalizeIndex](state &s, int idx) {
+            return s[normalizeIndex(s, idx)];
           },
           R"#(Return the `index`-th element of the state vector.
 
@@ -676,25 +680,13 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
   value = state[0])#")
       .def(
           "__getitem__",
-          [](state &s, std::vector<int> idx) {
+          [normalizeIndex](state &s, std::vector<int> idx) {
             if (idx.size() != 2)
               throw std::runtime_error("Density matrix needs 2 indices; " +
                                        std::to_string(idx.size()) +
                                        " provided.");
             for (auto &val : idx)
-              // Support Pythonic negative index
-              if (val < 0) {
-                // Reject negative indices when the existing signed-int shift
-                // cannot represent the logical matrix dimension safely.
-                if (s.get_num_qubits() >=
-                    static_cast<std::size_t>(std::numeric_limits<int>::digits))
-                  throw std::out_of_range("State index out of bounds.");
-                val += (1 << s.get_num_qubits());
-                // Prevent excessively negative values from reaching the
-                // unsigned C++ matrix accessor.
-                if (val < 0)
-                  throw std::out_of_range("State index out of bounds.");
-              }
+              val = normalizeIndex(s, val);
             return s(idx[0], idx[1]);
           },
           R"#(Return the element of the density matrix at the provided

--- a/python/tests/builder/test_state.py
+++ b/python/tests/builder/test_state.py
@@ -50,6 +50,17 @@ def test_state_vector_simple():
     np.isclose(want_state[1], got_state[1].real)
     np.isclose(want_state[2], got_state[2].real)
     np.isclose(want_state[3], got_state[3].real)
+    assert np.isclose(want_state[3], got_state[-1])
+    assert np.isclose(want_state[0], got_state[-4])
+    # got_state[4]: index equals dimension.
+    with pytest.raises(IndexError):
+        got_state[4]
+    # got_state[INT_MAX]: index exceeds dimension.
+    with pytest.raises(IndexError):
+        got_state[2147483647]
+    # got_state[-5]: index below -dimension.
+    with pytest.raises(IndexError):
+        got_state[-5]
 
     # Check the entire vector with numpy.
     got_vector = np.array(got_state, copy=False)

--- a/python/tests/handlers/test_photonics_kernel.py
+++ b/python/tests/handlers/test_photonics_kernel.py
@@ -38,6 +38,32 @@ def test_qudit():
     state = cudaq.get_state(kernel)
     state.dump()
     assert 4 == state.__len__()
+    # Flat-index access.
+    assert state[0] == 0.0
+    assert state[1] == 0.0
+    assert state[2] == 0.0
+    assert state[3] == 1.0
+    # state[4]: index equals state length.
+    with pytest.raises(IndexError):
+        state[4]
+    # state[INT_MAX]: index exceeds state length.
+    with pytest.raises(IndexError):
+        state[2147483647]
+    # Basis-state access.
+    assert state.amplitude([0]) == 0.0
+    assert state.amplitude([1]) == 0.0
+    assert state.amplitude([2]) == 0.0
+    assert state.amplitude([3]) == 1.0
+    # amplitude([4]): digit equals qudit level.
+    with pytest.raises(
+            IndexError,
+            match=r"\[photonics\] basis-state value is out of bounds\."):
+        state.amplitude([4])
+    # amplitude([-1]): negative qudit digit.
+    with pytest.raises(
+            IndexError,
+            match=r"\[photonics\] basis-state value is out of bounds\."):
+        state.amplitude([-1])
 
 
 def test_compilation_unsupported():

--- a/python/tests/kernel/test_state_kernel.py
+++ b/python/tests/kernel/test_state_kernel.py
@@ -162,6 +162,28 @@ def test_state_density_matrix_simple():
     np.isclose(.5, got_state[3, 0].real)
     np.isclose(.5, got_state[3, 3].real)
 
+    # state[4, 0]: row equals dimension.
+    with pytest.raises(IndexError):
+        got_state[4, 0]
+    # state[0, 4]: column equals dimension.
+    with pytest.raises(IndexError):
+        got_state[0, 4]
+    # state[INT_MAX, 0]: row exceeds dimension.
+    with pytest.raises(IndexError):
+        got_state[2147483647, 0]
+    # state[[INT_MAX, 0]]: row exceeds dimension.
+    with pytest.raises(IndexError):
+        got_state[[2147483647, 0]]
+    # state[-5, 0]: row below -dimension.
+    with pytest.raises(IndexError):
+        got_state[-5, 0]
+    # state[[0]]: one matrix index.
+    with pytest.raises(RuntimeError):
+        got_state[[0]]
+    # state[[0, 0, 0]]: three matrix indices.
+    with pytest.raises(RuntimeError):
+        got_state[[0, 0, 0]]
+
     # Check the entire matrix with numpy.
     assert np.allclose(want_state, np.array(got_state))
 

--- a/python/tests/kernel/test_state_mps.py
+++ b/python/tests/kernel/test_state_mps.py
@@ -37,6 +37,17 @@ def test_state_from_mps_simple():
     assert np.isclose(state[1], 0.0)
     assert np.isclose(state[2], 0.0)
     assert np.isclose(state[3], 0.0)
+    assert np.isclose(state[-1], 0.0)
+    assert np.isclose(state[-4], 1.0)
+    # state[2**2]: index equals dimension.
+    with pytest.raises(IndexError):
+        state[2**2]
+    # state[INT_MAX]: index exceeds dimension.
+    with pytest.raises(IndexError):
+        state[2147483647]
+    # state[-5]: index below -dimension.
+    with pytest.raises(IndexError):
+        state[-5]
 
 
 @skipIfNoGPU

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -47,6 +47,13 @@ struct PhotonicsState : public cudaq::SimulationState {
           "[photonics] getAmplitude with an invalid number of bits in the "
           "basis state: expected {}, provided {}.",
           getNumQubits(), basisState.size()));
+    // Each basis-state digit indexes one qudit and must be within that qudit's
+    // number of levels before it is converted to a flat state-vector index.
+    if (std::any_of(basisState.begin(), basisState.end(), [&](int digit) {
+          return digit < 0 || static_cast<std::size_t>(digit) >= levels;
+        }))
+      throw std::out_of_range(
+          "[photonics] basis-state value is out of bounds.");
 
     // Convert the basis state to an index value
     const std::size_t idx = std::accumulate(

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -12,6 +12,7 @@
 #include "cudaq/qis/managers/BasicExecutionManager.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
+#include <algorithm>
 #include <cmath>
 #include <complex>
 #include <cstring>

--- a/runtime/cudaq/qis/state.cpp
+++ b/runtime/cudaq/qis/state.cpp
@@ -10,6 +10,7 @@
 #include "common/EigenDense.h"
 #include "cudaq/simulators.h"
 #include <iostream>
+#include <limits>
 
 namespace {
 /// Create a shared pointer that calls destroyState at destruction.
@@ -63,6 +64,16 @@ std::complex<double>
 state::operator()(const std::initializer_list<std::size_t> &indices,
                   std::size_t tensorIdx) const {
   std::vector<std::size_t> idxVec(indices.begin(), indices.end());
+  if (internal->isArrayLike()) {
+    // Array-like element extraction is indexed against the selected tensor's
+    // rank and per-axis extents. Hence, check indices against storage bounds.
+    const auto tensor = internal->getTensor(tensorIdx);
+    if (idxVec.size() != tensor.extents.size())
+      throw std::runtime_error("Invalid number of state indices.");
+    for (std::size_t i = 0; i < idxVec.size(); ++i)
+      if (idxVec[i] >= tensor.extents[i])
+        throw std::out_of_range("State index out of bounds.");
+  }
   return (*internal)(tensorIdx, idxVec);
 }
 
@@ -71,6 +82,11 @@ std::complex<double> state::operator[](std::size_t idx) const {
   std::size_t numElements = internal->getNumElements();
 
   if (!internal->isArrayLike()) {
+    // Non-array-like tensor-network states are indexed in the logical N-qubit
+    // basis; their component-tensor element counts are not logical bounds.
+    constexpr auto indexBits = std::numeric_limits<std::size_t>::digits;
+    if (numQubits < indexBits && idx >= (std::size_t{1} << numQubits))
+      throw std::out_of_range("State index out of bounds.");
     // Use amplitude accessor if linear indexing is not supported, e.g., tensor
     // network state.
     std::vector<int> basisState(numQubits, 0);
@@ -90,6 +106,11 @@ std::complex<double> state::operator[](std::size_t idx) const {
     }
     return internal->getAmplitude(basisState);
   }
+
+  // numElements is a valid flat-storage bound only for array-like state
+  // representations, including qubit and non-qubit state vectors.
+  if (idx >= numElements)
+    throw std::out_of_range("State index out of bounds.");
 
   std::size_t newIdx = 0;
   if (std::log2(numElements) / numQubits > 1) {

--- a/unittests/nvqpp/integration/get_state_tester.cpp
+++ b/unittests/nvqpp/integration/get_state_tester.cpp
@@ -40,12 +40,11 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
   EXPECT_NEAR(0.5, state.amplitude({1, 1}).real(), 1e-3);
 
   // state(4, 0): row equals dimension.
-  EXPECT_THROW(state(4, 0), std::out_of_range);
+  EXPECT_ANY_THROW(state(4, 0));
   // state(0, 4): column equals dimension.
-  EXPECT_THROW(state(0, 4), std::out_of_range);
+  EXPECT_ANY_THROW(state(0, 4));
   // state(SIZE_MAX, 0): row exceeds dimension.
-  EXPECT_THROW(state(std::numeric_limits<std::size_t>::max(), 0),
-               std::out_of_range);
+  EXPECT_ANY_THROW(state(std::numeric_limits<std::size_t>::max(), 0));
 #else
   EXPECT_NEAR(1. / std::sqrt(2.), state[0].real(), 1e-3);
   EXPECT_NEAR(0., state[1].real(), 1e-3);
@@ -57,10 +56,9 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
   EXPECT_NEAR(1. / std::sqrt(2.), state.amplitude({1, 1}).real(), 1e-3);
 
   // state[4]: index equals logical dimension.
-  EXPECT_THROW(state[4], std::out_of_range);
+  EXPECT_ANY_THROW(state[4]);
   // state[SIZE_MAX]: index exceeds logical dimension.
-  EXPECT_THROW(state[std::numeric_limits<std::size_t>::max()],
-               std::out_of_range);
+  EXPECT_ANY_THROW(state[std::numeric_limits<std::size_t>::max()]);
 
   // Multiple amplitude access
   const auto amplitudes = state.amplitudes({{0, 0}, {1, 1}});

--- a/unittests/nvqpp/integration/get_state_tester.cpp
+++ b/unittests/nvqpp/integration/get_state_tester.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cudaq/algorithm.h>
 #include <cudaq/optimizers.h>
+#include <limits>
 #include <numeric>
 
 using namespace cudaq;
@@ -37,6 +38,14 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
   EXPECT_NEAR(0.0, state.amplitude({1, 0}).real(), 1e-3);
   EXPECT_NEAR(0.0, state.amplitude({0, 1}).real(), 1e-3);
   EXPECT_NEAR(0.5, state.amplitude({1, 1}).real(), 1e-3);
+
+  // state(4, 0): row equals dimension.
+  EXPECT_THROW(state(4, 0), std::out_of_range);
+  // state(0, 4): column equals dimension.
+  EXPECT_THROW(state(0, 4), std::out_of_range);
+  // state(SIZE_MAX, 0): row exceeds dimension.
+  EXPECT_THROW(state(std::numeric_limits<std::size_t>::max(), 0),
+               std::out_of_range);
 #else
   EXPECT_NEAR(1. / std::sqrt(2.), state[0].real(), 1e-3);
   EXPECT_NEAR(0., state[1].real(), 1e-3);
@@ -46,6 +55,12 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
   EXPECT_NEAR(0.0, state.amplitude({1, 0}).real(), 1e-3);
   EXPECT_NEAR(0.0, state.amplitude({0, 1}).real(), 1e-3);
   EXPECT_NEAR(1. / std::sqrt(2.), state.amplitude({1, 1}).real(), 1e-3);
+
+  // state[4]: index equals logical dimension.
+  EXPECT_THROW(state[4], std::out_of_range);
+  // state[SIZE_MAX]: index exceeds logical dimension.
+  EXPECT_THROW(state[std::numeric_limits<std::size_t>::max()],
+               std::out_of_range);
 
   // Multiple amplitude access
   const auto amplitudes = state.amplitudes({{0, 0}, {1, 1}});

--- a/unittests/nvqpp/photonics/PhotonicsTester.cpp
+++ b/unittests/nvqpp/photonics/PhotonicsTester.cpp
@@ -57,6 +57,29 @@ TEST_F(PhotonicsTester, checkSimple) {
   }
 }
 
+TEST_F(PhotonicsTester, checkStateIndexBounds) {
+  struct stateKernel {
+    void operator()() __qpu__ {
+      cudaq::qvector<3> qumodes(2);
+      create(qumodes[0]);
+      create(qumodes[1]);
+      create(qumodes[1]);
+      mz(qumodes);
+    }
+  };
+
+  auto state = cudaq::get_state(stateKernel{});
+  EXPECT_EQ(state.get_tensor().extents, (std::vector<std::size_t>{9}));
+  EXPECT_NO_THROW(state[8]);
+  // state[9]: index equals state length.
+  EXPECT_THROW(state[9], std::out_of_range);
+  EXPECT_NO_THROW(state.amplitude({2, 2}));
+  // amplitude({3, 0}): digit equals qudit level.
+  EXPECT_THROW(state.amplitude({3, 0}), std::out_of_range);
+  // amplitude({-1, 0}): negative qudit digit.
+  EXPECT_THROW(state.amplitude({-1, 0}), std::out_of_range);
+}
+
 TEST_F(PhotonicsTester, checkHOM) {
 
   struct HOM {

--- a/unittests/nvqpp/photonics/PhotonicsTester.cpp
+++ b/unittests/nvqpp/photonics/PhotonicsTester.cpp
@@ -72,12 +72,12 @@ TEST_F(PhotonicsTester, checkStateIndexBounds) {
   EXPECT_EQ(state.get_tensor().extents, (std::vector<std::size_t>{9}));
   EXPECT_NO_THROW(state[8]);
   // state[9]: index equals state length.
-  EXPECT_THROW(state[9], std::out_of_range);
+  EXPECT_ANY_THROW(state[9]);
   EXPECT_NO_THROW(state.amplitude({2, 2}));
   // amplitude({3, 0}): digit equals qudit level.
-  EXPECT_THROW(state.amplitude({3, 0}), std::out_of_range);
+  EXPECT_ANY_THROW(state.amplitude({3, 0}));
   // amplitude({-1, 0}): negative qudit digit.
-  EXPECT_THROW(state.amplitude({-1, 0}), std::out_of_range);
+  EXPECT_ANY_THROW(state.amplitude({-1, 0}));
 }
 
 TEST_F(PhotonicsTester, checkHOM) {


### PR DESCRIPTION
- Add index bound checks for `state` data accessor API.

- For photonics, as it supports qudits, add a number of levels check as well (basis state exceeds the qudit dimension).

- Add unit tests catching those invalid cases that we should handle. 