### PR TITLE
[python] Replace RegisterEverything with curated dialect registration

### DIFF
--- a/cudaq/include/cudaq/Optimizer/CAPI/Dialects.h
+++ b/cudaq/include/cudaq/Optimizer/CAPI/Dialects.h
@@ -19,8 +19,11 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Quake, quake);
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(QEC, qec);
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(CC, cc);
 
-// Register Quake, CC, and all upstream MLIR dialects into `context`.
-MLIR_CAPI_EXPORTED void cudaqRegisterAllDialects(MlirContext context);
+// Register Quake, CC, and relevant upstream MLIR dialects into `registry`.
+MLIR_CAPI_EXPORTED void cudaqRegisterAllDialects(MlirDialectRegistry registry);
+
+// Load Quake, CC, and relevant upstream MLIR dialects into `context`.
+MLIR_CAPI_EXPORTED void cudaqLoadAllDialects(MlirContext context);
 
 #ifdef __cplusplus
 }

--- a/cudaq/lib/Optimizer/CAPI/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/CAPI/CMakeLists.txt
@@ -17,5 +17,12 @@ add_mlir_public_c_api_library(CUDAQuantumMLIRCAPI
   QuakeDialect
   CCDialect
   QECDialect
-  MLIRRegisterAllDialects
+  MLIRArithDialect
+  MLIRControlFlowDialect
+  MLIRComplexDialect
+  MLIRFuncDialect
+  MLIRLLVMDialect
+  MLIRMathDialect
+  MLIRFuncInlinerExtension
+  MLIRLLVMIRTransforms
 )

--- a/cudaq/lib/Optimizer/CAPI/Dialects.cpp
+++ b/cudaq/lib/Optimizer/CAPI/Dialects.cpp
@@ -7,20 +7,24 @@
  ******************************************************************************/
 
 #include "cudaq/Optimizer/CAPI/Dialects.h"
-#include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
-#include "cudaq/Optimizer/Dialect/QEC/QECDialect.h"
-#include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
-#include "mlir/InitAllDialects.h"
+#include "cudaq/Optimizer/InitAllDialects.h"
+#include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
+#include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Quake, quake, cudaq::quake::QuakeDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(QEC, qec, cudaq::qec::QECDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(CC, cc, cudaq::cc::CCDialect)
 
-extern "C" void cudaqRegisterAllDialects(MlirContext context) {
+extern "C" void cudaqRegisterAllDialects(MlirDialectRegistry registry) {
+  mlir::DialectRegistry *reg = unwrap(registry);
+  cudaq::registerAllDialects(*reg);
+  mlir::func::registerInlinerExtension(*reg);
+  mlir::LLVM::registerInlinerInterface(*reg);
+}
+
+extern "C" void cudaqLoadAllDialects(MlirContext context) {
   mlir::DialectRegistry registry;
-  registry.insert<cudaq::quake::QuakeDialect, cudaq::qec::QECDialect,
-                  cudaq::cc::CCDialect>();
-  mlir::registerAllDialects(registry);
+  cudaqRegisterAllDialects(wrap(&registry));
   auto *mlirContext = unwrap(context);
   mlirContext->appendDialectRegistry(registry);
   mlirContext->loadAllAvailableDialects();

--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -54,6 +54,17 @@ declare_mlir_dialect_python_bindings(
     dialects/qec.py
   DIALECT_NAME qec)
 
+# Define the register_dialects hook to populate the default DialectRegistry
+# for every Context.
+declare_mlir_python_extension(CUDAQuantumPythonSources.SiteInitialize
+  MODULE_NAME _site_initialize_0
+  ADD_TO_PARENT CUDAQuantumPythonSources
+  SOURCES
+    SiteInitialize.cpp
+  EMBED_CAPI_LINK_LIBS
+    CUDAQuantumMLIRCAPI
+)
+
 if(APPLE)
   set(_quakeDialects_mlir_runtime_sources "")
   set(_quakeDialects_extra_link_libs
@@ -189,11 +200,11 @@ add_mlir_python_common_capi_library(CUDAQuantumPythonCAPI
   INSTALL_DESTINATION cudaq/mlir/_mlir_libs
   OUTPUT_DIRECTORY "${MLIR_BINARY_DIR}/python/cudaq/mlir/_mlir_libs"
   RELATIVE_INSTALL_ROOT "../.."
+  EMBED_LIBS
+    MLIRCAPITransforms
+    MLIRCAPIConversion
   DECLARED_SOURCES
     CUDAQuantumPythonSources
-    # TODO: Remove this in favor of showing fine grained registration once
-    # available.
-    MLIRPythonExtension.RegisterEverything
     MLIRPythonSources.Core
     # Include full MLIRPythonSources so dialect extensions' EMBED_CAPI_LINK_LIBS
     # (e.g. obj.MLIRCAPILLVM for the LLVM dialect) are embedded into the common
@@ -223,9 +234,6 @@ add_mlir_python_modules(CUDAQuantumPythonModules
   INSTALL_PREFIX "cudaq/mlir"
   DECLARED_SOURCES
     CUDAQuantumPythonSources
-    # TODO: Remove this in favor of showing fine grained registration once
-    # available.
-    MLIRPythonExtension.RegisterEverything
     MLIRPythonSources
   COMMON_CAPI_LINK_LIBS
     CUDAQuantumPythonCAPI

--- a/python/extension/SiteInitialize.cpp
+++ b/python/extension/SiteInitialize.cpp
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// CUDA-Q MLIR Python site initializer.
+
+#include "cudaq/Optimizer/CAPI/Dialects.h"
+#include "mlir/Bindings/Python/Nanobind.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
+
+NB_MODULE(_site_initialize_0, m) {
+  m.doc() = "CUDA-Q MLIR site initializer (default dialect registration).";
+
+  m.def("register_dialects", [](MlirDialectRegistry registry) {
+    cudaqRegisterAllDialects(registry);
+  });
+}

--- a/python/runtime/mlir/py_register_dialects.cpp
+++ b/python/runtime/mlir/py_register_dialects.cpp
@@ -47,8 +47,9 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
         if (!registered) {
 #ifdef __APPLE__
           cudaq_internal::compiler::initializeMLIR();
-#endif
+#else
           cudaq::registerAllPasses();
+#endif
           registered = true;
         }
       },

--- a/python/runtime/mlir/py_register_dialects.cpp
+++ b/python/runtime/mlir/py_register_dialects.cpp
@@ -47,9 +47,8 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
         if (!registered) {
 #ifdef __APPLE__
           cudaq_internal::compiler::initializeMLIR();
-#else
-          cudaq::registerCudaqPassesAndPipelines();
 #endif
+          cudaq::registerAllPasses();
           registered = true;
         }
       },
@@ -400,7 +399,7 @@ void cudaq::bindRegisterDialects(nanobind::module_ &mod) {
   });
 
   mod.def("register_all_dialects", [](MlirContext context) {
-    ::cudaqRegisterAllDialects(context);
+    ::cudaqLoadAllDialects(context);
     auto *mlirContext = unwrap(context);
     mlirContext->getOrLoadDialect<cudaq::codegen::CodeGenDialect>();
   });


### PR DESCRIPTION
I'm reworking the way we handle our MLIR dependencies, and this seemed like an obvious thing to fix.
