### PR TITLE
Adding bounds checks to SampleResult deserialization

### DIFF
--- a/runtime/common/SampleResult.cpp
+++ b/runtime/common/SampleResult.cpp
@@ -10,11 +10,11 @@
 #include "cudaq/spin_op.h"
 #include <algorithm>
 #include <climits>
+#include <iostream>
+#include <map>
 #include <numeric>
 #include <stdexcept>
 #include <string.h>
-#include <iostream>
-#include <map>
 #include <vector>
 
 static std::string longToBitString(std::size_t size, long x) {

--- a/runtime/common/SampleResult.cpp
+++ b/runtime/common/SampleResult.cpp
@@ -10,17 +10,26 @@
 #include "cudaq/spin_op.h"
 
 #include <algorithm>
+#include <limits>
 #include <numeric>
+#include <stdexcept>
 #include <string.h>
 
 #include <iostream>
 #include <map>
 #include <vector>
 
-static std::string longToBitString(int size, long x) {
+static std::string longToBitString(std::size_t size, long x) {
+  if (size > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+    throw std::runtime_error("Invalid serialized sample_result. Bitstring "
+                             "length exceeds supported range.");
+
   std::string s(size, '0');
-  int counter = 0;
+  std::size_t counter = 0;
   do {
+    if (counter >= s.size())
+      throw std::runtime_error("Invalid serialized sample_result. Bitstring "
+                               "value does not fit declared length.");
     s[counter] = '0' + (x & 1);
     counter++;
   } while (x >>= 1);
@@ -31,8 +40,16 @@ static std::string longToBitString(int size, long x) {
 static void
 deserializeCounts(std::vector<std::size_t> &data, std::size_t &stride,
                   std::unordered_map<std::string, std::size_t> &localCounts) {
+  if (stride >= data.size())
+    throw std::runtime_error(
+        "Invalid serialized sample_result. Missing counts length.");
   auto nBs = data[stride];
   stride++;
+
+  std::size_t remaining = data.size() - stride;
+  if (nBs > remaining / 3)
+    throw std::runtime_error(
+        "Invalid serialized sample_result. Counts length exceeds data size.");
 
   for (std::size_t j = stride; j < stride + nBs * 3; j += 3) {
     auto bitstring_as_long = data[j];
@@ -46,7 +63,14 @@ deserializeCounts(std::vector<std::size_t> &data, std::size_t &stride,
 
 static std::string extractNameFromData(std::vector<std::size_t> &data,
                                        std::size_t &stride) {
+  if (stride >= data.size())
+    throw std::runtime_error(
+        "Invalid serialized sample_result. Missing register name length.");
   auto nChars = data[stride++];
+
+  if (nChars > data.size() - stride)
+    throw std::runtime_error("Invalid serialized sample_result. Register name "
+                             "length exceeds data size.");
 
   std::string name(data.begin() + stride, data.begin() + stride + nChars);
 

--- a/runtime/common/SampleResult.cpp
+++ b/runtime/common/SampleResult.cpp
@@ -10,7 +10,7 @@
 #include "cudaq/spin_op.h"
 
 #include <algorithm>
-#include <limits>
+#include <climits>
 #include <numeric>
 #include <stdexcept>
 #include <string.h>
@@ -20,7 +20,7 @@
 #include <vector>
 
 static std::string longToBitString(std::size_t size, long x) {
-  if (size > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+  if (size > sizeof(long) * CHAR_BIT)
     throw std::runtime_error("Invalid serialized sample_result. Bitstring "
                              "length exceeds supported range.");
 

--- a/runtime/common/SampleResult.cpp
+++ b/runtime/common/SampleResult.cpp
@@ -8,13 +8,11 @@
 
 #include "SampleResult.h"
 #include "cudaq/spin_op.h"
-
 #include <algorithm>
 #include <climits>
 #include <numeric>
 #include <stdexcept>
 #include <string.h>
-
 #include <iostream>
 #include <map>
 #include <vector>
@@ -46,19 +44,22 @@ deserializeCounts(std::vector<std::size_t> &data, std::size_t &stride,
   auto nBs = data[stride];
   stride++;
 
+  // Each counts entry is serialized as 3 words: {value, length, count}.
+  constexpr std::size_t wordsPerEntry = 3;
   std::size_t remaining = data.size() - stride;
-  if (nBs > remaining / 3)
+  if (nBs > remaining / wordsPerEntry)
     throw std::runtime_error(
         "Invalid serialized sample_result. Counts length exceeds data size.");
 
-  for (std::size_t j = stride; j < stride + nBs * 3; j += 3) {
+  for (std::size_t j = stride; j < stride + nBs * wordsPerEntry;
+       j += wordsPerEntry) {
     auto bitstring_as_long = data[j];
     auto size_of_bitstring = data[j + 1];
     auto count = data[j + 2];
     auto bs = longToBitString(size_of_bitstring, bitstring_as_long);
     localCounts.insert({bs, count});
   }
-  stride += nBs * 3;
+  stride += nBs * wordsPerEntry;
 }
 
 static std::string extractNameFromData(std::vector<std::size_t> &data,

--- a/unittests/nvqpp/common/MeasureCountsTester.cpp
+++ b/unittests/nvqpp/common/MeasureCountsTester.cpp
@@ -64,3 +64,45 @@ CUDAQ_TEST(MeasureCountsTester, checkMeasureCountsSerialize) {
 
   EXPECT_TRUE(mm == mc);
 }
+
+CUDAQ_TEST(MeasureCountsTester, checkDeserializeRejectsMalformed) {
+  {
+    std::vector<std::size_t> data = {255};
+    cudaq::sample_result mm;
+    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+  }
+
+  {
+    std::vector<std::size_t> data = {1, static_cast<std::size_t>('a')};
+    cudaq::sample_result mm;
+    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+  }
+
+  {
+    std::vector<std::size_t> data = {0, 255};
+    cudaq::sample_result mm;
+    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+  }
+
+  {
+    std::vector<std::size_t> data = {0, 1, /*value*/ 1,
+                                     /*length*/ static_cast<std::size_t>(-1),
+                                     /*count*/ 1};
+    cudaq::sample_result mm;
+    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+  }
+
+  {
+    std::vector<std::size_t> data = {255};
+    ExecutionResult rr;
+    EXPECT_THROW(rr.deserialize(data), std::runtime_error);
+  }
+}
+
+CUDAQ_TEST(MeasureCountsTester, checkDeserializeAcceptsValid) {
+  ExecutionResult r{CountsDictionary{{"01", 400}, {"11", 600}}};
+  auto data = r.serialize();
+  ExecutionResult rr;
+  EXPECT_NO_THROW(rr.deserialize(data));
+  EXPECT_TRUE(rr == r);
+}

--- a/unittests/nvqpp/common/MeasureCountsTester.cpp
+++ b/unittests/nvqpp/common/MeasureCountsTester.cpp
@@ -79,19 +79,19 @@ CUDAQ_TEST(MeasureCountsTester, checkDeserializeRejectsMalformed) {
   {
     std::vector<std::size_t> data = {255};
     cudaq::sample_result mm;
-    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+    EXPECT_ANY_THROW(mm.deserialize(data));
   }
 
   {
     std::vector<std::size_t> data = {1, static_cast<std::size_t>('a')};
     cudaq::sample_result mm;
-    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+    EXPECT_ANY_THROW(mm.deserialize(data));
   }
 
   {
     std::vector<std::size_t> data = {0, 255};
     cudaq::sample_result mm;
-    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+    EXPECT_ANY_THROW(mm.deserialize(data));
   }
 
   {
@@ -99,13 +99,13 @@ CUDAQ_TEST(MeasureCountsTester, checkDeserializeRejectsMalformed) {
                                      /*length*/ static_cast<std::size_t>(-1),
                                      /*count*/ 1};
     cudaq::sample_result mm;
-    EXPECT_THROW(mm.deserialize(data), std::runtime_error);
+    EXPECT_ANY_THROW(mm.deserialize(data));
   }
 
   {
     std::vector<std::size_t> data = {255};
     ExecutionResult rr;
-    EXPECT_THROW(rr.deserialize(data), std::runtime_error);
+    EXPECT_ANY_THROW(rr.deserialize(data));
   }
 }
 


### PR DESCRIPTION
The deserialize helpers in `SampleResult.cpp` indexed an attacker-controlled length-prefixed vector with no validation. It allowed a heap out-of-bounds read/write from a malformed cloud-QPU reply. Now we are validating name/counts length and bitstring sizes against the buffer and throwing runtime exception on malformed input.