### PR TITLE
Fix type inference of captured arguments

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -35,8 +35,8 @@ from .utils import (Color, boundaryDiagnostic, containsMeasureHandle,
                     globalRegisteredOperations, globalRegisteredTypes,
                     nvqppPrefix, mlirTypeFromAnnotation, mlirTypeFromPyType,
                     getMLIRContext, is_recovered_value_ok,
-                    recover_value_of_or_none, cudaq__unique_attr_name,
-                    mlirTryCreateStructType)
+                    recover_annotation_of_or_none, recover_value_of_or_none,
+                    cudaq__unique_attr_name, mlirTryCreateStructType)
 
 State = cudaq_runtime.State
 
@@ -5956,7 +5956,20 @@ class PyASTBridge(ast.NodeVisitor):
             assert not node.id in self.signature.captured_variable_names()
 
             # Append as a new argument
-            argTy = mlirTypeFromPyType(type(value), self.ctx, argInstance=value)
+            if isinstance(value, list) and len(value) == 0:
+                annotation = recover_annotation_of_or_none(
+                    node.id, self.defFrame)
+                if annotation is None:
+                    self.emitFatalError(
+                        f"Cannot infer the element type of the captured empty "
+                        f"list '{node.id}'. Annotate it at module scope (e.g. "
+                        f"`{node.id}: list[float] = []`) so the type can be "
+                        f"recovered.", node)
+                argTy = mlirTypeFromPyType(annotation, self.ctx)
+            else:
+                argTy = mlirTypeFromPyType(type(value),
+                                           self.ctx,
+                                           argInstance=value)
             mlirVal = cudaq_runtime.appendKernelArgument(
                 self.kernelFuncOp, argTy)
             self.signature.add_variable_capture(node.id, argTy)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5963,8 +5963,10 @@ class PyASTBridge(ast.NodeVisitor):
                     self.emitFatalError(
                         f"Cannot infer the element type of the captured empty "
                         f"list '{node.id}'. Annotate it at module scope (e.g. "
-                        f"`{node.id}: list[float] = []`) so the type can be "
-                        f"recovered.", node)
+                        f"`{node.id}: list[float] = []`) or use a typed numpy "
+                        f"array (e.g. `{node.id} = np.array([], "
+                        f"dtype=np.float64)`) so the type can be recovered.",
+                        node)
                 argTy = mlirTypeFromPyType(annotation, self.ctx)
             else:
                 argTy = mlirTypeFromPyType(type(value),

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -670,7 +670,10 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
 
         if len(argInstance) == 0:
             if argTypeToCompareTo == None:
-                emitFatalError('Cannot infer runtime argument type')
+                # Setting list[int] as a default type for element when the list
+                # is empty. Need to make sure that the list is non-empty for
+                # floats, pauli_words so the type can be inferred.
+                return cc.StdvecType.get(mlirTypeFromPyType(int, ctx), ctx)
 
             eleTy = cc.StdvecType.getElementType(argTypeToCompareTo)
             return cc.StdvecType.get(eleTy, ctx)
@@ -681,8 +684,12 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
                     type(argInstance[0]),
                     ctx,
                     argInstance=argInstance[0],
-                    argTypeToCompareTo=cc.StdvecType.getElementType(
-                        argTypeToCompareTo)), ctx)
+                    argTypeToCompareTo=(
+                        cc.StdvecType.getElementType(argTypeToCompareTo)
+                        if argTypeToCompareTo is not None else None)), ctx)
+
+        if isinstance(argInstance[0], str):
+            return cc.StdvecType.get(cc.CharspanType.get(ctx), ctx)
 
         return cc.StdvecType.get(mlirTypeFromPyType(type(argInstance[0]), ctx),
                                  ctx)

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -217,6 +217,40 @@ def recover_value_of_or_none(name, frame=None):
         del frame
 
 
+def recover_annotation_of_or_none(name, frame=None):
+    """
+    Recover the type annotation of the symbol `name` from the enclosing
+    context, mirroring the frame walk of `recover_value_of_or_none`. Only
+    annotations stored in a namespace's `__annotations__` (e.g. a module-level
+    `name: list[float] = []`) are recoverable.
+    """
+    if '.' in name:
+        return None
+
+    try:
+        if frame is None:
+            frame = inspect.currentframe()
+            while frame is not None and get_module_name(frame).startswith(
+                    "cudaq.kernel"):
+                frame = frame.f_back
+
+        while frame is not None:
+            for namespace in (frame.f_locals, frame.f_globals):
+                if name in namespace:
+                    annotation = namespace.get('__annotations__', {}).get(name)
+                    if isinstance(annotation, str):
+                        try:
+                            annotation = eval(annotation, frame.f_globals,
+                                              frame.f_locals)
+                        except Exception:
+                            return None
+                    return annotation
+            frame = frame.f_back
+        return None
+    finally:
+        del frame
+
+
 def is_recovered_value_ok(result):
     try:
         if result != None:
@@ -670,10 +704,7 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
 
         if len(argInstance) == 0:
             if argTypeToCompareTo == None:
