### PR TITLE
[runtime] Preserve measurement handles across nested JIT calls

### DIFF
--- a/python/tests/interop/quantum_lib/quantum_lib.cpp
+++ b/python/tests/interop/quantum_lib/quantum_lib.cpp
@@ -94,3 +94,32 @@ cudaq::py_ret_test2(cudaq::qkernel<std::vector<float>(std::size_t)> &&qern) {
   rz(rots[2], qs[2]);
   mz(qs);
 }
+
+__qpu__ bool cudaq::measure_handle_lifetime_test(
+    cudaq::qkernel<void(cudaq::qvector<> &)> &&qern) {
+  cudaq::qvector retained(1), callbackQubits(1);
+  x(retained);
+  auto retainedResult = mz(retained[0]);
+
+  qern(callbackQubits);
+
+  // A nested callable shares the surrounding execution's result maps.
+  // Reading a handle created before that call must still produce |1>.
+  return retainedResult;
+}
+
+__qpu__ void cudaq::measure_handle_callback_test(
+    const cudaq::qkernel<std::vector<cudaq::measure_handle>(cudaq::qvector<> &)>
+        &qern) {
+  cudaq::qvector stable(1), random(1);
+  auto stableResult = qern(stable);
+
+  h(random);
+  auto randomResult = mz(random);
+
+  // The two random measurements cancel, leaving a detector on the stable
+  // measurement returned by the nested Python kernel.
+  std::vector<cudaq::measure_handle> support{stableResult[0], randomResult[0],
+                                             randomResult[0]};
+  cudaq::detector(support);
+}

--- a/python/tests/interop/quantum_lib/quantum_lib.h
+++ b/python/tests/interop/quantum_lib/quantum_lib.h
@@ -30,5 +30,10 @@ std::size_t
 callback_test(qkernel<std::size_t(cudaq::qvector<> &, std::size_t)> &&);
 void py_ret_test1(cudaq::qkernel<std::vector<float>()> &&qern);
 void py_ret_test2(cudaq::qkernel<std::vector<float>(std::size_t)> &&qern);
+bool measure_handle_lifetime_test(
+    cudaq::qkernel<void(cudaq::qvector<> &)> &&qern);
+void measure_handle_callback_test(
+    const cudaq::qkernel<std::vector<cudaq::measure_handle>(cudaq::qvector<> &)>
+        &qern);
 
 } // namespace cudaq

--- a/python/tests/interop/test_cpp_quantum_algorithm_module.cpp
+++ b/python/tests/interop/test_cpp_quantum_algorithm_module.cpp
@@ -8,6 +8,7 @@
 
 #include "quantum_lib/quantum_lib.h"
 #include "runtime/interop/PythonCppInterop.h"
+#include "cudaq/algorithms/dem.h"
 #include "cudaq/qis/qkernel.h"
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
@@ -87,6 +88,29 @@ NB_MODULE(cudaq_test_cpp_algo, m) {
         cudaq::python::launch_specialized_py_decorator<
             cudaq::qkernel<std::vector<float>(std::size_t)>>(
             qern, cudaq::py_ret_test2);
+      },
+      "");
+
+  m.def(
+      "run_measure_handle_lifetime",
+      [](nanobind::object qern) {
+        return cudaq::python::launch_specialized_py_decorator<
+            cudaq::qkernel<void(cudaq::qvector<> &)>>(
+            qern, cudaq::measure_handle_lifetime_test);
+      },
+      "");
+
+  m.def(
+      "run_measure_handle_callback",
+      [](nanobind::object qern) {
+        cudaq::python::CppPyKernelDecorator decorator(qern);
+        auto entryPoint = decorator.getDirectKernelCall<cudaq::qkernel<
+            std::vector<cudaq::measure_handle>(cudaq::qvector<> &)>>();
+        cudaq::M2DSparseMatrix m2d;
+        cudaq::M2OSparseMatrix m2o;
+        auto dem = cudaq::dem_from_kernel(cudaq::measure_handle_callback_test,
+                                          m2d, m2o, entryPoint);
+        return nanobind::make_tuple(dem, m2d.rows, m2d.num_measurements);
       },
       "");
 }

