### PR TITLE
[cudaq-realtime] Add support for UDP transport

### DIFF
--- a/realtime/CMakeLists.txt
+++ b/realtime/CMakeLists.txt
@@ -166,21 +166,25 @@ endif()
 
 add_subdirectory(lib)
 
-if (CUDA_FOUND)
-  configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cudaq-realtime-config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/cudaq-realtime-config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudaq-realtime)
+# Install the export set and package config unconditionally: members of
+# cudaq-realtime-targets exist on CUDA-less configures too (the UDP transport
+# is always built), and CMake silently installs an orphaned archive if a
+# target joins an export set that is never itself installed. The config file
+# only requires CUDAToolkit when this build had CUDA (see the @CUDA_FOUND@
+# substitution in cudaq-realtime-config.cmake.in).
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cudaq-realtime-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/cudaq-realtime-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudaq-realtime)
 
-  install(EXPORT cudaq-realtime-targets
-    FILE cudaq-realtime-targets.cmake
-    NAMESPACE cudaq::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudaq-realtime)
+install(EXPORT cudaq-realtime-targets
+  FILE cudaq-realtime-targets.cmake
+  NAMESPACE cudaq::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudaq-realtime)
 
-  install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/cudaq-realtime-config.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudaq-realtime)
-endif()
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/cudaq-realtime-config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudaq-realtime)
 
 if (CUDAQ_REALTIME_BUILD_EXAMPLES)
   message(STATUS "RoCE/DOCA examples removed for RPC dispatch workflow.")

