### PR TITLE
[Realtime] Fix compiler error in `host_dispatcher.cu`

### DIFF
--- a/realtime/lib/daemon/dispatcher/host_dispatcher.cu
+++ b/realtime/lib/daemon/dispatcher/host_dispatcher.cu
@@ -18,9 +18,6 @@
 using atomic_int_sys = cuda::std::atomic<int>;
 using atomic_uint64_sys = cuda::std::atomic<uint64_t>;
 
-static inline atomic_int_sys *as_atomic_int(void *p) {
-  return static_cast<atomic_int_sys *>(p);
-}
 static inline atomic_int_sys *as_atomic_int(volatile int *p) {
   // `const_cast` drops the flag's `volatile` qualifier (`reinterpret_cast`
   // can't cast away cv-qualifiers) so it can be written as a plain atomic.


### PR DESCRIPTION
Related to: https://github.com/NVIDIA/cuda-quantum/pull/4770

This `void*` overload is no longer used, which may cause error: `host_dispatcher.cu(21): error #177-D: function as_atomic_int(void *) was declared but never referenced`