### PR TITLE
Capping gzipDecompress output

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.cpp
@@ -54,7 +54,8 @@ std::string cudaq::qio::gzipCompress(const std::string &input) {
   return outstring;
 }
 
-std::string cudaq::qio::gzipDecompress(const std::string &input) {
+std::string cudaq::qio::gzipDecompress(const std::string &input,
+                                       std::size_t maxOutputSize) {
   z_stream zs; // z_stream is zlib's control structure
   memset(&zs, 0, sizeof(zs));
 
@@ -78,6 +79,13 @@ std::string cudaq::qio::gzipDecompress(const std::string &input) {
     ret = inflate(&zs, 0);
 
     if (outstring.size() < zs.total_out) {
+      if (zs.total_out > maxOutputSize) {
+        inflateEnd(&zs);
+        std::ostringstream oss;
+        oss << "Decompressed payload exceeds maximum allowed size of "
+            << maxOutputSize << " bytes.";
+        throw(std::runtime_error(oss.str()));
+      }
       outstring.append(outbuffer, zs.total_out - outstring.size());
     }
 

--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.h
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.h
@@ -15,7 +15,7 @@ inline constexpr std::size_t defaultMaxDecompressedSize = 512UL * 1024 * 1024;
 
 std::string gzipCompress(const std::string &input);
 
-/// Decompress a zlib stream, which produces `maxOutputSize` bytes.
+/// Decompress a `zlib` stream, which produces `maxOutputSize` bytes.
 std::string
 gzipDecompress(const std::string &input,
                std::size_t maxOutputSize = defaultMaxDecompressedSize);

--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.h
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.h
@@ -15,7 +15,7 @@ inline constexpr std::size_t defaultMaxDecompressedSize = 512UL * 1024 * 1024;
 
 std::string gzipCompress(const std::string &input);
 
-/// Decompress a `zlib` stream, which produces `maxOutputSize` bytes.
+/// Decompress a `zlib` stream, which produces less than `maxOutputSize` bytes.
 std::string
 gzipDecompress(const std::string &input,
                std::size_t maxOutputSize = defaultMaxDecompressedSize);

--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.h
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/qio/Compression.h
@@ -6,9 +6,17 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 #pragma once
+#include <cstddef>
 #include <string>
 
 namespace cudaq::qio {
+/// Default upper bound on the number of bytes `gzipDecompress` will produce.
+inline constexpr std::size_t defaultMaxDecompressedSize = 512UL * 1024 * 1024;
+
 std::string gzipCompress(const std::string &input);
-std::string gzipDecompress(const std::string &input);
+
+/// Decompress a zlib stream, which produces `maxOutputSize` bytes.
+std::string
+gzipDecompress(const std::string &input,
+               std::size_t maxOutputSize = defaultMaxDecompressedSize);
 } // namespace cudaq::qio


### PR DESCRIPTION
`cudaq::qio::gzipDecompress` inflated an untrusted zlib stream into an ever-growing `std::string` with no cap on output size.

Adding a maxOutputSize parameter to gzipDecompress (default 512 MB) and a check inside the inflate loop that throws std::runtime_error before the output exceeds the cap.