--- a/realtime/cmake/cudaq-realtime-config.cmake.in
+++ b/realtime/cmake/cudaq-realtime-config.cmake.in
@@ -10,7 +10,11 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(CUDAToolkit REQUIRED)
+# CUDAToolkit is only a dependency when the installed build had CUDA; a
+# CUDA-less build exports only the CPU-only targets (e.g. the UDP transport).
+if(@CUDA_FOUND@)
+  find_dependency(CUDAToolkit REQUIRED)
+endif()
 find_dependency(Threads REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cudaq-realtime-targets.cmake")

--- a/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
@@ -1,0 +1,90 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// @file udp_wrapper.h
+/// @brief C interface to a loopback/Ethernet UDP ring transceiver.
+///
+/// A development and CI stand-in for CpuRoceTransceiver (roce_wrapper.h) on
+/// hosts without an RDMA NIC: it exposes the same ring-buffer contract the
+/// RoCE transport provides -- an RX ring the far end's frames land in
+/// (rx_flag[slot] = slot data address when fresh, 0 when free) and a TX ring
+/// whose published slots (tx_flag[slot] = slot data address) are shipped to
+/// the peer and cleared -- so a host dispatcher or DeviceCallChannel wired to
+/// these rings is transport-agnostic between UDP and RoCE.
+///
+/// Wire behavior: one datagram carries one full slot stride (mirroring the
+/// RoCE TX SGE, which is the whole slot). Inbound datagrams larger than this
+/// end's slot stride are dropped, so BOTH ENDS MUST USE THE SAME page_size.
+/// Arriving frames fill RX slots in strict ring order (the same FIFO the
+/// RoCE recv-WQE path provides), with back-pressure until the in-order slot
+/// is fully recycled (rx flag cleared by the consumer AND tx response slot
+/// drained).
+///
+/// Deliberately no ibverbs, no CUDA: buildable and runnable anywhere.
+
+#ifndef CPU_UDP_WRAPPER_H
+#define CPU_UDP_WRAPPER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque handle to a UdpTransceiver.
+typedef void *cpu_udp_transceiver_t;
+
+//==============================================================================
+// Lifecycle
+//==============================================================================
+
+/// Construct a new transceiver with `num_pages` ring slots of `page_size`
+/// bytes each (both rings). Returns NULL on invalid arguments or allocation
+/// failure. Does not open a socket; call cpu_udp_bind() or cpu_udp_connect()
+/// next.
+cpu_udp_transceiver_t cpu_udp_create_transceiver(size_t page_size,
+                                                 unsigned num_pages);
+
+/// Destroy the transceiver. Idempotent. Implicitly calls cpu_udp_close if the
+/// transceiver is still running.
+void cpu_udp_destroy_transceiver(cpu_udp_transceiver_t handle);
+
+/// Service end: bind a loopback UDP endpoint (`port` 0 selects an ephemeral
+/// port; read it back with cpu_udp_get_port). Responses go to the source
+/// address of the most recent inbound datagram. Returns 1 on success.
+int cpu_udp_bind(cpu_udp_transceiver_t handle, uint16_t port);
+
+/// Caller end: connect the socket to the service endpoint. Returns 1 on
+/// success.
+int cpu_udp_connect(cpu_udp_transceiver_t handle, const char *host,
+                    uint16_t port);
+
+/// Bound local UDP port (valid after cpu_udp_bind / cpu_udp_connect).
+uint16_t cpu_udp_get_port(cpu_udp_transceiver_t handle);
+
+/// Start the RX and TX pump threads. Returns 1 on success.
+int cpu_udp_start(cpu_udp_transceiver_t handle);
+
+/// Stop the pump threads and close the socket. Idempotent.
+void cpu_udp_close(cpu_udp_transceiver_t handle);
+
+//==============================================================================
+// Ring access (addresses are host pointers, same contract as roce_wrapper.h)
+//==============================================================================
+
+uint64_t cpu_udp_get_rx_ring_flag_addr(cpu_udp_transceiver_t handle);
+uint64_t cpu_udp_get_rx_ring_data_addr(cpu_udp_transceiver_t handle);
+uint64_t cpu_udp_get_tx_ring_flag_addr(cpu_udp_transceiver_t handle);
+uint64_t cpu_udp_get_tx_ring_data_addr(cpu_udp_transceiver_t handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CPU_UDP_WRAPPER_H

--- a/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
@@ -50,8 +50,8 @@ typedef void *cpu_udp_transceiver_t;
 
 /// Construct a new transceiver with `num_pages` ring slots of `page_size`
 /// bytes each (both rings). Returns NULL on invalid arguments or allocation
-/// failure. Does not open a socket; call cpu_udp_bind() or cpu_udp_connect()
-/// next.
+/// failure. Does not open a socket; call cpu_udp_bind()/cpu_udp_bind_to() or
+/// cpu_udp_connect() next.
 cpu_udp_transceiver_t cpu_udp_create_transceiver(size_t page_size,
                                                  unsigned num_pages);
 
@@ -59,9 +59,15 @@ cpu_udp_transceiver_t cpu_udp_create_transceiver(size_t page_size,
 /// transceiver is still running.
 void cpu_udp_destroy_transceiver(cpu_udp_transceiver_t handle);
 
-/// Service end: bind a loopback UDP endpoint (`port` 0 selects an ephemeral
-/// port; read it back with cpu_udp_get_port). Responses go to the source
+/// Service end: bind a UDP endpoint for receiving requests. `host` selects
+/// the local interface address to listen on ("0.0.0.0" for all interfaces);
+/// NULL or "" binds the loopback interface. `port` 0 selects an ephemeral
+/// port; read it back with cpu_udp_get_port. Responses go to the source
 /// address of the most recent inbound datagram. Returns 1 on success.
+int cpu_udp_bind_to(cpu_udp_transceiver_t handle, const char *host,
+                    uint16_t port);
+
+/// Convenience form of cpu_udp_bind_to that binds the loopback interface.
 int cpu_udp_bind(cpu_udp_transceiver_t handle, uint16_t port);
 
 /// Caller end: connect the socket to the service endpoint. Returns 1 on

--- a/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
@@ -9,17 +9,21 @@
 /// @file udp_wrapper.h
 /// @brief C interface to a loopback/Ethernet UDP ring transceiver.
 ///
-/// A development and CI stand-in for CpuRoceTransceiver (roce_wrapper.h) on
-/// hosts without an RDMA NIC: it exposes the same ring-buffer contract the
+/// The plain-UDP counterpart of CpuRoceTransceiver (roce_wrapper.h) for
+/// systems without an RDMA NIC, usable over loopback or a real UDP network:
+/// it exposes the same ring-buffer contract the
 /// RoCE transport provides -- an RX ring the far end's frames land in
 /// (rx_flag[slot] = slot data address when fresh, 0 when free) and a TX ring
 /// whose published slots (tx_flag[slot] = slot data address) are shipped to
 /// the peer and cleared -- so a host dispatcher or DeviceCallChannel wired to
 /// these rings is transport-agnostic between UDP and RoCE.
 ///
-/// Wire behavior: one datagram carries one full slot stride (mirroring the
-/// RoCE TX SGE, which is the whole slot). Inbound datagrams larger than this
-/// end's slot stride are dropped, so BOTH ENDS MUST USE THE SAME page_size.
+/// Wire behavior: one datagram carries one full slot stride. (This is
+/// simpler than the RoCE transport, whose TX SGE covers only the actual
+/// frame bytes -- cu_frame_size, not the slot stride; this transport has no
+/// separate frame-size parameter.) Inbound datagrams larger than this end's
+/// slot stride are dropped with a one-time stderr warning, so BOTH ENDS MUST
+/// USE THE SAME page_size.
 /// Arriving frames fill RX slots in strict ring order (the same FIFO the
 /// RoCE recv-WQE path provides), with back-pressure until the in-order slot
 /// is fully recycled (rx flag cleared by the consumer AND tx response slot

--- a/realtime/lib/cpu_transport/CMakeLists.txt
+++ b/realtime/lib/cpu_transport/CMakeLists.txt
@@ -24,8 +24,8 @@
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
-# UDP ring transceiver: the loopback/CI stand-in for CpuRoceTransceiver with the
-# same ring contract (see udp_wrapper.h). No ibverbs, no CUDA -- always built.
+# UDP ring transceiver: carries the same ring contract as CpuRoceTransceiver
+# over plain UDP (see udp_wrapper.h). No ibverbs, no CUDA -- always built.
 # ------------------------------------------------------------------------------
 add_library(cudaq-realtime-udp-transport STATIC
   udp_transceiver.cpp

--- a/realtime/lib/cpu_transport/CMakeLists.txt
+++ b/realtime/lib/cpu_transport/CMakeLists.txt
@@ -23,9 +23,42 @@
 # without GPUs.
 # ==============================================================================
 
+# ------------------------------------------------------------------------------
+# UDP ring transceiver: the loopback/CI stand-in for CpuRoceTransceiver with the
+# same ring contract (see udp_wrapper.h). No ibverbs, no CUDA -- always built.
+# ------------------------------------------------------------------------------
+add_library(cudaq-realtime-udp-transport STATIC
+  udp_transceiver.cpp
+)
+add_library(cudaq::cudaq-realtime-udp-transport ALIAS cudaq-realtime-udp-transport)
+
+target_include_directories(cudaq-realtime-udp-transport
+  PUBLIC
+    $<BUILD_INTERFACE:${CUDAQ_REALTIME_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(cudaq-realtime-udp-transport
+  PUBLIC
+    Threads::Threads
+)
+
+set_target_properties(cudaq-realtime-udp-transport PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+)
+
+install(TARGETS cudaq-realtime-udp-transport
+  EXPORT cudaq-realtime-targets
+  COMPONENT realtime-lib
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+message(STATUS "  - cudaq-realtime-udp-transport (CPU UDP transport)")
+
 find_library(IBVERBS_LIBRARY NAMES ibverbs)
 if (NOT IBVERBS_LIBRARY)
-  message(STATUS "  - cpu_transport: libibverbs not found, skipping")
+  message(STATUS "  - cpu_transport: libibverbs not found, skipping RoCE transport")
   return()
 endif()
 

--- a/realtime/lib/cpu_transport/udp_transceiver.cpp
+++ b/realtime/lib/cpu_transport/udp_transceiver.cpp
@@ -7,7 +7,8 @@
  ******************************************************************************/
 
 /// @file udp_transceiver.cpp
-/// @brief UDP ring transceiver: the loopback stand-in for CpuRoceTransceiver.
+/// @brief UDP ring transceiver: the plain-UDP counterpart of
+/// CpuRoceTransceiver.
 ///
 /// See udp_wrapper.h for the ring contract. The RX thread places one inbound
 /// datagram into one RX ring slot in strict ring order (matching the FIFO
@@ -24,6 +25,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
@@ -165,8 +167,17 @@ private:
                      reinterpret_cast<sockaddr *>(&from), &fromlen);
       if (got <= 0)
         continue; // timeout/EINTR: re-check `running`
-      if (static_cast<std::size_t>(got) > page_size)
-        continue; // stride mismatch with the peer; drop
+      if (static_cast<std::size_t>(got) > page_size) {
+        // Stride mismatch with the peer; drop. Warn once -- a mismatch drops
+        // EVERY request, which otherwise looks like a silent hang upstream.
+        if (!oversize_warned.exchange(true))
+          std::fprintf(stderr,
+                       "[cudaq-udp-transport] dropping %zd-byte datagram: "
+                       "exceeds this end's page_size (%zu); both ends must "
+                       "use the same slot stride (further drops not logged)\n",
+                       got, page_size);
+        continue;
+      }
 
       {
         std::lock_guard<std::mutex> lock(peer_mutex);
@@ -189,8 +200,9 @@ private:
     }
   }
 
-  // Ship published TX slots to the peer as one full-stride datagram each
-  // (mirroring the RoCE TX SGE, which covers the whole slot) and clear them.
+  // Ship published TX slots to the peer as one full-stride datagram each and
+  // clear them (this transport has no per-message frame size; see the "Wire
+  // behavior" note in udp_wrapper.h).
   //
   // Slots are consumed in FIFO cursor order, NOT by index scan: both
   // producers (the udp device_call channel and a daemon mirroring request
@@ -233,6 +245,7 @@ private:
   int fd = -1;
   std::uint16_t local_port = 0;
   std::atomic<bool> running{false};
+  std::atomic<bool> oversize_warned{false};
   std::thread rx_thread;
   std::thread tx_thread;
   std::mutex peer_mutex;

--- a/realtime/lib/cpu_transport/udp_transceiver.cpp
+++ b/realtime/lib/cpu_transport/udp_transceiver.cpp
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// @file udp_transceiver.cpp
+/// @brief UDP ring transceiver: the loopback stand-in for CpuRoceTransceiver.
+///
+/// See udp_wrapper.h for the ring contract. The RX thread places one inbound
+/// datagram into one RX ring slot in strict ring order (matching the FIFO
+/// ordering the RoCE recv-WQE path provides); the TX thread ships any
+/// published TX slot (tx_flag[slot] == slot data address) to the peer as one
+/// full-stride datagram and clears the flag.
+
+#include "cudaq/realtime/cpu_transport/udp_wrapper.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace {
+
+std::uint64_t load_flag(const volatile std::uint64_t *flag) {
+  return __atomic_load_n(const_cast<const std::uint64_t *>(flag),
+                         __ATOMIC_ACQUIRE);
+}
+
+void store_flag(volatile std::uint64_t *flag, std::uint64_t value) {
+  __atomic_store_n(const_cast<std::uint64_t *>(flag), value, __ATOMIC_RELEASE);
+}
+
+std::uint8_t *aligned_ring(std::size_t bytes) {
+  void *ptr = nullptr;
+  if (posix_memalign(&ptr, 256, bytes) != 0)
+    return nullptr;
+  std::memset(ptr, 0, bytes);
+  return static_cast<std::uint8_t *>(ptr);
+}
+
+class UdpTransceiver {
+public:
+  UdpTransceiver(std::size_t page_size, unsigned num_pages)
+      : page_size(page_size), num_pages(num_pages) {
+    rx_flags = reinterpret_cast<volatile std::uint64_t *>(
+        aligned_ring(num_pages * sizeof(std::uint64_t)));
+    tx_flags = reinterpret_cast<volatile std::uint64_t *>(
+        aligned_ring(num_pages * sizeof(std::uint64_t)));
+    rx_data = aligned_ring(num_pages * page_size);
+    tx_data = aligned_ring(num_pages * page_size);
+  }
+
+  ~UdpTransceiver() {
+    close();
+    std::free(const_cast<std::uint64_t *>(rx_flags));
+    std::free(const_cast<std::uint64_t *>(tx_flags));
+    std::free(rx_data);
+    std::free(tx_data);
+  }
+
+  bool valid() const { return rx_flags && tx_flags && rx_data && tx_data; }
+
+  bool bind(std::uint16_t port) {
+    if (!openSocket())
+      return false;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    if (::bind(fd, reinterpret_cast<const sockaddr *>(&addr), sizeof(addr)) !=
+        0)
+      return false;
+    socklen_t addrlen = sizeof(addr);
+    ::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &addrlen);
+    local_port = ntohs(addr.sin_port);
+    return true;
+  }
+
+  bool connect(const char *host, std::uint16_t port) {
+    if (!openSocket())
+      return false;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    if (::inet_pton(AF_INET, host, &addr.sin_addr) != 1)
+      return false;
+    if (::connect(fd, reinterpret_cast<const sockaddr *>(&addr),
+                  sizeof(addr)) != 0)
+      return false;
+    {
+      std::lock_guard<std::mutex> lock(peer_mutex);
+      peer_addr = addr;
+      have_peer = true;
+    }
+    sockaddr_in local{};
+    socklen_t locallen = sizeof(local);
+    ::getsockname(fd, reinterpret_cast<sockaddr *>(&local), &locallen);
+    local_port = ntohs(local.sin_port);
+    return true;
+  }
+
+  bool start() {
+    if (fd < 0 || running)
+      return false;
+    running = true;
+    rx_thread = std::thread([this] { rxLoop(); });
+    tx_thread = std::thread([this] { txLoop(); });
+    return true;
+  }
+
+  void close() {
+    running = false;
+    if (rx_thread.joinable())
+      rx_thread.join();
+    if (tx_thread.joinable())
+      tx_thread.join();
+    if (fd >= 0) {
+      ::close(fd);
+      fd = -1;
+    }
+  }
+
+  std::uint16_t port() const { return local_port; }
+  volatile std::uint64_t *rxFlags() const { return rx_flags; }
+  volatile std::uint64_t *txFlags() const { return tx_flags; }
+  std::uint8_t *rxData() const { return rx_data; }
+  std::uint8_t *txData() const { return tx_data; }
+
+private:
+  bool openSocket() {
+    if (fd >= 0)
+      return true;
+    fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0)
+      return false;
+    // Bounded recv wait so rxLoop can observe shutdown.
+    const timeval rx_poll_interval{0, 100000}; // 100 ms
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rx_poll_interval,
+                 sizeof(rx_poll_interval));
+    return true;
+  }
+
+  // One inbound datagram -> one RX slot, in strict ring order. Back-pressure
+  // until the in-order slot is fully recycled: rx flag cleared by the consumer
+  // AND the slot's response drained from the TX ring.
+  void rxLoop() {
+    std::vector<std::uint8_t> buffer(65536);
+    unsigned next_slot = 0;
+    while (running) {
+      sockaddr_in from{};
+      socklen_t fromlen = sizeof(from);
+      const ssize_t got =
+          ::recvfrom(fd, buffer.data(), buffer.size(), 0,
+                     reinterpret_cast<sockaddr *>(&from), &fromlen);
+      if (got <= 0)
+        continue; // timeout/EINTR: re-check `running`
+      if (static_cast<std::size_t>(got) > page_size)
+        continue; // stride mismatch with the peer; drop
+
+      {
+        std::lock_guard<std::mutex> lock(peer_mutex);
+        peer_addr = from;
+        have_peer = true;
+      }
+
+      const unsigned slot = next_slot;
+      while (running && (load_flag(&rx_flags[slot]) != 0 ||
+                         load_flag(&tx_flags[slot]) != 0))
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+      if (!running)
+        return;
+
+      std::uint8_t *rx_slot = rx_data + slot * page_size;
+      std::memset(rx_slot, 0, page_size);
+      std::memcpy(rx_slot, buffer.data(), static_cast<std::size_t>(got));
+      store_flag(&rx_flags[slot], reinterpret_cast<std::uint64_t>(rx_slot));
+      next_slot = (slot + 1) % num_pages;
+    }
+  }
+
+  // Ship published TX slots to the peer as one full-stride datagram each
+  // (mirroring the RoCE TX SGE, which covers the whole slot) and clear them.
+  //
+  // Slots are consumed in FIFO cursor order, NOT by index scan: both
+  // producers (the udp device_call channel and a daemon mirroring request
+  // slots to response slots) publish slots strictly round-robin, so cursor
+  // order equals publish order. An index scan reorders any publish burst
+  // that spans the ring wrap (slot N-1 and slot 0 pending together get sent
+  // 0 first) -- fire-and-forget device_calls (enqueue_syndromes,
+  // reset_decoder) then arrive at the peer out of program order, violating
+  // the decoding server's in-order message contract
+  // (decoder_server_runtime.md, Message ordering).
+  void txLoop() {
+    unsigned cursor = 0;
+    while (running) {
+      const std::uint64_t value = load_flag(&tx_flags[cursor]);
+      if (value == 0) {
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+        continue;
+      }
+      const std::uint8_t *tx_slot = tx_data + cursor * page_size;
+      if (value == reinterpret_cast<std::uint64_t>(tx_slot)) {
+        std::lock_guard<std::mutex> lock(peer_mutex);
+        if (have_peer)
+          ::sendto(fd, tx_slot, page_size, 0,
+                   reinterpret_cast<const sockaddr *>(&peer_addr),
+                   sizeof(peer_addr));
+      }
+      // Non-address values (in-flight/error sentinels) are recycled too;
+      // this transport has no side channel to report them.
+      store_flag(&tx_flags[cursor], 0);
+      cursor = (cursor + 1) % num_pages;
+    }
+  }
+
+  const std::size_t page_size;
+  const unsigned num_pages;
+  volatile std::uint64_t *rx_flags = nullptr;
+  volatile std::uint64_t *tx_flags = nullptr;
+  std::uint8_t *rx_data = nullptr;
+  std::uint8_t *tx_data = nullptr;
+  int fd = -1;
+  std::uint16_t local_port = 0;
+  std::atomic<bool> running{false};
+  std::thread rx_thread;
+  std::thread tx_thread;
+  std::mutex peer_mutex;
+  sockaddr_in peer_addr{};
+  bool have_peer = false;
+};
+
+UdpTransceiver *cast(cpu_udp_transceiver_t handle) {
+  return static_cast<UdpTransceiver *>(handle);
+}
+
+} // namespace
+
+extern "C" {
+
+cpu_udp_transceiver_t cpu_udp_create_transceiver(size_t page_size,
+                                                 unsigned num_pages) {
+  if (page_size == 0 || num_pages == 0)
+    return nullptr;
+  auto *xcvr = new (std::nothrow) UdpTransceiver(page_size, num_pages);
+  if (!xcvr || !xcvr->valid()) {
+    delete xcvr;
+    return nullptr;
+  }
+  return xcvr;
+}
+
+void cpu_udp_destroy_transceiver(cpu_udp_transceiver_t handle) {
+  delete cast(handle);
+}
+
+int cpu_udp_bind(cpu_udp_transceiver_t handle, uint16_t port) {
+  return handle && cast(handle)->bind(port) ? 1 : 0;
+}
+
+int cpu_udp_connect(cpu_udp_transceiver_t handle, const char *host,
+                    uint16_t port) {
+  return handle && host && cast(handle)->connect(host, port) ? 1 : 0;
+}
+
+uint16_t cpu_udp_get_port(cpu_udp_transceiver_t handle) {
+  return handle ? cast(handle)->port() : 0;
+}
+
+int cpu_udp_start(cpu_udp_transceiver_t handle) {
+  return handle && cast(handle)->start() ? 1 : 0;
+}
+
+void cpu_udp_close(cpu_udp_transceiver_t handle) {
+  if (handle)
+    cast(handle)->close();
+}
+
+uint64_t cpu_udp_get_rx_ring_flag_addr(cpu_udp_transceiver_t handle) {
+  return handle ? reinterpret_cast<uint64_t>(cast(handle)->rxFlags()) : 0;
+}
+
+uint64_t cpu_udp_get_rx_ring_data_addr(cpu_udp_transceiver_t handle) {
+  return handle ? reinterpret_cast<uint64_t>(cast(handle)->rxData()) : 0;
+}
+
+uint64_t cpu_udp_get_tx_ring_flag_addr(cpu_udp_transceiver_t handle) {
+  return handle ? reinterpret_cast<uint64_t>(cast(handle)->txFlags()) : 0;
+}
+
+uint64_t cpu_udp_get_tx_ring_data_addr(cpu_udp_transceiver_t handle) {
+  return handle ? reinterpret_cast<uint64_t>(cast(handle)->txData()) : 0;
+}
+
+} // extern "C"

--- a/realtime/lib/cpu_transport/udp_transceiver.cpp
+++ b/realtime/lib/cpu_transport/udp_transceiver.cpp
@@ -73,12 +73,15 @@ public:
 
   bool valid() const { return rx_flags && tx_flags && rx_data && tx_data; }
 
-  bool bind(std::uint16_t port) {
+  bool bind(const char *host, std::uint16_t port) {
     if (!openSocket())
       return false;
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (!host || !*host)
+      addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    else if (::inet_pton(AF_INET, host, &addr.sin_addr) != 1)
+      return false;
     addr.sin_port = htons(port);
     if (::bind(fd, reinterpret_cast<const sockaddr *>(&addr), sizeof(addr)) !=
         0)
@@ -277,8 +280,13 @@ void cpu_udp_destroy_transceiver(cpu_udp_transceiver_t handle) {
   delete cast(handle);
 }
 
+int cpu_udp_bind_to(cpu_udp_transceiver_t handle, const char *host,
+                    uint16_t port) {
+  return handle && cast(handle)->bind(host, port) ? 1 : 0;
+}
+
 int cpu_udp_bind(cpu_udp_transceiver_t handle, uint16_t port) {
-  return handle && cast(handle)->bind(port) ? 1 : 0;
+  return cpu_udp_bind_to(handle, /*host=*/nullptr, port);
 }
 
 int cpu_udp_connect(cpu_udp_transceiver_t handle, const char *host,

--- a/realtime/unittests/cpu_transport/CMakeLists.txt
+++ b/realtime/unittests/cpu_transport/CMakeLists.txt
@@ -16,8 +16,10 @@
 #   - hsb_test_cpu.sh             Orchestration script (built artifact; copy at
 #                                 install time).
 #
-# All gated on TARGET cudaq-realtime-cpu-transport so this dir is silently
-# skipped on hosts without libibverbs.
+# The RoCE artifacts above are gated on TARGET cudaq-realtime-cpu-transport
+# (skipped on hosts without libibverbs). The UDP transceiver tests below run
+# BEFORE that gate -- they depend only on the always-built UDP target, so
+# ibverbs-only setup must stay below the return() guard.
 # ==============================================================================
 
 # ----------------------------------------------------------------------------

--- a/realtime/unittests/cpu_transport/CMakeLists.txt
+++ b/realtime/unittests/cpu_transport/CMakeLists.txt
@@ -20,6 +20,31 @@
 # skipped on hosts without libibverbs.
 # ==============================================================================
 
+# ----------------------------------------------------------------------------
+# test_udp_transceiver: loopback tests for the UDP ring transceiver. Pure CPU
+# (no CUDA, no ibverbs), so it builds and runs everywhere. Gated only on the
+# always-built UDP target.
+# ----------------------------------------------------------------------------
+if (TARGET cudaq-realtime-udp-transport)
+  add_executable(test_udp_transceiver test_udp_transceiver.cpp)
+
+  target_include_directories(test_udp_transceiver PRIVATE
+    ${CUDAQ_REALTIME_INCLUDE_DIR}
+  )
+
+  target_link_libraries(test_udp_transceiver PRIVATE
+    GTest::gtest_main
+    cudaq-realtime-udp-transport
+    Threads::Threads
+  )
+
+  add_dependencies(CudaqRealtimeUnitTests test_udp_transceiver)
+  gtest_discover_tests(test_udp_transceiver
+    TEST_PREFIX "test_udp_transceiver."
+  )
+  message(STATUS "  - test_udp_transceiver (UDP loopback ring transceiver)")
+endif()
+
 if (NOT TARGET cudaq-realtime-cpu-transport)
   return()
 endif()

--- a/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
+++ b/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Loopback tests for the UDP ring transceiver (udp_wrapper.h), the RDMA-free
+// stand-in for CpuRoceTransceiver. Everything here is plain CPU + loopback
+// sockets: no CUDA, no ibverbs, so these tests run on any CI runner.
+
+#include "cudaq/realtime/cpu_transport/udp_wrapper.h"
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <thread>
+
+namespace {
+
+constexpr std::size_t kPageSize = 256;
+constexpr unsigned kNumPages = 4;
+
+std::uint64_t loadFlag(std::uint64_t flagsAddr, unsigned slot) {
+  const auto *flags = reinterpret_cast<const std::uint64_t *>(flagsAddr);
+  return __atomic_load_n(&flags[slot], __ATOMIC_ACQUIRE);
+}
+
+void storeFlag(std::uint64_t flagsAddr, unsigned slot, std::uint64_t value) {
+  auto *flags = reinterpret_cast<std::uint64_t *>(flagsAddr);
+  __atomic_store_n(&flags[slot], value, __ATOMIC_RELEASE);
+}
+
+std::uint8_t *slotData(std::uint64_t dataAddr, unsigned slot,
+                       std::size_t pageSize = kPageSize) {
+  return reinterpret_cast<std::uint8_t *>(dataAddr) + slot * pageSize;
+}
+
+bool waitForFlag(std::uint64_t flagsAddr, unsigned slot,
+                 std::chrono::milliseconds timeout =
+                     std::chrono::milliseconds(5000)) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (loadFlag(flagsAddr, slot) != 0)
+      return true;
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+  }
+  return false;
+}
+
+bool waitForFlagClear(std::uint64_t flagsAddr, unsigned slot,
+                      std::chrono::milliseconds timeout =
+                          std::chrono::milliseconds(5000)) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (loadFlag(flagsAddr, slot) == 0)
+      return true;
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+  }
+  return false;
+}
+
+// A bound (service) and connected (caller) transceiver pair over loopback,
+// both pumping.
+class UdpTransceiverPairTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    service = cpu_udp_create_transceiver(kPageSize, kNumPages);
+    ASSERT_NE(nullptr, service);
+    ASSERT_EQ(1, cpu_udp_bind(service, /*port=*/0));
+    ASSERT_NE(0, cpu_udp_get_port(service));
+    ASSERT_EQ(1, cpu_udp_start(service));
+
+    caller = cpu_udp_create_transceiver(kPageSize, kNumPages);
+    ASSERT_NE(nullptr, caller);
+    ASSERT_EQ(1,
+              cpu_udp_connect(caller, "127.0.0.1", cpu_udp_get_port(service)));
+    ASSERT_EQ(1, cpu_udp_start(caller));
+
+    serviceRxFlags = cpu_udp_get_rx_ring_flag_addr(service);
+    serviceRxData = cpu_udp_get_rx_ring_data_addr(service);
+    serviceTxFlags = cpu_udp_get_tx_ring_flag_addr(service);
+    serviceTxData = cpu_udp_get_tx_ring_data_addr(service);
+    callerRxFlags = cpu_udp_get_rx_ring_flag_addr(caller);
+    callerRxData = cpu_udp_get_rx_ring_data_addr(caller);
+    callerTxFlags = cpu_udp_get_tx_ring_flag_addr(caller);
+    callerTxData = cpu_udp_get_tx_ring_data_addr(caller);
+  }
+
+  void TearDown() override {
+    cpu_udp_destroy_transceiver(caller);
+    cpu_udp_destroy_transceiver(service);
+  }
+
+  // Publish `payload` into the caller's TX slot; the caller's TX pump ships
+  // it to the service and clears the flag.
+  void publishFromCaller(unsigned slot, const std::string &payload) {
+    ASSERT_LT(payload.size(), kPageSize);
+    std::uint8_t *tx = slotData(callerTxData, slot);
+    std::memset(tx, 0, kPageSize);
+    std::memcpy(tx, payload.data(), payload.size());
+    storeFlag(callerTxFlags, slot, reinterpret_cast<std::uint64_t>(tx));
+  }
+
+  // Consume the service's RX slot: return its payload and recycle the slot
+  // (clear the rx flag) so the RX pump's back-pressure releases it.
+  std::string consumeAtService(unsigned slot) {
+    std::string payload(
+        reinterpret_cast<const char *>(slotData(serviceRxData, slot)));
+    storeFlag(serviceRxFlags, slot, 0);
+    return payload;
+  }
+
+  cpu_udp_transceiver_t service = nullptr;
+  cpu_udp_transceiver_t caller = nullptr;
+  std::uint64_t serviceRxFlags = 0, serviceRxData = 0;
+  std::uint64_t serviceTxFlags = 0, serviceTxData = 0;
+  std::uint64_t callerRxFlags = 0, callerRxData = 0;
+  std::uint64_t callerTxFlags = 0, callerTxData = 0;
+};
+
+TEST(UdpTransceiverLifecycle, RejectsInvalidArguments) {
+  EXPECT_EQ(nullptr, cpu_udp_create_transceiver(0, kNumPages));
+  EXPECT_EQ(nullptr, cpu_udp_create_transceiver(kPageSize, 0));
+  EXPECT_EQ(0, cpu_udp_bind(nullptr, 0));
+  EXPECT_EQ(0, cpu_udp_connect(nullptr, "127.0.0.1", 1));
+  EXPECT_EQ(0, cpu_udp_start(nullptr));
+  EXPECT_EQ(0, cpu_udp_get_port(nullptr));
+  cpu_udp_close(nullptr);          // must not crash
+  cpu_udp_destroy_transceiver(nullptr);
+}
+
+TEST(UdpTransceiverLifecycle, StartRequiresSocketAndCloseIsIdempotent) {
+  cpu_udp_transceiver_t xcvr = cpu_udp_create_transceiver(kPageSize, kNumPages);
+  ASSERT_NE(nullptr, xcvr);
+  // No bind/connect yet: no socket, so the pumps must refuse to start.
+  EXPECT_EQ(0, cpu_udp_start(xcvr));
+
+  ASSERT_EQ(1, cpu_udp_bind(xcvr, /*port=*/0));
+  EXPECT_NE(0, cpu_udp_get_port(xcvr));
+  EXPECT_EQ(1, cpu_udp_start(xcvr));
+  EXPECT_EQ(0, cpu_udp_start(xcvr)); // already running
+
+  cpu_udp_close(xcvr);
+  cpu_udp_close(xcvr); // idempotent
+  cpu_udp_destroy_transceiver(xcvr);
+}
+
+TEST_F(UdpTransceiverPairTest, DeliversPublishedSlotToServiceRxRing) {
+  publishFromCaller(0, "request-0");
+
+  ASSERT_TRUE(waitForFlag(serviceRxFlags, 0));
+  // The RX flag carries the slot's data address, same contract as RoCE.
+  EXPECT_EQ(reinterpret_cast<std::uint64_t>(slotData(serviceRxData, 0)),
+            loadFlag(serviceRxFlags, 0));
+  EXPECT_EQ("request-0", consumeAtService(0));
+  // The caller's TX pump recycles the published slot.
+  EXPECT_TRUE(waitForFlagClear(callerTxFlags, 0));
+}
+
+TEST_F(UdpTransceiverPairTest, RoundTripsResponseToCallerRxRing) {
+  publishFromCaller(0, "ping");
+  ASSERT_TRUE(waitForFlag(serviceRxFlags, 0));
+  EXPECT_EQ("ping", consumeAtService(0));
+
+  // Service answers through its own TX ring; responses go to the source of
+  // the most recent inbound datagram (the caller).
+  std::uint8_t *tx = slotData(serviceTxData, 0);
+  std::memset(tx, 0, kPageSize);
+  std::memcpy(tx, "pong", 4);
+  storeFlag(serviceTxFlags, 0, reinterpret_cast<std::uint64_t>(tx));
+
+  ASSERT_TRUE(waitForFlag(callerRxFlags, 0));
+  EXPECT_EQ(0, std::memcmp(slotData(callerRxData, 0), "pong", 4));
+  storeFlag(callerRxFlags, 0, 0);
+}
+
+TEST_F(UdpTransceiverPairTest, FillsRxSlotsInStrictRingOrder) {
+  for (unsigned i = 0; i < 2 * kNumPages; ++i) {
+    const unsigned slot = i % kNumPages;
+    const std::string payload = "msg-" + std::to_string(i);
+    publishFromCaller(slot, payload);
+    ASSERT_TRUE(waitForFlag(serviceRxFlags, slot)) << "message " << i;
+    EXPECT_EQ(payload, consumeAtService(slot)) << "message " << i;
+  }
+}
+
+// Regression test for the TX pump's FIFO contract: published slots ship in
+// cursor (publish) order, not ascending index order. A publish burst that
+// spans the ring wrap -- here slot kNumPages-1 published before slot 0 --
+// must arrive at the peer in publish order; an index scan would ship slot 0
+// first and reorder fire-and-forget device_calls on the wire.
+TEST_F(UdpTransceiverPairTest, ShipsWrappingPublishBurstInFifoOrder) {
+  // Advance the caller's TX cursor to the last slot.
+  for (unsigned slot = 0; slot < kNumPages - 1; ++slot) {
+    publishFromCaller(slot, "warmup-" + std::to_string(slot));
+    ASSERT_TRUE(waitForFlag(serviceRxFlags, slot));
+    consumeAtService(slot);
+    ASSERT_TRUE(waitForFlagClear(callerTxFlags, slot));
+  }
+
+  // Publish the wrapped slot 0 FIRST while the TX cursor still waits on slot
+  // kNumPages-1: an index-scan TX pump would ship slot 0 immediately, a FIFO
+  // pump must hold it until slot kNumPages-1 is published and shipped.
+  publishFromCaller(0, "second");
+  publishFromCaller(kNumPages - 1, "first");
+
+  // The service's RX ring assigns slots in arrival order, so the payload
+  // arriving first lands in the in-order RX slot kNumPages-1.
+  ASSERT_TRUE(waitForFlag(serviceRxFlags, kNumPages - 1));
+  EXPECT_EQ("first", consumeAtService(kNumPages - 1));
+  ASSERT_TRUE(waitForFlag(serviceRxFlags, 0));
+  EXPECT_EQ("second", consumeAtService(0));
+}
+
+TEST_F(UdpTransceiverPairTest, DropsDatagramsLargerThanOwnStride) {
+  // A peer with a larger stride ships full-stride datagrams that exceed this
+  // end's page size; the RX pump must drop them (both ends must agree on
+  // page_size).
+  cpu_udp_transceiver_t bigCaller =
+      cpu_udp_create_transceiver(2 * kPageSize, kNumPages);
+  ASSERT_NE(nullptr, bigCaller);
+  ASSERT_EQ(1, cpu_udp_connect(bigCaller, "127.0.0.1",
+                               cpu_udp_get_port(service)));
+  ASSERT_EQ(1, cpu_udp_start(bigCaller));
+
+  const std::uint64_t txFlags = cpu_udp_get_tx_ring_flag_addr(bigCaller);
+  const std::uint64_t txData = cpu_udp_get_tx_ring_data_addr(bigCaller);
+  std::uint8_t *tx = slotData(txData, 0, 2 * kPageSize);
+  std::memset(tx, 0xAB, 2 * kPageSize);
+  storeFlag(txFlags, 0, reinterpret_cast<std::uint64_t>(tx));
+
+  // The oversized datagram was shipped (TX flag recycled) ...
+  ASSERT_TRUE(waitForFlagClear(txFlags, 0));
+  // ... but never lands in the service's RX ring.
+  EXPECT_FALSE(waitForFlag(serviceRxFlags, 0, std::chrono::milliseconds(250)));
+
+  cpu_udp_destroy_transceiver(bigCaller);
+}
+
+} // namespace

