### PR TITLE
[Scaleway] Fixing OOB read in processResults

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/ScalewayServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/ScalewayServerHelper.cpp
@@ -244,8 +244,15 @@ ScalewayServerHelper::processResults(ServerMessage &postJobResponse,
     // Now add to `execResults` one register at a time
     for (const auto &[result, info] : jobOutputNames) {
       CountsDictionary regCounts;
-      for (const auto &[bits, count] : sampleResult)
+      for (const auto &[bits, count] : sampleResult) {
+        if (info.qubitNum >= bits.size())
+          throw std::runtime_error(
+              "Server returned a bitstring of length " +
+              std::to_string(bits.size()) +
+              " that is too short for measured qubit index " +
+              std::to_string(info.qubitNum) + ".");
         regCounts[std::string{bits[info.qubitNum]}] += count;
+      }
       execResults.emplace_back(regCounts, info.registerName);
     }
 


### PR DESCRIPTION
The per-register reduction loop indexed `bits[info.qubitNum]` without checking that qubitNum is within the server-returned bitstring length. A server returning a bitstring shorter than the measured qubit index caused a heap out-of-bounds read. This PR adds a bounds check that throws a clear error.