### PR TITLE
fix(contrib): resolve remaining encoding follow-ups from #4791

### DIFF
--- a/python/cudaq/contrib/encoding.py
+++ b/python/cudaq/contrib/encoding.py
@@ -83,13 +83,13 @@ def amplitude_encode(
        :math:`i < d` and :math:`x'_i = \texttt{pad}` for :math:`d \le i < N`.
 
     2. **Normalize** with the Euclidean (L2) norm (must be non-zero).
-       Coefficients are :math:`α_i = x'_i / \|\mathbf{x}'\|_2`.
+       Coefficients are :math:`\alpha_i = x'_i / \|\mathbf{x}'\|_2`.
 
     3. **Form the state** in the :math:`n`-qubit computational basis:
-       :math:`|\psi⟩ = \sum_{i=0}^{N-1} α_i |i⟩`, where
-       :math:`|i⟩` is the basis ``ket`` with index :math:`i` in binary.
+       :math:`|\psi\rangle = \sum_{i=0}^{N-1} \alpha_i |i\rangle`, where
+       :math:`|i\rangle` is the basis ``ket`` with index :math:`i` in binary.
 
-    The returned :class:`State` stores :math:`α_i` in little-endian index
+    The returned :class:`State` stores :math:`\alpha_i` in little-endian index
     order (consistent with ``cudaq.State`` / ``qvector(state)``). Real inputs are
     promoted to complex amplitudes with zero imaginary part before padding.
 
@@ -194,30 +194,30 @@ def angular_encode(kernel_or_q, q_or_angles, angles=None, *, rotation='Y'):
     Encode classical features as single-qubit rotation gates inside a kernel.
 
     Angular (rotation) encoding maps a classical angle vector
-    (:math:`θ_0`, :math:`\ldots`, :math:`θ_{n-1}`) to an
+    (:math:`\theta_0`, :math:`\ldots`, :math:`\theta_{n-1}`) to an
     :math:`n`-qubit product state by applying one parameterized rotation per
-    qubit. Starting from the :math:`n`-fold product of :math:`|0⟩`, the
+    qubit. Starting from the :math:`n`-fold product of :math:`|0\rangle`, the
     encoded state is
 
     .. math::
 
-       |ψ⟩
-       = \prod_{i=0}^{n-1} R_{\mathrm{axis}}(θ_i)\,|0⟩_i,
+       |\psi\rangle
+       = \prod_{i=0}^{n-1} R_{\mathrm{axis}}(\theta_i)\,|0\rangle_i,
 
-    where the product applies :math:`R_{\mathrm{axis}}(θ_i)` on qubit
+    where the product applies :math:`R_{\mathrm{axis}}(\theta_i)` on qubit
     :math:`i` and leaves other qubits unchanged. CUDA-Q uses the standard Pauli
     rotation convention
 
     .. math::
 
-       R_P(θ) = e^{-i θ P / 2}, \quad P \in \{X, Y, Z\},
+       R_P(\theta) = e^{-i \theta P / 2}, \quad P \in \{X, Y, Z\},
 
     implemented as ``rx(θ)``, ``ry(θ)``, or ``rz(θ)`` when
     ``rotation`` is ``'X'``, ``'Y'``, or ``'Z'`` respectively (default ``'Y'``).
 
     For example, ``rotation='Y'`` on qubit :math:`i` gives
-    :math:`R_Y(θ_i)|0⟩ = \cos(θ_i/2)|0⟩ +
-    \sin(θ_i/2)|1⟩`.
+    :math:`R_Y(\theta_i)|0\rangle = \cos(\theta_i/2)|0\rangle +
+    \sin(\theta_i/2)|1\rangle`.
 
     The number of angles must match the number of qubits in ``q`` when the
     register size is known at compile time.

--- a/runtime/cudaq/algorithms/encoding.cpp
+++ b/runtime/cudaq/algorithms/encoding.cpp
@@ -9,6 +9,7 @@
 #include "encoding.h"
 #include "cudaq/simulators.h"
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 
 namespace cudaq::contrib {
@@ -19,6 +20,12 @@ std::size_t nextPowerOfTwo(std::size_t n) {
     throw std::invalid_argument("amplitude_encode: input must be non-empty.");
   if ((n & (n - 1)) == 0)
     return n;
+  constexpr std::size_t maxPowerOfTwo =
+      std::size_t{1} << (std::numeric_limits<std::size_t>::digits - 1);
+  if (n > maxPowerOfTwo)
+    throw std::invalid_argument(
+        "amplitude_encode: input size exceeds the largest representable "
+        "power of two.");
   std::size_t p = 1;
   while (p < n)
     p <<= 1;

--- a/runtime/cudaq/algorithms/encoding.h
+++ b/runtime/cudaq/algorithms/encoding.h
@@ -31,13 +31,13 @@ namespace contrib {
 ///    \f$i < d\f$ and \f$x'_i = \texttt{pad}\f$ for \f$d \le i < N\f$.
 ///
 /// 2. **Normalize** with the Euclidean (L2) norm (must be non-zero).
-///    Coefficients are \f$α_i = x'_i / \|\mathbf{x}'\|_2\f$.
+///    Coefficients are \f$\alpha_i = x'_i / \|\mathbf{x}'\|_2\f$.
 ///
 /// 3. **Form the state** in the \f$n\f$-qubit computational basis:
-///    \f$|\psi\rangle = \sum_{i=0}^{N-1} α_i |i\rangle\f$, where
+///    \f$|\psi\rangle = \sum_{i=0}^{N-1} \alpha_i |i\rangle\f$, where
 ///    \f$|i\rangle\f$ is the basis ``ket`` with index \f$i\f$ in binary.
 ///
-/// The returned ``cudaq::state`` stores \f$α_i\f$ in little-endian index
+/// The returned ``cudaq::state`` stores \f$\alpha_i\f$ in little-endian index
 /// order (consistent with ``qvector(state)``). Real inputs are promoted to
 /// complex amplitudes with zero imaginary part before padding.
 ///

--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -11,6 +11,7 @@
 #include "kernel_builder.h"
 #include <complex>
 #include <functional>
+#include <optional>
 #include <span>
 #include <stdexcept>
 


### PR DESCRIPTION
## Summary

Resolves the remaining items of #4791. Item 1 (2-D list/tuple rejection) is in PR #4826, and item 4 (state tensor validation) was resolved by PR #4798, so this PR covers items 2, 3, and 5. Together with #4826 this closes out the issue. Item 6 (builder-mode `angular_encode` rejecting NumPy angle arrays) is left open as possibly intentional.

## Changes

**Item 2, C++ portability**: `runtime/cudaq/builder/kernels.h` declares `validateAngularEncodeSizes(std::optional<std::size_t>, ...)` but did not include `<optional>` directly. Added the direct include.

**Item 3, docs**: replaced literal Unicode math glyphs with LaTeX commands inside Doxygen (`encoding.h`) and Sphinx (`encoding.py`) math expressions, so the same formulas no longer mix glyphs and commands and LaTeX/PDF builds render consistently. Glyphs inside inline code literals (for example ``rx(θ)``) are left unchanged since they are not math expressions; happy to normalize those too if preferred.

**Item 5, C++ robustness**: `nextPowerOfTwo` doubled `p` until `p >= n`. For `n > 2^63` the shift overflows `p` to zero and the loop never terminates. Inputs larger than the largest representable power of two now raise `std::invalid_argument` with a clear message. Not reachable from practical vector sizes, but the function is now total.

## Validation

- `nextPowerOfTwo` exercised standalone with `clang++ -std=c++20 -Wall -Werror`: powers of two returned unchanged, `2^62 + 1 -> 2^63`, `2^63` accepted, `2^63 + 1` and `SIZE_MAX` raise (previously hung), `0` raises.
- `python3 -m py_compile python/cudaq/contrib/encoding.py` passes.
- `pre-commit run clang-format` (v22) passes on all changed C++ files.
- `grep -P '[^\x00-\x7F]'` confirms no remaining glyphs inside math expressions in the touched files.

Resolves #4791 together with #4826.