### PR TITLE
Fix complex matrix assignment ownership

### DIFF
--- a/runtime/cudaq/operators/matrix.h
+++ b/runtime/cudaq/operators/matrix.h
@@ -20,6 +20,7 @@
 #include <complex>
 #include <iterator>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace Eigen {
@@ -74,14 +75,17 @@ public:
 
   complex_matrix(const complex_matrix &other)
       : dimensions{other.dimensions},
-        data{new value_type[get_size(other.dimensions)]},
+        data{get_size(other.dimensions)
+                 ? new value_type[get_size(other.dimensions)]
+                 : nullptr},
         internal_order(other.internal_order) {
-    std::copy(other.data, other.data + get_size(dimensions), data);
+    if (data)
+      std::copy(other.data, other.data + get_size(dimensions), data);
   }
 
   complex_matrix(const complex_matrix &other, order order);
 
-  complex_matrix(complex_matrix &&other)
+  complex_matrix(complex_matrix &&other) noexcept
       : dimensions{other.dimensions}, data{other.data},
         internal_order(other.internal_order) {
     other.data = nullptr;
@@ -96,18 +100,14 @@ public:
   }
 
   complex_matrix &operator=(const complex_matrix &other) {
-    dimensions = other.dimensions;
-    data = new value_type[get_size(other.dimensions)];
-    std::copy(other.data, other.data + get_size(dimensions), data);
-    internal_order = other.internal_order;
+    complex_matrix copy(other);
+    swap(copy);
     return *this;
   }
 
-  complex_matrix &operator=(complex_matrix &&other) {
-    dimensions = other.dimensions;
-    data = other.data;
-    other.data = nullptr;
-    internal_order = other.internal_order;
+  complex_matrix &operator=(complex_matrix &&other) noexcept {
+    complex_matrix moved(std::move(other));
+    swap(moved);
     return *this;
   }
 
@@ -231,6 +231,13 @@ private:
   }
 
   static void check_size(std::size_t size, const Dimensions &dim);
+
+  void swap(complex_matrix &other) noexcept {
+    using std::swap;
+    swap(dimensions, other.dimensions);
+    swap(data, other.data);
+    swap(internal_order, other.internal_order);
+  }
 
   void swap(complex_matrix::value_type *new_data) {
     if (data)

--- a/runtime/cudaq/operators/matrix.h
+++ b/runtime/cudaq/operators/matrix.h
@@ -85,11 +85,7 @@ public:
 
   complex_matrix(const complex_matrix &other, order order);
 
-  complex_matrix(complex_matrix &&other) noexcept
-      : dimensions{other.dimensions}, data{other.data},
-        internal_order(other.internal_order) {
-    other.data = nullptr;
-  }
+  complex_matrix(complex_matrix &&other) noexcept { swap(other); }
 
   complex_matrix(const std::vector<value_type> &v,
                  const Dimensions &dim = {2, 2}, order order = order::row_major)
@@ -106,8 +102,7 @@ public:
   }
 
   complex_matrix &operator=(complex_matrix &&other) noexcept {
-    complex_matrix moved(std::move(other));
-    swap(moved);
+    swap(other);
     return *this;
   }
 
@@ -233,10 +228,9 @@ private:
   static void check_size(std::size_t size, const Dimensions &dim);
 
   void swap(complex_matrix &other) noexcept {
-    using std::swap;
-    swap(dimensions, other.dimensions);
-    swap(data, other.data);
-    swap(internal_order, other.internal_order);
+    std::swap(dimensions, other.dimensions);
+    std::swap(data, other.data);
+    std::swap(internal_order, other.internal_order);
   }
 
   void swap(complex_matrix::value_type *new_data) {

--- a/unittests/utils/Matrix.cpp
+++ b/unittests/utils/Matrix.cpp
@@ -55,6 +55,39 @@ TEST(Tensor, initializationError) {
   }
 }
 
+TEST(Tensor, assignment) {
+  const cudaq::complex_matrix empty;
+  const cudaq::complex_matrix small({1., 2., 3., 4.});
+  const cudaq::complex_matrix large({1., 2., 3., 4., 5., 6.}, {2, 3},
+                                    cudaq::complex_matrix::order::column_major);
+
+  cudaq::complex_matrix copy;
+  for (std::size_t i = 0; i < 100; ++i) {
+    copy = empty;
+    EXPECT_EQ(copy, empty);
+    copy = small;
+    EXPECT_EQ(copy, small);
+    copy = large;
+    EXPECT_EQ(copy, large);
+  }
+
+  copy = copy;
+  EXPECT_EQ(copy, large);
+
+  cudaq::complex_matrix moved({7., 8., 9., 10.});
+  for (std::size_t i = 0; i < 100; ++i) {
+    moved = cudaq::complex_matrix();
+    EXPECT_EQ(moved, empty);
+    moved = cudaq::complex_matrix(small);
+    EXPECT_EQ(moved, small);
+    moved = cudaq::complex_matrix(large);
+    EXPECT_EQ(moved, large);
+  }
+
+  moved = std::move(moved);
+  EXPECT_EQ(moved, large);
+}
+
 TEST(Tensor, access) {
   {
     cudaq::complex_matrix m1({1., 0., 0., 1.});

--- a/unittests/utils/Matrix.cpp
+++ b/unittests/utils/Matrix.cpp
@@ -74,6 +74,11 @@ TEST(Tensor, assignment) {
   copy = copy;
   EXPECT_EQ(copy, large);
 
+  cudaq::complex_matrix moveSource(large);
+  cudaq::complex_matrix moveConstructed(std::move(moveSource));
+  EXPECT_EQ(moveConstructed, large);
+  EXPECT_EQ(moveSource, empty);
+
   cudaq::complex_matrix moved({7., 8., 9., 10.});
   for (std::size_t i = 0; i < 100; ++i) {
     moved = cudaq::complex_matrix();


### PR DESCRIPTION
## Summary

- make copy assignment release the previous allocation through copy-and-swap
- make move assignment safely transfer ownership through swap, including self-move
- mark move construction and assignment `noexcept`
- cover repeated assignments across empty and differently sized matrices, self-copy, and self-move

Both assignment operators previously overwrote an owning pointer without releasing its allocation. Aliasing the source made the behavior worse: self-copy discarded the original values, while self-move nulled its own pointer.

## Testing

- `pre-commit run --files runtime/cudaq/operators/matrix.h unittests/utils/Matrix.cpp`
- macOS Apple Clang ASan+UBSan harness: 10,000 repeated copy/move assignments and self-assignment checks
- macOS `leaks`: 0 leaks