--- a/python/tests/interop/test_interop.py
+++ b/python/tests/interop/test_interop.py
@@ -357,6 +357,34 @@ def test_py_kernel_from_cpp_with_returns():
     cudaq_test_cpp_algo.run6(foo)
 
 
+def test_measure_handles_survive_python_callback():
+    pytest.importorskip('cudaq_test_cpp_algo')
+
+    import cudaq_test_cpp_algo
+
+    @cudaq.kernel
+    def measure(qs: cudaq.qview) -> list[cudaq.measure_handle]:
+        return mz(qs)
+
+    dem, m2d_rows, num_measurements = \
+        cudaq_test_cpp_algo.run_measure_handle_callback(measure)
+    assert dem.strip() == 'detector D0'
+    assert m2d_rows == [[0]]
+    assert num_measurements == 2
+
+
+def test_measure_handle_created_before_python_callback_survives():
+    pytest.importorskip('cudaq_test_cpp_algo')
+
+    import cudaq_test_cpp_algo
+
+    @cudaq.kernel
+    def callback(qs: cudaq.qview):
+        x(qs)
+
+    assert cudaq_test_cpp_algo.run_measure_handle_lifetime(callback)
+
+
 def test_cpp_kernel_from_builder_apply_call():
     """Test that a kernel builder can call a decorator that itself calls C++ kernels."""
     pytest.importorskip('cudaq_test_cpp_algo')

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -365,7 +365,8 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
           cudaq_internal::compiler::CompiledModuleHelper::createJitArtifacts(
               kernelName,
               cudaq_internal::compiler::createJITEngine(
-                  clonedModule, target->pipelineConfig.codegenTranslation),
+                  clonedModule, target->pipelineConfig.codegenTranslation,
+                  isEntryPoint),
               resultInfo, isFullySpecialized);
       // The first artifact is the kernel entry point; rename it to the
       // per-module name (relevant for the multi-module observe path where the

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -165,9 +165,8 @@ insertResultMapCleanupOperations(Operation *module,
   }
 }
 
