### PR TITLE
fix(python): reject 2-D list/tuple in amplitude_encode

### DIFF
--- a/python/cudaq/contrib/encoding.py
+++ b/python/cudaq/contrib/encoding.py
@@ -52,7 +52,10 @@ def _as_amplitude_vector(data, dtype):
                           "Install cupy-cuda13x or pass a NumPy array/list.")
 
     if isinstance(data, (list, tuple)):
-        return np, np.asarray(data, dtype=dtype).ravel()
+        arr = np.asarray(data, dtype=dtype)
+        if arr.ndim != 1:
+            raise ValueError("amplitude_encode: expected a 1D vector.")
+        return np, arr.ravel()
 
     if isinstance(data, np.ndarray):
         if data.ndim != 1:

--- a/python/tests/contrib/test_amplitude_encode.py
+++ b/python/tests/contrib/test_amplitude_encode.py
@@ -99,3 +99,12 @@ def test_amplitude_encode_zero_vector():
 def test_amplitude_encode_2d_rejected():
     with pytest.raises(ValueError, match="1D vector"):
         cudaq.contrib.amplitude_encode(np.eye(2), pad=0)
+
+
+def test_amplitude_encode_2d_list_rejected():
+    # A nested list/tuple must be rejected like the equivalent 2-D array,
+    # rather than being silently flattened into a 1-D vector.
+    with pytest.raises(ValueError, match="1D vector"):
+        cudaq.contrib.amplitude_encode([[0.5, 0.5], [0.5, 0.5]], pad=0)
+    with pytest.raises(ValueError, match="1D vector"):
+        cudaq.contrib.amplitude_encode(((0.5, 0.5), (0.5, 0.5)), pad=0)

--- a/python/tests/contrib/test_amplitude_encode.py
+++ b/python/tests/contrib/test_amplitude_encode.py
@@ -101,10 +101,14 @@ def test_amplitude_encode_2d_rejected():
         cudaq.contrib.amplitude_encode(np.eye(2), pad=0)
 
 
-def test_amplitude_encode_2d_list_rejected():
-    # A nested list/tuple must be rejected like the equivalent 2-D array,
-    # rather than being silently flattened into a 1-D vector.
+@pytest.mark.parametrize("nested", [
+    [[0.5, 0.5], [0.5, 0.5]],  # nested list
+    ((0.5, 0.5), (0.5, 0.5)),  # nested tuple
+])
+def test_amplitude_encode_2d_sequence_rejected(nested):
+    # A nested Python sequence (list or tuple) must be rejected like the
+    # equivalent 2-D array, rather than being silently flattened into a 1-D
+    # vector. Both types convert to the same 2-D array, so one parametrized
+    # test covers both without duplicating the assertion.
     with pytest.raises(ValueError, match="1D vector"):
-        cudaq.contrib.amplitude_encode([[0.5, 0.5], [0.5, 0.5]], pad=0)
-    with pytest.raises(ValueError, match="1D vector"):
-        cudaq.contrib.amplitude_encode(((0.5, 0.5), (0.5, 0.5)), pad=0)
+        cudaq.contrib.amplitude_encode(nested, pad=0)


### PR DESCRIPTION
## Summary

`cudaq.contrib.amplitude_encode` raises `ValueError("expected a 1D vector")` for a 2-D NumPy array, but an **equivalent nested Python list/tuple is silently flattened** by `np.asarray(data, dtype=dtype).ravel()` in `_as_amplitude_vector`, producing a different-length state with no error.

```python
cudaq.contrib.amplitude_encode(np.eye(2))          # ValueError (correct)
cudaq.contrib.amplitude_encode([[0.5, 0.5],
                                [0.5, 0.5]])       # silently encodes a 4-vector (wrong)
```

This addresses **item 1 (High severity, Python correctness)** of #4791.

## Fix

Validate `ndim` in the `list`/`tuple` branch of `_as_amplitude_vector`, mirroring the existing NumPy-array path, so nested sequences raise the same `ValueError`. 1-D lists/tuples and empty lists are unaffected.

## Test

Adds `test_amplitude_encode_2d_list_rejected` (nested list and nested tuple), mirroring the existing `test_amplitude_encode_2d_rejected` array case.

Scope is limited to item 1; the C++/docs follow-ups in #4791 are left for separate PRs.

Credit to @spital for the detailed report.

_Note: verified the input-handling logic standalone with NumPy; the full CUDA-Q Python suite requires a built runtime._