### PR TITLE
Fix mixed int/float arithmetic promotion

### DIFF
--- a/python/cudaq/kernel/quake_value.py
+++ b/python/cudaq/kernel/quake_value.py
@@ -99,18 +99,23 @@ class QuakeValue(object):
             otherVal = self.__intToVal(other)
             mulOpStr = '{}IOp'.format(opStr)
             # Could be that this value is a float, in which
-            # case we should cast the other to an int
+            # case we should cast the other to a float.
             if F64Type.isinstance(thisVal.type):
                 otherVal = self.__intToFloat(otherVal)
                 mulOpStr = '{}FOp'.format(opStr)
         else:
             # Here we know that the other value is a QuakeValue
             otherVal = other.mlirValue
-            mulOpStr = '{}FOp'.format(opStr) if F64Type.isinstance(
-                thisVal.type) else '{}IOp'.format(opStr)
-            if mulOpStr == '{}FOp'.format(opStr) and IntegerType.isinstance(
-                    otherVal.type):
-                otherVal = arith.SIToFPOp(self.floatType, otherVal).result
+            thisIsFloat = F64Type.isinstance(thisVal.type)
+            otherIsFloat = F64Type.isinstance(otherVal.type)
+            if thisIsFloat or otherIsFloat:
+                mulOpStr = '{}FOp'.format(opStr)
+                if IntegerType.isinstance(thisVal.type):
+                    thisVal = self.__intToFloat(thisVal)
+                if IntegerType.isinstance(otherVal.type):
+                    otherVal = self.__intToFloat(otherVal)
+            else:
+                mulOpStr = '{}IOp'.format(opStr)
 
         return thisVal, otherVal, mulOpStr
 

--- a/python/tests/builder/test_quake_value.py
+++ b/python/tests/builder/test_quake_value.py
@@ -64,6 +64,53 @@ def test_quake_value_operators(type_):
     assert test != value_1
 
 
+def test_mixed_quake_value_arithmetic_promotes_int_to_float():
+    kernel, int_value, float_value = cudaq.make_kernel(int, float)
+    qubit = kernel.qalloc()
+
+    # Checking the binary operators with mixed `QuakeValue` types in both
+    # operand orders.
+    test = int_value + float_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.rx(test, qubit)
+
+    test = float_value + int_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.rx(test, qubit)
+
+    test = int_value - float_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.ry(test, qubit)
+
+    test = float_value - int_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.ry(test, qubit)
+
+    test = int_value * float_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.rz(test, qubit)
+
+    test = float_value * int_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.rz(test, qubit)
+
+    test = int_value / float_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.r1(test, qubit)
+
+    test = float_value / int_value
+    assert type(test) == cudaq.QuakeValue
+    assert test != int_value and test != float_value
+    kernel.r1(test, qubit)
+
+
 def test_QuakeValueLifetimeAndPrint():
     """Tests Bug #64 for the lifetime of a QuakeValue"""
     circuit = cudaq.make_kernel()


### PR DESCRIPTION
## Summary
Fix mixed `int`/`float` arithmetic between Python `QuakeValue` operands.
Before this change, `int_value + float_value` selected an integer arithmetic op from the left operand type and emitted invalid MLIR:
```mlir
arith.addi(%arg0, %arg1) : (i64, f64) -> i64
```
The fix checks both operands and promotes integer operands to f64 whenever either side is floating-point.

## Reproducer
```python
import cudaq

kernel, i, x = cudaq.make_kernel(int, float)
q = kernel.qalloc(1)

expr = i + x
kernel.rx(expr, q[0])

print(str(kernel))
```

Before the fix this fails with:
```
error: 'arith.addi' op operand #1 must be signless-integer-like, but got 'f64'
RuntimeError: pass pipeline failed
```
After the fix it emits arith.sitofp followed by arith.addf.