-cudaq::JitEngine
-cudaq_internal::compiler::createJITEngine(ModuleOp &moduleOp,
-                                          llvm::StringRef convertTo) {
+cudaq::JitEngine cudaq_internal::compiler::createJITEngine(
+    ModuleOp &moduleOp, llvm::StringRef convertTo, bool isEntryPoint) {
   // The "fast" instruction selection compilation algorithm is actually very
   // slow for large quantum circuits. Disable that here.
   ScopedTraceWithContext(cudaq::TIMING_JIT, "createJITEngine");
@@ -179,7 +178,7 @@ cudaq_internal::compiler::createJITEngine(ModuleOp &moduleOp,
   opts.transformer = std::move(transformerTemp);
   opts.jitCodeGenOptLevel = llvm::CodeGenOptLevel::None;
   auto llvmModuleBuilderTemp =
-      [convertTo = convertTo.str()](
+      [convertTo = convertTo.str(), isEntryPoint](
           Operation *module,
           llvm::LLVMContext &llvmContext) -> std::unique_ptr<llvm::Module> {
     ScopedTraceWithContext(cudaq::TIMING_JIT,
@@ -240,7 +239,12 @@ cudaq_internal::compiler::createJITEngine(ModuleOp &moduleOp,
     const auto entryPointFuncs = collectEntryPointFunctions(module);
     if (containsWireSet)
       insertWireSetSetupAndCleanupOperations(module, entryPointFuncs);
-    insertResultMapCleanupOperations(module, entryPointFuncs);
+    // Direct-callable JIT modules also carry `cudaq-entrypoint` because the
+    // lowering pipeline needs a code-generation root. They can nevertheless
+    // execute inside another kernel, whose measurement handles must remain
+    // valid until the outer execution completes.
+    if (isEntryPoint)
+      insertResultMapCleanupOperations(module, entryPointFuncs);
 
     auto llvmModule = translateModuleToLLVMIR(module, llvmContext);
     if (!llvmModule)

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
@@ -30,7 +30,12 @@ class Type;
 namespace cudaq_internal::compiler {
 
 /// Lower ModuleOp to QIR/LLVM IR and create a JIT execution engine.
+///
+/// \param isEntryPoint True when the JIT module defines a complete execution
+/// boundary. A nested direct-callable module may still carry `cudaq-entrypoint`
+/// as a code-generation root; passing false prevents it from clearing runtime
+/// state owned by its caller.
 cudaq::JitEngine createJITEngine(mlir::ModuleOp &moduleOp,
-                                 llvm::StringRef convertTo);
+                                 llvm::StringRef convertTo, bool isEntryPoint);
 
 } // namespace cudaq_internal::compiler

--- a/runtime/nvqir/dem/DemScope.cpp
+++ b/runtime/nvqir/dem/DemScope.cpp
@@ -15,6 +15,8 @@
 #include <unordered_set>
 #include <utility>
 
+extern "C" void __quantum__rt__clear_result_maps();
+
 namespace nvqir::dem {
 
 namespace {
@@ -52,9 +54,21 @@ void ensurePluginLoaded(const std::string &plugin_name) {
 AnalysisScope make_scope(std::string plugin_name) {
   ensurePluginLoaded(plugin_name);
 
+  // Result handles belong to the complete DEM execution, not to any nested
+  // callable it invokes. Reset them at this analysis boundary so AOT and JIT
+  // entry points have the same lifecycle and exception paths cannot leak
+  // handles into a later analysis.
+  auto clearResultMaps = [](CircuitSimulator &) {
+    __quantum__rt__clear_result_maps();
+  };
   return AnalysisScope::from_plugin(
       "dem", std::move(plugin_name),
-      {.on_enter = [](CircuitSimulator &sim) { sim.endExecution(); }});
+      {.on_enter =
+           [clearResultMaps](CircuitSimulator &sim) {
+             clearResultMaps(sim);
+             sim.endExecution();
+           },
+       .on_exit = clearResultMaps});
 }
 
 } // namespace nvqir::dem


### PR DESCRIPTION
### Summary

* Fixes #4830 by making result-map cleanup follow the lifetime of the complete quantum execution instead of every JIT function carrying `cudaq-entrypoint`.

* CUDA-QX's memory-circuit implementation invokes Python-defined operation encodings as direct-callable JIT kernels from a precompiled C++ kernel. These Python kernels must share measurement-handle state with their caller.

### Root cause

`CppPyKernelDecorator` already distinguishes the two compilation modes:

- `getEntryPointFunction()` passes `isEntryPoint=true`.
- `getDirectKernelCall()` passes `isEntryPoint=false`.

The distinction was not carried into `createJITEngine`. Instead, result-map cleanup was injected into every function carrying `cudaq-entrypoint`.

Direct-callable kernels legitimately retain that attribute because it marks a code-generation root. It does not mean that invoking the function begins a new quantum execution.

Consequently, a nested Python callback cleared the thread-local measurement maps on entry and return. This invalidated:

1. handles created by the outer C++ kernel before the callback; and
2. handles produced by the callback and returned to the outer kernel.

Because NVQIR supports raw chronological measurement indices as a compatibility fallback, stale handles did not necessarily produce an invalid-handle error.
They could instead resolve to plausible but incorrect measurements. In #4830, this appeared as a non-deterministic-detector error from Stim.

### Changes

- Propagate `isEntryPoint` through `createJITEngine`.
- Inject `__quantum__rt__clear_result_maps` calls only when the JIT module represents a genuine top-level execution.
- Preserve `cudaq-entrypoint` on direct-callable modules because the lowering pipeline still requires it as a code-generation root.
- Clear result maps when entering and leaving a DEM analysis scope.

The DEM-scope cleanup is needed because the outer CUDA-QX memory circuit is a precompiled C++ kernel. It does not pass through JIT cleanup injection. The scope is the common lifetime boundary for AOT, JIT, and exception paths.
