### PR TITLE
Support individual-qubit operand in `exp_pauli`

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -3299,9 +3299,9 @@ class PyASTBridge(ast.NodeVisitor):
             if node.func.id == 'exp_pauli':
                 if len(node.args) == 3:
                     # Both supported forms can have three arguments:
-                    #   exp_pauli(theta, target, pauli_word)
-                    #   exp_pauli(theta, pauli_word, qubit)
-                    # Distinguish them by the second operand's type.
+                    #   `exp_pauli(theta, target, pauli_word)`
+                    #   `exp_pauli(theta, pauli_word, qubit)`
+                    # Distinguish them by the second `operand`'s type.
                     theta, second, third = self.__groupValues(
                         node.args, [1, 1, 1])
                     if self.isQuantumType(second.type):
@@ -3314,7 +3314,7 @@ class PyASTBridge(ast.NodeVisitor):
                                                 targets).result
                 else:
                     # C++-compatible variadic form:
-                    #   exp_pauli(theta, pauli_word, qubit, ...)
+                    #   `exp_pauli(theta, pauli_word, qubit, ...)`
                     theta, pauliWord, targets = self.__groupValues(
                         node.args, [1, 1, (1, -1)])
                     checkControlAndTargetTypes([], targets)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -3297,11 +3297,28 @@ class PyASTBridge(ast.NodeVisitor):
                 return
 
             if node.func.id == 'exp_pauli':
-                # Note: C++ also has a constructor that takes an `f64`,
-                # `string`, any any number of qubits. We don't support this
-                # here.
-                theta, target, pauliWord = self.__groupValues(
-                    node.args, [1, 1, 1])
+                if len(node.args) == 3:
+                    # Both supported forms can have three arguments:
+                    #   exp_pauli(theta, target, pauli_word)
+                    #   exp_pauli(theta, pauli_word, qubit)
+                    # Distinguish them by the second operand's type.
+                    theta, second, third = self.__groupValues(
+                        node.args, [1, 1, 1])
+                    if self.isQuantumType(second.type):
+                        target, pauliWord = second, third
+                    else:
+                        pauliWord = second
+                        targets = [third]
+                        checkControlAndTargetTypes([], targets)
+                        target = quake.ConcatOp(self.getVeqType(),
+                                                targets).result
+                else:
+                    # C++-compatible variadic form:
+                    #   exp_pauli(theta, pauli_word, qubit, ...)
+                    theta, pauliWord, targets = self.__groupValues(
+                        node.args, [1, 1, (1, -1)])
+                    checkControlAndTargetTypes([], targets)
+                    target = quake.ConcatOp(self.getVeqType(), targets).result
                 theta = self.changeOperandToType(self.getFloatType(), theta)
                 processQuantumOperation("ExpPauli", [], [target], [], [theta],
                                         broadcast=False,

--- a/python/tests/kernel/test_kernel_exp_pauli.py
+++ b/python/tests/kernel/test_kernel_exp_pauli.py
@@ -7,6 +7,8 @@
 # ============================================================================ #
 
 import math
+import subprocess
+import sys
 
 import cudaq
 import pytest
@@ -110,3 +112,48 @@ def test_exp_pauli_variadic_targets_must_be_qubits():
     with pytest.raises(RuntimeError,
                        match="invalid argument type for target operand"):
         test.compile()
+
+
+def _run_exp_pauli_runtime_error_case(case):
+
+    if case == "word_length":
+
+        @cudaq.kernel
+        def test():
+            q = cudaq.qvector(1)
+            exp_pauli(1.0, "XYZ", q[0])
+    elif case == "duplicate_targets":
+
+        @cudaq.kernel
+        def test():
+            q = cudaq.qvector(1)
+            exp_pauli(1.0, "XX", q[0], q[0])
+    else:
+        raise ValueError(f"unknown runtime error case: {case}")
+
+    with pytest.raises(RuntimeError):
+        cudaq.sample(test)
+
+
+def _assert_runtime_error_in_subprocess(case):
+    result = subprocess.run([sys.executable, __file__, case],
+                            capture_output=True,
+                            text=True,
+                            timeout=120)
+    assert result.returncode == 0, (
+        f"runtime error case {case} failed in subprocess\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+
+def test_exp_pauli_word_length_must_match_individual_targets():
+    # Runtime exceptions can leave a simulator unusable, so isolate the check.
+    _assert_runtime_error_in_subprocess("word_length")
+
+
+def test_exp_pauli_individual_targets_must_be_unique():
+    # Runtime exceptions can leave a simulator unusable, so isolate the check.
+    _assert_runtime_error_in_subprocess("duplicate_targets")
+
+
+if __name__ == "__main__":
+    _run_exp_pauli_runtime_error_case(sys.argv[1])

--- a/python/tests/kernel/test_kernel_exp_pauli.py
+++ b/python/tests/kernel/test_kernel_exp_pauli.py
@@ -6,7 +6,10 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+import math
+
 import cudaq
+import pytest
 
 
 def test_exp_pauli():
@@ -35,3 +38,75 @@ def test_exp_pauli_param():
     assert '11' in counts
     assert not '01' in counts
     assert not '10' in counts
+
+
+def test_exp_pauli_individual_qubits():
+
+    @cudaq.kernel
+    def test(theta: float):
+        q = cudaq.qvector(3)
+        exp_pauli(theta, "YX", q[0], q[2])
+
+    counts = cudaq.sample(test, math.pi / 2.0)
+    assert len(counts) == 1
+    assert "101" in counts
+
+
+def test_exp_pauli_single_individual_qubit():
+
+    @cudaq.kernel
+    def test(theta: float):
+        q = cudaq.qvector(3)
+        exp_pauli(theta, "X", q[1])
+
+    counts = cudaq.sample(test, math.pi / 2.0)
+    assert len(counts) == 1
+    assert "010" in counts
+
+
+def test_exp_pauli_three_individual_qubits():
+
+    @cudaq.kernel
+    def test(theta: float):
+        q = cudaq.qvector(3)
+        exp_pauli(theta, "XXX", q[2], q[0], q[1])
+
+    counts = cudaq.sample(test, math.pi / 2.0)
+    assert len(counts) == 1
+    assert "111" in counts
+
+
+def test_exp_pauli_individual_qubit_ordering():
+
+    @cudaq.kernel
+    def test(theta: float):
+        q = cudaq.qvector(2)
+        # Ordering-sensitive: X flips q[0], while Z leaves q[1] in |0>.
+        exp_pauli(theta, "XZ", q[0], q[1])
+
+    counts = cudaq.sample(test, math.pi / 2.0)
+    assert len(counts) == 1
+    assert "10" in counts
+
+
+def test_exp_pauli_single_individual_target_must_be_qubit():
+
+    @cudaq.kernel
+    def test():
+        exp_pauli(1.0, "X", 0)
+
+    with pytest.raises(RuntimeError,
+                       match="invalid argument type for target operand"):
+        test.compile()
+
+
+def test_exp_pauli_variadic_targets_must_be_qubits():
+
+    @cudaq.kernel
+    def test():
+        q = cudaq.qvector(1)
+        exp_pauli(1.0, "XX", q[0], 0)
+
+    with pytest.raises(RuntimeError,
+                       match="invalid argument type for target operand"):
+        test.compile()


### PR DESCRIPTION
C++ kernels can apply `exp_pauli` to explicitly listed qubits (`exp_pauli(theta, "YX", qubits[a], qubits[b])`), while Python kernels cannot.

This PR addresses that and adds some test cases.

Resolved: https://github.com/NVIDIA/cuda-quantum/issues/4849