### PR TITLE
More hardening for the QIR output-record parsing

### DIFF
--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -32,6 +32,19 @@ std::size_t getTypeByteSize(const std::string &type) {
     throw std::runtime_error("Unsupported element type in struct type.");
   throw std::runtime_error("Unsupported data type: " + type);
 }
+
+void validateOutputRecord(
+    const std::vector<std::string> &entries,
+    const std::optional<cudaq::RecordSchemaType> &declaredSchema) {
+  if (entries.size() < 3 || entries.size() > 4)
+    throw std::runtime_error("Invalid OUTPUT record");
+  if (declaredSchema.has_value()) {
+    const std::size_t expectedFields =
+        declaredSchema.value() == cudaq::RecordSchemaType::LABELED ? 4 : 3;
+    if (entries.size() != expectedFields)
+      throw std::runtime_error("Unexpected record size for schema");
+  }
+}
 } // namespace
 
 void cudaq::RecordLogParser::parse(const std::string &outputLog) {
@@ -43,6 +56,13 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
 
   // Collect log from a single shot and process it only if it is successful.
   bool processingShot = false;
+  // Track whether we have seen framed output (between START and END) or not
+  bool sawFramedOutput = false;
+  bool sawUnframedOutput = false;
+  bool sawOutput = false;
+  // Keep explicit declarations separate: `schema` is also inferred from
+  // legacy labeled container records.
+  std::optional<RecordSchemaType> declaredSchema;
   // Maintain the starting index of each shot's data
   std::size_t shotStart = 0;
 
@@ -53,22 +73,39 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
       continue;
 
     const std::string &recordType = entries[0];
-    if (recordType == "HEADER")
-      handleHeader(entries);
-    else if (recordType == "METADATA")
+    if (recordType == "HEADER") {
+      if (sawOutput)
+        throw std::runtime_error("HEADER record after output");
+      handleHeader(entries, declaredSchema);
+    } else if (recordType == "METADATA")
       handleMetadata(entries);
     else if (recordType == "START") {
+      if (entries.size() != 1)
+        throw std::runtime_error("Invalid START record");
+      if (processingShot)
+        throw std::runtime_error("Nested START record");
+      if (sawUnframedOutput)
+        throw std::runtime_error("Mixed framed and unframed output");
       processingShot = true;
       shotStart = 0;
     } else if (recordType == "OUTPUT") {
-      if (processingShot)
+      validateOutputRecord(entries, declaredSchema);
+      sawOutput = true;
+      if (processingShot) {
+        sawFramedOutput = true;
         shotStart = shotStart == 0 ? idx : shotStart;
-      else
+      } else {
+        if (sawFramedOutput)
+          throw std::runtime_error("Mixed framed and unframed output");
+        sawUnframedOutput = true;
         handleOutput(entries);
+      }
     } else if (recordType == "END") {
-      if (entries.size() < 2)
-        throw std::runtime_error("Missing shot status");
-      if (entries[1] == "0") {
+      if (entries.size() != 2)
+        throw std::runtime_error("Invalid END record");
+      if (!processingShot)
+        throw std::runtime_error("END record without START");
+      if (detail::parseSize(entries[1]) == 0) {
         if (processingShot) {
           // Successful shot, process it
           for (std::size_t j = shotStart; j < idx; ++j)
@@ -84,19 +121,28 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
       throw std::runtime_error("Invalid record type: " + recordType);
     }
   }
+
+  if (processingShot)
+    throw std::runtime_error("Unterminated shot");
 }
 
 void cudaq::RecordLogParser::handleHeader(
-    const std::vector<std::string> &entries) {
-  if (entries.size() < 3)
+    const std::vector<std::string> &entries,
+    std::optional<RecordSchemaType> &declaredSchema) {
+  if (entries.size() != 3)
     throw std::runtime_error("Invalid HEADER record");
   if (entries[1] == "schema_id") {
+    RecordSchemaType parsedSchema;
     if (entries[2] == "labeled")
-      schema = RecordSchemaType::LABELED;
+      parsedSchema = RecordSchemaType::LABELED;
     else if (entries[2] == "ordered")
-      schema = RecordSchemaType::ORDERED;
+      parsedSchema = RecordSchemaType::ORDERED;
     else
       throw std::runtime_error("Unknown schema type");
+    if (declaredSchema.has_value() && declaredSchema != parsedSchema)
+      throw std::runtime_error("Conflicting schema declarations");
+    declaredSchema = parsedSchema;
+    schema = parsedSchema;
   }
   /// TODO: Handle schema version if needed
 }
@@ -108,6 +154,7 @@ void cudaq::RecordLogParser::handleMetadata(
   if (entries.size() == 3) {
     if (entries[1] == cudaq::opt::qir1_0::RequiredResultsAttrName ||
         entries[1] == cudaq::opt::qir0_1::RequiredResultsAttrName) {
+      detail::parseSize(entries[2]);
       metadata[ResultCountMetadataName] = entries[2];
     } else {
       metadata[entries[1]] = entries[2];
@@ -119,10 +166,6 @@ void cudaq::RecordLogParser::handleMetadata(
 
 void cudaq::RecordLogParser::handleOutput(
     const std::vector<std::string> &entries) {
-  if (entries.size() < 3)
-    throw std::runtime_error("Insufficient data in a record");
-  if ((schema == RecordSchemaType::LABELED) && (entries.size() != 4))
-    throw std::runtime_error("Unexpected record size for a labeled record");
   const std::string &recType = entries[1];
   const std::string &recValue = entries[2];
   std::string recLabel = (entries.size() == 4) ? entries[3] : "";
@@ -154,7 +197,7 @@ void cudaq::RecordLogParser::handleOutput(
       // `qir-base` profile.
       containerMeta.m_type = ContainerType::ARRAY;
       containerMeta.elementCount =
-          std::stoul(metadata[ResultCountMetadataName]);
+          detail::parseSize(metadata[ResultCountMetadataName]);
       containerMeta.arrayType = "i1";
       preallocateArray();
     }
@@ -205,7 +248,7 @@ void cudaq::RecordLogParser::handleOutput(
                           recLabel.empty() ? ContainerStorage::FLAT
                                            : ContainerStorage::PREALLOCATED);
     containerMeta.m_type = ContainerType::ARRAY;
-    containerMeta.elementCount = std::stoul(recValue);
+    containerMeta.elementCount = detail::parseSize(recValue);
     if (!recLabel.empty()) {
       schema = RecordSchemaType::LABELED;
       containerMeta.extractArrayInfo(recLabel);
@@ -218,7 +261,7 @@ void cudaq::RecordLogParser::handleOutput(
                           recLabel.empty() ? ContainerStorage::FLAT
                                            : ContainerStorage::PREALLOCATED);
     containerMeta.m_type = ContainerType::TUPLE;
-    containerMeta.elementCount = std::stoul(recValue);
+    containerMeta.elementCount = detail::parseSize(recValue);
     if (!recLabel.empty()) {
       schema = RecordSchemaType::LABELED;
       containerMeta.extractTupleInfo(recLabel);

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -11,9 +11,11 @@
 #include "cudaq/utils/cudaq_utils.h"
 #include <charconv>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <string_view>
@@ -29,6 +31,41 @@ enum struct OutputType { RESULT, BOOL, INT, DOUBLE };
 enum struct ContainerType { NONE, ARRAY, TUPLE };
 
 namespace detail {
+
+template <typename T>
+T parseInteger(const std::string &value) {
+  static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>);
+  if (value.empty())
+    throw std::runtime_error("Invalid integer value");
+
+  std::string_view input(value);
+  if (input.front() == '+') {
+    input.remove_prefix(1);
+    if (input.empty() || input.front() == '+' || input.front() == '-')
+      throw std::runtime_error("Invalid integer value");
+  }
+
+  std::int64_t parsed = 0;
+  const auto [end, error] =
+      std::from_chars(input.data(), input.data() + input.size(), parsed);
+  if (error != std::errc{} || end != input.data() + input.size() ||
+      parsed < static_cast<std::int64_t>(std::numeric_limits<T>::min()) ||
+      parsed > static_cast<std::int64_t>(std::numeric_limits<T>::max()))
+    throw std::runtime_error("Invalid integer value");
+  return static_cast<T>(parsed);
+}
+
+inline std::size_t parseSize(std::string_view value) {
+  if (value.empty())
+    throw std::runtime_error("Invalid size value");
+
+  std::size_t parsed = 0;
+  const auto [end, error] =
+      std::from_chars(value.data(), value.data() + value.size(), parsed);
+  if (error != std::errc{} || end != value.data() + value.size())
+    throw std::runtime_error("Invalid size value");
+  return parsed;
+}
 
 //===----------------------------------------------------------------------===//
 // Type conversion infrastructure for string-to-value parsing
@@ -57,10 +94,7 @@ template <typename T>
 class IntegerConverter : public TypeConverterBase<T> {
 public:
   T convert(const std::string &value) const override {
-    if constexpr (sizeof(T) <= 4)
-      return static_cast<T>(std::stoi(value));
-    else
-      return static_cast<T>(std::stoll(value));
+    return parseInteger<T>(value);
   }
 };
 
@@ -68,10 +102,29 @@ template <typename T>
 class FloatConverter : public TypeConverterBase<T> {
 public:
   T convert(const std::string &value) const override {
-    if constexpr (std::is_same_v<T, float>)
-      return std::stof(value);
-    else
-      return std::stod(value);
+    if (value.empty())
+      throw std::runtime_error("Invalid floating-point value");
+
+    std::string_view input(value);
+    bool negative = false;
+    if (input.front() == '+' || input.front() == '-') {
+      negative = input.front() == '-';
+      input.remove_prefix(1);
+      if (input.empty() || input.front() == '+' || input.front() == '-')
+        throw std::runtime_error("Invalid floating-point value");
+    }
+
+    // `from_chars` accepts `inf`/`infinity`/`nan` case-insensitively.
+    // Non-finite values are allowed on purpose: the runtime records doubles via
+    // `ostringstream`, which emits lowercase "inf"/"nan". Do not add an
+    // `isfinite()` reject here or it will drop the runtime's own output.
+    T parsed = 0;
+    const auto [end, error] =
+        std::from_chars(input.data(), input.data() + input.size(), parsed,
+                        std::chars_format::general);
+    if (error != std::errc{} || end != input.data() + input.size())
+      throw std::runtime_error("Invalid floating-point value");
+    return negative ? -parsed : parsed;
   }
 };
 
@@ -200,8 +253,8 @@ public:
     if ((isArray == std::string::npos) || (lessThan == std::string::npos) ||
         (greaterThan == std::string::npos) || (x == std::string::npos))
       throw std::runtime_error("Array label missing keyword");
-    if (elementCount != static_cast<size_t>(std::stoi(
-                            label.substr(x + 2, greaterThan - x - 2))))
+    if (elementCount !=
+        parseSize(std::string_view(label).substr(x + 2, greaterThan - x - 2)))
       throw std::runtime_error("Array size mismatch in value and label.");
     arrayType = label.substr(lessThan + 1, x - lessThan - 2);
   }
@@ -337,7 +390,8 @@ private:
   enum struct ContainerStorage { FLAT, PREALLOCATED };
 
   /// Process different types of records
-  void handleHeader(const std::vector<std::string> &);
+  void handleHeader(const std::vector<std::string> &,
+                    std::optional<RecordSchemaType> &);
   void handleMetadata(const std::vector<std::string> &);
   /// Central dispatcher that handles different output types including scalar
   /// values, arrays, and tuples.

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -9,12 +9,12 @@
 #pragma once
 
 #include "cudaq/utils/cudaq_utils.h"
+#include <cctype>
 #include <charconv>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <functional>
 #include <limits>
 #include <optional>
 #include <stdexcept>
@@ -102,29 +102,34 @@ template <typename T>
 class FloatConverter : public TypeConverterBase<T> {
 public:
   T convert(const std::string &value) const override {
-    if (value.empty())
+    // The `<charconv>` float overloads are annotated as introduced in
+    // macOS 26.0 and are unavailable at CUDA-Q's macOS 13.0 deployment
+    // target. Use `std::stof`/`std::stod` and enforce the same
+    // "full-token, no leading whitespace" grammar via an explicit
+    // length check and an `isspace` prefix guard. `stof`/`stod` accept
+    // `inf`/`infinity`/`nan` case-insensitively; those non-finite
+    // spellings are the runtime's own output (see the `ostringstream`
+    // emitter) and must round-trip.
+    if (value.empty() ||
+        std::isspace(static_cast<unsigned char>(value.front())))
       throw std::runtime_error("Invalid floating-point value");
 
-    std::string_view input(value);
-    bool negative = false;
-    if (input.front() == '+' || input.front() == '-') {
-      negative = input.front() == '-';
-      input.remove_prefix(1);
-      if (input.empty() || input.front() == '+' || input.front() == '-')
+    try {
+      std::size_t parsedLength = 0;
+      T parsed{};
+      if constexpr (std::is_same_v<T, float>)
+        parsed = std::stof(value, &parsedLength);
+      else
+        parsed = std::stod(value, &parsedLength);
+      if (parsedLength != value.size())
         throw std::runtime_error("Invalid floating-point value");
-    }
-
-    // `from_chars` accepts `inf`/`infinity`/`nan` case-insensitively.
-    // Non-finite values are allowed on purpose: the runtime records doubles via
-    // `ostringstream`, which emits lowercase "inf"/"nan". Do not add an
-    // `isfinite()` reject here or it will drop the runtime's own output.
-    T parsed = 0;
-    const auto [end, error] =
-        std::from_chars(input.data(), input.data() + input.size(), parsed,
-                        std::chars_format::general);
-    if (error != std::errc{} || end != input.data() + input.size())
+      return parsed;
+    } catch (const std::logic_error &) {
+      // `std::invalid_argument` (no conversion) and `std::out_of_range`
+      // (overflow/underflow) both derive from `std::logic_error`; the
+      // record grammar treats them identically.
       throw std::runtime_error("Invalid floating-point value");
-    return negative ? -parsed : parsed;
+    }
   }
 };
 

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -526,6 +526,7 @@ CUDAQ_TEST(ParserTester, checkStrictValueValidation) {
       "OUTPUT\tDOUBLE\t1junk\tf64\n",
       "OUTPUT\tDOUBLE\t+-1\tf64\n",
       "OUTPUT\tDOUBLE\t1e99999\tf64\n",
+      "OUTPUT\tDOUBLE\t 1\tf64\n",
       "OUTPUT\tARRAY\t1junk\tarray<i32 x 1>\n",
       "OUTPUT\tARRAY\t1\tarray<i32 x 1junk>\n",
       "OUTPUT\tARRAY\t" + sizeOverflow + "\tarray<i32 x 1>\n",

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -8,7 +8,10 @@
 
 #include "CUDAQTestUtils.h"
 #include "common/RecordLogParser.h"
+#include <array>
+#include <cmath>
 #include <cudaq.h>
+#include <limits>
 
 CUDAQ_TEST(ParserTester, checkSingleBoolean) {
   {
@@ -107,6 +110,36 @@ CUDAQ_TEST(ParserTester, checkDoubles) {
   free(buffer);
   buffer = nullptr;
   origBuffer = nullptr;
+}
+
+CUDAQ_TEST(ParserTester, checkFloatingPointValueParsing) {
+  const std::string log = "OUTPUT\tDOUBLE\t1e+3\tf64\n"
+                          "OUTPUT\tDOUBLE\t2.5e-2\tf64\n"
+                          "OUTPUT\tDOUBLE\t-3.5\tf64\n"
+                          "OUTPUT\tDOUBLE\tINF\tf64\n"
+                          "OUTPUT\tDOUBLE\t-INFINITY\tf64\n"
+                          "OUTPUT\tDOUBLE\t+NAN\tf64\n"
+                          "OUTPUT\tDOUBLE\tinf\tf64\n"
+                          "OUTPUT\tDOUBLE\t-InFiNiTy\tf64\n"
+                          "OUTPUT\tDOUBLE\tnan\tf64\n";
+  cudaq::RecordLogParser parser;
+  parser.parse(log);
+  ASSERT_EQ(parser.getBufferSize(), 9 * sizeof(double));
+  std::array<double, 9> values{};
+  std::memcpy(values.data(), parser.getBufferPtr(), sizeof(values));
+  EXPECT_DOUBLE_EQ(values[0], 1e3);
+  EXPECT_DOUBLE_EQ(values[1], 2.5e-2);
+  EXPECT_DOUBLE_EQ(values[2], -3.5);
+  EXPECT_TRUE(std::isinf(values[3]));
+  EXPECT_FALSE(std::signbit(values[3]));
+  EXPECT_TRUE(std::isinf(values[4]));
+  EXPECT_TRUE(std::signbit(values[4]));
+  EXPECT_TRUE(std::isnan(values[5]));
+  EXPECT_TRUE(std::isinf(values[6]));
+  EXPECT_FALSE(std::signbit(values[6]));
+  EXPECT_TRUE(std::isinf(values[7]));
+  EXPECT_TRUE(std::signbit(values[7]));
+  EXPECT_TRUE(std::isnan(values[8]));
 }
 
 CUDAQ_TEST(ParserTester, checkArrayOrdered) {
@@ -480,6 +513,66 @@ CUDAQ_TEST(ParserTester, checkNumericValidation) {
     cudaq::RecordLogParser parser;
     EXPECT_ANY_THROW(parser.parse(log));
   }
+}
+
+CUDAQ_TEST(ParserTester, checkStrictValueValidation) {
+  const std::string sizeOverflow =
+      std::to_string(std::numeric_limits<std::size_t>::max()) + "0";
+  const std::vector<std::string> invalidLogs = {
+      "OUTPUT\tINT\t1junk\ti32\n",
+      "OUTPUT\tINT\t128\ti8\n",
+      "OUTPUT\tINT\t-129\ti8\n",
+      "OUTPUT\tINT\t+-1\ti32\n",
+      "OUTPUT\tDOUBLE\t1junk\tf64\n",
+      "OUTPUT\tDOUBLE\t+-1\tf64\n",
+      "OUTPUT\tDOUBLE\t1e99999\tf64\n",
+      "OUTPUT\tARRAY\t1junk\tarray<i32 x 1>\n",
+      "OUTPUT\tARRAY\t1\tarray<i32 x 1junk>\n",
+      "OUTPUT\tARRAY\t" + sizeOverflow + "\tarray<i32 x 1>\n",
+      "START\nOUTPUT\tINT\t7\ti32\nEND\t1junk\n",
+      "METADATA\trequired_num_results\t1junk\n"
+      "OUTPUT\tRESULT\t0\n"};
+  for (const auto &log : invalidLogs) {
+    cudaq::RecordLogParser parser;
+    EXPECT_ANY_THROW(parser.parse(log));
+  }
+
+  cudaq::RecordLogParser zeroStatusParser;
+  EXPECT_NO_THROW(
+      zeroStatusParser.parse("START\nOUTPUT\tINT\t7\ti32\nEND\t00\n"));
+  ASSERT_EQ(zeroStatusParser.getBufferSize(), sizeof(std::int32_t));
+  std::int32_t value = 0;
+  std::memcpy(&value, zeroStatusParser.getBufferPtr(), sizeof(value));
+  EXPECT_EQ(value, 7);
+}
+
+CUDAQ_TEST(ParserTester, checkRecordGrammarValidation) {
+  const std::vector<std::string> invalidLogs = {
+      "HEADER\tschema_id\tlabeled\textra\n",
+      "START\textra\nEND\t0\n",
+      "END\t0\n",
+      "START\nEND\t0\textra\n",
+      "START\nSTART\nEND\t0\n",
+      "START\nOUTPUT\tINT\t1\ti32\n",
+      "OUTPUT\tINT\t1\ti32\nSTART\nEND\t0\n",
+      "START\nOUTPUT\tINT\t1\ti32\nEND\t0\nOUTPUT\tINT\t1\ti32\n",
+      "HEADER\tschema_id\tlabeled\nOUTPUT\tINT\t1\n",
+      "HEADER\tschema_id\tordered\nOUTPUT\tINT\t1\ti32\n",
+      "OUTPUT\tINT\t1\ti32\textra\n",
+      "HEADER\tschema_id\tlabeled\nSTART\nOUTPUT\tINT\t1\nEND\t1\n",
+      "HEADER\tschema_id\tlabeled\nHEADER\tschema_id\tordered\n",
+      "OUTPUT\tINT\t1\ti32\nHEADER\tschema_id\tordered\n"};
+  for (const auto &log : invalidLogs) {
+    cudaq::RecordLogParser parser;
+    EXPECT_ANY_THROW(parser.parse(log));
+  }
+
+  cudaq::RecordLogParser orderedParser;
+  EXPECT_NO_THROW(
+      orderedParser.parse("HEADER\tschema_id\tordered\nOUTPUT\tINT\t1\n"));
+  cudaq::RecordLogParser labeledParser;
+  EXPECT_NO_THROW(
+      labeledParser.parse("HEADER\tschema_id\tlabeled\nOUTPUT\tINT\t1\ti32\n"));
 }
 
 CUDAQ_TEST(ParserTester, checkContainerValidation) {


### PR DESCRIPTION
### Summary

* Follow-up to https://github.com/NVIDIA/cuda-quantum/pull/4799

- Hardens `RecordLogParser` against malformed output records.
-- Validates framing, schema-specific arity, and complete numeric tokens.
-- Accepts signed exponent, negative, and case-insensitive non-finite floating-point values.
-- Adds parser and end-to-end regression coverage.