-                # Setting list[int] as a default type for element when the list
-                # is empty. Need to make sure that the list is non-empty for
-                # floats, pauli_words so the type can be inferred.
-                return cc.StdvecType.get(mlirTypeFromPyType(int, ctx), ctx)
+                emitFatalError('Cannot infer runtime argument type')
 
             eleTy = cc.StdvecType.getElementType(argTypeToCompareTo)
             return cc.StdvecType.get(eleTy, ctx)

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -252,14 +252,7 @@ def recover_annotation_of_or_none(name, frame=None):
 
 
 def is_recovered_value_ok(result):
-    try:
-        if result != None:
-            return True
-    except ValueError:
-        # `nd.array` values raise `ValueError` with the above `if result` but
-        # are otherwise legit here.
-        return True
-    return False
+    return result is not None
 
 
 def recover_value_of(name, frame=None):
@@ -703,6 +696,12 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
             'argTypeToCompareTo'] if 'argTypeToCompareTo' in kwargs else None
 
         if len(argInstance) == 0:
+            if isinstance(argInstance, np.ndarray):
+                eleTy = mlirTypeFromPyType(argInstance.dtype.type, ctx)
+                for _ in range(argInstance.ndim - 1):
+                    eleTy = cc.StdvecType.get(eleTy, ctx)
+                return cc.StdvecType.get(eleTy, ctx)
+
             if argTypeToCompareTo == None:
                 emitFatalError('Cannot infer runtime argument type')
 

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -221,7 +221,7 @@ def recover_annotation_of_or_none(name, frame=None):
     """
     Recover the type annotation of the symbol `name` from the enclosing
     context, mirroring the frame walk of `recover_value_of_or_none`. Only
-    annotations stored in a namespace's `__annotations__` (e.g. a module-level
+    annotations stored in a `namespace's` `__annotations__` (e.g. a module-level
     `name: list[float] = []`) are recoverable.
     """
     if '.' in name:

--- a/python/cudaq/runtime/utils.py
+++ b/python/cudaq/runtime/utils.py
@@ -97,11 +97,7 @@ def __isBroadcast(kernel, *args):
                     )
 
         firstArg = args[0]
-        firstArgTypeIsFlatStdvec = False  # whether `argTypes[0]` is a non-nested Vec
-        if cc.StdvecType.isinstance(argTypes[0]):
-            eleTy = cc.StdvecType.getElementType(argTypes[0])
-            if not cc.StdvecType.isinstance(eleTy):
-                firstArgTypeIsFlatStdvec = True
+        firstArgTypeIsFlatStdvec = cc.StdvecType.isinstance(argTypes[0])
         if (isinstance(firstArg, list) or
                 isinstance(firstArg, List)) and not firstArgTypeIsFlatStdvec:
             return True

--- a/python/tests/kernel/test_captured_globals.py
+++ b/python/tests/kernel/test_captured_globals.py
@@ -10,6 +10,7 @@
 # A module-level Python scalar used as a rotation parameter must be lifted into
 # the kernel signature as an f64 value, not as `!cc.ptr<f64>`.
 
+import numpy as np
 import pytest
 
 import cudaq
@@ -255,3 +256,45 @@ def test_nested_list_arg_sample_equals_get_state():
     cudaq.get_state(kernel, nw, nc)
     counts = cudaq.sample(kernel, nw, nc)
     assert len(counts) >= 1
+
+
+_CAPTURED_EMPTY_NDARRAY = np.array([], dtype=np.float64)
+_CAPTURED_EMPTY_NDARRAY_INT = np.array([], dtype=np.int64)
+_CAPTURED_NDARRAY = np.array([0.5, -0.5])
+
+
+def test_captured_empty_ndarray():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(1)
+        for i in range(len(_CAPTURED_EMPTY_NDARRAY)):
+            rx(_CAPTURED_EMPTY_NDARRAY[i], q[0])
+
+    counts = cudaq.sample(kernel)
+    assert '0' in counts
+
+
+def test_captured_empty_ndarray_int():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(2)
+        for i in range(len(_CAPTURED_EMPTY_NDARRAY_INT)):
+            x(q[_CAPTURED_EMPTY_NDARRAY_INT[i]])
+        x(q[1])
+
+    counts = cudaq.sample(kernel)
+    assert '01' in counts
+
+
+def test_captured_nonempty_ndarray():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(1)
+        for i in range(len(_CAPTURED_NDARRAY)):
+            ry(_CAPTURED_NDARRAY[i], q[0])
+
+    counts = cudaq.sample(kernel)
+    assert '0' in counts

--- a/python/tests/kernel/test_captured_globals.py
+++ b/python/tests/kernel/test_captured_globals.py
@@ -168,10 +168,11 @@ def test_multiple_captured_globals_in_one_kernel():
     assert len(counts) >= 1
 
 
-_CAPTURED_EMPTY = []
+_CAPTURED_EMPTY: list[int] = []
+_CAPTURED_EMPTY_NO_ANNOTATION = []
 
 
-def test_captured_empty_list():
+def test_captured_empty_list_with_annotation():
 
     @cudaq.kernel
     def kernel():
