### PR TITLE
[testing][Python] Fix backend `observe` tests

### DIFF
--- a/python/tests/backends/test_Quantinuum_LocalEmulation_kernel.py
+++ b/python/tests/backends/test_Quantinuum_LocalEmulation_kernel.py
@@ -126,7 +126,8 @@ def test_quantinuum_exp_pauli():
 
     # Run the observe task on quantinuum synchronously
     res = cudaq.observe(ansatz, hamiltonian, .59 * -0.5, shots_count=100000)
-    assert assert_close(-1.7, res.expectation())
+    sync_expectation = res.expectation()
+    assert assert_close(-1.7, sync_expectation)
 
     # Launch it asynchronously, enters the job into the queue
     future = cudaq.observe_async(ansatz,
@@ -135,7 +136,8 @@ def test_quantinuum_exp_pauli():
                                  shots_count=100000)
     # Retrieve the results (since we're emulating)
     res = future.get()
-    assert assert_close(-1.7, res.expectation())
+    async_expectation = res.expectation()
+    assert assert_close(-1.7, async_expectation)
 
 
 def test_u3_emulatation():

--- a/python/tests/utils/mock_qpu/ionq/__init__.py
+++ b/python/tests/utils/mock_qpu/ionq/__init__.py
@@ -6,6 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+import cudaq
 from fastapi import FastAPI, HTTPException, Header
 from typing import Union
 import uuid, base64, ctypes
@@ -165,5 +166,6 @@ async def getResults(jobId: str):
 
 
 def startServer(port):
+    cudaq.set_random_seed(13)
     import uvicorn
     uvicorn.run(app, port=port, host='0.0.0.0', log_level="info")

--- a/python/tests/utils/mock_qpu/quantinuum/__init__.py
+++ b/python/tests/utils/mock_qpu/quantinuum/__init__.py
@@ -431,5 +431,6 @@ async def create_decoder_config(job: dict):
 
 
 def startServer(port):
+    cudaq.set_random_seed(13)
     import uvicorn
     uvicorn.run(app, port=port, host='0.0.0.0', log_level="info")

--- a/runtime/cudaq/algorithms/observe.h
+++ b/runtime/cudaq/algorithms/observe.h
@@ -142,9 +142,12 @@ auto runObservationAsync(KernelFunctor &&wrappedKernel, const spin_op &H,
 
   // If the platform is not remote, then we can handle asynchronous execution
   // via a new worker thread.
+  std::size_t seed = cudaq::get_random_seed();
   KernelExecutionTask task(
-      [&, H, qpu_id, shots, kernelName,
+      [&, H, qpu_id, shots, kernelName, seed,
        kernel = std::forward<KernelFunctor>(wrappedKernel)]() mutable {
+        if (seed > 0)
+          cudaq::set_random_seed(seed);
         return detail::runObservation(kernel, H, platform, shots, kernelName,
                                       qpu_id)
             .raw_data();


### PR DESCRIPTION
### Summary

Fix intermittent Python backend observe-test failures by propagating explicit random seeds across the execution boundaries the tests use.

- Seed Quantinuum and IonQ mock servers inside their multiprocessing child processes.
- Capture and apply the caller seed in the local `observe_async` worker thread.


### Root cause

The tests seeded their parent Python process, but mock servers run in `forkserver` children and local async observation runs on a worker thread.
CUDA-Q random-seed and simulator state are thread-local, so those execution contexts started with the default nondeterministic seed.
