### PR TITLE
Strip detectors and observable ops from hardware emulations

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
@@ -118,6 +118,7 @@ createEmulationTargetPrepPipeline(OpPassManager &pm,
                                   const TargetPrepPipelineOptions &options) {
   if (options.eraseNoise)
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createEraseNoise());
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createEraseQEC());
   createTargetPrepPipeline(pm, options);
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createStatePreparation());
 }

--- a/python/tests/analysis/test_dem_from_kernel.py
+++ b/python/tests/analysis/test_dem_from_kernel.py
@@ -206,6 +206,9 @@ def test_emulate_target_independent():
             "observables": 1
         }
 
+        counts = cudaq.sample(kernel, shots_count=10)
+        assert counts["0"] == 10
+
         @cudaq.kernel
         def hyperedge_kernel():
             q0 = cudaq.qubit()

--- a/targettests/execution/dem_from_kernel_emulate.cpp
+++ b/targettests/execution/dem_from_kernel_emulate.cpp
@@ -107,13 +107,13 @@ static void runCase(const char *label, Kernel &&kernel) {
   }
 }
 
-// Unlike dem_from_kernel, cudaq::sample routes through createEmulationTargetPrepPipeline, which must strip QEC ops.
+// Unlike dem_from_kernel, cudaq::sample routes through
+// createEmulationTargetPrepPipeline, which must strip QEC ops.
 template <typename Kernel>
 static void runSampleCase(const char *label, Kernel &&kernel) {
   try {
     auto counts = cudaq::sample(std::forward<Kernel>(kernel));
-    std::printf("%s most_probable=%s\n", label,
-                counts.most_probable().c_str());
+    std::printf("%s most_probable=%s\n", label, counts.most_probable().c_str());
   } catch (const std::exception &e) {
     std::printf("%s THREW: %s\n", label, e.what());
   }

--- a/targettests/execution/dem_from_kernel_emulate.cpp
+++ b/targettests/execution/dem_from_kernel_emulate.cpp
@@ -107,6 +107,18 @@ static void runCase(const char *label, Kernel &&kernel) {
   }
 }
 
+// Unlike dem_from_kernel, cudaq::sample routes through createEmulationTargetPrepPipeline, which must strip QEC ops.
+template <typename Kernel>
+static void runSampleCase(const char *label, Kernel &&kernel) {
+  try {
+    auto counts = cudaq::sample(std::forward<Kernel>(kernel));
+    std::printf("%s most_probable=%s\n", label,
+                counts.most_probable().c_str());
+  } catch (const std::exception &e) {
+    std::printf("%s THREW: %s\n", label, e.what());
+  }
+}
+
 template <typename Kernel>
 static void runDecomposeCase(const char *label, Kernel &&kernel) {
   try {
@@ -134,6 +146,7 @@ int main() {
   runCase("SINGLE", singleDetector{});
   runCase("THREE_MZ", threeMzMultiDetector{});
   runDecomposeCase("CORRELATED_XX", correlatedXXHyperedge{});
+  runSampleCase("SAMPLE_QEC_KERNEL", singleDetector{});
   return 0;
 }
 
@@ -141,3 +154,4 @@ int main() {
 // CHECK: THREE_MZ detectors=1 observables=1
 // CHECK: CORRELATED_XX_RAW hyperedge=1 caret=0
 // CHECK: CORRELATED_XX_DECOMPOSED hyperedge=0 caret=1
+// CHECK: SAMPLE_QEC_KERNEL most_probable=0


### PR DESCRIPTION
## Summary

For hardware targets, the JIT lowering runs one of two preparation pipelines
(`runtime/internal/compiler/JITTargetPipeline.cpp:46-52`):

- **Real submission** → `hw-jit-prep-pipeline`, which runs the `erase-qec` pass
  and deletes `qec.detector` / `qec.observable` / `qec.pair_detectors` before
  QIR-profile lowering (`cudaq/lib/Optimizer/Transforms/Pipelines.cpp:99`).
- **`--emulate`** → `emul-jit-prep-pipeline`, which erases noise ops but **not**
  QEC ops (`Pipelines.cpp:117-123`).

Consequently a kernel containing `cudaq::detector(...)` compiles and submits
fine to real hardware (the detectors are silently stripped), but the same
program aborts under `--emulate` with:

```
error: failed to legalize operation 'qec.detector'
Could not successfully translate to qir-adaptive:1.0:...
```

See this reproduction:
```
#include "cudaq.h"

__qpu__ bool detector_kernel() {
  cudaq::qubit data, ancilla;

  auto check = mz(ancilla);
  cudaq::detector(check);

  return mz(data);
}

int main() {
  auto results = cudaq::run(/*shots=*/100, detector_kernel);
  printf("detector_kernel ran %zu shots\n", results.size());
  return 0;
}
```

```
$ nvq++ --target stim repro.cpp -o repro_stim && ./repro_stim
=> detector_kernel ran 100 shots

$ nvq++ --target quantinuum --emulate --quantinuum-machine Helios-Fake \
        repro.cpp -o repro_emulate && ./repro_emulate
"error: failed to legalize operation 'qec.detector'"
```

This is a problem when trying to apply DEMs constructed from via `dem_from_kernel` to an emulated hardware target, as two copies of the kernel must be written, with and without the detector annotations. This PR resolves the issue by applying EraseQEC to emulated targets, removing the detector annotations.
