### PR TITLE
Preserve adjoints in quake simplification

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/QuakeSimplify.cpp
+++ b/cudaq/lib/Optimizer/Transforms/QuakeSimplify.cpp
@@ -297,7 +297,8 @@ public:
   }
 };
 
-// Z = SS
+// Z = SS = S<adj>S<adj>
+// I = SS<adj> = S<adj>S
 class DoubleSOp : public OpRewritePattern<cudaq::quake::SOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -362,6 +363,17 @@ public:
       }
     }
 
+    if (qop.isAdj() != prev.isAdj()) {
+      // Opposite adjoints cancel. Forward the wires entering the pair to users
+      // of the second operation, then erase the first operation.
+      SmallVector<Value> replacementWires;
+      replacementWires.append(prevCtls.begin(), prevCtls.end());
+      replacementWires.append(prevTrgs.begin(), prevTrgs.end());
+      rewriter.replaceOp(qop, replacementWires);
+      rewriter.eraseOp(prev);
+      return success();
+    }
+
     // Rewrite the back-to-back S gates.
     LLVM_DEBUG(llvm::dbgs() << "replaced: " << qop << '\n' << prev << '\n');
     rewriter.replaceOpWithNewOp<cudaq::quake::ZOp>(
@@ -373,6 +385,8 @@ public:
 };
 
 // S = TT
+// S<adj> = T<adj>T<adj>
+// I = TT<adj> = T<adj>T
 class DoubleTOp : public OpRewritePattern<cudaq::quake::TOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -437,11 +451,22 @@ public:
       }
     }
 
+    if (qop.isAdj() != prev.isAdj()) {
+      // Opposite adjoints cancel. Forward the wires entering the pair to users
+      // of the second operation, then erase the first operation.
+      SmallVector<Value> replacementWires;
+      replacementWires.append(prevCtls.begin(), prevCtls.end());
+      replacementWires.append(prevTrgs.begin(), prevTrgs.end());
+      rewriter.replaceOp(qop, replacementWires);
+      rewriter.eraseOp(prev);
+      return success();
+    }
+
     // Rewrite the back-to-back S gates.
     LLVM_DEBUG(llvm::dbgs() << "replaced: " << qop << '\n' << prev << '\n');
     rewriter.replaceOpWithNewOp<cudaq::quake::SOp>(
-        qop, qop.getResultTypes(), UnitAttr{}, ValueRange{}, prevCtls, prevTrgs,
-        DenseBoolArrayAttr{});
+        qop, qop.getResultTypes(), qop.getIsAdjAttr(), ValueRange{}, prevCtls,
+        prevTrgs, DenseBoolArrayAttr{});
     rewriter.eraseOp(prev);
     return success();
   }