@@ -181,6 +182,19 @@ def test_captured_empty_list():
 
     counts = cudaq.sample(kernel)
     assert '0' in counts
+
+
+def test_captured_empty_list_without_annotation():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(1)
+        if len(_CAPTURED_EMPTY_NO_ANNOTATION) > 0:
+            x(q[0])
+
+    with pytest.raises(RuntimeError) as e:
+        cudaq.sample(kernel)
+    assert '_CAPTURED_EMPTY_NO_ANNOTATION' in repr(e)
 
 
 _CAPTURED_PAULI_STRINGS = ['XI', 'ZZ']

--- a/python/tests/kernel/test_captured_globals.py
+++ b/python/tests/kernel/test_captured_globals.py
@@ -166,3 +166,78 @@ def test_multiple_captured_globals_in_one_kernel():
 
     counts = cudaq.sample(kernel)
     assert len(counts) >= 1
+
+
+_CAPTURED_EMPTY = []
+
+
+def test_captured_empty_list():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(1)
+        if len(_CAPTURED_EMPTY) > 0:
+            x(q[0])
+
+    counts = cudaq.sample(kernel)
+    assert '0' in counts
+
+
+_CAPTURED_PAULI_STRINGS = ['XI', 'ZZ']
+
+
+def test_captured_list_of_strings_as_pauli_words():
+
+    @cudaq.kernel
+    def with_arg(words: list[cudaq.pauli_word]):
+        q = cudaq.qvector(2)
+        for i in range(len(words)):
+            exp_pauli(0.1, q, words[i])
+
+    @cudaq.kernel
+    def with_capture():
+        q = cudaq.qvector(2)
+        for i in range(len(_CAPTURED_PAULI_STRINGS)):
+            exp_pauli(0.1, q, _CAPTURED_PAULI_STRINGS[i])
+
+    counts_arg = cudaq.sample(with_arg,
+                              [cudaq.pauli_word(w) for w in ['XI', 'ZZ']])
+    counts_cap = cudaq.sample(with_capture)
+    assert len(counts_arg) >= 1
+    assert len(counts_cap) >= 1
+
+
+_CAPTURED_NESTED = [[0.5, -0.5], [1.0]]
+
+
+def test_captured_nested_list():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(2)
+        for i in range(len(_CAPTURED_NESTED)):
+            for j in range(len(_CAPTURED_NESTED[i])):
+                ry(_CAPTURED_NESTED[i][j], q[0])
+
+    counts = cudaq.sample(kernel)
+    assert len(counts) >= 1
+
+
+def test_nested_list_arg_sample_equals_get_state():
+
+    @cudaq.kernel
+    def kernel(ws: list[list[cudaq.pauli_word]], cs: list[list[float]]):
+        q = cudaq.qvector(2)
+        for i in range(len(ws)):
+            g = ws[i]
+            gc = cs[i]
+            for j in range(len(g)):
+                exp_pauli(gc[j], q, g[j])
+
+    nw = [[cudaq.pauli_word('XY'),
+           cudaq.pauli_word('YX')], [cudaq.pauli_word('ZI')]]
+    nc = [[0.5, -0.5], [1.0]]
+
+    cudaq.get_state(kernel, nw, nc)
+    counts = cudaq.sample(kernel, nw, nc)
+    assert len(counts) >= 1

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -901,20 +901,16 @@ def test_list_list_string_argument_error():
 
 def test_broadcast():
 
-    with pytest.raises(RuntimeError) as e:
+    @cudaq.kernel
+    def kernel(l: list[list[int]]):
+        q = cudaq.qvector(2)
+        for inner in l:
+            for i in inner:
+                x(q[i])
 
-        @cudaq.kernel
-        def kernel(l: list[list[int]]):
-            q = cudaq.qvector(2)
-            for inner in l:
-                for i in inner:
-                    x(q[i])
-
-        #FIXME: update broadcast detection logic to allow this case.
-        # https://github.com/NVIDIA/cuda-quantum/issues/2895
-        counts = cudaq.sample(kernel, [[0, 1]])
-    assert 'Invalid runtime argument type. Argument of type list[int] was provided' in repr(
-        e)
+    # list[list[int]] is a single argument, not a broadcast — verify it runs.
+    counts = cudaq.sample(kernel, [[0, 1]])
+    assert '11' in counts
 
 
 def test_list_creation_with_cast():


### PR DESCRIPTION
- `mlirTypeFromPyType` now infers a type of captured lists when there is no annotation to compare against. String elements maps to charspan (pauli_word), and nested lists recurse with a None comparison type instead of dereferencing it.
- A captured empty list carries no element to infer a type from, and the inferred type is fixed for all later calls, so we do not guess one. Instead, the element type is recovered from a module-level annotation without one, the error names the captured variable and suggests adding the annotation.
- Broadcast detection in `__isBroadcast` now treats any stdvec type first parameter as a single argument, so cudaq.sample accepts the same nested-list arguments as cudaq.get_state.

Fixes #4847 