### PR TITLE
[core] Devirtualize the OOP code in UnitarySynthesis.cpp

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/UnitarySynthesis.cpp
+++ b/cudaq/lib/Optimizer/Transforms/UnitarySynthesis.cpp
@@ -19,8 +19,10 @@
 #include "mlir/Transforms/Passes.h"
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <unsupported/Eigen/KroneckerProduct>
 #include <unsupported/Eigen/MatrixFunctions>
+#include <variant>
 
 namespace cudaq::opt {
 #define GEN_PASS_DEF_UNITARYSYNTHESIS
@@ -30,8 +32,6 @@ namespace cudaq::opt {
 #define DEBUG_TYPE "unitary-synthesis"
 
 using namespace mlir;
-
-namespace {
 
 /// Tight tolerance for the input-unitarity *contract* and the pure
 /// numerical-safety guards (division by a near-zero determinant, Gram-Schmidt
@@ -62,40 +62,13 @@ constexpr double TOL = 1e-7;
 /// results. The input-unitarity contract above stays at the tight `TOL`.
 constexpr double RECON_TOL = 1e-5;
 
-/// Base class for unitary synthesis, i.e. decomposing an arbitrary unitary
-/// matrix into native gate set. The native gate set here includes all the
-/// quantum operations supported by CUDA-Q. Additional passes may be required to
-/// convert CUDA-Q gate set to hardware specific gate set.
-class Decomposer {
-private:
-  Eigen::MatrixXcd targetMatrix;
+/// Free helper shared by all decomposer structs.
+static bool isAboveThreshold(double value) { return std::abs(value) > TOL; }
 
-protected:
-  /// Set to `false` by a decomposer when its synthesis cannot reproduce the
-  /// target matrix within `TOL` (e.g. accumulated numerical error). The pass
-  /// uses this to stay composable: on an invalid result it leaves the original
-  /// IR unchanged instead of emitting a wrong circuit or crashing the compiler.
-  bool valid = true;
-
-public:
-  /// Whether the decomposition reproduces the target matrix within `TOL`.
-  bool isValid() const { return valid; }
-  /// Function which implements the unitary synthesis algorithm. The result of
-  /// decomposition which depends on the algorithm must be convertible to
-  /// quantum operations. For example, result is saved into class member(s) as
-  /// the parameters to be applied to  `Rx`, `Ry`, and `Rz` gates.
-  virtual void decompose() = 0;
-  /// Create the replacement function which invokes native quantum operations.
-  /// The original `quake.custom_op` is replaced by `quake.apply` operation that
-  /// calls the new replacement function with the same operands as the original
-  /// operation. The 'control' and 'adjoint' variations are handled by
-  /// `ApplySpecialization` pass.
-  virtual void
-  emitDecomposedFuncOp(cudaq::quake::CustomUnitaryConstantOp customOp,
-                       OpBuilder &rewriter, std::string funcName) = 0;
-  bool isAboveThreshold(double value) { return std::abs(value) > TOL; };
-  virtual ~Decomposer() = default;
-};
+namespace {
+/// Forward declaration so NQubitOpQSD can store AnyDecomposer children via
+/// unique_ptr before AnyDecomposer's full definition is available.
+struct AnyDecomposer;
 
 /// Result structure for 1-q Euler decomposition in ZYZ basis
 struct EulerAngles {
@@ -104,47 +77,20 @@ struct EulerAngles {
   double gamma;
 };
 
-struct OneQubitOpZYZ : public Decomposer {
+/// Plain-data struct for 1-qubit ZYZ synthesis.
+///
+/// This logic is based on https://arxiv.org/pdf/quant-ph/9503016 and its
+/// corresponding explanation in https://threeplusone.com/pubs/on_gates.pdf,
+/// Section 4.
+struct OneQubitOpZYZ {
   Eigen::Matrix2cd targetMatrix;
   EulerAngles angles;
   /// Updates to the global phase
   double phase;
-
-  /// This logic is based on https://arxiv.org/pdf/quant-ph/9503016 and its
-  /// corresponding explanation in https://threeplusone.com/pubs/on_gates.pdf,
-  /// Section 4.
-  void decompose() override {
-    using namespace std::complex_literals;
-    /// Rescale the input unitary matrix, `u`, to be special unitary.
-    /// Extract a phase factor, `phase`, so that
-    /// `determinant(inverse_phase * unitary) = 1`
-    auto det = targetMatrix.determinant();
-    phase = 0.5 * std::arg(det);
-    Eigen::Matrix2cd specialUnitary = std::exp(-1i * phase) * targetMatrix;
-    auto abs00 = std::abs(specialUnitary(0, 0));
-    auto abs01 = std::abs(specialUnitary(0, 1));
-    /// The Y-rotation angle is `beta = 2 * atan2(|u01|, |u00|)`. Using `atan2`
-    /// of the two magnitudes (rather than `acos(|u00|)` or `asin(|u01|)`) is
-    /// numerically robust: `acos`/`asin` are ill-conditioned near their +/-1
-    /// endpoints (derivative diverges, amplifying round-off to ~1e-8) and,
-    /// worse, return NaN when their argument exceeds 1 by even a rounding ULP
-    /// -- which happens for the near-degenerate sub-blocks produced deep in a
-    /// recursive Quantum Shannon Decomposition (e.g. a controlled single-qubit
-    /// gate, where |u00| ~ 0 and |u01| ~ 1). `atan2` is well-conditioned over
-    /// the whole domain and needs no clamping, so the same gate is emitted
-    /// reliably across the advertised 3-5 qubit range.
-    angles.beta = 2.0 * std::atan2(abs01, abs00);
-    auto sum =
-        std::atan2(specialUnitary(1, 1).imag(), specialUnitary(1, 1).real());
-    auto diff =
-        std::atan2(specialUnitary(1, 0).imag(), specialUnitary(1, 0).real());
-    angles.alpha = sum + diff;
-    angles.gamma = sum - diff;
-  }
+  bool valid = true;
 
   void emitDecomposedFuncOp(cudaq::quake::CustomUnitaryConstantOp customOp,
-                            OpBuilder &rewriter,
-                            std::string funcName) override {
+                            OpBuilder &rewriter, std::string funcName) const {
     auto parentModule = customOp->getParentOfType<ModuleOp>();
     Location loc = customOp->getLoc();
     auto targets = customOp.getTargets();
@@ -185,10 +131,10 @@ struct OneQubitOpZYZ : public Decomposer {
     /// hence, we need to multiply the angle by 2
     auto globalPhase = 2.0 * phase;
     if (isAboveThreshold(globalPhase)) {
-      auto phase = cudaq::opt::factory::createFloatConstant(
+      auto phaseVal = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, globalPhase, floatTy);
-      Value negPhase = arith::NegFOp::create(rewriter, loc, phase);
-      cudaq::quake::R1Op::create(rewriter, loc, phase, ValueRange{},
+      Value negPhase = arith::NegFOp::create(rewriter, loc, phaseVal);
+      cudaq::quake::R1Op::create(rewriter, loc, phaseVal, ValueRange{},
                                  arguments[0]);
       cudaq::quake::RzOp::create(rewriter, loc, negPhase, ValueRange{},
                                  arguments[0]);
@@ -197,9 +143,33 @@ struct OneQubitOpZYZ : public Decomposer {
     rewriter.restoreInsertionPoint(insPt);
   }
 
-  OneQubitOpZYZ(const Eigen::Matrix2cd &vec) {
-    targetMatrix = vec;
-    decompose();
+  OneQubitOpZYZ(const Eigen::Matrix2cd &mat) : targetMatrix(mat) {
+    using namespace std::complex_literals;
+    /// Rescale the input unitary matrix, `u`, to be special unitary.
+    /// Extract a phase factor, `phase`, so that
+    /// `determinant(inverse_phase * unitary) = 1`
+    auto det = targetMatrix.determinant();
+    phase = 0.5 * std::arg(det);
+    Eigen::Matrix2cd specialUnitary = std::exp(-1i * phase) * targetMatrix;
+    auto abs00 = std::abs(specialUnitary(0, 0));
+    auto abs01 = std::abs(specialUnitary(0, 1));
+    /// The Y-rotation angle is `beta = 2 * atan2(|u01|, |u00|)`. Using `atan2`
+    /// of the two magnitudes (rather than `acos(|u00|)` or `asin(|u01|)`) is
+    /// numerically robust: `acos`/`asin` are ill-conditioned near their +/-1
+    /// endpoints (derivative diverges, amplifying round-off to ~1e-8) and,
+    /// worse, return NaN when their argument exceeds 1 by even a rounding ULP
+    /// -- which happens for the near-degenerate sub-blocks produced deep in a
+    /// recursive Quantum Shannon Decomposition (e.g. a controlled single-qubit
+    /// gate, where |u00| ~ 0 and |u01| ~ 1). `atan2` is well-conditioned over
+    /// the whole domain and needs no clamping, so the same gate is emitted
+    /// reliably across the advertised 3-5 qubit range.
+    angles.beta = 2.0 * std::atan2(abs01, abs00);
+    auto sum =
+        std::atan2(specialUnitary(1, 1).imag(), specialUnitary(1, 1).real());
+    auto diff =
+        std::atan2(specialUnitary(1, 0).imag(), specialUnitary(1, 0).real());
+    angles.alpha = sum + diff;
+    angles.gamma = sum - diff;
   }
 };
 
@@ -217,13 +187,14 @@ struct KAKComponents {
   double y;
   double z;
 };
+} // namespace
 
 /// Helper function to convert a matrix into 'magic' basis
 /// M = 1 / sqrt(2) *  1  0  0  i
 ///                    0  i  1  0
 ///                    0  i −1  0
 ///                    1  0  0 −i
-const Eigen::Matrix4cd &MagicBasisMatrix() {
+static const Eigen::Matrix4cd &MagicBasisMatrix() {
   using namespace std::complex_literals;
   static Eigen::Matrix4cd MagicBasisMatrix;
   MagicBasisMatrix << 1.0, 0.0, 0.0, 1i, 0.0, 1i, 1.0, 0, 0, 1i, -1.0, 0, 1.0,
@@ -233,7 +204,7 @@ const Eigen::Matrix4cd &MagicBasisMatrix() {
 }
 
 /// Helper function to convert a matrix into 'magic' basis
-const Eigen::Matrix4cd &MagicBasisMatrixAdj() {
+static const Eigen::Matrix4cd &MagicBasisMatrixAdj() {
   static Eigen::Matrix4cd MagicBasisMatrixAdj = MagicBasisMatrix().adjoint();
   return MagicBasisMatrixAdj;
 }
@@ -243,7 +214,7 @@ const Eigen::Matrix4cd &MagicBasisMatrixAdj() {
 ///                +1 +1 +1 −1
 ///                +1 −1 −1 −1
 ///                +1 −1 +1 +1
-const Eigen::Matrix4cd &GammaFactor() {
+static const Eigen::Matrix4cd &GammaFactor() {
 
   static Eigen::Matrix4cd GammaT;
   GammaT << 1, 1, 1, 1, 1, 1, -1, -1, -1, 1, -1, 1, 1, -1, -1, 1;
@@ -263,7 +234,7 @@ const Eigen::Matrix4cd &GammaFactor() {
 /// `RECON_TOL` so the caller can bail out gracefully and leave the IR
 /// unchanged. The final KAK reconstruction check is the authoritative
 /// correctness backstop.
-std::tuple<Eigen::Matrix4d, Eigen::Matrix4cd, Eigen::Matrix4d>
+static std::tuple<Eigen::Matrix4d, Eigen::Matrix4cd, Eigen::Matrix4d>
 bidiagonalize(const Eigen::Matrix4cd &matrix, bool &ok) {
   Eigen::Matrix4d real = matrix.real();
   Eigen::Matrix4d imag = matrix.imag();
@@ -284,7 +255,7 @@ bidiagonalize(const Eigen::Matrix4cd &matrix, bool &ok) {
 /// Separate input matrix into local operations. The input matrix must be
 /// special orthogonal. Given a map, SU(2) × SU(2) -> SO(4),
 /// map(A, B) = M.adjoint() (A ⊗ B∗) M, find A and B.
-std::tuple<Eigen::Matrix2cd, Eigen::Matrix2cd, std::complex<double>>
+static std::tuple<Eigen::Matrix2cd, Eigen::Matrix2cd, std::complex<double>>
 extractSU2FromSO4(const Eigen::Matrix4cd &matrix, bool &ok) {
   /// Verify input matrix is special orthogonal. On a marginal sub-block from a
   /// deep recursion this can drift; clear `ok` instead of asserting so the
@@ -335,7 +306,7 @@ extractSU2FromSO4(const Eigen::Matrix4cd &matrix, bool &ok) {
 }
 
 /// Compute exp(i(x XX + y YY + z ZZ)) matrix for verification
-Eigen::Matrix4cd canonicalVecToMatrix(double x, double y, double z) {
+static Eigen::Matrix4cd canonicalVecToMatrix(double x, double y, double z) {
   using namespace std::complex_literals;
   Eigen::Matrix2cd X{Eigen::Matrix2cd::Zero()};
   Eigen::Matrix2cd Y{Eigen::Matrix2cd::Zero()};
@@ -349,65 +320,21 @@ Eigen::Matrix4cd canonicalVecToMatrix(double x, double y, double z) {
   return (1i * (x * XX + y * YY + z * ZZ)).exp();
 }
 
-struct TwoQubitOpKAK : public Decomposer {
+namespace {
+/// Plain-data struct for 2-qubit KAK synthesis.
+///
+/// This logic is based on the Cartan's KAK decomposition.
+/// Ref: https://arxiv.org/pdf/quant-ph/0507171
+/// Ref: https://arxiv.org/pdf/0806.4015
+struct TwoQubitOpKAK {
   Eigen::Matrix4cd targetMatrix;
   KAKComponents components;
   /// Updates to the global phase
   std::complex<double> phase;
-
-  /// This logic is based on the Cartan's KAK decomposition.
-  /// Ref: https://arxiv.org/pdf/quant-ph/0507171
-  /// Ref: https://arxiv.org/pdf/0806.4015
-  void decompose() override {
-    using namespace std::complex_literals;
-    /// Step0: Convert to special unitary
-    phase = std::pow(targetMatrix.determinant(), 0.25);
-    auto specialUnitary = targetMatrix / phase;
-    /// Step1: Convert into magic basis
-    Eigen::Matrix4cd matrixMagicBasis =
-        MagicBasisMatrixAdj() * specialUnitary * MagicBasisMatrix();
-    /// Step2: Diagonalize. The intermediate sanity checks below are composable:
-    /// they clear `ok` (and hence `valid`) instead of asserting, so a marginal
-    /// sub-block from a deep recursion makes the pass leave the IR unchanged
-    /// rather than aborting the compiler.
-    bool ok = true;
-    auto [left, diagonal, right] = bidiagonalize(matrixMagicBasis, ok);
-    /// Step3: Get the KAK components
-    auto [a1, a0, aPh] = extractSU2FromSO4(left, ok);
-    components.a0 = a0;
-    components.a1 = a1;
-    phase *= aPh;
-    auto [b1, b0, bPh] = extractSU2FromSO4(right, ok);
-    components.b0 = b0;
-    components.b1 = b1;
-    phase *= bPh;
-    valid = valid && ok;
-    /// Step4: Get the coefficients of canonical class vector
-    if (diagonal.determinant().real() < 0.0)
-      diagonal(0, 0) *= 1.0;
-    Eigen::Vector4cd diagonalPhases;
-    for (size_t i = 0; i < 4; i++)
-      diagonalPhases(i) = std::arg(diagonal(i, i));
-    auto coefficients = GammaFactor() * diagonalPhases;
-    components.x = coefficients(1).real();
-    components.y = coefficients(2).real();
-    components.z = coefficients(3).real();
-    phase *= std::exp(1i * coefficients(0));
-    /// Final check to verify results. This runs unconditionally (not just in
-    /// debug builds): on failure we mark the decomposition invalid so the pass
-    /// can leave the input IR untouched rather than emit a wrong circuit.
-    auto canVecToMat =
-        canonicalVecToMatrix(components.x, components.y, components.z);
-    if (!targetMatrix.isApprox(phase * Eigen::kroneckerProduct(a1, a0) *
-                                   canVecToMat *
-                                   Eigen::kroneckerProduct(b1, b0),
-                               RECON_TOL))
-      valid = false;
-  }
+  bool valid = true;
 
   void emitDecomposedFuncOp(cudaq::quake::CustomUnitaryConstantOp customOp,
-                            OpBuilder &rewriter,
-                            std::string funcName) override {
+                            OpBuilder &rewriter, std::string funcName) const {
     auto a0 = OneQubitOpZYZ(components.a0);
     a0.emitDecomposedFuncOp(customOp, rewriter, funcName + "a0");
     auto a1 = OneQubitOpZYZ(components.a1);
@@ -496,10 +423,10 @@ struct TwoQubitOpKAK : public Decomposer {
         ValueRange{}, ValueRange{arguments[0]});
     auto globalPhase = 2.0 * std::arg(phase);
     if (isAboveThreshold(globalPhase)) {
-      auto phase = cudaq::opt::factory::createFloatConstant(
+      auto phaseVal = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, globalPhase, floatTy);
-      Value negPhase = arith::NegFOp::create(rewriter, loc, phase);
-      cudaq::quake::R1Op::create(rewriter, loc, phase, ValueRange{},
+      Value negPhase = arith::NegFOp::create(rewriter, loc, phaseVal);
+      cudaq::quake::R1Op::create(rewriter, loc, phaseVal, ValueRange{},
                                  arguments[0]);
       cudaq::quake::RzOp::create(rewriter, loc, negPhase, ValueRange{},
                                  arguments[0]);
@@ -508,9 +435,51 @@ struct TwoQubitOpKAK : public Decomposer {
     rewriter.restoreInsertionPoint(insPt);
   }
 
-  TwoQubitOpKAK(const Eigen::MatrixXcd &vec) {
-    targetMatrix = vec;
-    decompose();
+  TwoQubitOpKAK(const Eigen::MatrixXcd &vec) : targetMatrix(vec) {
+    using namespace std::complex_literals;
+    /// Step0: Convert to special unitary
+    phase = std::pow(targetMatrix.determinant(), 0.25);
+    auto specialUnitary = targetMatrix / phase;
+    /// Step1: Convert into magic basis
+    Eigen::Matrix4cd matrixMagicBasis =
+        MagicBasisMatrixAdj() * specialUnitary * MagicBasisMatrix();
+    /// Step2: Diagonalize. The intermediate sanity checks below are composable:
+    /// they clear `ok` (and hence `valid`) instead of asserting, so a marginal
+    /// sub-block from a deep recursion makes the pass leave the IR unchanged
+    /// rather than aborting the compiler.
+    bool ok = true;
+    auto [left, diagonal, right] = bidiagonalize(matrixMagicBasis, ok);
+    /// Step3: Get the KAK components
+    auto [a1, a0, aPh] = extractSU2FromSO4(left, ok);
+    components.a0 = a0;
+    components.a1 = a1;
+    phase *= aPh;
+    auto [b1, b0, bPh] = extractSU2FromSO4(right, ok);
+    components.b0 = b0;
+    components.b1 = b1;
+    phase *= bPh;
+    valid = valid && ok;
+    /// Step4: Get the coefficients of canonical class vector
+    if (diagonal.determinant().real() < 0.0)
+      diagonal(0, 0) *= 1.0;
+    Eigen::Vector4cd diagonalPhases;
+    for (size_t i = 0; i < 4; i++)
+      diagonalPhases(i) = std::arg(diagonal(i, i));
+    auto coefficients = GammaFactor() * diagonalPhases;
+    components.x = coefficients(1).real();
+    components.y = coefficients(2).real();
+    components.z = coefficients(3).real();
+    phase *= std::exp(1i * coefficients(0));
+    /// Final check to verify results. This runs unconditionally (not just in
+    /// debug builds): on failure we mark the decomposition invalid so the pass
+    /// can leave the input IR untouched rather than emit a wrong circuit.
+    auto canVecToMat =
+        canonicalVecToMatrix(components.x, components.y, components.z);
+    if (!targetMatrix.isApprox(phase * Eigen::kroneckerProduct(a1, a0) *
+                                   canVecToMat *
+                                   Eigen::kroneckerProduct(b1, b0),
+                               RECON_TOL))
+      valid = false;
   }
 };
 
@@ -522,14 +491,15 @@ struct CSDComponents {
   Eigen::MatrixXcd l0, l1, r0, r1;
   Eigen::VectorXd c, s;
 };
+} // namespace
 
 /// Deterministically extend a set of orthonormal columns to a full unitary by
 /// projecting the standard basis vectors onto the orthogonal complement. Used
 /// to fill the columns of a singular-vector basis that are left undetermined by
 /// degenerate (repeated) singular values, e.g. for permutation-like operators
 /// such as Toffoli.
-Eigen::MatrixXcd completeUnitaryBasis(const Eigen::MatrixXcd &definedCols,
-                                      Eigen::Index n) {
+static Eigen::MatrixXcd
+completeUnitaryBasis(const Eigen::MatrixXcd &definedCols, Eigen::Index n) {
   Eigen::MatrixXcd basis = definedCols;
   /// `Eigen::Index` is the natural index type of Eigen containers, so taking
   /// `.cols()` directly avoids a truncating cast and any signed/unsigned mix
@@ -555,7 +525,8 @@ Eigen::MatrixXcd completeUnitaryBasis(const Eigen::MatrixXcd &definedCols,
 /// block. The right singular vectors are shared by both block rows, which lets
 /// us recover the remaining factors. Degenerate singular values are handled via
 /// `completeUnitaryBasis`. Ref: arXiv quant-ph/0404089.
-CSDComponents cosineSineDecomposition(const Eigen::MatrixXcd &u, bool &ok) {
+static CSDComponents cosineSineDecomposition(const Eigen::MatrixXcd &u,
+                                             bool &ok) {
   Eigen::Index m = u.rows() / 2;
   Eigen::MatrixXcd u00 = u.topLeftCorner(m, m);
   Eigen::MatrixXcd u01 = u.topRightCorner(m, m);
@@ -632,9 +603,9 @@ CSDComponents cosineSineDecomposition(const Eigen::MatrixXcd &u, bool &ok) {
 /// d^dagger)` is a uniformly-controlled Rz on the multiplexor qubit. The
 /// returned `angles` are the corresponding Rz rotation angles.
 /// Ref: arXiv quant-ph/0406176.
-void demultiplex(const Eigen::MatrixXcd &a, const Eigen::MatrixXcd &b,
-                 Eigen::MatrixXcd &vOut, Eigen::MatrixXcd &wOut,
-                 std::vector<double> &angles, bool &ok) {
+static void demultiplex(const Eigen::MatrixXcd &a, const Eigen::MatrixXcd &b,
+                        Eigen::MatrixXcd &vOut, Eigen::MatrixXcd &wOut,
+                        std::vector<double> &angles, bool &ok) {
   Eigen::Index m = a.rows();
   /// `a * b^dagger` is unitary (hence normal); its complex Schur form is
   /// diagonal with unitary Schur vectors, giving an orthonormal eigenbasis.
@@ -659,6 +630,12 @@ void demultiplex(const Eigen::MatrixXcd &a, const Eigen::MatrixXcd &b,
     ok = false;
 }
 
+namespace {
+/// Plain-data struct for N-qubit QSD synthesis.
+///
+/// Method bodies that construct or dereference AnyDecomposer are defined after
+/// AnyDecomposer's full definition to break the mutual-dependency cycle.
+///
 /// Recursive Quantum Shannon Decomposition (QSD) for an arbitrary `n`-qubit
 /// (`2^n x 2^n`) unitary with `n >= 3`. One level of QSD splits the unitary,
 /// via a Cosine-Sine decomposition and two multiplexor demultiplexings, into
@@ -668,52 +645,21 @@ void demultiplex(const Eigen::MatrixXcd &a, const Eigen::MatrixXcd &b,
 /// base cases. Each factorization step is exact, so no global phase correction
 /// is needed at this level (the base cases track their own global phase).
 /// Refs: arXiv quant-ph/0404089, arXiv quant-ph/0406176.
-struct NQubitOpQSD : public Decomposer {
+struct NQubitOpQSD {
   Eigen::MatrixXcd targetMatrix;
   size_t numQubits;
   /// `targetMatrix = (I (x) vL) * muxRz(muxRzLeft) * (I (x) wL) * muxRy(muxRy)
   ///               * (I (x) vR) * muxRz(muxRzRight) * (I (x) wR)`
   Eigen::MatrixXcd vL, wL, vR, wR;
   std::vector<double> muxRzLeft, muxRy, muxRzRight;
-  /// The four `(n-1)`-qubit sub-unitary decomposers, built during `decompose()`
+  /// The four `(n-1)`-qubit sub-unitary decomposers, built during construction
   /// so the whole recursion tree is validated before any IR is emitted.
-  std::unique_ptr<Decomposer> childWr, childVr, childWl, childVl;
+  std::unique_ptr<AnyDecomposer> childWr, childVr, childWl, childVl;
+  bool valid = true;
 
   /// Build the decomposer for an `(n-1)`-qubit sub-unitary, dispatching to the
   /// base cases (ZYZ for 1 qubit, KAK for 2) or recursing with QSD otherwise.
-  std::unique_ptr<Decomposer> makeChild(const Eigen::MatrixXcd &matrix) {
-    size_t childQubits = numQubits - 1;
-    if (childQubits == 1) {
-      Eigen::Matrix2cd m2 = matrix;
-      return std::make_unique<OneQubitOpZYZ>(m2);
-    }
-    if (childQubits == 2)
-      return std::make_unique<TwoQubitOpKAK>(matrix);
-    return std::make_unique<NQubitOpQSD>(matrix);
-  }
-
-  void decompose() override {
-    bool ok = true;
-    auto csd = cosineSineDecomposition(targetMatrix, ok);
-    demultiplex(csd.r0, csd.r1, vR, wR, muxRzRight, ok);
-    demultiplex(csd.l0, csd.l1, vL, wL, muxRzLeft, ok);
-    valid = valid && ok;
-    int m = static_cast<int>(targetMatrix.rows()) / 2;
-    muxRy.resize(m);
-    for (int k = 0; k < m; ++k)
-      muxRy[k] = 2.0 * std::atan2(csd.s(k), csd.c(k));
-    /// Only recurse once this level reconstructs cleanly: feeding the marginal
-    /// sub-blocks of a failed split into the children could trip their own
-    /// numerical checks. Validate the whole tree before emitting any IR.
-    if (valid) {
-      childWr = makeChild(wR);
-      childVr = makeChild(vR);
-      childWl = makeChild(wL);
-      childVl = makeChild(vL);
-      valid = childWr->isValid() && childVr->isValid() && childWl->isValid() &&
-              childVl->isValid();
-    }
-  }
+  std::unique_ptr<AnyDecomposer> makeChild(const Eigen::MatrixXcd &matrix);
 
   /// Emit a uniformly-controlled rotation (multiplexed Rz or Ry) on `target`
   /// controlled by `controls` (most-significant first), using the optimal
@@ -727,122 +673,208 @@ struct NQubitOpQSD : public Decomposer {
   /// (arXiv quant-ph/0407010), Shende-Bullock-Markov (arXiv quant-ph/0406176).
   void emitMux(const std::vector<double> &angles, ArrayRef<Value> controls,
                Value target, bool isRy, OpBuilder &rewriter, Location loc,
-               FloatType floatTy) {
-    auto emitRot = [&](double angle) {
-      if (!isAboveThreshold(angle))
-        return;
-      auto a = cudaq::opt::factory::createFloatConstant(loc, rewriter, angle,
-                                                        floatTy);
-      if (isRy)
-        cudaq::quake::RyOp::create(rewriter, loc, a, ValueRange{}, target);
-      else
-        cudaq::quake::RzOp::create(rewriter, loc, a, ValueRange{}, target);
+               FloatType floatTy) const;
+
+  void emitDecomposedFuncOp(cudaq::quake::CustomUnitaryConstantOp customOp,
+                            OpBuilder &rewriter, std::string funcName) const;
+
+  explicit NQubitOpQSD(const Eigen::MatrixXcd &vec);
+};
+} // namespace
+
+/// Modern C++ type class concept for unitary decomposers. Satisfied by any
+/// plain-data struct that exposes a `valid` flag and an `emitDecomposedFuncOp`
+/// method. No base class or vtable is required.
+template <typename T>
+concept DecomposerType =
+    requires(T &d, cudaq::quake::CustomUnitaryConstantOp customOp,
+             OpBuilder &rewriter, std::string funcName) {
+      { d.valid } -> std::convertible_to<bool>;
+      d.emitDecomposedFuncOp(customOp, rewriter, std::move(funcName));
     };
-    size_t k = controls.size();
-    // Base case: a plain (uncontrolled) rotation.
-    if (k == 0) {
-      emitRot(angles[0]);
-      return;
-    }
-    size_t n = angles.size(); // == 2^k
-    // Transform the desired per-state angles into the gray-code rotation
-    // angles: theta'_i = 2^{-k} * sum_j (-1)^{<gray(i), j>} * angles[j].
-    std::vector<double> theta(n, 0.0);
-    for (size_t i = 0; i < n; ++i) {
-      size_t gi = i ^ (i >> 1); // binary-reflected gray code of i
-      double acc = 0.0;
-      for (size_t j = 0; j < n; ++j) {
-        int sign = (llvm::popcount(gi & j) & 1) ? -1 : 1;
-        acc += sign * angles[j];
-      }
-      theta[i] = acc / static_cast<double>(n);
-    }
-    // Emit `R(theta'_i)` followed by a single CNOT whose control is the qubit
-    // flipped between gray(i) and gray(i+1). `controls` is most-significant
-    // first, so bit position `p` (0 == least significant) maps to
-    // `controls[k-1-p]`. The closing CNOT (i == n-1) flips the most-significant
-    // control, returning the accumulated control parity to the identity.
-    for (size_t i = 0; i < n; ++i) {
-      emitRot(theta[i]);
-      size_t flipBit = (i == n - 1) ? (k - 1) : llvm::countr_zero(i + 1);
-      Value ctrl = controls[k - 1 - flipBit];
-      cudaq::quake::XOp::create(rewriter, loc, ctrl, target);
-    }
+
+static_assert(DecomposerType<OneQubitOpZYZ>);
+static_assert(DecomposerType<TwoQubitOpKAK>);
+static_assert(DecomposerType<NQubitOpQSD>);
+
+namespace {
+/// Type-erased sum of all decomposer instances. Dispatch is via `std::visit`
+/// rather than virtual dispatch: no vtable, no mandatory heap allocation for
+/// the 1- and 2-qubit base cases.
+struct AnyDecomposer {
+  using Variant = std::variant<OneQubitOpZYZ, TwoQubitOpKAK, NQubitOpQSD>;
+  Variant inner;
+
+  bool isValid() const {
+    return std::visit([](const auto &d) -> bool { return d.valid; }, inner);
   }
 
   void emitDecomposedFuncOp(cudaq::quake::CustomUnitaryConstantOp customOp,
-                            OpBuilder &rewriter,
-                            std::string funcName) override {
-    /// Emit using the children built (and validated) in `decompose()`.
-    childWr->emitDecomposedFuncOp(customOp, rewriter, funcName + "wr");
-    childVr->emitDecomposedFuncOp(customOp, rewriter, funcName + "vr");
-    childWl->emitDecomposedFuncOp(customOp, rewriter, funcName + "wl");
-    childVl->emitDecomposedFuncOp(customOp, rewriter, funcName + "vl");
-    auto parentModule = customOp->getParentOfType<ModuleOp>();
-    Location loc = customOp->getLoc();
-    auto targets = customOp.getTargets();
-    /// This decomposer emits a `numQubits`-qubit replacement function. The
-    /// arity is taken from `numQubits` (not from `customOp`) so that it stays
-    /// correct when QSD is invoked recursively on an `(n-1)`-qubit sub-unitary
-    /// of a larger parent operation.
-    SmallVector<Type> argTys(numQubits, targets[0].getType());
-    auto funcTy = FunctionType::get(parentModule.getContext(), argTys, {});
-    auto insPt = rewriter.saveInsertionPoint();
-    rewriter.setInsertionPointToStart(parentModule.getBody());
-    auto func = func::FuncOp::create(rewriter, parentModule->getLoc(), funcName,
-                                     funcTy);
-    func.setPrivate();
-    auto *block = func.addEntryBlock();
-    rewriter.setInsertionPointToStart(block);
-    auto arguments = func.getArguments();
-    FloatType floatTy = rewriter.getF64Type();
-    /// `arguments[0]` is the most-significant qubit (the multiplexor target),
-    /// `arguments[1..n-1]` carry the `(n-1)`-qubit sub-unitaries and act as the
-    /// controls for the multiplexed rotations.
-    Value top = arguments[0];
-    SmallVector<Value> lower(arguments.begin() + 1, arguments.end());
-    auto applyChild = [&](std::string name) {
-      cudaq::quake::ApplyOp::create(
-          rewriter, loc, TypeRange{},
-          SymbolRefAttr::get(rewriter.getContext(), name), false, ValueRange{},
-          ValueRange(lower));
-    };
-    /// Operator notation is right-to-left, so the right-most factor is emitted
-    /// first.
-    applyChild(funcName + "wr");
-    emitMux(muxRzRight, lower, top, false, rewriter, loc, floatTy);
-    applyChild(funcName + "vr");
-    emitMux(muxRy, lower, top, true, rewriter, loc, floatTy);
-    applyChild(funcName + "wl");
-    emitMux(muxRzLeft, lower, top, false, rewriter, loc, floatTy);
-    applyChild(funcName + "vl");
-    func::ReturnOp::create(rewriter, loc);
-    rewriter.restoreInsertionPoint(insPt);
+                            OpBuilder &rewriter, std::string funcName) const {
+    std::visit(
+        [&](const auto &d) {
+          d.emitDecomposedFuncOp(customOp, rewriter, std::move(funcName));
+        },
+        inner);
   }
 
-  NQubitOpQSD(const Eigen::MatrixXcd &vec) {
-    targetMatrix = vec;
-    numQubits = static_cast<size_t>(std::llround(std::log2(vec.rows())));
-    decompose();
-  }
+  template <DecomposerType T>
+  explicit AnyDecomposer(T &&t) : inner(std::forward<T>(t)) {}
 };
+} // namespace
+
+// ---------------------------------------------------------------------------
+// NQubitOpQSD out-of-line definitions (AnyDecomposer is now complete)
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<AnyDecomposer>
+NQubitOpQSD::makeChild(const Eigen::MatrixXcd &matrix) {
+  size_t childQubits = numQubits - 1;
+  if (childQubits == 1) {
+    Eigen::Matrix2cd m2 = matrix;
+    return std::make_unique<AnyDecomposer>(OneQubitOpZYZ(m2));
+  }
+  if (childQubits == 2)
+    return std::make_unique<AnyDecomposer>(TwoQubitOpKAK(matrix));
+  return std::make_unique<AnyDecomposer>(NQubitOpQSD(matrix));
+}
+
+void NQubitOpQSD::emitMux(const std::vector<double> &angles,
+                          ArrayRef<Value> controls, Value target, bool isRy,
+                          OpBuilder &rewriter, Location loc,
+                          FloatType floatTy) const {
+  auto emitRot = [&](double angle) {
+    if (!isAboveThreshold(angle))
+      return;
+    auto a =
+        cudaq::opt::factory::createFloatConstant(loc, rewriter, angle, floatTy);
+    if (isRy)
+      cudaq::quake::RyOp::create(rewriter, loc, a, ValueRange{}, target);
+    else
+      cudaq::quake::RzOp::create(rewriter, loc, a, ValueRange{}, target);
+  };
+  size_t k = controls.size();
+  // Base case: a plain (uncontrolled) rotation.
+  if (k == 0) {
+    emitRot(angles[0]);
+    return;
+  }
+  size_t n = angles.size(); // == 2^k
+  // Transform the desired per-state angles into the gray-code rotation
+  // angles: theta'_i = 2^{-k} * sum_j (-1)^{<gray(i), j>} * angles[j].
+  std::vector<double> theta(n, 0.0);
+  for (size_t i = 0; i < n; ++i) {
+    size_t gi = i ^ (i >> 1); // binary-reflected gray code of i
+    double acc = 0.0;
+    for (size_t j = 0; j < n; ++j) {
+      int sign = (llvm::popcount(gi & j) & 1) ? -1 : 1;
+      acc += sign * angles[j];
+    }
+    theta[i] = acc / static_cast<double>(n);
+  }
+  // Emit `R(theta'_i)` followed by a single CNOT whose control is the qubit
+  // flipped between gray(i) and gray(i+1). `controls` is most-significant
+  // first, so bit position `p` (0 == least significant) maps to
+  // `controls[k-1-p]`. The closing CNOT (i == n-1) flips the most-significant
+  // control, returning the accumulated control parity to the identity.
+  for (size_t i = 0; i < n; ++i) {
+    emitRot(theta[i]);
+    size_t flipBit = (i == n - 1) ? (k - 1) : llvm::countr_zero(i + 1);
+    Value ctrl = controls[k - 1 - flipBit];
+    cudaq::quake::XOp::create(rewriter, loc, ctrl, target);
+  }
+}
+
+void NQubitOpQSD::emitDecomposedFuncOp(
+    cudaq::quake::CustomUnitaryConstantOp customOp, OpBuilder &rewriter,
+    std::string funcName) const {
+  /// Emit using the children built (and validated) in the constructor.
+  childWr->emitDecomposedFuncOp(customOp, rewriter, funcName + "wr");
+  childVr->emitDecomposedFuncOp(customOp, rewriter, funcName + "vr");
+  childWl->emitDecomposedFuncOp(customOp, rewriter, funcName + "wl");
+  childVl->emitDecomposedFuncOp(customOp, rewriter, funcName + "vl");
+  auto parentModule = customOp->getParentOfType<ModuleOp>();
+  Location loc = customOp->getLoc();
+  auto targets = customOp.getTargets();
+  /// This decomposer emits a `numQubits`-qubit replacement function. The
+  /// arity is taken from `numQubits` (not from `customOp`) so that it stays
+  /// correct when QSD is invoked recursively on an `(n-1)`-qubit sub-unitary
+  /// of a larger parent operation.
+  SmallVector<Type> argTys(numQubits, targets[0].getType());
+  auto funcTy = FunctionType::get(parentModule.getContext(), argTys, {});
+  auto insPt = rewriter.saveInsertionPoint();
+  rewriter.setInsertionPointToStart(parentModule.getBody());
+  auto func =
+      func::FuncOp::create(rewriter, parentModule->getLoc(), funcName, funcTy);
+  func.setPrivate();
+  auto *block = func.addEntryBlock();
+  rewriter.setInsertionPointToStart(block);
+  auto arguments = func.getArguments();
+  FloatType floatTy = rewriter.getF64Type();
+  /// `arguments[0]` is the most-significant qubit (the multiplexor target),
+  /// `arguments[1..n-1]` carry the `(n-1)`-qubit sub-unitaries and act as the
+  /// controls for the multiplexed rotations.
+  Value top = arguments[0];
+  SmallVector<Value> lower(arguments.begin() + 1, arguments.end());
+  auto applyChild = [&](std::string name) {
+    cudaq::quake::ApplyOp::create(
+        rewriter, loc, TypeRange{},
+        SymbolRefAttr::get(rewriter.getContext(), name), false, ValueRange{},
+        ValueRange(lower));
+  };
+  /// Operator notation is right-to-left, so the right-most factor is emitted
+  /// first.
+  applyChild(funcName + "wr");
+  emitMux(muxRzRight, lower, top, false, rewriter, loc, floatTy);
+  applyChild(funcName + "vr");
+  emitMux(muxRy, lower, top, true, rewriter, loc, floatTy);
+  applyChild(funcName + "wl");
+  emitMux(muxRzLeft, lower, top, false, rewriter, loc, floatTy);
+  applyChild(funcName + "vl");
+  func::ReturnOp::create(rewriter, loc);
+  rewriter.restoreInsertionPoint(insPt);
+}
+
+NQubitOpQSD::NQubitOpQSD(const Eigen::MatrixXcd &vec) : targetMatrix(vec) {
+  numQubits = static_cast<size_t>(std::llround(std::log2(vec.rows())));
+  bool ok = true;
+  auto csd = cosineSineDecomposition(targetMatrix, ok);
+  demultiplex(csd.r0, csd.r1, vR, wR, muxRzRight, ok);
+  demultiplex(csd.l0, csd.l1, vL, wL, muxRzLeft, ok);
+  valid = valid && ok;
+  int m = static_cast<int>(targetMatrix.rows()) / 2;
+  muxRy.resize(m);
+  for (int k = 0; k < m; ++k)
+    muxRy[k] = 2.0 * std::atan2(csd.s(k), csd.c(k));
+  /// Only recurse once this level reconstructs cleanly: feeding the marginal
+  /// sub-blocks of a failed split into the children could trip their own
+  /// numerical checks. Validate the whole tree before emitting any IR.
+  if (valid) {
+    childWr = makeChild(wR);
+    childVr = makeChild(vR);
+    childWl = makeChild(wL);
+    childVl = makeChild(vL);
+    valid = childWr->isValid() && childVr->isValid() && childWl->isValid() &&
+            childVl->isValid();
+  }
+}
 
 /// Build the decomposer for a `dimension x dimension` custom-operation matrix,
-/// or return null when the dimension is outside the supported synthesis range
-/// (a power of two with `2 <= dimension <= 32`, i.e. 1-5 qubits). The returned
-/// decomposer has already run its factorization; callers consult `isValid()` to
-/// learn whether the reconstruction stayed within tolerance.
-static std::shared_ptr<Decomposer>
+/// or return nullopt when the dimension is outside the supported synthesis
+/// range (a power of two with `2 <= dimension <= 32`, i.e. 1-5 qubits). The
+/// returned decomposer has already run its factorization; callers consult
+/// `isValid()` to learn whether the reconstruction stayed within tolerance.
+static std::optional<AnyDecomposer>
 makeDecomposer(const Eigen::MatrixXcd &unitary, size_t dimension) {
   if (dimension == 2) {
     Eigen::Matrix2cd m2 = unitary;
-    return std::make_shared<OneQubitOpZYZ>(m2);
+    return AnyDecomposer{OneQubitOpZYZ(m2)};
   }
   if (dimension == 4)
-    return std::make_shared<TwoQubitOpKAK>(unitary);
+    return AnyDecomposer{TwoQubitOpKAK(unitary)};
   if (dimension >= 8 && dimension <= 32 && (dimension & (dimension - 1)) == 0)
-    return std::make_shared<NQubitOpQSD>(unitary);
-  return nullptr;
+    return AnyDecomposer{NQubitOpQSD(unitary)};
+  return std::nullopt;
 }
 
 /// Cached classification of a custom operation's generator matrix. The
@@ -855,7 +887,8 @@ struct DecompInfo {
     UnsupportedDim,      ///< not a power of two, or a power of two > 32
     ReconstructionFailed ///< supported dimension but reconstruction missed
   };
-  std::shared_ptr<Decomposer> decomposer; ///< non-null only when `Convertible`
+  std::optional<AnyDecomposer>
+      decomposer; ///< non-empty only when `Convertible`
   Status status = UnsupportedDim;
   size_t dimension = 0;
   bool powerOfTwo = false;
@@ -897,6 +930,8 @@ static std::string replacementFuncName(StringRef generatorName) {
   auto pair = generatorName.split(".rodata");
   return pair.first.str() + ".kernel" + pair.second.str();
 }
+
+namespace {
 
 /// Lowers a synthesizable `quake.custom_unitary_constant` into a `quake.apply`
 /// of its decomposed kernel. The kernels are generated up-front by the pass
@@ -1016,5 +1051,4 @@ public:
     LLVM_DEBUG(llvm::dbgs() << "After unitary synthesis: " << module << '\n');
   }
 };
-
 } // namespace


### PR DESCRIPTION
Replaces the virtual classes and inheritance with modern C++ using concepts and templates. This eliminates virtual calls, stack allocations, pointer management hackery, etc.

Bring into alignment with LLVM coding style.