--- a/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
+++ b/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
@@ -133,6 +133,57 @@ TEST(UdpTransceiverLifecycle, RejectsInvalidArguments) {
   cpu_udp_destroy_transceiver(nullptr);
 }
 
+TEST(UdpTransceiverLifecycle, BindToConfigurableAddress) {
+  // Explicit interface address.
+  cpu_udp_transceiver_t xcvr = cpu_udp_create_transceiver(kPageSize, kNumPages);
+  ASSERT_NE(nullptr, xcvr);
+  EXPECT_EQ(1, cpu_udp_bind_to(xcvr, "127.0.0.1", /*port=*/0));
+  EXPECT_NE(0, cpu_udp_get_port(xcvr));
+  cpu_udp_destroy_transceiver(xcvr);
+
+  // NULL and "" mean loopback.
+  xcvr = cpu_udp_create_transceiver(kPageSize, kNumPages);
+  ASSERT_NE(nullptr, xcvr);
+  EXPECT_EQ(1, cpu_udp_bind_to(xcvr, "", /*port=*/0));
+  cpu_udp_destroy_transceiver(xcvr);
+
+  // A malformed address must fail, not fall back silently.
+  xcvr = cpu_udp_create_transceiver(kPageSize, kNumPages);
+  ASSERT_NE(nullptr, xcvr);
+  EXPECT_EQ(0, cpu_udp_bind_to(xcvr, "not-an-address", /*port=*/0));
+  cpu_udp_destroy_transceiver(xcvr);
+}
+
+TEST(UdpTransceiverLifecycle, DeliversAcrossAnyInterfaceBind) {
+  // Service listening on all interfaces is reachable via loopback.
+  cpu_udp_transceiver_t service =
+      cpu_udp_create_transceiver(kPageSize, kNumPages);
+  ASSERT_NE(nullptr, service);
+  ASSERT_EQ(1, cpu_udp_bind_to(service, "0.0.0.0", /*port=*/0));
+  ASSERT_EQ(1, cpu_udp_start(service));
+
+  cpu_udp_transceiver_t caller =
+      cpu_udp_create_transceiver(kPageSize, kNumPages);
+  ASSERT_NE(nullptr, caller);
+  ASSERT_EQ(1, cpu_udp_connect(caller, "127.0.0.1", cpu_udp_get_port(service)));
+  ASSERT_EQ(1, cpu_udp_start(caller));
+
+  const std::uint64_t txFlags = cpu_udp_get_tx_ring_flag_addr(caller);
+  const std::uint64_t txData = cpu_udp_get_tx_ring_data_addr(caller);
+  std::uint8_t *tx = slotData(txData, 0);
+  std::memset(tx, 0, kPageSize);
+  std::memcpy(tx, "any-if", 6);
+  storeFlag(txFlags, 0, reinterpret_cast<std::uint64_t>(tx));
+
+  const std::uint64_t rxFlags = cpu_udp_get_rx_ring_flag_addr(service);
+  const std::uint64_t rxData = cpu_udp_get_rx_ring_data_addr(service);
+  ASSERT_TRUE(waitForFlag(rxFlags, 0));
+  EXPECT_EQ(0, std::memcmp(slotData(rxData, 0), "any-if", 6));
+
+  cpu_udp_destroy_transceiver(caller);
+  cpu_udp_destroy_transceiver(service);
+}
+
 TEST(UdpTransceiverLifecycle, StartRequiresSocketAndCloseIsIdempotent) {
   cpu_udp_transceiver_t xcvr = cpu_udp_create_transceiver(kPageSize, kNumPages);
   ASSERT_NE(nullptr, xcvr);

--- a/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
+++ b/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
@@ -6,9 +6,9 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// Loopback tests for the UDP ring transceiver (udp_wrapper.h), the RDMA-free
-// stand-in for CpuRoceTransceiver. Everything here is plain CPU + loopback
-// sockets: no CUDA, no ibverbs, so these tests run on any CI runner.
+// Loopback tests for the UDP ring transceiver (udp_wrapper.h), the plain-UDP
+// counterpart of CpuRoceTransceiver. Everything here is plain CPU + loopback
+// sockets: no CUDA, no ibverbs, so these tests run anywhere.
 
 #include "cudaq/realtime/cpu_transport/udp_wrapper.h"
 #include <gtest/gtest.h>
@@ -39,9 +39,9 @@ std::uint8_t *slotData(std::uint64_t dataAddr, unsigned slot,
   return reinterpret_cast<std::uint8_t *>(dataAddr) + slot * pageSize;
 }
 
-bool waitForFlag(std::uint64_t flagsAddr, unsigned slot,
-                 std::chrono::milliseconds timeout =
-                     std::chrono::milliseconds(5000)) {
+bool waitForFlag(
+    std::uint64_t flagsAddr, unsigned slot,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(5000)) {
   const auto deadline = std::chrono::steady_clock::now() + timeout;
   while (std::chrono::steady_clock::now() < deadline) {
     if (loadFlag(flagsAddr, slot) != 0)
@@ -51,9 +51,9 @@ bool waitForFlag(std::uint64_t flagsAddr, unsigned slot,
   return false;
 }
 
-bool waitForFlagClear(std::uint64_t flagsAddr, unsigned slot,
-                      std::chrono::milliseconds timeout =
-                          std::chrono::milliseconds(5000)) {
+bool waitForFlagClear(
+    std::uint64_t flagsAddr, unsigned slot,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(5000)) {
   const auto deadline = std::chrono::steady_clock::now() + timeout;
   while (std::chrono::steady_clock::now() < deadline) {
     if (loadFlag(flagsAddr, slot) == 0)
@@ -129,7 +129,7 @@ TEST(UdpTransceiverLifecycle, RejectsInvalidArguments) {
   EXPECT_EQ(0, cpu_udp_connect(nullptr, "127.0.0.1", 1));
   EXPECT_EQ(0, cpu_udp_start(nullptr));
   EXPECT_EQ(0, cpu_udp_get_port(nullptr));
-  cpu_udp_close(nullptr);          // must not crash
+  cpu_udp_close(nullptr); // must not crash
   cpu_udp_destroy_transceiver(nullptr);
 }
 
@@ -223,8 +223,8 @@ TEST_F(UdpTransceiverPairTest, DropsDatagramsLargerThanOwnStride) {
   cpu_udp_transceiver_t bigCaller =
       cpu_udp_create_transceiver(2 * kPageSize, kNumPages);
   ASSERT_NE(nullptr, bigCaller);
-  ASSERT_EQ(1, cpu_udp_connect(bigCaller, "127.0.0.1",
-                               cpu_udp_get_port(service)));
+  ASSERT_EQ(1,
+            cpu_udp_connect(bigCaller, "127.0.0.1", cpu_udp_get_port(service)));
   ASSERT_EQ(1, cpu_udp_start(bigCaller));
 
   const std::uint64_t txFlags = cpu_udp_get_tx_ring_flag_addr(bigCaller);

--- a/runtime/internal/device_call/CMakeLists.txt
+++ b/runtime/internal/device_call/CMakeLists.txt
@@ -36,6 +36,15 @@ if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME)
     message(STATUS "  - device_call: cpu_roce channel enabled (libibverbs)")
   endif()
 
+  # UDP loopback channel: the RDMA-free stand-in for cpu_roce (development,
+  # CI, and two-process tests on hosts without an RDMA NIC).
+  set(CUDAQ_DEVICE_CALL_UDP_LIB "")
+  if (TARGET cudaq::cudaq-realtime-udp-transport)
+    list(APPEND CUDAQ_DEVICE_CALL_SOURCES UdpChannel.cpp)
+    set(CUDAQ_DEVICE_CALL_UDP_LIB cudaq::cudaq-realtime-udp-transport)
+    message(STATUS "  - device_call: udp channel enabled")
+  endif()
+
   add_library(cudaq-device-call-runtime
     SHARED
       ${CUDAQ_DEVICE_CALL_SOURCES})
@@ -55,6 +64,7 @@ if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME)
       cudaq-common
       cudaq::cudaq-realtime
       ${CUDAQ_DEVICE_CALL_CPU_ROCE_LIB}
+      ${CUDAQ_DEVICE_CALL_UDP_LIB}
       LLVMSupport
       CUDA::cudart_static
       dl)

--- a/runtime/internal/device_call/CMakeLists.txt
+++ b/runtime/internal/device_call/CMakeLists.txt
@@ -36,8 +36,8 @@ if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME)
     message(STATUS "  - device_call: cpu_roce channel enabled (libibverbs)")
   endif()
 
-  # UDP loopback channel: the RDMA-free stand-in for cpu_roce (development,
-  # CI, and two-process tests on hosts without an RDMA NIC).
+  # UDP channel: device_call over plain UDP for systems without an RDMA NIC,
+  # over loopback or a real network.
   set(CUDAQ_DEVICE_CALL_UDP_LIB "")
   if (TARGET cudaq::cudaq-realtime-udp-transport)
     list(APPEND CUDAQ_DEVICE_CALL_SOURCES UdpChannel.cpp)

--- a/runtime/internal/device_call/CpuRoceChannel.cpp
+++ b/runtime/internal/device_call/CpuRoceChannel.cpp
@@ -34,26 +34,16 @@
 // (authenticate/configure_roce); only this rendezvous step changes, not the
 // data-plane wire.
 //
-// Slot correlation (v1): the daemon's host dispatcher mirrors its rx slot to
-// its tx slot.  Our request Write carries the slot in imm_data, and our RX of
-// the service's Send decodes the slot from the recv-WQE wr_id (FIFO order).
-// Both ends are only correct for *in-order* traffic.  To keep this correct
-// without changing the (already-merged) host dispatcher or the transceiver,
-// dispatchFrame serializes response-bearing dispatch and assigns the ring slot
-// at dispatch time in round-robin order, so the daemon's FIFO rx slot always
-// equals our slot.  request_id stays globally monotonic for
-// uniqueness/validation.  True concurrent in-flight dispatch (imm-decode RX +
+// The frame lifecycle and v1 slot-correlation protocol (round-robin slot
+// assignment, serialized response-bearing dispatch, fire-and-forget response
+// draining) are the shared RingSlotChannel implementation; see
+// RingSlotChannel.h.  True concurrent in-flight dispatch (imm-decode RX +
 // daemon tx-slot=request_id) is a documented follow-up; see
 // phase2_imm_convention.
 
-#include "cudaq_internal/device_call/DeviceCallChannel.h"
-#include "cudaq_internal/device_call/DeviceCallError.h"
-#include "cudaq_internal/device_call/RpcFrame.h"
+#include "cudaq_internal/device_call/RingSlotChannel.h"
 
 #include "cudaq/realtime/cpu_transport/roce_wrapper.h"
-#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
-
-#include "cudaq/runtime/logger/logger.h"
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -61,16 +51,11 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <atomic>
 #include <cerrno>
 #include <chrono>
 #include <cstdint>
-#include <cstring>
-#include <memory>
-#include <mutex>
 #include <string>
 #include <thread>
-#include <vector>
 
 namespace {
 
@@ -86,20 +71,7 @@ struct RendezvousInfo {
   std::uint32_t roce_ipv4 = 0; // network-order IPv4 of this end's RoCE GID
 };
 
-// Per-lease state hung off DeviceCallFrame::channelPrivate.  Holds host-visible
-// scratch the caller writes args into / reads results out of; dispatchFrame
-// copies between this scratch and the RDMA-registered ring slot it picks.
-struct FrameState {
-  std::uint32_t functionId = 0;
-  std::uint32_t requestId = 0;
-  std::uint64_t requestBytes = 0;
-  std::uint64_t responseCapacity = 0;
-  bool inUse = false;
-  std::vector<std::byte> requestScratch;  // [RPCHeader | args]
-  std::vector<std::byte> responseScratch; // [RPCResponse | result]
-};
-
-class CpuRoceChannel : public DeviceCallChannel {
+class CpuRoceChannel : public RingSlotChannel {
 public:
   ~CpuRoceChannel() override { stop(); }
 
@@ -192,157 +164,11 @@ public:
     rxFlags = cpu_roce_get_rx_ring_flag_addr(xcvr);
     rxStride = cpu_roce_get_page_size(xcvr);
 
-    ffPending.assign(numSlots, 0);
-    ffPendingRequestId.assign(numSlots, 0);
+    initRingState();
 
     // Run the transceiver RX/TX loops on a background thread.
     monitorThread = std::thread([this] { cpu_roce_blocking_monitor(xcvr); });
     started = true;
-  }
-
-  void acquireFrame(std::uint32_t functionId, std::uint64_t requestBytes,
-                    std::uint64_t responseCapacity,
-                    DeviceCallFrame &frame) override {
-    frame = {};
-    if (CUDAQ_RPC_HEADER_SIZE + requestBytes > slotSize)
-      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
-                            "cpu_roce request exceeds slot size");
-    if (sizeof(cudaq::realtime::RPCResponse) + responseCapacity > slotSize)
-      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
-                            "cpu_roce response capacity exceeds slot size");
-
-    auto state = std::make_unique<FrameState>();
-    state->functionId = functionId;
-    state->requestBytes = requestBytes;
-    state->responseCapacity = responseCapacity;
-    state->requestId = requestIdCounter.fetch_add(1, std::memory_order_relaxed);
-    state->requestScratch.assign(CUDAQ_RPC_HEADER_SIZE + requestBytes,
-                                 std::byte{0});
-    state->responseScratch.assign(
-        sizeof(cudaq::realtime::RPCResponse) + responseCapacity, std::byte{0});
-    state->inUse = true;
-
-    // Lay down the request header in the scratch; args follow it.
-    auto *hdr = reinterpret_cast<cudaq::realtime::RPCHeader *>(
-        state->requestScratch.data());
-    hdr->magic = cudaq::realtime::RPC_MAGIC_REQUEST;
-    hdr->function_id = functionId;
-    hdr->arg_len = static_cast<std::uint32_t>(requestBytes);
-    hdr->request_id = state->requestId;
-    hdr->ptp_timestamp = 0;
-
-    frame.functionId = functionId;
-    frame.request.data = requestPayload(state->requestScratch.data());
-    frame.request.capacity = requestBytes;
-    frame.response.data = responsePayload(state->responseScratch.data());
-    frame.response.capacity = responseCapacity;
-    frame.channelPrivate = state.release();
-
-    CUDAQ_DBG("[device-call] cpu_roce acquire functionId={} requestBytes={} "
-              "responseCapacity={} requestId={}",
-              functionId, requestBytes, responseCapacity,
-              reinterpret_cast<FrameState *>(frame.channelPrivate)->requestId);
-  }
-
-  std::uint64_t dispatchFrame(DeviceCallFrame &frame) override {
-    auto *state = static_cast<FrameState *>(frame.channelPrivate);
-    if (!state || !state->inUse)
-      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
-                            "cpu_roce dispatch on invalid frame");
-
-    // v1: serialize the wire round-trip so the daemon's FIFO rx slot tracks the
-    // ring slot we pick here.  See file header.
-    std::lock_guard<std::mutex> lock(dispatchMutex);
-
-    const std::uint32_t slot = rrCounter % numSlots;
-    rrCounter = (rrCounter + 1u) % numSlots;
-
-    // If this slot still has an outstanding fire-and-forget whose response we
-    // never read, drain that late (zero-length) response before reuse.  The
-    // service Sends a response for every request, including fire-and-forget;
-    // that Send lands in this slot and, if left, would be read as THIS
-    // request's response (carrying the stale request_id).  Wait for it to land,
-    // then clear it.
-    if (ffPending[slot]) {
-      if (waitFlagNonZero(rxFlags[slot], "rx-drain"))
-        __atomic_store_n(&rxFlags[slot], std::uint64_t{0}, __ATOMIC_RELEASE);
-      else
-        CUDAQ_DBG("[device-call] cpu_roce fire-and-forget drain timed out "
-                  "slot={} requestId={}",
-                  slot, ffPendingRequestId[slot]);
-      ffPending[slot] = 0;
-    }
-
-    const std::uint64_t txAddr =
-        reinterpret_cast<std::uint64_t>(txData) + slot * txStride;
-    const std::uint64_t rxAddr =
-        reinterpret_cast<std::uint64_t>(rxData) + slot * rxStride;
-
-    // Back-pressure: wait for the TX thread to have drained any prior send in
-    // this slot before we overwrite it.
-    waitFlagZero(txFlags[slot], "tx");
-    // Defensive: clear any stale response flag for this slot before reuse.
-    __atomic_store_n(&rxFlags[slot], std::uint64_t{0}, __ATOMIC_RELEASE);
-
-    // Zero the full transmitted range before writing.  The transceiver's TX
-    // SGE length is the whole slot stride, so any bytes beyond [RPCHeader |
-    // args] would otherwise carry stale ring contents from a previous message
-    // onto the wire.  The daemon only reads arg_len, but we must not transmit
-    // uninitialized/stale memory.
-    std::memset(reinterpret_cast<void *>(txAddr), 0, txStride);
-    // Copy [RPCHeader | args] into the TX ring slot and publish it.
-    std::memcpy(reinterpret_cast<void *>(txAddr), state->requestScratch.data(),
-                state->requestScratch.size());
-    __atomic_store_n(&txFlags[slot], txAddr, __ATOMIC_RELEASE);
-
-    CUDAQ_DBG("[device-call] cpu_roce dispatch slot={} requestId={} "
-              "functionId={} fireAndForget={}",
-              slot, state->requestId, state->functionId,
-              state->responseCapacity == 0);
-
-    if (state->responseCapacity == 0) {
-      // Async fire-and-forget: return immediately per the device_call contract.
-      // Mark the slot so its next reuse drains the service's late zero-length
-      // response (see the drain above) before overwriting the slot.
-      ffPending[slot] = 1;
-      ffPendingRequestId[slot] = state->requestId;
-      return 0;
-    }
-
-    // Wait for the service's Send response to land in our rx slot.
-    if (!waitFlagNonZero(rxFlags[slot], "rx"))
-      throw DeviceCallError(DeviceCallStatus::Timeout,
-                            "cpu_roce timed out waiting for response");
-
-    void *respFrame = reinterpret_cast<void *>(rxAddr);
-    std::uint64_t resultLen = 0;
-    try {
-      resultLen = validateResponseFrame(respFrame, state->requestId,
-                                        state->responseCapacity, rxStride);
-      // Hand the validated result bytes back through the caller's scratch view.
-      std::memcpy(state->responseScratch.data(), respFrame,
-                  sizeof(cudaq::realtime::RPCResponse) + resultLen);
-    } catch (...) {
-      __atomic_store_n(&rxFlags[slot], std::uint64_t{0}, __ATOMIC_RELEASE);
-      throw;
-    }
-
-    // Release the rx slot so the RX thread can re-arm its recv WQE.
-    __atomic_store_n(&rxFlags[slot], std::uint64_t{0}, __ATOMIC_RELEASE);
-
-    CUDAQ_DBG("[device-call] cpu_roce dispatch complete slot={} requestId={} "
-              "resultLen={}",
-              slot, state->requestId, resultLen);
-    return resultLen;
-  }
-
-  void releaseFrame(DeviceCallFrame &frame) noexcept override {
-    auto *state = static_cast<FrameState *>(frame.channelPrivate);
-    if (state) {
-      state->inUse = false;
-      delete state;
-    }
-    frame = {};
   }
 
   void stop() noexcept override {
@@ -358,24 +184,31 @@ public:
   }
 
 private:
+  const char *channelTag() const noexcept override { return "cpu_roce"; }
+
+  // Latency-sensitive RDMA wire: busy-spin between flag polls.
+  void relax() const override {
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__)
+    asm volatile("yield" ::: "memory");
+#endif
+  }
+
   // ---- argument parsing -----------------------------------------------------
 
   void parseArguments(const std::vector<std::string> &arguments) {
-    for (const auto &arg : arguments) {
-      const auto eq = arg.find('=');
-      if (eq == std::string::npos)
-        continue;
-      const std::string key = arg.substr(0, eq);
-      const std::string value = arg.substr(eq + 1);
-      if (key == "ib-device")
-        ibDevice = value;
-      else if (key == "local-ip")
-        localIp = value;
-      else if (key == "rendezvous-host")
-        rendezvousHost = value;
-      else if (key == "rendezvous-port")
-        rendezvousPort = static_cast<std::uint16_t>(std::stoul(value));
-    }
+    forEachKeyValue(arguments,
+                    [this](const std::string &key, const std::string &value) {
+                      if (key == "ib-device")
+                        ibDevice = value;
+                      else if (key == "local-ip")
+                        localIp = value;
+                      else if (key == "rendezvous-host")
+                        rendezvousHost = value;
+                      else if (key == "rendezvous-port")
+                        rendezvousPort = parsePort(value, "rendezvous-port");
+                    });
   }
 
   static std::uint32_t parseIpv4(const std::string &ip) {
@@ -461,45 +294,9 @@ private:
     return true;
   }
 
-  // ---- flag handshakes ------------------------------------------------------
-
-  void waitFlagZero(std::uint64_t &flag, const char *which) {
-    const auto deadline =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
-    while (__atomic_load_n(&flag, __ATOMIC_ACQUIRE) != 0) {
-      if (std::chrono::steady_clock::now() > deadline)
-        throw DeviceCallError(DeviceCallStatus::Timeout,
-                              std::string("cpu_roce ") + which +
-                                  " slot back-pressure timed out");
-      cpuRelax();
-    }
-  }
-
-  bool waitFlagNonZero(std::uint64_t &flag, const char *) {
-    const auto deadline =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
-    while (__atomic_load_n(&flag, __ATOMIC_ACQUIRE) == 0) {
-      if (std::chrono::steady_clock::now() > deadline)
-        return false;
-      cpuRelax();
-    }
-    return true;
-  }
-
-  static inline void cpuRelax() {
-#if defined(__x86_64__) || defined(__i386__)
-    __builtin_ia32_pause();
-#elif defined(__aarch64__)
-    asm volatile("yield" ::: "memory");
-#endif
-  }
-
   // ---- configuration / state ------------------------------------------------
 
   DeviceCallChannelConfig channelConfig;
-  std::uint32_t numSlots = 0;
-  std::uint64_t slotSize = 0;
-  std::uint64_t timeoutMs = DefaultTimeoutMs;
 
   std::string ibDevice;
   std::string localIp;
@@ -509,25 +306,6 @@ private:
   cpu_roce_transceiver_t xcvr = nullptr;
   std::thread monitorThread;
   bool started = false;
-
-  std::uint8_t *txData = nullptr;
-  std::uint64_t *txFlags = nullptr;
-  std::size_t txStride = 0;
-  std::uint8_t *rxData = nullptr;
-  std::uint64_t *rxFlags = nullptr;
-  std::size_t rxStride = 0;
-
-  std::mutex dispatchMutex; // v1: serialize wire round-trips
-  std::uint32_t rrCounter = 0;
-  // Per-slot tracking of an outstanding fire-and-forget whose (ignored)
-  // zero-length response has not yet been drained.  The service Sends a
-  // response for *every* request, including fire-and-forget; that late Send
-  // lands in this slot, so we must drain it before reusing the slot or it would
-  // be read as the next request's response (with the stale request_id).  Sized
-  // to numSlots in initialize().
-  std::vector<char> ffPending;
-  std::vector<std::uint32_t> ffPendingRequestId;
-  std::atomic<std::uint32_t> requestIdCounter{1};
 };
 
 CUDAQ_REGISTER_TYPE(DeviceCallChannel, CpuRoceChannel, cpu_roce)

--- a/runtime/internal/device_call/UdpChannel.cpp
+++ b/runtime/internal/device_call/UdpChannel.cpp
@@ -1,0 +1,306 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// UdpChannel — a DeviceCallChannel that carries device_call RPCs over UDP
+// datagrams using the cpu_transport UdpTransceiver.  It is the loopback/CI
+// stand-in for CpuRoceChannel on hosts without an RDMA NIC: same wire frames
+// ([RPCHeader | args] request, [RPCResponse | result] response), same ring
+// contract, and the same caller-side frame lifecycle, so the service end (a
+// daemon wiring the transceiver rings into libcudaq-realtime's HOST_CALL
+// dispatcher) is transport-agnostic between UDP and RoCE.
+//
+// No QP/rkey rendezvous is needed (UDP addressing replaces it): the channel
+// just connects to the daemon's UDP endpoint.
+//
+// Slot correlation (v1, matching CpuRoceChannel): the daemon's host dispatcher
+// mirrors its rx slot to its tx slot, and both transceivers fill RX slots in
+// strict arrival order, so serializing response-bearing dispatch and assigning
+// ring slots round-robin keeps the daemon's FIFO rx slot equal to ours.
+// request_id stays globally monotonic for uniqueness/validation.
+//
+// Channel arguments (key=value tokens on the device_call command line):
+//   udp-host=<ipv4>   service daemon address (required)
+//   udp-port=<port>   service daemon UDP port (required)
+//
+// Both ends must use the same slot stride (each datagram carries one full
+// slot, mirroring the RoCE TX SGE); the daemon's --slot-size must equal this
+// channel's configured slot size.
+
+#include "cudaq_internal/device_call/DeviceCallChannel.h"
+#include "cudaq_internal/device_call/DeviceCallError.h"
+#include "cudaq_internal/device_call/RpcFrame.h"
+
+#include "cudaq/realtime/cpu_transport/udp_wrapper.h"
+#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
+
+#include "cudaq/runtime/logger/logger.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace cudaq_internal::device_call;
+
+class UdpChannel : public DeviceCallChannel {
+public:
+  ~UdpChannel() override { stop(); }
+
+  void initialize(DeviceCallChannelCreateArgs &&args) override {
+    numSlots = args.channelConfig.numSlots;
+    slotSize = args.channelConfig.slotSize;
+    timeoutMs = args.channelConfig.timeoutMs;
+    parseArguments(args.arguments);
+    CUDAQ_INFO("[device-call] udp channel initialize host={} port={} "
+               "slots={} slotSize={} timeoutMs={}",
+               serviceHost, servicePort, numSlots, slotSize, timeoutMs);
+    if (serviceHost.empty() || servicePort == 0)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            "udp channel requires udp-host=... udp-port=...");
+
+    xcvr = cpu_udp_create_transceiver(slotSize, numSlots);
+    if (!xcvr)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            "udp channel: transceiver create failed");
+    if (!cpu_udp_connect(xcvr, serviceHost.c_str(), servicePort)) {
+      stop();
+      throw DeviceCallError(DeviceCallStatus::RemoteError,
+                            "udp channel: transceiver connect failed");
+    }
+    if (!cpu_udp_start(xcvr)) {
+      stop();
+      throw DeviceCallError(DeviceCallStatus::RemoteError,
+                            "udp channel: transceiver start failed");
+    }
+
+    rxFlags = reinterpret_cast<volatile std::uint64_t *>(
+        cpu_udp_get_rx_ring_flag_addr(xcvr));
+    txFlags = reinterpret_cast<volatile std::uint64_t *>(
+        cpu_udp_get_tx_ring_flag_addr(xcvr));
+    rxData =
+        reinterpret_cast<std::uint8_t *>(cpu_udp_get_rx_ring_data_addr(xcvr));
+    txData =
+        reinterpret_cast<std::uint8_t *>(cpu_udp_get_tx_ring_data_addr(xcvr));
+    ffPending.assign(numSlots, 0);
+  }
+
+  void acquireFrame(std::uint32_t functionId, std::uint64_t requestBytes,
+                    std::uint64_t responseCapacity,
+                    DeviceCallFrame &frame) override {
+    frame = {};
+    if (CUDAQ_RPC_HEADER_SIZE + requestBytes > slotSize)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            "udp request exceeds slot size");
+    if (sizeof(cudaq::realtime::RPCResponse) + responseCapacity > slotSize)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            "udp response capacity exceeds slot size");
+
+    auto state = std::make_unique<FrameState>();
+    state->requestId = requestIdCounter.fetch_add(1, std::memory_order_relaxed);
+    state->responseCapacity = responseCapacity;
+    state->requestScratch.assign(CUDAQ_RPC_HEADER_SIZE + requestBytes,
+                                 std::byte{0});
+    state->responseScratch.assign(
+        sizeof(cudaq::realtime::RPCResponse) + responseCapacity, std::byte{0});
+    state->inUse = true;
+
+    // Lay down the request header in the scratch; args follow it.
+    auto *hdr = reinterpret_cast<cudaq::realtime::RPCHeader *>(
+        state->requestScratch.data());
+    hdr->magic = cudaq::realtime::RPC_MAGIC_REQUEST;
+    hdr->function_id = functionId;
+    hdr->arg_len = static_cast<std::uint32_t>(requestBytes);
+    hdr->request_id = state->requestId;
+    hdr->ptp_timestamp = 0;
+
+    frame.functionId = functionId;
+    frame.request.data = requestPayload(state->requestScratch.data());
+    frame.request.capacity = requestBytes;
+    frame.response.data = responsePayload(state->responseScratch.data());
+    frame.response.capacity = responseCapacity;
+    frame.channelPrivate = state.release();
+
+    CUDAQ_DBG("[device-call] udp acquire functionId={} requestBytes={} "
+              "responseCapacity={} requestId={}",
+              functionId, requestBytes, responseCapacity,
+              static_cast<FrameState *>(frame.channelPrivate)->requestId);
+  }
+
+  std::uint64_t dispatchFrame(DeviceCallFrame &frame) override {
+    auto *state = static_cast<FrameState *>(frame.channelPrivate);
+    if (!state || !state->inUse)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            "udp dispatch on invalid frame");
+
+    // v1: serialize the wire round-trip so the daemon's FIFO rx slot tracks
+    // the ring slot we pick here (see file header).
+    std::lock_guard<std::mutex> lock(dispatchMutex);
+
+    const std::uint32_t slot = rrCounter % numSlots;
+    rrCounter = (rrCounter + 1u) % numSlots;
+
+    // If this slot still has an outstanding fire-and-forget whose response we
+    // never read, drain that late (zero-length) response before reuse.
+    if (ffPending[slot]) {
+      if (waitFlagNonZero(&rxFlags[slot], "rx-drain"))
+        clearFlag(&rxFlags[slot]);
+      else
+        CUDAQ_DBG("[device-call] udp fire-and-forget drain timed out slot={}",
+                  slot);
+      ffPending[slot] = 0;
+    }
+
+    // Back-pressure: wait for the TX thread to have shipped any prior send in
+    // this slot before overwriting it, and clear any stale response flag.
+    waitFlagZero(&txFlags[slot], "tx");
+    clearFlag(&rxFlags[slot]);
+
+    std::uint8_t *tx_slot = txData + slot * slotSize;
+    // Zero the full transmitted range: the datagram carries the whole slot
+    // stride (mirroring the RoCE TX SGE), so bytes beyond [RPCHeader | args]
+    // must not leak stale ring contents onto the wire.
+    std::memset(tx_slot, 0, slotSize);
+    std::memcpy(tx_slot, state->requestScratch.data(),
+                state->requestScratch.size());
+    publishFlag(&txFlags[slot], reinterpret_cast<std::uint64_t>(tx_slot));
+
+    CUDAQ_DBG("[device-call] udp dispatch slot={} requestId={} "
+              "fireAndForget={}",
+              slot, state->requestId, state->responseCapacity == 0);
+
+    if (state->responseCapacity == 0) {
+      // Async fire-and-forget: return immediately per the device_call
+      // contract; the service still Sends a zero-length response, drained on
+      // this slot's next reuse (see above).
+      ffPending[slot] = 1;
+      return 0;
+    }
+
+    // Wait for the service's response datagram to land in our rx slot.
+    if (!waitFlagNonZero(&rxFlags[slot], "rx"))
+      throw DeviceCallError(DeviceCallStatus::Timeout,
+                            "udp timed out waiting for response");
+
+    void *respFrame = rxData + slot * slotSize;
+    std::uint64_t resultLen = 0;
+    try {
+      resultLen = validateResponseFrame(respFrame, state->requestId,
+                                        state->responseCapacity, slotSize);
+      std::memcpy(state->responseScratch.data(), respFrame,
+                  sizeof(cudaq::realtime::RPCResponse) + resultLen);
+    } catch (...) {
+      clearFlag(&rxFlags[slot]);
+      throw;
+    }
+
+    // Release the rx slot so the transceiver's RX thread can reuse it.
+    clearFlag(&rxFlags[slot]);
+
+    CUDAQ_DBG("[device-call] udp dispatch complete slot={} requestId={} "
+              "resultLen={}",
+              slot, state->requestId, resultLen);
+    return resultLen;
+  }
+
+  void releaseFrame(DeviceCallFrame &frame) noexcept override {
+    auto *state = static_cast<FrameState *>(frame.channelPrivate);
+    if (state) {
+      state->inUse = false;
+      delete state;
+    }
+    frame = {};
+  }
+
+  void stop() noexcept override {
+    if (xcvr) {
+      cpu_udp_close(xcvr);
+      cpu_udp_destroy_transceiver(xcvr);
+      xcvr = nullptr;
+    }
+  }
+
+private:
+  struct FrameState {
+    std::uint32_t requestId = 0;
+    std::uint64_t responseCapacity = 0;
+    std::vector<std::byte> requestScratch;
+    std::vector<std::byte> responseScratch;
+    bool inUse = false;
+  };
+
+  static std::uint64_t loadFlag(const volatile std::uint64_t *flag) {
+    return __atomic_load_n(const_cast<const std::uint64_t *>(flag),
+                           __ATOMIC_ACQUIRE);
+  }
+  static void publishFlag(volatile std::uint64_t *flag, std::uint64_t value) {
+    __atomic_store_n(const_cast<std::uint64_t *>(flag), value,
+                     __ATOMIC_RELEASE);
+  }
+  static void clearFlag(volatile std::uint64_t *flag) {
+    publishFlag(flag, 0);
+  }
+
+  bool waitFlagNonZero(const volatile std::uint64_t *flag, const char *what) {
+    return waitFlag(flag, /*wantZero=*/false, what);
+  }
+  bool waitFlagZero(const volatile std::uint64_t *flag, const char *what) {
+    return waitFlag(flag, /*wantZero=*/true, what);
+  }
+
+  bool waitFlag(const volatile std::uint64_t *flag, bool wantZero,
+                const char *what) {
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(timeoutMs);
+    while ((loadFlag(flag) == 0) != wantZero) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        CUDAQ_DBG("[device-call] udp wait timed out on {}", what);
+        return false;
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(50));
+    }
+    return true;
+  }
+
+  void parseArguments(const std::vector<std::string> &arguments) {
+    for (const auto &arg : arguments) {
+      const auto eq = arg.find('=');
+      if (eq == std::string::npos)
+        continue;
+      const std::string key = arg.substr(0, eq);
+      const std::string value = arg.substr(eq + 1);
+      if (key == "udp-host")
+        serviceHost = value;
+      else if (key == "udp-port")
+        servicePort = static_cast<std::uint16_t>(std::stoul(value));
+    }
+  }
+
+  std::string serviceHost;
+  std::uint16_t servicePort = 0;
+  std::uint32_t numSlots = DefaultNumSlots;
+  std::uint64_t slotSize = DefaultSlotSize;
+  std::uint64_t timeoutMs = DefaultTimeoutMs;
+  cpu_udp_transceiver_t xcvr = nullptr;
+  volatile std::uint64_t *rxFlags = nullptr;
+  volatile std::uint64_t *txFlags = nullptr;
+  std::uint8_t *rxData = nullptr;
+  std::uint8_t *txData = nullptr;
+  std::atomic<std::uint32_t> requestIdCounter{1};
+  std::mutex dispatchMutex;
+  std::uint32_t rrCounter = 0;
+  std::vector<std::uint8_t> ffPending;
+};
+
+CUDAQ_REGISTER_TYPE(DeviceCallChannel, UdpChannel, udp)
+
+} // namespace

