### PR TITLE
Harden QIR output record parsing

### DIFF
--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -28,6 +28,8 @@ std::size_t getTypeByteSize(const std::string &type) {
     return sizeof(float);
   if (type == "f64")
     return sizeof(double);
+  if (type == "error")
+    throw std::runtime_error("Unsupported element type in struct type.");
   throw std::runtime_error("Unsupported data type: " + type);
 }
 } // namespace
@@ -140,7 +142,8 @@ void cudaq::RecordLogParser::handleOutput(
         (containerMeta.m_type == ContainerType::ARRAY &&
          containerMeta.elementCount == 0);
     if (isUninitializedContainer) {
-      validateRootContainer(ContainerType::ARRAY);
+      validateRootContainer(ContainerType::ARRAY,
+                            ContainerStorage::PREALLOCATED);
       // NOTE: This is a temporary workaround until all backends consistently
       // use the new transformation pass that wraps result records inside an
       // array record output. For now, we permit "naked" RESULT records, i.e.,
@@ -198,7 +201,9 @@ void cudaq::RecordLogParser::handleOutput(
     return;
   }
   if (recType == "ARRAY") {
-    validateRootContainer(ContainerType::ARRAY);
+    validateRootContainer(ContainerType::ARRAY,
+                          recLabel.empty() ? ContainerStorage::FLAT
+                                           : ContainerStorage::PREALLOCATED);
     containerMeta.m_type = ContainerType::ARRAY;
     containerMeta.elementCount = std::stoul(recValue);
     if (!recLabel.empty()) {
@@ -209,7 +214,9 @@ void cudaq::RecordLogParser::handleOutput(
     return;
   }
   if (recType == "TUPLE") {
-    validateRootContainer(ContainerType::TUPLE);
+    validateRootContainer(ContainerType::TUPLE,
+                          recLabel.empty() ? ContainerStorage::FLAT
+                                           : ContainerStorage::PREALLOCATED);
     containerMeta.m_type = ContainerType::TUPLE;
     containerMeta.elementCount = std::stoul(recValue);
     if (!recLabel.empty()) {
@@ -250,6 +257,16 @@ void cudaq::RecordLogParser::validateRootContainer(ContainerType type) {
   if (rootContainerType.has_value() && rootContainerType.value() != type)
     throw std::runtime_error("Inconsistent root result types");
   rootContainerType = type;
+}
+
+void cudaq::RecordLogParser::validateRootContainer(
+    ContainerType type, ContainerStorage containerStorage) {
+  validateRootContainer(type);
+  if (rootContainerStorage.has_value() &&
+      rootContainerStorage.value() != containerStorage)
+    throw std::runtime_error(
+        "Inconsistent root result storage representations");
+  rootContainerStorage = containerStorage;
 }
 
 cudaq::detail::DataHandlerBase &

--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -12,6 +12,26 @@
 #include "cudaq/Optimizer/CodeGen/QIRAttributeNames.h"
 #include "cudaq/runtime/logger/logger.h"
 
+namespace {
+std::size_t getTypeByteSize(const std::string &type) {
+  if (type == "i1")
+    return sizeof(bool);
+  if (type == "i8")
+    return sizeof(std::int8_t);
+  if (type == "i16")
+    return sizeof(std::int16_t);
+  if (type == "i32")
+    return sizeof(std::int32_t);
+  if (type == "i64")
+    return sizeof(std::int64_t);
+  if (type == "f32")
+    return sizeof(float);
+  if (type == "f64")
+    return sizeof(double);
+  throw std::runtime_error("Unsupported data type: " + type);
+}
+} // namespace
+
 void cudaq::RecordLogParser::parse(const std::string &outputLog) {
   ScopedTraceWithContext(cudaq::TIMING_RUN, "RecordLogParser::parse");
   CUDAQ_DBG("Parsing log:\n{}", outputLog);
@@ -82,7 +102,7 @@ void cudaq::RecordLogParser::handleHeader(
 void cudaq::RecordLogParser::handleMetadata(
     const std::vector<std::string> &entries) {
   if (entries.size() < 2 || entries.size() > 3)
-    cudaq::info("Unexpected METADATA record: {}. Ignored.\n", entries);
+    throw std::runtime_error("Invalid METADATA record");
   if (entries.size() == 3) {
     if (entries[1] == cudaq::opt::qir1_0::RequiredResultsAttrName ||
         entries[1] == cudaq::opt::qir0_1::RequiredResultsAttrName) {
@@ -120,6 +140,7 @@ void cudaq::RecordLogParser::handleOutput(
         (containerMeta.m_type == ContainerType::ARRAY &&
          containerMeta.elementCount == 0);
     if (isUninitializedContainer) {
+      validateRootContainer(ContainerType::ARRAY);
       // NOTE: This is a temporary workaround until all backends consistently
       // use the new transformation pass that wraps result records inside an
       // array record output. For now, we permit "naked" RESULT records, i.e.,
@@ -177,6 +198,7 @@ void cudaq::RecordLogParser::handleOutput(
     return;
   }
   if (recType == "ARRAY") {
+    validateRootContainer(ContainerType::ARRAY);
     containerMeta.m_type = ContainerType::ARRAY;
     containerMeta.elementCount = std::stoul(recValue);
     if (!recLabel.empty()) {
@@ -187,6 +209,7 @@ void cudaq::RecordLogParser::handleOutput(
     return;
   }
   if (recType == "TUPLE") {
+    validateRootContainer(ContainerType::TUPLE);
     containerMeta.m_type = ContainerType::TUPLE;
     containerMeta.elementCount = std::stoul(recValue);
     if (!recLabel.empty()) {
@@ -216,8 +239,17 @@ void cudaq::RecordLogParser::handleOutput(
     if (containerMeta.processedElements == containerMeta.elementCount) {
       containerMeta.reset();
     }
-  } else
+  } else {
+    if (containerMeta.elementCount == 0)
+      validateRootContainer(ContainerType::NONE);
     processSingleRecord(recValue, recLabel);
+  }
+}
+
+void cudaq::RecordLogParser::validateRootContainer(ContainerType type) {
+  if (rootContainerType.has_value() && rootContainerType.value() != type)
+    throw std::runtime_error("Inconsistent root result types");
+  rootContainerType = type;
 }
 
 cudaq::detail::DataHandlerBase &
@@ -267,9 +299,20 @@ void cudaq::RecordLogParser::preallocateTuple() {
         "Data layout information missing for the struct / tuple type.");
   if (dataLayoutInfo.second.size() != containerMeta.tupleTypes.size())
     throw std::runtime_error("Tuple size mismatch in kernel and label.");
+  const std::size_t tupleSize = dataLayoutInfo.first.value();
+  for (std::size_t i = 0; i < dataLayoutInfo.second.size(); ++i) {
+    const std::size_t offset = dataLayoutInfo.second[i];
+    const std::size_t end = i + 1 < dataLayoutInfo.second.size()
+                                ? dataLayoutInfo.second[i + 1]
+                                : tupleSize;
+    if (offset >= tupleSize || end <= offset || end > tupleSize)
+      throw std::runtime_error("Invalid tuple layout");
+    if (getTypeByteSize(containerMeta.tupleTypes[i]) > end - offset)
+      throw std::runtime_error("Tuple element exceeds its layout slot");
+  }
   containerMeta.dataOffset = bufferHandler.getBufferSize();
   // Directly allocate memory for the tuple, update offsets
-  bufferHandler.resizeBuffer(dataLayoutInfo.first.value());
+  bufferHandler.resizeBuffer(tupleSize);
   containerMeta.tupleOffsets = dataLayoutInfo.second;
 }
 

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -9,11 +9,15 @@
 #pragma once
 
 #include "cudaq/utils/cudaq_utils.h"
+#include <charconv>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <optional>
 #include <stdexcept>
+#include <string_view>
+#include <system_error>
 #include <type_traits>
 
 namespace cudaq {
@@ -128,22 +132,22 @@ public:
     T *startPtr = innerBuffer;
     T *end0Ptr = innerBuffer + arrSize;
     T *end1Ptr = end0Ptr;
-    /// Store the pointers into the outer vector (buffer)
-    T **ptrLoc = reinterpret_cast<T **>(buffer.data() + vectorOffset);
-    ptrLoc[0] = startPtr;
-    ptrLoc[1] = end0Ptr;
-    ptrLoc[2] = end1Ptr;
+    /// Store the pointers into the outer vector (buffer) without assuming the
+    /// byte offset is suitably aligned for a T** access.
+    T *pointers[] = {startPtr, end0Ptr, end1Ptr};
+    std::memcpy(buffer.data() + vectorOffset, pointers, sizeof(pointers));
     return vectorOffset;
   }
 
   template <typename T>
   void insertIntoArray(size_t offset, std::size_t index, T value) {
     if constexpr (std::is_same_v<T, bool>) {
-      auto v = reinterpret_cast<std::vector<bool> *>(buffer.data() + offset);
+      auto *v = reinterpret_cast<std::vector<bool> *>(buffer.data() + offset);
       (*v)[index] = value;
     } else {
-      T **ptrLoc = reinterpret_cast<T **>(buffer.data() + offset);
-      ptrLoc[0][index] = value;
+      T *innerBuffer = nullptr;
+      std::memcpy(&innerBuffer, buffer.data() + offset, sizeof(innerBuffer));
+      innerBuffer[index] = value;
     }
   }
 
@@ -157,6 +161,8 @@ public:
 
   template <typename T>
   void insertIntoTuple(size_t offset, T value) {
+    if (offset > buffer.size() || sizeof(T) > buffer.size() - offset)
+      throw std::runtime_error("Tuple element exceeds result buffer");
     std::memcpy(buffer.data() + offset, &value, sizeof(T));
   }
 
@@ -218,11 +224,20 @@ public:
 
   /// Parse string like "[0]" for array index, and ".0" for tuple index.
   std::size_t extractIndex(const std::string &label) {
-    if ((label[0] == '[') && (label[label.size() - 1] == ']'))
-      return std::stoi(label.substr(1, label.size() - 2));
-    if (label[0] == '.')
-      return std::stoi(label.substr(1, label.size() - 1));
-    throw std::runtime_error("Index not found in label");
+    std::string_view index;
+    if (label.size() >= 3 && label.front() == '[' && label.back() == ']')
+      index = std::string_view(label).substr(1, label.size() - 2);
+    else if (label.size() >= 2 && label.front() == '.')
+      index = std::string_view(label).substr(1);
+    else
+      throw std::runtime_error("Index not found in label");
+
+    std::size_t value = 0;
+    const auto [end, error] =
+        std::from_chars(index.data(), index.data() + index.size(), value);
+    if (error != std::errc{} || end != index.data() + index.size())
+      throw std::runtime_error("Invalid index in label");
+    return value;
   }
 
   ContainerType m_type = ContainerType::ARRAY;
@@ -330,11 +345,14 @@ private:
   /// appropriate type and store in the pre-allocated buffer
   void processArrayEntry(const std::string &, const std::string &);
   void processTupleEntry(const std::string &, const std::string &);
+  /// Require every root result in a log to use one container shape.
+  void validateRootContainer(ContainerType);
   /// Get data handler for the specified type
   detail::DataHandlerBase &getDataHandler(const std::string &dataType);
 
   RecordSchemaType schema = RecordSchemaType::ORDERED;
   OutputType currentOutput;
+  std::optional<ContainerType> rootContainerType;
   /// Manages the underlying buffer storage
   detail::BufferHandler bufferHandler;
   /// Tracks container metadata during decoding

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -329,6 +329,13 @@ public:
   std::size_t getBufferSize() const { return bufferHandler.getBufferSize(); }
 
 private:
+  /// Result-buffer storage for aggregate roots. FLAT appends element bytes;
+  /// PREALLOCATED reserves the host layout before indexed insertion. This is
+  /// separate from `RecordSchemaType` for implicit `RESULT` arrays which are
+  /// materialized as a preallocated `vector<bool>` even when no labeled schema
+  /// was declared.
+  enum struct ContainerStorage { FLAT, PREALLOCATED };
+
   /// Process different types of records
   void handleHeader(const std::vector<std::string> &);
   void handleMetadata(const std::vector<std::string> &);
@@ -347,12 +354,15 @@ private:
   void processTupleEntry(const std::string &, const std::string &);
   /// Require every root result in a log to use one container shape.
   void validateRootContainer(ContainerType);
+  /// Require every aggregate root to use one storage representation.
+  void validateRootContainer(ContainerType, ContainerStorage);
   /// Get data handler for the specified type
   detail::DataHandlerBase &getDataHandler(const std::string &dataType);
 
   RecordSchemaType schema = RecordSchemaType::ORDERED;
   OutputType currentOutput;
   std::optional<ContainerType> rootContainerType;
+  std::optional<ContainerStorage> rootContainerStorage;
   /// Manages the underlying buffer storage
   detail::BufferHandler bufferHandler;
   /// Tracks container metadata during decoding

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -332,7 +332,7 @@ private:
   /// Result-buffer storage for aggregate roots. FLAT appends element bytes;
   /// PREALLOCATED reserves the host layout before indexed insertion. This is
   /// separate from `RecordSchemaType` for implicit `RESULT` arrays which are
-  /// materialized as a preallocated `vector<bool>` even when no labeled schema
+  /// materialized as a pre-allocated `vector<bool>` even when no labeled schema
   /// was declared.
   enum struct ContainerStorage { FLAT, PREALLOCATED };
 

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -458,6 +458,56 @@ CUDAQ_TEST(ParserTester, checkFailureCases) {
   }
 }
 
+CUDAQ_TEST(ParserTester, checkMetadataValidation) {
+  cudaq::RecordLogParser validParser;
+  EXPECT_NO_THROW(validParser.parse("METADATA\tentry_point\n"));
+
+  for (const auto &log : {"METADATA\n", "METADATA\tkey\tvalue\textra\n"}) {
+    cudaq::RecordLogParser parser;
+    EXPECT_ANY_THROW(parser.parse(log));
+  }
+}
+
+CUDAQ_TEST(ParserTester, checkNumericValidation) {
+  const std::vector<std::string> invalidLogs = {
+      "OUTPUT\tARRAY\t1\tarray<i32 x 1>\n"
+      "OUTPUT\tINT\t0\t[99999999999]\n",
+      "OUTPUT\tARRAY\t1\tarray<i32 x 1>\n"
+      "OUTPUT\tINT\t0\t[abc]\n",
+      "OUTPUT\tARRAY\t1\tarray<i32 x 1>\n"
+      "OUTPUT\tINT\t0\t[]\n"};
+  for (const auto &log : invalidLogs) {
+    cudaq::RecordLogParser parser;
+    EXPECT_ANY_THROW(parser.parse(log));
+  }
+}
+
+CUDAQ_TEST(ParserTester, checkContainerValidation) {
+  const std::vector<std::string> invalidLogs = {
+      "OUTPUT\tINT\t1\n"
+      "OUTPUT\tRESULT\t0\n",
+      "OUTPUT\tINT\t1\n"
+      "OUTPUT\tARRAY\t1\tarray<i32 x 1>\n"
+      "OUTPUT\tINT\t9\t[0]\n"};
+  for (const auto &log : invalidLogs) {
+    cudaq::RecordLogParser parser;
+    EXPECT_ANY_THROW(parser.parse(log));
+  }
+}
+
+CUDAQ_TEST(ParserTester, checkTupleLayoutValidation) {
+  const std::pair<std::size_t, std::vector<std::size_t>> layout{2, {0, 1}};
+  cudaq::RecordLogParser parser(layout);
+  const std::string log = "OUTPUT\tTUPLE\t2\ttuple<i8, i32>\n"
+                          "OUTPUT\tINT\t1\t.0\n"
+                          "OUTPUT\tINT\t9\t.1\n";
+  EXPECT_ANY_THROW(parser.parse(log));
+
+  cudaq::detail::BufferHandler buffer;
+  buffer.resizeBuffer(2);
+  EXPECT_ANY_THROW(buffer.insertIntoTuple<std::int32_t>(1, 9));
+}
+
 CUDAQ_TEST(ParserTester, checkResultType) {
   const std::string log =
       "HEADER\tschema_id\tlabeled\nHEADER\tschema_version\t1."

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -484,11 +484,18 @@ CUDAQ_TEST(ParserTester, checkNumericValidation) {
 
 CUDAQ_TEST(ParserTester, checkContainerValidation) {
   const std::vector<std::string> invalidLogs = {
+      // A scalar root cannot be followed by an implicit RESULT array.
       "OUTPUT\tINT\t1\n"
       "OUTPUT\tRESULT\t0\n",
+      // A scalar root cannot be followed by an explicit array.
       "OUTPUT\tINT\t1\n"
       "OUTPUT\tARRAY\t1\tarray<i32 x 1>\n"
-      "OUTPUT\tINT\t9\t[0]\n"};
+      "OUTPUT\tINT\t9\t[0]\n",
+      // Flat and preallocated array representations cannot be mixed.
+      "OUTPUT\tARRAY\t1\n"
+      "OUTPUT\tINT\t7\ti32\n"
+      "OUTPUT\tARRAY\t1\tarray<i1 x 1>\n"
+      "OUTPUT\tBOOL\t1\t[0]\n"};
   for (const auto &log : invalidLogs) {
     cudaq::RecordLogParser parser;
     EXPECT_ANY_THROW(parser.parse(log));


### PR DESCRIPTION
* Validate metadata, container indices, and tuple layout bounds before accessing result storage. 
* Avoid misaligned array-buffer accesses.
* Add focused regression coverage for malformed output records.