@@ -455,6 +480,11 @@ public:
   LogicalResult matchAndRewrite(cudaq::quake::XOp qop,
                                 PatternRewriter &rewriter) const override {
     if (qop.getNegatedQubitControls())
+      return failure();
+
+    // The uncontrolled rewrite is equal up to global phase. Under control,
+    // that phase is relative between control branches and is observable.
+    if (!qop.getControls().empty())
       return failure();
 
     auto targets = qop.getTargets();

--- a/cudaq/test/Transforms/quake_simplify.qke
+++ b/cudaq/test/Transforms/quake_simplify.qke
@@ -268,7 +268,7 @@ func.func @simp7() -> (i1, i1) {
 // CHECK:           return %[[VAL_7]], %[[VAL_8]] : i1, i1
 // CHECK:         }
 
-// S = YSX
+// Controlled YSX must not reduce to S because its phase is relative.
 func.func @simp8() -> (i1, i1) {
   %0 = quake.null_wire
   %1 = quake.null_wire
@@ -287,12 +287,31 @@ func.func @simp8() -> (i1, i1) {
 // CHECK-LABEL:   func.func @simp8() -> (i1, i1) {
 // CHECK:           %[[VAL_0:.*]] = quake.null_wire
 // CHECK:           %[[VAL_1:.*]] = quake.null_wire
-// CHECK:           %[[VAL_2:.*]]:2 = quake.s {{\[}}%[[VAL_0]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = quake.mz %[[VAL_2]]#0 : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = quake.mz %[[VAL_2]]#1 : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK:           %[[VAL_7:.*]] = quake.discriminate %[[VAL_3]] : (!quake.measure) -> i1
-// CHECK:           %[[VAL_8:.*]] = quake.discriminate %[[VAL_5]] : (!quake.measure) -> i1
-// CHECK:           quake.sink %[[VAL_4]] : !quake.wire
+// CHECK:           %[[VAL_2:.*]]:2 = quake.y {{\[}}%[[VAL_0]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_3:.*]]:2 = quake.s {{\[}}%[[VAL_2]]#0] %[[VAL_2]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_4:.*]]:2 = quake.x {{\[}}%[[VAL_3]]#0] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = quake.mz %[[VAL_4]]#0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_4]]#1 : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_9:.*]] = quake.discriminate %[[VAL_5]] : (!quake.measure) -> i1
+// CHECK:           %[[VAL_10:.*]] = quake.discriminate %[[VAL_7]] : (!quake.measure) -> i1
 // CHECK:           quake.sink %[[VAL_6]] : !quake.wire
-// CHECK:           return %[[VAL_7]], %[[VAL_8]] : i1, i1
+// CHECK:           quake.sink %[[VAL_8]] : !quake.wire
+// CHECK:           return %[[VAL_9]], %[[VAL_10]] : i1, i1
 // CHECK:         }
+
+// Uncontrolled YSX may reduce to S under current global-phase semantics.
+func.func @simp9() {
+  %0 = quake.null_wire
+  %1 = quake.y %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.s %1 : (!quake.wire) -> !quake.wire
+  %3 = quake.x %2 : (!quake.wire) -> !quake.wire
+  quake.sink %3 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @simp9() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      %[[VAL_1:.*]] = quake.s %[[VAL_0]] : (!quake.wire) -> !quake.wire
+// CHECK-NEXT:      quake.sink %[[VAL_1]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/cudaq/test/Transforms/quake_simplify_adjoint.qke
+++ b/cudaq/test/Transforms/quake_simplify_adjoint.qke
@@ -1,0 +1,158 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         //
+// All rights reserved.                                                        //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.    //
+// ========================================================================== //
+
+// RUN: cudaq-opt --quake-simplify %s | FileCheck %s
+// RUN: cudaq-opt --quake-simplify %s | CircuitCheck %s
+
+// CircuitCheck intentionally uses strict unitary equivalence in this file to
+// detect both global and relative phase changes. Global-phase-only rewrites
+// accepted by current CUDA-Q semantics remain in quake_simplify.qke.
+
+func.func @cancel_t_tdg() {
+  %0 = quake.null_wire
+  %1 = quake.t %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.t<adj> %1 : (!quake.wire) -> !quake.wire
+  quake.sink %2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @cancel_t_tdg() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      quake.sink %[[VAL_0]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @cancel_tdg_t() {
+  %0 = quake.null_wire
+  %1 = quake.t<adj> %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.t %1 : (!quake.wire) -> !quake.wire
+  quake.sink %2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @cancel_tdg_t() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      quake.sink %[[VAL_0]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @combine_tdg_tdg() {
+  %0 = quake.null_wire
+  %1 = quake.t<adj> %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.t<adj> %1 : (!quake.wire) -> !quake.wire
+  quake.sink %2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @combine_tdg_tdg() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      %[[VAL_1:.*]] = quake.s<adj> %[[VAL_0]] : (!quake.wire) -> !quake.wire
+// CHECK-NEXT:      quake.sink %[[VAL_1]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @cancel_s_sdg() {
+  %0 = quake.null_wire
+  %1 = quake.s %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.s<adj> %1 : (!quake.wire) -> !quake.wire
+  quake.sink %2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @cancel_s_sdg() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      quake.sink %[[VAL_0]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @cancel_sdg_s() {
+  %0 = quake.null_wire
+  %1 = quake.s<adj> %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.s %1 : (!quake.wire) -> !quake.wire
+  quake.sink %2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @cancel_sdg_s() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      quake.sink %[[VAL_0]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @combine_sdg_sdg() {
+  %0 = quake.null_wire
+  %1 = quake.s<adj> %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.s<adj> %1 : (!quake.wire) -> !quake.wire
+  quake.sink %2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @combine_sdg_sdg() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      %[[VAL_1:.*]] = quake.z %[[VAL_0]] : (!quake.wire) -> !quake.wire
+// CHECK-NEXT:      quake.sink %[[VAL_1]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @preserve_controlled_ysx() {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2:2 = quake.y [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %3:2 = quake.s [%2#0] %2#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %4:2 = quake.x [%3#0] %3#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %4#0 : !quake.wire
+  quake.sink %4#1 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @preserve_controlled_ysx() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      %[[VAL_1:.*]] = quake.null_wire
+// CHECK-NEXT:      %[[VAL_2:.*]]:2 = quake.y {{\[}}%[[VAL_0]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK-NEXT:      %[[VAL_3:.*]]:2 = quake.s {{\[}}%[[VAL_2]]#0] %[[VAL_2]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK-NEXT:      %[[VAL_4:.*]]:2 = quake.x {{\[}}%[[VAL_3]]#0] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK-NEXT:      quake.sink %[[VAL_4]]#0 : !quake.wire
+// CHECK-NEXT:      quake.sink %[[VAL_4]]#1 : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @cancel_controlled_t_tdg() {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2:2 = quake.t [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %3:2 = quake.t<adj> [%2#0] %2#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %3#0 : !quake.wire
+  quake.sink %3#1 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @cancel_controlled_t_tdg() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      %[[VAL_1:.*]] = quake.null_wire
+// CHECK-NEXT:      quake.sink %[[VAL_0]] : !quake.wire
+// CHECK-NEXT:      quake.sink %[[VAL_1]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @cancel_controlled_s_sdg() {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2:2 = quake.s [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %3:2 = quake.s<adj> [%2#0] %2#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %3#0 : !quake.wire
+  quake.sink %3#1 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @cancel_controlled_s_sdg() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK-NEXT:      %[[VAL_1:.*]] = quake.null_wire
+// CHECK-NEXT:      quake.sink %[[VAL_0]] : !quake.wire
+// CHECK-NEXT:      quake.sink %[[VAL_1]] : !quake.wire
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }


### PR DESCRIPTION
This change fixes incorrect adjoint handling in quake-simplify. Previously, inverse pairs such as $T$, $T^\dagger$ and $S$, $S^\dagger$ were rewritten to $S$ and $Z$ instead of cancelling, while $T^\dagger$ and  $T^\dagger$ incorrectly produced $S$ instead of $S\dagger$. These errors change relative phase and are observable circuit differences. Likewise for `ReduceYSX` under control the optimization is  not valid as the global phase is observable, ie., it is $YSX \rightarrow e^{i\pi} S$ (@cabreraam , fyi). 

I am considering how to build a grindable validation framework for optimization passes and I'd fold global phase into this in the future.

The updated rewrites account for and preserve adjoint attributes. I've also added regressions covering controlled and uncontrolled cases.