--- a/runtime/internal/device_call/UdpChannel.cpp
+++ b/runtime/internal/device_call/UdpChannel.cpp
@@ -7,52 +7,52 @@
  ******************************************************************************/
 
 // UdpChannel — a DeviceCallChannel that carries device_call RPCs over UDP
-// datagrams using the cpu_transport UdpTransceiver.  It is the loopback/CI
-// stand-in for CpuRoceChannel on hosts without an RDMA NIC: same wire frames
+// datagrams using the cpu_transport UdpTransceiver.  It is the plain-UDP
+// counterpart of CpuRoceChannel for systems without an RDMA NIC — anything
+// from loopback development to a real UDP network: same wire frames
 // ([RPCHeader | args] request, [RPCResponse | result] response), same ring
-// contract, and the same caller-side frame lifecycle, so the service end (a
-// daemon wiring the transceiver rings into libcudaq-realtime's HOST_CALL
-// dispatcher) is transport-agnostic between UDP and RoCE.
+// contract, and the same caller-side frame lifecycle (RingSlotChannel), so
+// the service end (a daemon wiring the transceiver rings into
+// libcudaq-realtime's HOST_CALL dispatcher) is transport-agnostic between UDP
+// and RoCE.
 //
 // No QP/rkey rendezvous is needed (UDP addressing replaces it): the channel
 // just connects to the daemon's UDP endpoint.
 //
