### PR TITLE
Validate buffer size in legacy spin_op deserialization

### DIFF
--- a/python/tests/operator/test_spin_op.py
+++ b/python/tests/operator/test_spin_op.py
@@ -729,6 +729,16 @@ def test_legacy_foreach():
     assert xSupports == [0, 1]
 
 
+def test_legacy_deserialize_size_validation():
+    good = [1.0, 11.0, 0.0, 2.0, 22.0, 0.0, 2.0]
+    op = SpinOperator(good, 1)
+    assert _term_tuples(op) == {("X0", 11.0 + 0j), ("Z0", 22.0 + 0j)}
+
+    bad = [1.0, 11.0, 0.0, 2.0, 22.0, 0.0, 0.0, 2.0]
+    with pytest.raises(RuntimeError):
+        SpinOperator(bad, 1)
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)

--- a/runtime/cudaq/operators/sum_op.cpp
+++ b/runtime/cudaq/operators/sum_op.cpp
@@ -1928,8 +1928,12 @@ sum_op<HandlerTy>::sum_op(const std::vector<double> &input_vec,
   if (input_vec.size() == 0)
     throw std::runtime_error("input vector must not be empty");
   auto n_terms = (std::size_t)input_vec.back();
-  if (n_terms == 0 ||
-      nQubits != (((input_vec.size() - 1) - 2 * n_terms) / n_terms))
+  auto body = input_vec.size() - 1;
+  if (n_terms == 0 || body % n_terms != 0)
+    throw std::runtime_error("Invalid data representation for construction "
+                             "spin_op. Number of data elements is incorrect.");
+  auto per_term = body / n_terms;
+  if (per_term < 2 || per_term - 2 != nQubits)
     throw std::runtime_error("Invalid data representation for construction "
                              "spin_op. Number of data elements is incorrect.");
 


### PR DESCRIPTION
## Background
Hello, This PR is intended to attempt to resolve the nvbug ticket: [https://nvbugspro.nvidia.com/bug/6385153](https://nvbugspro.nvidia.com/bug/6385153). Not sure which team filed this bug, but it was arb to me, so I'm attempting to fix it, thanks for the review. 

## Summary
The deprecated legacy `spin_op` deserialization constructor validated the serialized buffer size with truncating integer division, which accepted buffers with extra trailing elements. The parse loop then read past the input with unchecked `operator[]`, causing an out-of-bounds heap read (CWE-125). Reachable via the public `SpinOperator(data, num_qubits)` and`SpinOperator(filename, legacy=True)` APIs.

Replaced the check with division/remainder validation, which also rejects the `size_t` overflow a multiplication-based check would allow for large `num_qubits`. Added a regression test covering the oversized buffer and the overflow input.
