### PR TITLE
docs: clarify ConnectX-7 dual-port QSFP recommendation for NVQLink demo

### DIFF
--- a/realtime/docs/nvqlink_latency_demo.md
+++ b/realtime/docs/nvqlink_latency_demo.md
@@ -19,7 +19,11 @@ Connecting an `APB` `ILA` for Debug" section below.
 
 > **Note:** For this experiment, we recommend using NVIDIA ConnectX-7 NIC
 with dual `QSFP` ports. Prior ConnectX generations may not have all
-the capabilities required.
+the capabilities required. The dual `QSFP112` port model is recommended
+for physical compatibility with the RFSoC board's `QSFP` interface.
+A single-port `OSFP` 400G ConnectX-7 is not a drop-in replacement for
+this setup, as connecting `OSFP` to `QSFP` requires additional
+interconnect hardware due to `PAM4`/`NRZ` signal incompatibilities.
 
 ## Steps to do the experiment
 


### PR DESCRIPTION
Fixes #4828

## Summary
The ConnectX-7 dual-port recommendation lacked explanation, causing 
confusion for users purchasing hardware. Based on maintainer clarification 
in the issue, added a note explaining that the dual QSFP112 port model is 
required for physical compatibility with the RFSoC board's QSFP interface, 
and that a single-port OSFP 400G ConnectX-7 is not a drop-in replacement 
due to PAM4/NRZ signal incompatibilities.

## Changes
- `realtime/docs/nvqlink_latency_demo.md`: Expanded the ConnectX-7 
  recommendation note with compatibility context