-// Slot correlation (v1, matching CpuRoceChannel): the daemon's host dispatcher
-// mirrors its rx slot to its tx slot, and both transceivers fill RX slots in
-// strict arrival order, so serializing response-bearing dispatch and assigning
-// ring slots round-robin keeps the daemon's FIFO rx slot equal to ours.
-// request_id stays globally monotonic for uniqueness/validation.
+// Slot correlation is the shared v1 protocol (see RingSlotChannel.h).  Known
+// v1 limitation on this transport: correlation is purely positional, and UDP
+// -- unlike the RoCE RC wire -- gives no delivery guarantee, so a datagram
+// that is lost (e.g. socket-buffer overflow under a large-numSlots burst) or
+// delayed past timeoutMs (e.g. a fire-and-forget handler stalling longer
+// than the drain timeout) permanently shifts the arrival cursor against the
+// round-robin slot counter; every later response-bearing dispatch then fails
+// validation or times out until the channel is torn down and re-created.
+// Default configurations cannot reach this state (in-flight traffic is
+// capped at numSlots datagrams, far below any realistic socket buffer); the
+// phase-2 request_id-keyed correlation removes the fragility outright.
 //
 // Channel arguments (key=value tokens on the device_call command line):
 //   udp-host=<ipv4>   service daemon address (required)
 //   udp-port=<port>   service daemon UDP port (required)
 //
