### PR TITLE
[python] Install notebook from requirements

### DIFF
--- a/docker/build/devdeps.Dockerfile
+++ b/docker/build/devdeps.Dockerfile
@@ -173,6 +173,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y wget ca-certifi
     && apt-get remove -y wget ca-certificates \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH="${PATH}:/usr/local/cmake-3.28/bin"
+COPY requirements.txt /cuda-quantum/requirements.txt
 COPY requirements-dev.txt /cuda-quantum/requirements-dev.txt
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git gdb ninja-build file lldb ccache libatomic1 \

--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -60,8 +60,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 -m pip install --no-cache-dir --break-system-packages numpy scipy \
     && ln -s /bin/python3 /bin/python
+ADD ./requirements.txt /tmp/requirements.txt
 RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ python3-dev \
-    && python3 -m pip install --no-cache-dir --break-system-packages notebook==7.3.2 "qutip>5" matplotlib \
+    && python3 -m pip install --no-cache-dir --break-system-packages -r /tmp/requirements.txt "qutip>5" matplotlib \
+    && rm /tmp/requirements.txt \
     && apt-get remove -y gcc g++ python3-dev \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/release/cudaq.ext.Dockerfile
+++ b/docker/release/cudaq.ext.Dockerfile
@@ -42,13 +42,15 @@ RUN cuda_version_suffix=$(echo ${CUDA_VERSION} | tr . -) && \
     fi && \
     # just here for convenience:
     apt-get install -y --no-install-recommends curl jq 
+ADD ./requirements.txt /tmp/requirements.txt
 RUN if [ -x "$(command -v pip)" ]; then \
         apt-get install -y --no-install-recommends gcc libpython3-dev \
-        && pip install --no-cache-dir jupyterlab==4.5.7; \
+        && pip install --no-cache-dir -r /tmp/requirements.txt; \
         if [ -n "$MPI_ROOT" ]; then \
             pip install --no-cache-dir mpi4py~=4.1; \
         fi; \
-    fi
+    fi \
+    && rm /tmp/requirements.txt
 # Install CUDA Python packages based on CUDA version
 RUN cuda_major_version=$(echo ${CUDA_VERSION} | cut -d . -f1) && \
     if [ "$cuda_major_version" = "12" ]; then \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,27 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# Development dependencies for building and testing CUDA-Q
-build
-delocate; sys_platform == "darwin"
-auditwheel; sys_platform == "linux"
-lit==18.1.4
-pytest==9.0.3
-pytest-xdist==3.8.0
-psutil
-numpy==1.26.4
--r requirements.txt
-nbconvert==7.17.1
-llvmlite==0.47.0
-scipy==1.16.3
-requests==2.32.3
-fastapi==0.111.0
-uvicorn==0.29.0
-pydantic==2.12.5
-openfermionpyscf==0.5
-h5py==3.12.1
-matplotlib
-pyspelling==2.10
-pymdown-extensions==10.21.3
-nanobind>=2.12.0
-yapf==0.43.0
+# Single place these versions are pinned; used by the release image,
+# installation validation, and requirements-dev.txt.
+notebook==7.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@
 
 # Single place these versions are pinned; used by the release image,
 # installation validation, and requirements-dev.txt.
+jupyterlab==4.5.7
 notebook==7.5.6

--- a/scripts/validate_installation.sh
+++ b/scripts/validate_installation.sh
@@ -543,7 +543,12 @@ if [ -n "$(find examples/ applications/ -name '*.ipynb')" ]; then
     echo "Installing Jupyter kernel infrastructure..."
     # Only install what's needed to register the kernel
     pip install --upgrade pip -q
-    pip install jupyter ipykernel notebook -q
+    notebook_requirements="$this_script_dir/../requirements.txt"
+    if [ -f "$notebook_requirements" ]; then
+        pip install jupyter ipykernel -r "$notebook_requirements" -q
+    else
+        pip install jupyter ipykernel notebook -q
+    fi
     
     # Register the venv as a Jupyter kernel
     # Notebooks will execute in this environment and can install their own packages


### PR DESCRIPTION
Instead of hardcoding the notebook version, use a requirements.txt file to have a single source of truth so versions can not go out of date.