### PR TITLE
Fix `sample_result::get_marginal` bound check

### DIFF
--- a/python/tests/builder/test_sample.py
+++ b/python/tests/builder/test_sample.py
@@ -435,6 +435,10 @@ def test_sample_marginalize():
     marginal_result = sample_result.get_marginal_counts([1, 2, 3])
     assert marginal_result.most_probable() == "101"
 
+    # Index 4 equals the bitstring width and is therefore out of bounds.
+    with pytest.raises(RuntimeError):
+        sample_result.get_marginal_counts([4])
+
 
 def test_swap_2q():
     """

--- a/runtime/common/SampleResult.cpp
+++ b/runtime/common/SampleResult.cpp
@@ -410,7 +410,7 @@ sample_result::get_marginal(const std::vector<std::size_t> &marginalIndices,
     for ([[maybe_unused]] auto &m : mutableIndices)
       newBits += "0";
     for (int counter = 0; auto &index : mutableIndices) {
-      if (index > bits.size())
+      if (index >= bits.size())
         throw std::runtime_error("Invalid marginal index (" +
                                  std::to_string(index) +
                                  ", size=" + std::to_string(bits.size()));

--- a/unittests/nvqpp/common/MeasureCountsTester.cpp
+++ b/unittests/nvqpp/common/MeasureCountsTester.cpp
@@ -32,6 +32,16 @@ CUDAQ_TEST(MeasureCountsTester, checkCount) {
   EXPECT_EQ(0, mc.count("1111"));
 }
 
+CUDAQ_TEST(MeasureCountsTester, checkMarginalIndexBounds) {
+  ExecutionResult r{CountsDictionary{{"00", 400}, {"11", 600}}};
+  cudaq::sample_result result(r);
+  // Both valid boundary indices must remain accepted.
+  EXPECT_NO_THROW(result.get_marginal({0}));
+  EXPECT_NO_THROW(result.get_marginal({1}));
+  // Index 2 equals the bitstring width and is therefore out of bounds.
+  EXPECT_ANY_THROW(result.get_marginal({2}));
+}
+
 CUDAQ_TEST(MeasureCountsTester, checkExpValZ) {
   ExecutionResult r{CountsDictionary{{"0", 400}, {"1", 600}}};
   cudaq::sample_result mc(r);


### PR DESCRIPTION
For an invalid index check, we need to check for `index >= size` rather than `>` as `index==size` is an invalid index.

Add some test cases as well.