-// Both ends must use the same slot stride (each datagram carries one full
-// slot, mirroring the RoCE TX SGE); the daemon's --slot-size must equal this
-// channel's configured slot size.
+// Both ends must use the same slot stride: each datagram carries one full
+// slot (see udp_wrapper.h, "Wire behavior"), so the daemon's --slot-size must
+// equal this channel's configured slot size or the receiving end silently
+// drops every request.
 
-#include "cudaq_internal/device_call/DeviceCallChannel.h"
-#include "cudaq_internal/device_call/DeviceCallError.h"
-#include "cudaq_internal/device_call/RpcFrame.h"
+#include "cudaq_internal/device_call/RingSlotChannel.h"
 
 #include "cudaq/realtime/cpu_transport/udp_wrapper.h"
-#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
 
-#include "cudaq/runtime/logger/logger.h"
-
-#include <atomic>
 #include <chrono>
-#include <cstring>
-#include <mutex>
 #include <string>
 #include <thread>
-#include <vector>
 
 namespace {
 
 using namespace cudaq_internal::device_call;
 
-class UdpChannel : public DeviceCallChannel {
+class UdpChannel : public RingSlotChannel {
 public:
   ~UdpChannel() override { stop(); }
 
@@ -83,142 +83,17 @@ public:
                             "udp channel: transceiver start failed");
     }
 
-    rxFlags = reinterpret_cast<volatile std::uint64_t *>(
-        cpu_udp_get_rx_ring_flag_addr(xcvr));
-    txFlags = reinterpret_cast<volatile std::uint64_t *>(
-        cpu_udp_get_tx_ring_flag_addr(xcvr));
+    rxFlags =
+        reinterpret_cast<std::uint64_t *>(cpu_udp_get_rx_ring_flag_addr(xcvr));
+    txFlags =
+        reinterpret_cast<std::uint64_t *>(cpu_udp_get_tx_ring_flag_addr(xcvr));
     rxData =
         reinterpret_cast<std::uint8_t *>(cpu_udp_get_rx_ring_data_addr(xcvr));
     txData =
         reinterpret_cast<std::uint8_t *>(cpu_udp_get_tx_ring_data_addr(xcvr));
-    ffPending.assign(numSlots, 0);
-  }
-
-  void acquireFrame(std::uint32_t functionId, std::uint64_t requestBytes,
-                    std::uint64_t responseCapacity,
-                    DeviceCallFrame &frame) override {
-    frame = {};
-    if (CUDAQ_RPC_HEADER_SIZE + requestBytes > slotSize)
-      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
-                            "udp request exceeds slot size");
-    if (sizeof(cudaq::realtime::RPCResponse) + responseCapacity > slotSize)
-      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
-                            "udp response capacity exceeds slot size");
-
-    auto state = std::make_unique<FrameState>();
-    state->requestId = requestIdCounter.fetch_add(1, std::memory_order_relaxed);
-    state->responseCapacity = responseCapacity;
-    state->requestScratch.assign(CUDAQ_RPC_HEADER_SIZE + requestBytes,
-                                 std::byte{0});
-    state->responseScratch.assign(
-        sizeof(cudaq::realtime::RPCResponse) + responseCapacity, std::byte{0});
-    state->inUse = true;
-
-    // Lay down the request header in the scratch; args follow it.
-    auto *hdr = reinterpret_cast<cudaq::realtime::RPCHeader *>(
-        state->requestScratch.data());
-    hdr->magic = cudaq::realtime::RPC_MAGIC_REQUEST;
-    hdr->function_id = functionId;
-    hdr->arg_len = static_cast<std::uint32_t>(requestBytes);
-    hdr->request_id = state->requestId;
-    hdr->ptp_timestamp = 0;
-
-    frame.functionId = functionId;
-    frame.request.data = requestPayload(state->requestScratch.data());
-    frame.request.capacity = requestBytes;
-    frame.response.data = responsePayload(state->responseScratch.data());
-    frame.response.capacity = responseCapacity;
-    frame.channelPrivate = state.release();
-
-    CUDAQ_DBG("[device-call] udp acquire functionId={} requestBytes={} "
-              "responseCapacity={} requestId={}",
-              functionId, requestBytes, responseCapacity,
-              static_cast<FrameState *>(frame.channelPrivate)->requestId);
-  }
-
-  std::uint64_t dispatchFrame(DeviceCallFrame &frame) override {
-    auto *state = static_cast<FrameState *>(frame.channelPrivate);
-    if (!state || !state->inUse)
-      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
-                            "udp dispatch on invalid frame");
-
-    // v1: serialize the wire round-trip so the daemon's FIFO rx slot tracks
-    // the ring slot we pick here (see file header).
-    std::lock_guard<std::mutex> lock(dispatchMutex);
-
-    const std::uint32_t slot = rrCounter % numSlots;
-    rrCounter = (rrCounter + 1u) % numSlots;
-
-    // If this slot still has an outstanding fire-and-forget whose response we
-    // never read, drain that late (zero-length) response before reuse.
-    if (ffPending[slot]) {
-      if (waitFlagNonZero(&rxFlags[slot], "rx-drain"))
-        clearFlag(&rxFlags[slot]);
-      else
-        CUDAQ_DBG("[device-call] udp fire-and-forget drain timed out slot={}",
-                  slot);
-      ffPending[slot] = 0;
-    }
-
-    // Back-pressure: wait for the TX thread to have shipped any prior send in
-    // this slot before overwriting it, and clear any stale response flag.
-    waitFlagZero(&txFlags[slot], "tx");
-    clearFlag(&rxFlags[slot]);
-
-    std::uint8_t *tx_slot = txData + slot * slotSize;
-    // Zero the full transmitted range: the datagram carries the whole slot
-    // stride (mirroring the RoCE TX SGE), so bytes beyond [RPCHeader | args]
-    // must not leak stale ring contents onto the wire.
-    std::memset(tx_slot, 0, slotSize);
-    std::memcpy(tx_slot, state->requestScratch.data(),
-                state->requestScratch.size());
-    publishFlag(&txFlags[slot], reinterpret_cast<std::uint64_t>(tx_slot));
-
-    CUDAQ_DBG("[device-call] udp dispatch slot={} requestId={} "
-              "fireAndForget={}",
-              slot, state->requestId, state->responseCapacity == 0);
-
-    if (state->responseCapacity == 0) {
-      // Async fire-and-forget: return immediately per the device_call
-      // contract; the service still Sends a zero-length response, drained on
-      // this slot's next reuse (see above).
-      ffPending[slot] = 1;
-      return 0;
-    }
-
-    // Wait for the service's response datagram to land in our rx slot.
-    if (!waitFlagNonZero(&rxFlags[slot], "rx"))
-      throw DeviceCallError(DeviceCallStatus::Timeout,
-                            "udp timed out waiting for response");
-
-    void *respFrame = rxData + slot * slotSize;
-    std::uint64_t resultLen = 0;
-    try {
-      resultLen = validateResponseFrame(respFrame, state->requestId,
-                                        state->responseCapacity, slotSize);
-      std::memcpy(state->responseScratch.data(), respFrame,
-                  sizeof(cudaq::realtime::RPCResponse) + resultLen);
-    } catch (...) {
-      clearFlag(&rxFlags[slot]);
-      throw;
-    }
-
-    // Release the rx slot so the transceiver's RX thread can reuse it.
-    clearFlag(&rxFlags[slot]);
-
-    CUDAQ_DBG("[device-call] udp dispatch complete slot={} requestId={} "
-              "resultLen={}",
-              slot, state->requestId, resultLen);
-    return resultLen;
-  }
-
-  void releaseFrame(DeviceCallFrame &frame) noexcept override {
-    auto *state = static_cast<FrameState *>(frame.channelPrivate);
-    if (state) {
-      state->inUse = false;
-      delete state;
-    }
-    frame = {};
+    rxStride = slotSize;
+    txStride = slotSize;
+    initRingState();
   }
 
   void stop() noexcept override {
@@ -230,75 +105,27 @@ public:
   }
 
 private:
-  struct FrameState {
-    std::uint32_t requestId = 0;
-    std::uint64_t responseCapacity = 0;
-    std::vector<std::byte> requestScratch;
-    std::vector<std::byte> responseScratch;
-    bool inUse = false;
-  };
+  const char *channelTag() const noexcept override { return "udp"; }
 
-  static std::uint64_t loadFlag(const volatile std::uint64_t *flag) {
-    return __atomic_load_n(const_cast<const std::uint64_t *>(flag),
-                           __ATOMIC_ACQUIRE);
-  }
-  static void publishFlag(volatile std::uint64_t *flag, std::uint64_t value) {
-    __atomic_store_n(const_cast<std::uint64_t *>(flag), value,
-                     __ATOMIC_RELEASE);
-  }
-  static void clearFlag(volatile std::uint64_t *flag) {
-    publishFlag(flag, 0);
-  }
-
-  bool waitFlagNonZero(const volatile std::uint64_t *flag, const char *what) {
-    return waitFlag(flag, /*wantZero=*/false, what);
-  }
-  bool waitFlagZero(const volatile std::uint64_t *flag, const char *what) {
-    return waitFlag(flag, /*wantZero=*/true, what);
-  }
-
-  bool waitFlag(const volatile std::uint64_t *flag, bool wantZero,
-                const char *what) {
-    const auto deadline = std::chrono::steady_clock::now() +
-                          std::chrono::milliseconds(timeoutMs);
-    while ((loadFlag(flag) == 0) != wantZero) {
-      if (std::chrono::steady_clock::now() > deadline) {
-        CUDAQ_DBG("[device-call] udp wait timed out on {}", what);
-        return false;
-      }
-      std::this_thread::sleep_for(std::chrono::microseconds(50));
-    }
-    return true;
+  // A 5us sleep keeps the per-poll latency floor small without pinning a
+  // core the way the RDMA channel's cpuRelax spin does.
+  void relax() const override {
+    std::this_thread::sleep_for(std::chrono::microseconds(5));
   }
 
   void parseArguments(const std::vector<std::string> &arguments) {
-    for (const auto &arg : arguments) {
-      const auto eq = arg.find('=');
-      if (eq == std::string::npos)
-        continue;
-      const std::string key = arg.substr(0, eq);
-      const std::string value = arg.substr(eq + 1);
-      if (key == "udp-host")
-        serviceHost = value;
-      else if (key == "udp-port")
-        servicePort = static_cast<std::uint16_t>(std::stoul(value));
-    }
+    forEachKeyValue(arguments,
+                    [this](const std::string &key, const std::string &value) {
+                      if (key == "udp-host")
+                        serviceHost = value;
+                      else if (key == "udp-port")
+                        servicePort = parsePort(value, "udp-port");
+                    });
   }
 
   std::string serviceHost;
   std::uint16_t servicePort = 0;
-  std::uint32_t numSlots = DefaultNumSlots;
-  std::uint64_t slotSize = DefaultSlotSize;
-  std::uint64_t timeoutMs = DefaultTimeoutMs;
   cpu_udp_transceiver_t xcvr = nullptr;
-  volatile std::uint64_t *rxFlags = nullptr;
-  volatile std::uint64_t *txFlags = nullptr;
-  std::uint8_t *rxData = nullptr;
-  std::uint8_t *txData = nullptr;
-  std::atomic<std::uint32_t> requestIdCounter{1};
-  std::mutex dispatchMutex;
-  std::uint32_t rrCounter = 0;
-  std::vector<std::uint8_t> ffPending;
 };
 
 CUDAQ_REGISTER_TYPE(DeviceCallChannel, UdpChannel, udp)

