### PR TITLE
Own parsed QIR sample results

### DIFF
--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -47,7 +47,20 @@ void validateOutputRecord(
 }
 } // namespace
 
+std::vector<std::vector<bool>>
+cudaq::RecordLogParser::parseResults(const std::string &outputLog) {
+  std::vector<std::vector<bool>> parsedResults;
+  parseImpl(outputLog, &parsedResults);
+  return parsedResults;
+}
+
 void cudaq::RecordLogParser::parse(const std::string &outputLog) {
+  parseImpl(outputLog, nullptr);
+}
+
+void cudaq::RecordLogParser::parseImpl(
+    const std::string &outputLog,
+    std::vector<std::vector<bool>> *parsedResults) {
   ScopedTraceWithContext(cudaq::TIMING_RUN, "RecordLogParser::parse");
   CUDAQ_DBG("Parsing output log ({} bytes).", outputLog.size());
   completedResultCount = 0;
@@ -103,7 +116,7 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
         if (sawFramedOutput)
           throw std::runtime_error("Mixed framed and unframed output");
         sawUnframedOutput = true;
-        handleOutput(entries);
+        handleOutput(entries, parsedResults);
       }
     } else if (recordType == "END") {
       if (entries.size() != 2)
@@ -112,7 +125,7 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
         throw std::runtime_error("END record without START");
       if (detail::parseSize(entries[1]) == 0) {
         for (const auto &outputRecord : shotOutputRecords)
-          handleOutput(outputRecord);
+          handleOutput(outputRecord, parsedResults);
         rejectIncompleteContainer();
       } else {
         CUDAQ_DBG("Discarding shot data due to non-zero END status.");
@@ -169,7 +182,8 @@ void cudaq::RecordLogParser::handleMetadata(
 }
 
 void cudaq::RecordLogParser::handleOutput(
-    const std::vector<std::string> &entries) {
+    const std::vector<std::string> &entries,
+    std::vector<std::vector<bool>> *parsedResults) {
   const std::string &recType = entries[1];
   const std::string &recValue = entries[2];
   std::string recLabel = (entries.size() == 4) ? entries[3] : "";
@@ -205,8 +219,23 @@ void cudaq::RecordLogParser::handleOutput(
       containerMeta.arrayType = "i1";
       bufferHandler.chargeContainerTracking(containerMeta.elementCount);
       containerMeta.processedSlots.assign(containerMeta.elementCount, false);
-      preallocateArray();
+      if (parsedResults) {
+        bufferHandler.chargeResultStorage(containerMeta.elementCount);
+        parsedResults->emplace_back(containerMeta.elementCount);
+      } else {
+        preallocateArray();
+      }
       countAndResetContainerIfComplete();
+    }
+
+    if (parsedResults) {
+      if (!containerMeta.arrayType.empty() && containerMeta.arrayType != "i1")
+        throw std::runtime_error("Sample result array must contain i1 values");
+      if (containerMeta.processedElements == 0 &&
+          parsedResults->size() == completedResultCount) {
+        bufferHandler.chargeResultStorage(containerMeta.elementCount);
+        parsedResults->emplace_back(containerMeta.elementCount);
+      }
     }
 
     // Note: For ordered schema, we expect the results are sequential in the
@@ -246,7 +275,18 @@ void cudaq::RecordLogParser::handleOutput(
       }
     }
 
-    processArrayEntry(recValue, fmt::format("[{}]", idxLabel));
+    if (parsedResults) {
+      const auto index =
+          containerMeta.extractIndex(fmt::format("[{}]", idxLabel));
+      if (index >= containerMeta.elementCount)
+        throw std::runtime_error("Array index out of bounds");
+      containerMeta.requireUnprocessed(index);
+      parsedResults->back()[index] =
+          detail::BooleanConverter().convert(recValue);
+      containerMeta.markProcessed(index);
+    } else {
+      processArrayEntry(recValue, fmt::format("[{}]", idxLabel));
+    }
     countAndResetContainerIfComplete();
     return;
   }
@@ -263,11 +303,14 @@ void cudaq::RecordLogParser::handleOutput(
       containerMeta.extractArrayInfo(recLabel);
       bufferHandler.chargeContainerTracking(containerMeta.elementCount);
       containerMeta.processedSlots.assign(containerMeta.elementCount, false);
-      preallocateArray();
+      if (!parsedResults)
+        preallocateArray();
     }
     countAndResetContainerIfComplete();
     return;
   }
