### PR TITLE
[python] Fix translation of return-typed kernels

### DIFF
--- a/python/tests/kernel/test_kernel_translate.py
+++ b/python/tests/kernel/test_kernel_translate.py
@@ -57,6 +57,18 @@ def kernel_with_call():
     inner()
 
 
+@cudaq.kernel
+def kernel_returns_bool() -> bool:
+    return False
+
+
+@cudaq.kernel
+def kernel_measures_and_returns() -> bool:
+    q = cudaq.qubit()
+    x(q)
+    return mz(q)
+
+
 def test_translate_openqasm():
     asm = cudaq.translate(bell_pair, format="openqasm2")
     assert "qreg var0[2];" in asm
@@ -93,6 +105,11 @@ def test_translate_openqasm_synth():
 def test_translate_openqasm_call():
     asm = cudaq.translate(kernel_with_call, format="openqasm2")
     assert 'qreg var0[2];' in asm
+
+
+def test_translate_openqasm_return_typed_kernel():
+    asm = cudaq.translate(kernel_returns_bool, format="openqasm2")
+    assert "OPENQASM 2.0;" in asm
 
 
 def test_translate_qir():
@@ -150,3 +167,28 @@ def test_translate_qir_adaptive_args():
         synth = cudaq.synthesize(kernel_loop_params, 5)
         qir = cudaq.translate(synth, 5, format="qir-adaptive")
     assert 'Invalid number of argu' in repr(e)
+
+
+def test_translate_qir_return_typed_kernel():
+    qir = cudaq.translate(kernel_returns_bool, format="qir")
+    assert "define i1 @__nvqpp__mlirgen__" in qir
+    assert "ret i1 false" in qir
+
+
+@pytest.mark.parametrize("fmt,expected", [
+    ("qir", "define i1 @__nvqpp__mlirgen__"),
+    ("qir-base", '"qir_profiles"="base_profile"'),
+    ("qir-adaptive", '"qir_profiles"="adaptive_profile"'),
+])
+def test_translate_return_typed_kernel_qir_profiles(fmt, expected):
+    qir = cudaq.translate(kernel_measures_and_returns, format=fmt)
+    assert expected in qir
+
+
+def test_translate_qir_return_typed_kernel_with_emulated_target():
+    cudaq.set_target("ionq", emulate=True)
+    try:
+        qir = cudaq.translate(kernel_returns_bool, format="qir")
+        assert "ret i1 false" in qir
+    finally:
+        cudaq.reset_target()

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -46,11 +46,14 @@ std::string cudaq::detail::lower_to_qir_llvm(const std::string &name,
   auto target =
       getDefaultCompileTarget(other_policies{}, cudaq::getExecutionContext());
   target->fullySpecialize = true;
+  // Translation consumes only the compiled MLIR artifact.
+  target->emitJit = false;
   cudaq_internal::compiler::Compiler compiler(std::move(target));
 
   auto rawArgs = args.getArgs();
-  auto compiled = compiler.runPassPipeline(name, module.getAsOpaquePointer(),
-                                           {rawArgs}, true);
+  auto compiled =
+      compiler.runPassPipeline(name, module.getAsOpaquePointer(), {rawArgs},
+                               /*isEntryPoint=*/false);
   auto compiled_module =
       cudaq_internal::compiler::CompiledModuleHelper::getMlirModuleOp(
           *compiled.getMlir());
@@ -90,11 +93,14 @@ std::string cudaq::detail::lower_to_openqasm(const std::string &name,
   auto target =
       getDefaultCompileTarget(other_policies{}, cudaq::getExecutionContext());
   target->fullySpecialize = true;
+  // Translation consumes only the compiled MLIR artifact.
+  target->emitJit = false;
   cudaq_internal::compiler::Compiler compiler(std::move(target));
 
   auto rawArgs = args.getArgs();
-  auto compiled = compiler.runPassPipeline(name, module.getAsOpaquePointer(),
-                                           {rawArgs}, true);
+  auto compiled =
+      compiler.runPassPipeline(name, module.getAsOpaquePointer(), {rawArgs},
+                               /*isEntryPoint=*/false);
   auto compiled_module =
       cudaq_internal::compiler::CompiledModuleHelper::getMlirModuleOp(
           *compiled.getMlir());


### PR DESCRIPTION
### Summary

* Follow-up to PR https://github.com/NVIDIA/cuda-quantum/pull/4636
* Fixes #4856.
* Prevent `cudaq.translate` from requiring unused JIT artifacts for return-typed kernels, including with emulated targets. 

