### PR TITLE
Enable available optimizations for FTQC/NISQ targets

### DIFF
--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
@@ -11,9 +11,9 @@ description: "Logical FTQC benchmark target lowering to a pre-synthesis Clifford
 
 config:
   nvqir-simulation-backend: qpp
-  # Target mid-level stage: clean up quantum allocation form, restore
-  # memory-semantics IR for resource counting, then enforce the logical FTQC
-  # basis. The basis preserves T-family gates and unresolved single-qubit
-  # rotations for layer-one FTQC metrics.
-  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),func.func(regtomem),decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1),y(1),z(1),x(2),z(2)}"
+  # Target mid-level stage: enforce the logical basis and fold commuting RZ
+  # phases while the circuit uses memory semantics, then enter value semantics
+  # once for local gate simplification. The basis preserves T-family gates and
+  # unresolved single-qubit rotations for layer-one FTQC metrics.
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1),y(1),z(1),x(2),z(2)},func.func(add-dealloc,combine-quantum-alloc),phase-folding-pipeline{min-length=0 min-rz-weight=0},func.func(canonicalize,dqe,memtoreg,quake-simplify,canonicalize,dqe,regtomem)"
   

--- a/runtime/cudaq/platform/default/compiler-bench-nisq.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-nisq.yml
@@ -17,12 +17,12 @@ target-arguments:
 
 config:
   nvqir-simulation-backend: qpp
-  # Target mid-level stage: decompose to a CX routing basis before allocation
-  # cleanup, prepare wire metadata, optionally route, then decompose again after
-  # regtomem to lower routed two-qubit work to CZ. The second decomposition is
-  # needed because qubit-mapping can introduce SWAP/CX work after the first
-  # decomposition. `quake-to-cc-prep` rewrites mx/my to quake gates plus mz
-  # before final decomposition so resource counting sees the normalized
-  # CZ/rotation basis. With no device argument, routing is bypassed.
-  jit-mid-level-pipeline: "decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(regtomem),quake-to-cc-prep,decomposition{basis=h,rx,ry,rz,x,z(1)}"
+  # Target mid-level stage: decompose to a CX routing basis, fold commuting RZ
+  # phases in memory semantics, then enter value semantics once for local gate
+  # simplification and optional SABRE routing. A second simplification cleans up
+  # mapped work before returning to memory semantics. `quake-to-cc-prep`
+  # rewrites mx/my to quake gates plus mz before final decomposition so resource
+  # counting sees the normalized CZ/rotation basis. With no device argument,
+  # routing is bypassed.
+  jit-mid-level-pipeline: "decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc),phase-folding-pipeline{min-length=0 min-rz-weight=0},func.func(canonicalize,dqe,memtoreg,quake-simplify,canonicalize,dqe),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(quake-simplify,canonicalize,dqe,regtomem),quake-to-cc-prep,decomposition{basis=h,rx,ry,rz,x,z(1)}"
   


### PR DESCRIPTION
## Summary
Based on #4829 and should only be merged after.

Run CUDA-Q's existing circuit optimizations in the FTQC logical and NISQ
compiler benchmark targets.

The pipelines now:

- run `phase-folding-pipeline` while the circuit is in memory semantics
- enter value semantics once with `memtoreg`
- run `quake-simplify` before FTQC handoff or NISQ mapping
- run an additional local simplification after NISQ mapping
- preserve the existing output basis contracts
- 
## Benchmark Results
A simple smoke benchmark.

| Benchmark | Metric | Before | After | Change |
|---|---:|---:|---:|---:|
| NISQ `random_ansatz` | Gates | 1,600 | 1,573 | -27 (-1.7%) |
| NISQ `random_ansatz` | Depth | 235 | 235 | 0 |
| NISQ `random_ansatz` | Two-qubit gates | 320 | 320 | 0 |
| NISQ `vqe_block_ansatz` | Gates | 6,688 | 6,032 | -656 (-9.8%) |
| NISQ `vqe_block_ansatz` | Depth | 961 | 932 | -29 (-3.0%) |
| NISQ `vqe_block_ansatz` | Two-qubit gates | 864 | 864 | 0 |
| FTQC `feynman:qft_4` | Gates | 159 | 151 | -8 (-5.0%) |
| FTQC `feynman:qft_4` | Depth | 134 | 126 | -8 (-6.0%) |
| FTQC `feynman:qft_4` | H gates | 46 | 38 | -8 (-17.4%) |

