### PR TITLE
Exclude cudaq/mlir from the python build-tree copy

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -38,11 +38,13 @@ else()
 endif()
 
 set(METADATA_FILE "${CMAKE_BINARY_DIR}/python/cudaq/_metadata.py" )
+# Excludes cudaq/mlir; see copy_python_files.cmake.
 add_custom_target(
   CopyPythonFiles ALL
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_BINARY_DIR}/python
+  COMMAND ${CMAKE_COMMAND}
+  -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+  -DDESTINATION_DIR=${CMAKE_BINARY_DIR}
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/copy_python_files.cmake
   COMMAND ${CMAKE_COMMAND}
   -DMETADATA_FILE="${METADATA_FILE}"
   -DCUDA_VERSION_MAJOR=${CUDAToolkit_VERSION_MAJOR}

--- a/python/copy_python_files.cmake
+++ b/python/copy_python_files.cmake
@@ -1,0 +1,19 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Copies the python source tree into the build directory for the
+# CopyPythonFiles target. Excludes cudaq/mlir: the MLIR python machinery
+# stages that subtree via symlink rules, and a second producer races them
+# ("failed to create symbolic link ...: File exists").
+
+if(NOT SOURCE_DIR OR NOT DESTINATION_DIR)
+    message(FATAL_ERROR "SOURCE_DIR and DESTINATION_DIR must be defined")
+endif()
+
+file(COPY "${SOURCE_DIR}" DESTINATION "${DESTINATION_DIR}"
+     REGEX "/cudaq/mlir(/|$)" EXCLUDE)


### PR DESCRIPTION
CopyPythonFiles copied the whole python/ tree into the build directory, including cudaq/mlir/dialects/{quake,cc,qec}.py, which the MLIR python machinery also stages there via symlink rules. The two producers have no ordering edge, so parallel builds intermittently fail with "failed to create symbolic link ...: File exists".

Replace copy_directory with a script that excludes cudaq/mlir, leaving the MLIR staging as the single producer of that subtree.

See the failure at https://github.com/NVIDIA/cuda-quantum/actions/runs/28880392782/job/85669399820