### PR TITLE
[realtime] Remove redundant hololink_wrapper_generic static library

### DIFF
--- a/realtime/lib/daemon/bridge/hololink/CMakeLists.txt
+++ b/realtime/lib/daemon/bridge/hololink/CMakeLists.txt
@@ -170,7 +170,6 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND
 
   target_link_libraries(cudaq-realtime-bridge-hololink
     PRIVATE
-      hololink_wrapper_generic
       ${GPU_ROCE_TRANSCEIVER_LIB}
       ${BASE_RECEIVER_OP_LIB}
       ${HOLOLINK_CORE_LIB}
@@ -190,7 +189,6 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND
     "LINKER:--allow-multiple-definition")
 
   if (holoscan_FOUND)
-    target_link_libraries(cudaq-realtime-bridge-hololink PRIVATE holoscan::core)
     target_link_libraries(cudaq-realtime-bridge-hololink PRIVATE holoscan::core)
   endif()
 

--- a/realtime/unittests/utils/CMakeLists.txt
+++ b/realtime/unittests/utils/CMakeLists.txt
@@ -165,25 +165,6 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND
   message(STATUS "Building hololink_bridge (generic increment)")
   message(STATUS "  GPU RoCE Transceiver: ${GPU_ROCE_TRANSCEIVER_LIB}")
 
-  # Hololink wrapper static library (compiled by g++, isolates fmt).
-  # Use the realtime source root so this path works when nested in CUDA-Q.
-  add_library(hololink_wrapper_generic STATIC
-    ${CUDAQ_REALTIME_SOURCE_DIR}/lib/daemon/bridge/hololink/hololink_wrapper.cpp)
-
-  target_include_directories(hololink_wrapper_generic
-    PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      ${CUDAQ_REALTIME_INCLUDE_DIR}
-      "${HOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR}/src"
-      ${DOCA_INCLUDE_DIR}
-      ${CUDAToolkit_INCLUDE_DIRS}
-      ${FMT_INCLUDE_DIR})
-
-  target_link_libraries(hololink_wrapper_generic
-    PRIVATE ${GPU_ROCE_TRANSCEIVER_LIB})
-
-  target_compile_options(hololink_wrapper_generic PRIVATE -Wno-deprecated-declarations)
-
   # Increment function table (compiled by nvcc)
   add_library(rpc_increment_ft STATIC
     init_rpc_increment_function_table.cu)
@@ -217,7 +198,6 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND
       rpc_increment_ft
       cudaq-realtime-dispatch
       cudaq-realtime-bridge-hololink
-      hololink_wrapper_generic
       ${GPU_ROCE_TRANSCEIVER_LIB}
       ${BASE_RECEIVER_OP_LIB}
       ${HOLOLINK_CORE_LIB}
@@ -234,7 +214,6 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND
 
   if (holoscan_FOUND)
     target_link_libraries(hololink_bridge PRIVATE holoscan::core)
-    target_link_libraries(hololink_wrapper_generic PRIVATE holoscan::core)
   endif()
 
   # Set RPATH for shared libraries


### PR DESCRIPTION
hololink_wrapper.cpp is already compiled directly into the cudaq-realtime-bridge-hololink shared library, and its symbols are exported (default visibility). The separate hololink_wrapper_generic static archive was built from the same source and linked into both the shared library and the hololink_bridge tool, which:

  - lived under unittests/utils, so building the hololink bridge required CUDAQ_REALTIME_BUILD_TESTS=ON (otherwise the link failed with `cannot find -lhololink_wrapper_generic`).

Neither consumer actually needs the archive: bridge_impl.cpp (inside the .so) is the only direct caller of the wrapper functions, and hololink_bridge only links the .so. Drop the target entirely and link the shared library instead.