### PR TITLE
[opt] Refuse adjoint generation for multi-result loops

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -591,6 +591,14 @@ public:
                  << "cannot make adjoint of kernel with a measurement\n");
       return failure();
     }
+    if (func.walk([](cudaq::cc::LoopOp loop) {
+              return loop.getNumResults() > 1 ? WalkResult::interrupt()
+                                               : WalkResult::advance();
+            }).wasInterrupted()) {
+      LLVM_DEBUG(llvm::dbgs() << "cannot make adjoint of kernel with "
+                                 "multi-result loops\n");
+      return failure();
+    }
 
     auto funcTy = func.getFunctionType();
     auto newFunc = cudaq::opt::factory::createFunction(

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -2967,6 +2967,47 @@ def test_adjoint_bug():
 
 
 @pytest.mark.skip_macos_arm64_jit
+def test_adjoint_loop_carried_classical_update_errors():
+    cudaq.set_target("qpp-cpu")
+    try:
+        @cudaq.kernel
+        def rotate_each(qubits: cudaq.qview, angles: list[float]):
+            index = 0
+            for i in range(qubits.size()):
+                ry(angles[index], qubits[i])
+                index += 1
+
+        @cudaq.kernel
+        def undo_rotate_each(qubits: cudaq.qview, angles: list[float]):
+            index = qubits.size() - 1
+            for i in range(qubits.size()):
+                ry(-angles[index], qubits[qubits.size() - 1 - i])
+                index -= 1
+
+        @cudaq.kernel
+        def roundtrip_autogen(angles: list[float]):
+            qubits = cudaq.qvector(3)
+            rotate_each(qubits, angles)
+            cudaq.adjoint(rotate_each, qubits, angles)
+
+        @cudaq.kernel
+        def roundtrip_manual(angles: list[float]):
+            qubits = cudaq.qvector(3)
+            rotate_each(qubits, angles)
+            undo_rotate_each(qubits, angles)
+
+        angles = [0.3, 0.5, 0.7]
+        manual = np.asarray(cudaq.get_state(roundtrip_manual, angles))
+        assert np.isclose(abs(manual[0]), 1.0, atol=1e-12)
+
+        with pytest.raises(RuntimeError,
+                           match="could not autogenerate the adjoint"):
+            cudaq.get_state(roundtrip_autogen, angles)
+    finally:
+        cudaq.reset_target()
+
+
+@pytest.mark.skip_macos_arm64_jit
 def test_trap_fail():
     """Tests that a recoverable run time error correctly clears the simulator"""
 


### PR DESCRIPTION
## Summary

Fixes #4897 by refusing automatic adjoint generation for kernels that contain multi-result `cc.loop` operations. Today `ApplyOpSpecialization` can reverse the recognized monotonic induction variable, but loop-carried classical values can still be left in an inconsistent forward state. That can silently produce a non-adjoint circuit.

This patch takes the conservative path already allowed by the issue: fail adjoint autogeneration loudly instead of generating a wrong circuit.

## Reproducer

I reproduced #4897 on Linux via a temporary fork-only GitHub Actions run using CUDA-Q 0.15.0 and `qpp-cpu`:

https://github.com/aryanputta/cuda-quantum/actions/runs/29108694342

Key output:

```text
cudaq version: CUDA-Q Version 0.15.0 (https://github.com/NVIDIA/cuda-quantum 2beb73fe61723f5d21435d5d61651f66a1291820)
cudaq.adjoint roundtrip:  |<000|state>| = 0.9751703272018156
hand-written undo:        |<000|state>| = 0.9999999999999996
reproduced issue 4897: autogenerated adjoint is not identity
```

## Changes

- Add a guard in `createAdjointVariantOf` that rejects functions containing multi-result `cc.loop` operations.
- Add a Python regression test for the #4897 loop-carried classical update case.
- The regression verifies the hand-written inverse remains valid, then checks that autogenerated adjoint now raises instead of silently returning a non-identity state.

## Validation

Local:

```text
git diff --check
python3 -m py_compile python/tests/kernel/test_kernel_features.py
```

Not run locally: full CUDA-Q source build or pytest against the patched runtime. My Mac does not have a local CUDA-Q build, and PyPI CUDA-Q wheels are not available for this Darwin x86_64 environment. Opening as draft so upstream CI can validate the C++ build and Python regression.
