### PR TITLE
Fix cudaq.run infinite loop when backend returns fewer shots than requested (#4881)

### DIFF
--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -29,7 +29,19 @@ static std::vector<nanobind::object>
 readRunResults(mlir::ModuleOp module, mlir::Type ty,
                detail::RunResultSpan &results, std::size_t count) {
   std::vector<nanobind::object> ret;
+  if (count == 0)
+    return ret;
   std::size_t byteSize = results.lengthInBytes / count;
+  // A remote backend may return fewer results than the requested number of
+  // shots. In that case `byteSize` underflows to 0, which would make the loop
+  // below never advance (infinite loop, then OOM kill). Fail with a clear
+  // error instead. See https://github.com/NVIDIA/cuda-quantum/issues/4881.
+  if (byteSize == 0)
+    throw std::runtime_error(
+        "cudaq::run received fewer result bytes (" +
+        std::to_string(results.lengthInBytes) +
+        ") than the requested number of shots (" + std::to_string(count) +
+        "). The backend may have returned an incomplete result set.");
   for (std::size_t i = 0; i < results.lengthInBytes; i += byteSize) {
     nanobind::object obj = convertResult(module, ty, results.data + i);
     ret.push_back(obj);


### PR DESCRIPTION
### Summary

Fixes #4881.

\`cudaq.run\` assumes a remote backend returns exactly the requested number of shots. When it returns fewer, Python result decoding enters an infinite loop and is eventually killed by the OS for memory exhaustion.

The cause is in \`readRunResults\` (\`python/runtime/cudaq/algorithms/py_run.cpp\`):

\`\`\`cpp
std::size_t byteSize = results.lengthInBytes / count;
for (std::size_t i = 0; i < results.lengthInBytes; i += byteSize) { ... }
\`\`\`

\`count\` is the requested shot count. If the returned buffer is smaller than \`count\` bytes (e.g. requested 100 shots, 80 bytes returned), the division underflows to \`byteSize == 0\`, so \`i += byteSize\` never advances and the loop spins forever, growing \`ret\` until OOM.

### Fix

- Return early when \`count == 0\` (defensive; the \`run_impl\` callers already short-circuit \`shots_count == 0\`, but the helper should not divide by zero).
- Raise a clear \`std::runtime_error\` when \`byteSize == 0\`, reporting the received byte count and the requested shot count, instead of hanging.

This turns a silent hang + OOM kill into an explicit, actionable error.

### Testing

The failure path is only reachable through a remote backend that returns a short result buffer, so it is not exercised by the local simulator test suite. The guard fires precisely on the reported condition (\`lengthInBytes < count\`), matching the reproduction in #4881. I can add a mock-server regression test under \`unittests/nvqpp/backends\` if maintainers prefer coverage there.