--- a/runtime/internal/device_call/include/cudaq_internal/device_call/RingSlotChannel.h
+++ b/runtime/internal/device_call/include/cudaq_internal/device_call/RingSlotChannel.h
@@ -1,0 +1,312 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+// RingSlotChannel -- the transport-independent caller side of the v1
+// ring-slot device_call RPC protocol, shared by CpuRoceChannel (RDMA wire)
+// and UdpChannel (loopback/Ethernet UDP wire).  Everything protocol-shaped
+// lives here so a fix or protocol evolution (e.g. the documented
+// phase2_imm_convention concurrent-dispatch follow-up) lands in exactly one
+// place; the subclasses supply only transport setup/teardown and argument
+// parsing.
+//
+// Protocol (v1): the service's host dispatcher mirrors its rx slot to its tx
+// slot, and both ends fill RX slots in strict arrival order, so serializing
+// response-bearing dispatch and assigning ring slots round-robin keeps the
+// service's FIFO rx slot equal to ours.  request_id stays globally monotonic
+// for uniqueness/validation.  The service sends a response for *every*
+// request, including fire-and-forget; a fire-and-forget's (ignored)
+// zero-length response is drained on the slot's next reuse so it is never
+// read as a later request's response.
+//
+// Subclass contract: initialize() must fill the protected ring/config members
+// (numSlots, slotSize, timeoutMs, tx/rx data + flags + strides) and call
+// initRingState() before the first dispatch.  Flags are host-visible
+// std::uint64_t ring entries accessed with acquire/release atomics; a
+// non-zero value means "slot published/fresh", zero means "free".
+
+#include "cudaq_internal/device_call/DeviceCallChannel.h"
+#include "cudaq_internal/device_call/DeviceCallError.h"
+#include "cudaq_internal/device_call/RpcFrame.h"
+
+#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
+
+#include "cudaq/runtime/logger/logger.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace cudaq_internal::device_call {
+
+class RingSlotChannel : public DeviceCallChannel {
+public:
+  void acquireFrame(std::uint32_t functionId, std::uint64_t requestBytes,
+                    std::uint64_t responseCapacity,
+                    DeviceCallFrame &frame) override {
+    frame = {};
+    if (CUDAQ_RPC_HEADER_SIZE + requestBytes > slotSize)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            std::string(channelTag()) +
+                                " request exceeds slot size");
+    if (sizeof(cudaq::realtime::RPCResponse) + responseCapacity > slotSize)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            std::string(channelTag()) +
+                                " response capacity exceeds slot size");
+
+    auto state = std::make_unique<FrameState>();
+    state->functionId = functionId;
+    state->requestBytes = requestBytes;
+    state->responseCapacity = responseCapacity;
+    state->requestId = requestIdCounter.fetch_add(1, std::memory_order_relaxed);
+    state->requestScratch.assign(CUDAQ_RPC_HEADER_SIZE + requestBytes,
+                                 std::byte{0});
+    state->responseScratch.assign(
+        sizeof(cudaq::realtime::RPCResponse) + responseCapacity, std::byte{0});
+    state->inUse = true;
+
+    // Lay down the request header in the scratch; args follow it.
+    auto *hdr = reinterpret_cast<cudaq::realtime::RPCHeader *>(
+        state->requestScratch.data());
+    hdr->magic = cudaq::realtime::RPC_MAGIC_REQUEST;
+    hdr->function_id = functionId;
+    hdr->arg_len = static_cast<std::uint32_t>(requestBytes);
+    hdr->request_id = state->requestId;
+    hdr->ptp_timestamp = 0;
+
+    frame.functionId = functionId;
+    frame.request.data = requestPayload(state->requestScratch.data());
+    frame.request.capacity = requestBytes;
+    frame.response.data = responsePayload(state->responseScratch.data());
+    frame.response.capacity = responseCapacity;
+    frame.channelPrivate = state.release();
+
+    CUDAQ_DBG("[device-call] {} acquire functionId={} requestBytes={} "
+              "responseCapacity={} requestId={}",
+              channelTag(), functionId, requestBytes, responseCapacity,
+              static_cast<FrameState *>(frame.channelPrivate)->requestId);
+  }
+
+  std::uint64_t dispatchFrame(DeviceCallFrame &frame) override {
+    auto *state = static_cast<FrameState *>(frame.channelPrivate);
+    if (!state || !state->inUse)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            std::string(channelTag()) +
+                                " dispatch on invalid frame");
+
+    // v1: serialize the wire round-trip so the service's FIFO rx slot tracks
+    // the ring slot we pick here.  See file header.
+    std::lock_guard<std::mutex> lock(dispatchMutex);
+
+    const std::uint32_t slot = rrCounter % numSlots;
+    rrCounter = (rrCounter + 1u) % numSlots;
+
+    // If this slot still has an outstanding fire-and-forget whose response we
+    // never read, drain that late (zero-length) response before reuse.
+    if (ffPending[slot]) {
+      if (waitFlagNonZero(rxFlags[slot]))
+        clearFlag(rxFlags[slot]);
+      else
+        CUDAQ_DBG("[device-call] {} fire-and-forget drain timed out slot={} "
+                  "requestId={}",
+                  channelTag(), slot, ffPendingRequestId[slot]);
+      ffPending[slot] = 0;
+    }
+
+    std::uint8_t *const txSlot = txData + slot * txStride;
+    std::uint8_t *const rxSlot = rxData + slot * rxStride;
+
+    // Back-pressure: the prior send in this slot must have been shipped by
+    // the transport before we overwrite it.  A still-published flag past the
+    // timeout means the transport TX path is wedged; overwriting anyway would
+    // corrupt an in-flight message, so fail the dispatch instead.
+    waitFlagZeroOrThrow(txFlags[slot], "tx");
+    // Defensive: clear any stale response flag for this slot before reuse.
+    clearFlag(rxFlags[slot]);
+
+    // Zero the full transmitted range before writing.  The transport ships
+    // the whole per-slot stride, so any bytes beyond [RPCHeader | args] would
+    // otherwise carry stale ring contents from a previous message onto the
+    // wire.  The service only reads arg_len, but we must not transmit
+    // uninitialized/stale memory.
+    std::memset(txSlot, 0, txStride);
+    std::memcpy(txSlot, state->requestScratch.data(),
+                state->requestScratch.size());
+    publishFlag(txFlags[slot], reinterpret_cast<std::uint64_t>(txSlot));
+
+    CUDAQ_DBG("[device-call] {} dispatch slot={} requestId={} functionId={} "
+              "fireAndForget={}",
+              channelTag(), slot, state->requestId, state->functionId,
+              state->responseCapacity == 0);
+
+    if (state->responseCapacity == 0) {
+      // Async fire-and-forget: return immediately per the device_call
+      // contract.  Mark the slot so its next reuse drains the service's late
+      // zero-length response (see the drain above) before overwriting it.
+      ffPending[slot] = 1;
+      ffPendingRequestId[slot] = state->requestId;
+      return 0;
+    }
+
+    // Wait for the service's response to land in our rx slot.
+    if (!waitFlagNonZero(rxFlags[slot]))
+      throw DeviceCallError(DeviceCallStatus::Timeout,
+                            std::string(channelTag()) +
+                                " timed out waiting for response");
+
+    std::uint64_t resultLen = 0;
+    try {
+      resultLen = validateResponseFrame(rxSlot, state->requestId,
+                                        state->responseCapacity, rxStride);
+      // Hand the validated result bytes back through the caller's scratch.
+      std::memcpy(state->responseScratch.data(), rxSlot,
+                  sizeof(cudaq::realtime::RPCResponse) + resultLen);
+    } catch (...) {
+      clearFlag(rxFlags[slot]);
+      throw;
+    }
+
+    // Release the rx slot so the transport's RX path can reuse it.
+    clearFlag(rxFlags[slot]);
+
+    CUDAQ_DBG("[device-call] {} dispatch complete slot={} requestId={} "
+              "resultLen={}",
+              channelTag(), slot, state->requestId, resultLen);
+    return resultLen;
+  }
+
+  void releaseFrame(DeviceCallFrame &frame) noexcept override {
+    auto *state = static_cast<FrameState *>(frame.channelPrivate);
+    if (state) {
+      state->inUse = false;
+      delete state;
+    }
+    frame = {};
+  }
+
+protected:
+  // Per-lease state hung off DeviceCallFrame::channelPrivate.  Holds
+  // host-visible scratch the caller writes args into / reads results out of;
+  // dispatchFrame copies between this scratch and the ring slot it picks.
+  struct FrameState {
+    std::uint32_t functionId = 0;
+    std::uint32_t requestId = 0;
+    std::uint64_t requestBytes = 0;
+    std::uint64_t responseCapacity = 0;
+    bool inUse = false;
+    std::vector<std::byte> requestScratch;  // [RPCHeader | args]
+    std::vector<std::byte> responseScratch; // [RPCResponse | result]
+  };
+
+  // Short transport tag used in log and error messages ("cpu_roce", "udp").
+  virtual const char *channelTag() const noexcept = 0;
+
+  // Called between flag polls.  Transports pick their wait posture: busy-spin
+  // (cpuRelax) for latency-sensitive RDMA, a short sleep for the UDP
+  // transport.
+  virtual void relax() const = 0;
+
+  // Subclass initialize() fills these, then calls initRingState().
+  std::uint32_t numSlots = DefaultNumSlots;
+  std::uint64_t slotSize = DefaultSlotSize;
+  std::uint64_t timeoutMs = DefaultTimeoutMs;
+  std::uint8_t *txData = nullptr;
+  std::uint64_t *txFlags = nullptr;
+  std::size_t txStride = 0;
+  std::uint8_t *rxData = nullptr;
+  std::uint64_t *rxFlags = nullptr;
+  std::size_t rxStride = 0;
+
+  void initRingState() {
+    ffPending.assign(numSlots, 0);
+    ffPendingRequestId.assign(numSlots, 0);
+  }
+
+  // ---- flag handshakes (acquire/release atomics on ring flag entries) ----
+
+  static std::uint64_t loadFlag(std::uint64_t &flag) {
+    return __atomic_load_n(&flag, __ATOMIC_ACQUIRE);
+  }
+  static void publishFlag(std::uint64_t &flag, std::uint64_t value) {
+    __atomic_store_n(&flag, value, __ATOMIC_RELEASE);
+  }
+  static void clearFlag(std::uint64_t &flag) { publishFlag(flag, 0); }
+
+  void waitFlagZeroOrThrow(std::uint64_t &flag, const char *which) const {
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    while (loadFlag(flag) != 0) {
+      if (std::chrono::steady_clock::now() > deadline)
+        throw DeviceCallError(DeviceCallStatus::Timeout,
+                              std::string(channelTag()) + " " + which +
+                                  " slot back-pressure timed out");
+      relax();
+    }
+  }
+
+  bool waitFlagNonZero(std::uint64_t &flag) const {
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    while (loadFlag(flag) == 0) {
+      if (std::chrono::steady_clock::now() > deadline)
+        return false;
+      relax();
+    }
+    return true;
+  }
+
+  // ---- argument parsing helpers ----
+
+  // Invoke fn(key, value) for every "key=value" token; other tokens are
+  // ignored (they may belong to other components on the command line).
+  template <typename Fn>
+  static void forEachKeyValue(const std::vector<std::string> &arguments,
+                              Fn &&fn) {
+    for (const auto &arg : arguments) {
+      const auto eq = arg.find('=');
+      if (eq == std::string::npos)
+        continue;
+      fn(arg.substr(0, eq), arg.substr(eq + 1));
+    }
+  }
+
+  // Parse a UDP/TCP port argument, rejecting non-numeric input and values
+  // outside [1, 65535] with a DeviceCallError instead of letting std::stoul's
+  // raw exceptions (or a silent uint16_t truncation) escape.
+  std::uint16_t parsePort(const std::string &value, const char *key) const {
+    unsigned long port = 0;
+    std::size_t consumed = 0;
+    try {
+      port = std::stoul(value, &consumed);
+    } catch (const std::exception &) {
+      consumed = 0;
+    }
+    if (consumed != value.size() || value.empty() || port == 0 || port > 65535)
+      throw DeviceCallError(DeviceCallStatus::InvalidArgument,
+                            std::string(channelTag()) + " channel: " + key +
+                                "=" + value + " is not a valid port (1-65535)");
+    return static_cast<std::uint16_t>(port);
+  }
+
+private:
+  std::mutex dispatchMutex; // v1: serialize wire round-trips
+  std::uint32_t rrCounter = 0;
+  // Per-slot tracking of an outstanding fire-and-forget whose (ignored)
+  // zero-length response has not yet been drained.  Sized in initRingState().
+  std::vector<char> ffPending;
+  std::vector<std::uint32_t> ffPendingRequestId;
+  std::atomic<std::uint32_t> requestIdCounter{1};
+};
+
+} // namespace cudaq_internal::device_call


### PR DESCRIPTION
Builds off of #4866; will rebase once that merge lands. Correspondingly, the PR is currently targeting the 4866 branch, but that will change once it lands.

Adds a plain-UDP transport for `device_call`, for systems without an RDMA NIC (loopback or a real network):

- **`cudaq-realtime-udp-transport`**: a UDP ring transceiver with the same ring contract as the RoCE transport. No ibverbs, no CUDA - always built. TX ships published slots in FIFO cursor order so fire-and-forget bursts keep program order on the wire. Bind address is configurable (`cpu_udp_bind_to`, `"0.0.0.0"` for all interfaces).
- **`UdpChannel`**: the `udp` device_call channel over that transport (`udp-host=`/`udp-port=` args). The transport-independent v1 ring-slot RPC protocol is factored into a shared `RingSlotChannel` base reused by `CpuRoceChannel`, which also picks up stricter TX back-pressure timeout handling and validated port parsing.
- **Standalone tests** in `realtime/unittests/cpu_transport` (pure CPU, run on any Realtime CI runner via `ctest`): lifecycle, loopback delivery, round trips, strict RX ring order, FIFO TX order across ring wrap, and oversized-datagram rejection.

Verified end-to-end against the experimental cudaq-qec decoding server: two-process UDP tests (incl. dual decoders) and a 1000-shot distance-5 surface-code memory experiment decoded by a separate daemon.