+  if (parsedResults)
+    throw std::runtime_error("Sample output must contain RESULT values");
   if (recType == "TUPLE") {
     if (containerMeta.active())
       throw std::runtime_error("New container before previous container ends");

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -171,6 +171,12 @@ public:
     chargeDynamicAllocation(elements);
   }
 
+  void chargeResultStorage(std::size_t elements) {
+    // Conservatively charge one byte per logical result before allocating an
+    // owning vector<bool>.
+    chargeDynamicAllocation(elements);
+  }
+
   void resizeBuffer(std::size_t more) {
     if (more > std::numeric_limits<std::size_t>::max() - buffer.size())
       throw std::runtime_error("Result buffer size overflow");
@@ -429,6 +435,11 @@ public:
   /// length may be queried and returned as a result.
   void parse(const std::string &outputLog);
 
+  /// Parse sampled QIR result records into owning C++ objects. Unlike the
+  /// generic host-return buffer, this representation does not depend on the
+  /// object layout of std::vector<bool>.
+  std::vector<std::vector<bool>> parseResults(const std::string &outputLog);
+
   /// Get a pointer to the data buffer. Note that the data buffer will be
   /// deallocated as soon as the RecordLogParser object is deconstructed.
   void *getBufferPtr() const { return bufferHandler.getBufferPtr(); }
@@ -452,9 +463,14 @@ private:
   void handleHeader(const std::vector<std::string> &,
                     std::optional<RecordSchemaType> &);
   void handleMetadata(const std::vector<std::string> &);
+  /// Parse records into either the generic return buffer or an optional
+  /// sampled-result output.
+  void parseImpl(const std::string &,
+                 std::vector<std::vector<bool>> *parsedResults);
   /// Central dispatcher that handles different output types including scalar
   /// values, arrays, and tuples.
-  void handleOutput(const std::vector<std::string> &);
+  void handleOutput(const std::vector<std::string> &,
+                    std::vector<std::vector<bool>> *parsedResults);
   /// Allocate storage for the current array result.
   void preallocateArray();
   /// Allocate contiguous storage for the current tuple result.

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -159,17 +159,7 @@ public:
   createSampleResultFromQirOutput(const std::string &qirOutputLog) {
     // Parse the QIR output log
     cudaq::RecordLogParser parser;
-    parser.parse(qirOutputLog);
-
-    // Get the buffer and length of buffer (in bytes) from the parser.
-    auto *origBuffer = parser.getBufferPtr();
-    std::size_t bufferSize = parser.getBufferSize();
-    char *buffer = static_cast<char *>(malloc(bufferSize));
-    std::memcpy(buffer, origBuffer, bufferSize);
-
-    std::vector<std::vector<bool>> results = {
-        reinterpret_cast<std::vector<bool> *>(buffer),
-        reinterpret_cast<std::vector<bool> *>(buffer + bufferSize)};
+    auto results = parser.parseResults(qirOutputLog);
     const auto numShots = results.size();
     // Create the counts dictionary
     cudaq::CountsDictionary globalCounts;

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -58,6 +58,61 @@ CUDAQ_TEST(ParserTester, checkMoreBoolean) {
   origBuffer = nullptr;
 }
 
+CUDAQ_TEST(ParserTester, checkOwningResultVectors) {
+  const auto parseResults = [](const std::string &log) {
+    cudaq::RecordLogParser parser;
+    return parser.parseResults(log);
+  };
+
+  EXPECT_TRUE(parseResults("").empty());
+  {
+    const std::string log = "METADATA\trequired_num_results\t1\n"
+                            "START\nOUTPUT\tRESULT\t1\tr00000\nEND\t0\n";
+    const auto results = parseResults(log);
+    ASSERT_EQ(1, results.size());
+    EXPECT_EQ(std::vector<bool>({true}), results[0]);
+  }
+  {
+    const std::string log =
+        "METADATA\trequired_num_results\t3\n"
+        "START\nOUTPUT\tRESULT\t1\tr00000\n"
+        "OUTPUT\tRESULT\t0\tr00001\nOUTPUT\tRESULT\t1\tr00002\nEND\t0\n"
+        "START\nOUTPUT\tRESULT\t0\tr00000\n"
+        "OUTPUT\tRESULT\t1\tr00001\nOUTPUT\tRESULT\t0\tr00002\nEND\t0\n";
+    const auto results = parseResults(log);
+    ASSERT_EQ(2, results.size());
+    EXPECT_EQ(std::vector<bool>({true, false, true}), results[0]);
+    EXPECT_EQ(std::vector<bool>({false, true, false}), results[1]);
+  }
+  {
+    const std::string log =
+        "HEADER\tschema_id\tlabeled\n"
+        "START\nOUTPUT\tARRAY\t2\tarray<i1 x 2>\n"
+        "OUTPUT\tRESULT\t1\t[0]\nOUTPUT\tRESULT\t0\t[1]\nEND\t0\n"
+        "START\nOUTPUT\tARRAY\t2\tarray<i1 x 2>\n"
+        "OUTPUT\tRESULT\t0\t[0]\nOUTPUT\tRESULT\t1\t[1]\nEND\t0\n";
+    const auto results = parseResults(log);
+    ASSERT_EQ(2, results.size());
+    EXPECT_EQ(std::vector<bool>({true, false}), results[0]);
+    EXPECT_EQ(std::vector<bool>({false, true}), results[1]);
+  }
+
+  EXPECT_ANY_THROW(parseResults("METADATA\trequired_num_results\t2\n"
+                                "START\nOUTPUT\tRESULT\t1\tr00000\n"
+                                "OUTPUT\tRESULT\t0\tr00000\nEND\t0\n"));
+  EXPECT_ANY_THROW(parseResults("METADATA\trequired_num_results\t8000000000\n"
+                                "OUTPUT\tRESULT\t1\tr00000\n"));
+}
+
+CUDAQ_TEST(ParserTester, checkParseAfterParsingResults) {
+  const std::string log = "METADATA\trequired_num_results\t1\n"
+                          "START\nOUTPUT\tRESULT\t1\tr00000\nEND\t0\n";
+  cudaq::RecordLogParser parser;
+  parser.parseResults(log);
+  parser.parse(log);
+  EXPECT_EQ(sizeof(std::vector<bool>), parser.getBufferSize());
+}
+
 CUDAQ_TEST(ParserTester, checkIntegers) {
   {
     const std::string log = "OUTPUT\tINT\t0\ti32\n"


### PR DESCRIPTION
## Summary

- parse sampled QIR results directly into owning `std::vector<std::vector<bool>>` values
- stop copying and reinterpreting `std::vector<bool>` object representations in the server result path
- cover zero, one, and multiple sampled-result shots

`std::vector<bool>` is not trivially copyable, so treating copied bytes as live vector objects depends on alignment and the standard-library ABI. The new result-specific parser API constructs ordinary owning vectors instead. The existing generic return-value buffer remains unchanged for `run`.

## Testing

- `pre-commit run --files runtime/common/RecordLogParser.h runtime/common/RecordLogParser.cpp runtime/common/ServerHelper.h unittests/output_record/RecordParserTester.cpp`