### PR TITLE
Continue to harden QIR output record parsing

### DIFF
--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -108,9 +108,9 @@ pyRunTheKernel(const std::string &name, quantum_platform &platform,
 
 static std::vector<nanobind::object>
 pyReadResults(detail::RunResultSpan results, mlir::ModuleOp mod,
-              std::size_t shots_count, const std::string &name) {
+              const std::string &name) {
   auto returnTy = recoverReturnType(mod, name);
-  return readRunResults(mod, returnTy, results, shots_count);
+  return readRunResults(mod, returnTy, results, results.resultCount);
 }
 
 /// @brief Run `cudaq::run` on the provided kernel.
@@ -140,7 +140,7 @@ run_impl(const std::string &shortName, MlirModule module,
     span = pyRunTheKernel(shortName, platform, mod, compiled, shots_count,
                           qpu_id, opaques);
   }
-  auto results = pyReadResults(span, mod, shots_count, shortName);
+  auto results = pyReadResults(span, mod, shortName);
 
   if (noise_model.has_value())
     platform.reset_noise();
@@ -239,13 +239,13 @@ run_async_impl(const std::string &shortName, MlirModule module,
         std::launch::deferred,
         [sf = std::move(spanFuture), ef = std::move(errorFuture),
          errorPtr = result.error.get(), resultsPtr = result.results.get(), mod,
-         shots_count, shortName]() mutable {
+         shortName]() mutable {
           auto error = ef.get();
           std::swap(*errorPtr, error);
           if (error.empty()) {
             auto span = sf.get();
             nanobind::gil_scoped_acquire gil{};
-            auto results = pyReadResults(span, mod, shots_count, shortName);
+            auto results = pyReadResults(span, mod, shortName);
             std::swap(*resultsPtr, results);
           }
         });
@@ -271,7 +271,8 @@ Args:
   noise_model: The optional noise model to add noise to the kernel execution.
 
 Returns:
-  A list of kernel return values from each execution. The length equals `shots_count`.
+  A list containing the return value from each successful execution. Its length
+  may be less than `shots_count` if the backend reports failed shots.
 )#");
 }
 
@@ -309,6 +310,8 @@ Args:
   qpu_id: The id of the QPU. Defaults to 0.
 
 Returns:
-  AsyncRunResult: A handle which can be waited on via a `get()` method.
+  AsyncRunResult: A handle whose `get()` method returns one value per successful
+  execution. The result may contain fewer than `shots_count` values if the
+  backend reports failed shots.
 )#");
 }

--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -33,15 +33,15 @@ readRunResults(mlir::ModuleOp module, mlir::Type ty,
     return ret;
   std::size_t byteSize = results.lengthInBytes / count;
   if (byteSize == 0)
-    throw std::runtime_error(
-        "run: result buffer (" + std::to_string(results.lengthInBytes) +
-        " bytes) is too small for " + std::to_string(count) +
-        " shots. The backend returned fewer results than requested.");
+    throw std::runtime_error("run: result buffer (" +
+                             std::to_string(results.lengthInBytes) +
+                             " bytes) is too small for " +
+                             std::to_string(count) + " decoded results.");
   if (results.lengthInBytes % count != 0)
     throw std::runtime_error("run: result buffer (" +
                              std::to_string(results.lengthInBytes) +
                              " bytes) is not evenly divisible by " +
-                             std::to_string(count) + " shots.");
+                             std::to_string(count) + " decoded results.");
   for (std::size_t i = 0; i < results.lengthInBytes; i += byteSize) {
     nanobind::object obj = convertResult(module, ty, results.data + i);
     ret.push_back(obj);

--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -49,12 +49,17 @@ void validateOutputRecord(
 
 void cudaq::RecordLogParser::parse(const std::string &outputLog) {
   ScopedTraceWithContext(cudaq::TIMING_RUN, "RecordLogParser::parse");
-  CUDAQ_DBG("Parsing log:\n{}", outputLog);
+  CUDAQ_DBG("Parsing output log ({} bytes).", outputLog.size());
+  completedResultCount = 0;
+  // Limit logical array-payload and slot-tracking charges to the raw log size.
+  // Under the current textual grammar, each charged element has its own record
+  // whose text exceeds its combined payload and tracking charge. Revisit this
+  // bound if the format gains compact encodings or larger element types.
+  bufferHandler.setDynamicAllocationBudget(outputLog.size());
   std::vector<std::string> lines = cudaq::split(outputLog, '\n');
   if (lines.empty())
     return;
 
-  // Collect log from a single shot and process it only if it is successful.
   bool processingShot = false;
   // Track whether we have seen framed output (between START and END) or not
   bool sawFramedOutput = false;
@@ -63,11 +68,11 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
   // Keep explicit declarations separate: `schema` is also inferred from
   // legacy labeled container records.
   std::optional<RecordSchemaType> declaredSchema;
-  // Maintain the starting index of each shot's data
-  std::size_t shotStart = 0;
+  // Defer OUTPUT decoding until END reports success. An explicit collection,
+  // instead of line-index sentinel, also represents a shot with no output.
+  std::vector<std::vector<std::string>> shotOutputRecords;
 
-  for (std::size_t idx = 0; idx < lines.size(); ++idx) {
-    const auto &line = lines[idx];
+  for (const auto &line : lines) {
     std::vector<std::string> entries = cudaq::split(line, '\t');
     if (entries.empty())
       continue;
@@ -87,13 +92,13 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
       if (sawUnframedOutput)
         throw std::runtime_error("Mixed framed and unframed output");
       processingShot = true;
-      shotStart = 0;
+      shotOutputRecords.clear();
     } else if (recordType == "OUTPUT") {
       validateOutputRecord(entries, declaredSchema);
       sawOutput = true;
       if (processingShot) {
         sawFramedOutput = true;
-        shotStart = shotStart == 0 ? idx : shotStart;
+        shotOutputRecords.push_back(std::move(entries));
       } else {
         if (sawFramedOutput)
           throw std::runtime_error("Mixed framed and unframed output");
@@ -106,16 +111,14 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
       if (!processingShot)
         throw std::runtime_error("END record without START");
       if (detail::parseSize(entries[1]) == 0) {
-        if (processingShot) {
-          // Successful shot, process it
-          for (std::size_t j = shotStart; j < idx; ++j)
-            handleOutput(cudaq::split(lines[j], '\t'));
-        }
+        for (const auto &outputRecord : shotOutputRecords)
+          handleOutput(outputRecord);
+        rejectIncompleteContainer();
       } else {
         CUDAQ_DBG("Discarding shot data due to non-zero END status.");
       }
       processingShot = false;
-      shotStart = 0;
+      shotOutputRecords.clear();
       containerMeta.reset();
     } else {
       throw std::runtime_error("Invalid record type: " + recordType);
@@ -124,6 +127,7 @@ void cudaq::RecordLogParser::parse(const std::string &outputLog) {
 
   if (processingShot)
     throw std::runtime_error("Unterminated shot");
+  rejectIncompleteContainer();
 }
 
 void cudaq::RecordLogParser::handleHeader(
@@ -199,7 +203,10 @@ void cudaq::RecordLogParser::handleOutput(
       containerMeta.elementCount =
           detail::parseSize(metadata[ResultCountMetadataName]);
       containerMeta.arrayType = "i1";
+      bufferHandler.chargeContainerTracking(containerMeta.elementCount);
+      containerMeta.processedSlots.assign(containerMeta.elementCount, false);
       preallocateArray();
+      countAndResetContainerIfComplete();
     }
 
     // Note: For ordered schema, we expect the results are sequential in the
@@ -240,10 +247,12 @@ void cudaq::RecordLogParser::handleOutput(
     }
 
     processArrayEntry(recValue, fmt::format("[{}]", idxLabel));
-    containerMeta.processedElements++;
+    countAndResetContainerIfComplete();
     return;
   }
   if (recType == "ARRAY") {
+    if (containerMeta.active())
+      throw std::runtime_error("New container before previous container ends");
     validateRootContainer(ContainerType::ARRAY,
                           recLabel.empty() ? ContainerStorage::FLAT
                                            : ContainerStorage::PREALLOCATED);
@@ -252,11 +261,16 @@ void cudaq::RecordLogParser::handleOutput(
     if (!recLabel.empty()) {
       schema = RecordSchemaType::LABELED;
       containerMeta.extractArrayInfo(recLabel);
+      bufferHandler.chargeContainerTracking(containerMeta.elementCount);
+      containerMeta.processedSlots.assign(containerMeta.elementCount, false);
       preallocateArray();
     }
+    countAndResetContainerIfComplete();
     return;
   }
   if (recType == "TUPLE") {
+    if (containerMeta.active())
+      throw std::runtime_error("New container before previous container ends");
     validateRootContainer(ContainerType::TUPLE,
                           recLabel.empty() ? ContainerStorage::FLAT
                                            : ContainerStorage::PREALLOCATED);
@@ -265,8 +279,11 @@ void cudaq::RecordLogParser::handleOutput(
     if (!recLabel.empty()) {
       schema = RecordSchemaType::LABELED;
       containerMeta.extractTupleInfo(recLabel);
+      bufferHandler.chargeContainerTracking(containerMeta.elementCount);
+      containerMeta.processedSlots.assign(containerMeta.elementCount, false);
       preallocateTuple();
     }
+    countAndResetContainerIfComplete();
     return;
   }
   if (recType == "BOOL")
@@ -285,15 +302,29 @@ void cudaq::RecordLogParser::handleOutput(
       processArrayEntry(recValue, recLabel);
     else if (containerMeta.m_type == ContainerType::TUPLE)
       processTupleEntry(recValue, recLabel);
-    containerMeta.processedElements++;
-    if (containerMeta.processedElements == containerMeta.elementCount) {
-      containerMeta.reset();
-    }
-  } else {
-    if (containerMeta.elementCount == 0)
-      validateRootContainer(ContainerType::NONE);
+    countAndResetContainerIfComplete();
+  } else if (containerMeta.active()) {
     processSingleRecord(recValue, recLabel);
+    containerMeta.markProcessed(containerMeta.processedElements);
+    countAndResetContainerIfComplete();
+  } else {
+    validateRootContainer(ContainerType::NONE);
+    processSingleRecord(recValue, recLabel);
+    ++completedResultCount;
   }
+}
+
+void cudaq::RecordLogParser::countAndResetContainerIfComplete() {
+  if (!containerMeta.active() ||
+      containerMeta.processedElements != containerMeta.elementCount)
+    return;
+  ++completedResultCount;
+  containerMeta.reset();
+}
+
+void cudaq::RecordLogParser::rejectIncompleteContainer() const {
+  if (containerMeta.active())
+    throw std::runtime_error("Incomplete container in output log");
 }
 
 void cudaq::RecordLogParser::validateRootContainer(ContainerType type) {
@@ -400,8 +431,10 @@ void cudaq::RecordLogParser::processArrayEntry(const std::string &recValue,
   std::size_t index = containerMeta.extractIndex(recLabel);
   if (index >= containerMeta.elementCount)
     throw std::runtime_error("Array index out of bounds");
+  containerMeta.requireUnprocessed(index);
   cudaq::detail::DataHandlerBase &dh = getDataHandler(containerMeta.arrayType);
   dh.insertIntoArray(bufferHandler, containerMeta.dataOffset, index, recValue);
+  containerMeta.markProcessed(index);
 }
 
 void cudaq::RecordLogParser::processTupleEntry(const std::string &recValue,
@@ -409,9 +442,11 @@ void cudaq::RecordLogParser::processTupleEntry(const std::string &recValue,
   std::size_t index = containerMeta.extractIndex(recLabel);
   if (index >= containerMeta.elementCount)
     throw std::runtime_error("Tuple index out of bounds");
+  containerMeta.requireUnprocessed(index);
   cudaq::detail::DataHandlerBase &dh =
       getDataHandler(containerMeta.tupleTypes[index]);
   dh.insertIntoTuple(
       bufferHandler,
       containerMeta.dataOffset + containerMeta.tupleOffsets[index], recValue);
+  containerMeta.markProcessed(index);
 }

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -158,37 +158,59 @@ public:
 
   std::size_t getBufferSize() const { return buffer.size(); }
 
-  void resizeBuffer(std::size_t more) { buffer.resize(buffer.size() + more); }
+  /// Set the per-parse limit for logical array-payload and container-tracking
+  /// charges. This does not measure the result buffer, allocation overhead, or
+  /// parser temporaries.
+  void setDynamicAllocationBudget(std::size_t budget) {
+    dynamicAllocationBudget = budget;
+    chargedDynamicAllocationBytes = 0;
+  }
+
+  void chargeContainerTracking(std::size_t elements) {
+    // Charge one byte per logical slot before allocating `processedSlots`.
+    chargeDynamicAllocation(elements);
+  }
+
+  void resizeBuffer(std::size_t more) {
+    if (more > std::numeric_limits<std::size_t>::max() - buffer.size())
+      throw std::runtime_error("Result buffer size overflow");
+    buffer.resize(buffer.size() + more);
+  }
 
   template <typename T>
   void addPrimitiveRecord(T value) {
     std::size_t position = buffer.size();
-    buffer.resize(position + sizeof(T));
+    resizeBuffer(sizeof(T));
     std::memcpy(buffer.data() + position, &value, sizeof(T));
   }
 
   template <typename T>
-  size_t allocateArrayRecord(size_t arrSize) {
-    size_t vectorOffset = buffer.size();
+  std::size_t allocateArrayRecord(std::size_t arrSize) {
+    std::size_t vectorOffset = buffer.size();
     if constexpr (std::is_same_v<T, bool>) {
+      chargeDynamicAllocation(arrSize);
       auto *allocation = new std::vector<bool>(arrSize);
-      if (!allocation)
-        throw std::runtime_error("Memory allocation failed");
       auto byteLength = sizeof(*allocation);
-      buffer.resize(vectorOffset + byteLength);
+      resizeBuffer(byteLength);
       std::memcpy(buffer.data() + vectorOffset, allocation, byteLength);
       return vectorOffset;
     }
 
-    buffer.resize(vectorOffset + 3 * sizeof(T *));
-    size_t byteLength = arrSize * sizeof(T);
-    T *innerBuffer = static_cast<T *>(malloc(byteLength));
-    if (!innerBuffer)
-      throw std::runtime_error("Memory allocation failed");
-    std::memset(innerBuffer, 0, byteLength);
+    if (arrSize > std::numeric_limits<std::size_t>::max() / sizeof(T))
+      throw std::runtime_error("Array allocation size overflow");
+    const std::size_t byteLength = arrSize * sizeof(T);
+    chargeDynamicAllocation(byteLength);
+    resizeBuffer(3 * sizeof(T *));
+    T *innerBuffer = nullptr;
+    if (byteLength != 0) {
+      innerBuffer = static_cast<T *>(malloc(byteLength));
+      if (!innerBuffer)
+        throw std::runtime_error("Memory allocation failed");
+      std::memset(innerBuffer, 0, byteLength);
+    }
     /// Initialize the three pointers of the inner vector
     T *startPtr = innerBuffer;
-    T *end0Ptr = innerBuffer + arrSize;
+    T *end0Ptr = byteLength == 0 ? nullptr : innerBuffer + arrSize;
     T *end1Ptr = end0Ptr;
     /// Store the pointers into the outer vector (buffer) without assuming the
     /// byte offset is suitably aligned for a T** access.
@@ -198,7 +220,7 @@ public:
   }
 
   template <typename T>
-  void insertIntoArray(size_t offset, std::size_t index, T value) {
+  void insertIntoArray(std::size_t offset, std::size_t index, T value) {
     if constexpr (std::is_same_v<T, bool>) {
       auto *v = reinterpret_cast<std::vector<bool> *>(buffer.data() + offset);
       (*v)[index] = value;
@@ -211,21 +233,33 @@ public:
 
   /// NOTE: This is used only if data layout (alignment) is missing
   template <typename T>
-  size_t allocateTupleRecord() {
-    size_t position = buffer.size();
-    buffer.resize(position + sizeof(T));
+  std::size_t allocateTupleRecord() {
+    std::size_t position = buffer.size();
+    resizeBuffer(sizeof(T));
     return position;
   }
 
   template <typename T>
-  void insertIntoTuple(size_t offset, T value) {
+  void insertIntoTuple(std::size_t offset, T value) {
     if (offset > buffer.size() || sizeof(T) > buffer.size() - offset)
       throw std::runtime_error("Tuple element exceeds result buffer");
     std::memcpy(buffer.data() + offset, &value, sizeof(T));
   }
 
 private:
+  /// Charge a logical allocation before requesting memory. The subtraction
+  /// form prevents overflow and rejects charges larger than the remaining
+  /// per-parse budget.
+  void chargeDynamicAllocation(std::size_t bytes) {
+    if (chargedDynamicAllocationBytes > dynamicAllocationBudget ||
+        bytes > dynamicAllocationBudget - chargedDynamicAllocationBytes)
+      throw std::runtime_error("Decoded aggregate exceeds allocation budget");
+    chargedDynamicAllocationBytes += bytes;
+  }
+
   std::vector<char> buffer;
+  std::size_t dynamicAllocationBudget = std::numeric_limits<std::size_t>::max();
+  std::size_t chargedDynamicAllocationBytes = 0;
 };
 
 //===----------------------------------------------------------------------===//
@@ -247,6 +281,21 @@ public:
     dataOffset = 0;
     tupleTypes.clear();
     tupleOffsets.clear();
+    processedSlots.clear();
+  }
+
+  bool active() const { return m_type != ContainerType::NONE; }
+
+  void requireUnprocessed(std::size_t index) const {
+    if (!processedSlots.empty() && processedSlots[index])
+      throw std::runtime_error("Duplicate container index");
+  }
+
+  void markProcessed(std::size_t index) {
+    if (!processedSlots.empty()) {
+      processedSlots[index] = true;
+    }
+    ++processedElements;
   }
 
   /// Parse string like "array<i32 x 4>"
@@ -298,13 +347,14 @@ public:
     return value;
   }
 
-  ContainerType m_type = ContainerType::ARRAY;
+  ContainerType m_type = ContainerType::NONE;
   std::size_t elementCount = 0;
   std::size_t processedElements = 0;
   std::size_t dataOffset = 0;
   std::string arrayType;
   std::vector<std::string> tupleTypes;
   std::vector<std::size_t> tupleOffsets;
+  std::vector<bool> processedSlots;
 };
 
 //===----------------------------------------------------------------------===//
@@ -316,10 +366,10 @@ class DataHandlerBase {
 public:
   virtual ~DataHandlerBase() = default;
   virtual void addRecord(BufferHandler &bh, const std::string &value) = 0;
-  virtual size_t allocateArray(BufferHandler &bh, std::size_t arrSize) = 0;
+  virtual std::size_t allocateArray(BufferHandler &bh, std::size_t arrSize) = 0;
   virtual void insertIntoArray(BufferHandler &bh, std::size_t offset,
                                std::size_t index, const std::string &value) = 0;
-  virtual size_t allocateTuple(BufferHandler &bh) = 0;
+  virtual std::size_t allocateTuple(BufferHandler &bh) = 0;
   virtual void insertIntoTuple(BufferHandler &bh, std::size_t offset,
                                const std::string &value) = 0;
 };
@@ -335,14 +385,14 @@ public:
   void addRecord(BufferHandler &bh, const std::string &value) override {
     bh.addPrimitiveRecord<T>(converter->convert(value));
   }
-  size_t allocateArray(BufferHandler &bh, std::size_t arrSize) override {
+  std::size_t allocateArray(BufferHandler &bh, std::size_t arrSize) override {
     return bh.allocateArrayRecord<T>(arrSize);
   }
   void insertIntoArray(BufferHandler &bh, std::size_t offset, std::size_t index,
                        const std::string &value) override {
     bh.insertIntoArray<T>(offset, index, converter->convert(value));
   }
-  size_t allocateTuple(BufferHandler &bh) override {
+  std::size_t allocateTuple(BufferHandler &bh) override {
     return bh.allocateTupleRecord<T>();
   }
   void insertIntoTuple(BufferHandler &bh, std::size_t offset,
@@ -386,6 +436,10 @@ public:
   /// Get the size of the data buffer (in bytes).
   std::size_t getBufferSize() const { return bufferHandler.getBufferSize(); }
 
+  /// Get the number of results completed during the most recent parse attempt.
+  /// Failed framed shots do not contribute to this count.
+  std::size_t getResultCount() const { return completedResultCount; }
+
 private:
   /// Result-buffer storage for aggregate roots. FLAT appends element bytes;
   /// PREALLOCATED reserves the host layout before indexed insertion. This is
@@ -401,9 +455,9 @@ private:
   /// Central dispatcher that handles different output types including scalar
   /// values, arrays, and tuples.
   void handleOutput(const std::vector<std::string> &);
-  /// Allocate inner buffer for array records - one per shot
+  /// Allocate storage for the current array result.
   void preallocateArray();
-  /// Allocate contiguous memory for tuple records - one per shot
+  /// Allocate contiguous storage for the current tuple result.
   void preallocateTuple();
   /// Process scalar values and non-labeled array/tuple entries
   void processSingleRecord(const std::string &, const std::string &);
@@ -411,6 +465,10 @@ private:
   /// appropriate type and store in the pre-allocated buffer
   void processArrayEntry(const std::string &, const std::string &);
   void processTupleEntry(const std::string &, const std::string &);
+  /// Count and clear the current aggregate once all declared elements arrive.
+  void countAndResetContainerIfComplete();
+  /// Reject an aggregate that still has unprocessed elements.
+  void rejectIncompleteContainer() const;
   /// Require every root result in a log to use one container shape.
   void validateRootContainer(ContainerType);
   /// Require every aggregate root to use one storage representation.
@@ -432,5 +490,6 @@ private:
   /// Metadata information extracted from the log
   std::unordered_map<std::string, std::string> metadata = {
       {ResultCountMetadataName, "1"}};
+  std::size_t completedResultCount = 0;
 };
 } // namespace cudaq

--- a/runtime/cudaq/algorithms/run.cpp
+++ b/runtime/cudaq/algorithms/run.cpp
@@ -55,18 +55,21 @@ cudaq::detail::RunResultSpan cudaq::detail::runTheKernel(
   // 4. Get the buffer and length of buffer (in bytes) from the parser.
   auto *origBuffer = parser.getBufferPtr();
   std::size_t bufferSize = parser.getBufferSize();
+  std::size_t resultCount = parser.getResultCount();
 
-  // Validate that the buffer size is consistent with the requested shot count.
-  // A mismatch (e.g. fewer results returned than requested) can cause
-  // division-by-zero or infinite loops in downstream result decoding.
-  if (shots > 0 && bufferSize % shots != 0)
+  // Validate that the buffer size is consistent with the successful shot count.
+  if (resultCount > 0 && bufferSize % resultCount != 0)
     throw std::runtime_error(
         "run: the number of result bytes (" + std::to_string(bufferSize) +
-        ") is not evenly divisible by the number of shots (" +
-        std::to_string(shots) +
-        "). The backend may have returned fewer results than requested.");
-  char *buffer = static_cast<char *>(malloc(bufferSize));
-  std::memcpy(buffer, origBuffer, bufferSize);
+        ") is not evenly divisible by the number of decoded results (" +
+        std::to_string(resultCount) + ").");
+  char *buffer = nullptr;
+  if (bufferSize != 0) {
+    buffer = static_cast<char *>(malloc(bufferSize));
+    if (!buffer)
+      throw std::runtime_error("run: result buffer allocation failed.");
+    std::memcpy(buffer, origBuffer, bufferSize);
+  }
 
   // 5. Clear the outputLog (?)
   circuitSimulator->outputLog.clear();

--- a/runtime/cudaq/algorithms/run.cpp
+++ b/runtime/cudaq/algorithms/run.cpp
@@ -76,5 +76,5 @@ cudaq::detail::RunResultSpan cudaq::detail::runTheKernel(
 
   // 6. Pass the span back as a RunResultSpan. NB: it is the responsibility of
   // the caller to free the buffer.
-  return {buffer, bufferSize};
+  return {buffer, bufferSize, resultCount};
 }

--- a/runtime/cudaq/algorithms/run.h
+++ b/runtime/cudaq/algorithms/run.h
@@ -42,13 +42,17 @@ namespace detail {
 struct RunResultSpan {
   char *data;
   std::uint64_t lengthInBytes;
+  std::uint64_t resultCount = 0;
 };
 
 // The main entry point to launching a kernel, \p kernel, in a `cudaq::run`
 // context and getting back a span containing the results. (The kernel is
 // logically executed \p shots times, which can result in up to \p shots
 // distinct result values. The results are returned in a span, which is a
-// pointer to a buffer and the size of that buffer in bytes.
+// pointer to a buffer and the size of that buffer in bytes. Backend
+// executions with nonzero END status are omitted, so the returned span may
+// contain fewer than \p shots results and reports its actual count.
+
 RunResultSpan
 runTheKernel(std::function<void()> &&kernel, quantum_platform &platform,
              const std::string &kernel_name, const std::string &original_name,

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -13,6 +13,10 @@
 #include <cudaq.h>
 #include <limits>
 
+//===----------------------------------------------------------------------===//
+// Scalar output
+//===----------------------------------------------------------------------===//
+
 CUDAQ_TEST(ParserTester, checkSingleBoolean) {
   {
     const std::string log = "OUTPUT\tBOOL\ttrue\ti1\n";
@@ -44,6 +48,7 @@ CUDAQ_TEST(ParserTester, checkMoreBoolean) {
   auto *origBuffer = parser.getBufferPtr();
   std::size_t bufferSize = parser.getBufferSize();
   EXPECT_EQ(2, bufferSize / sizeof(char));
+  EXPECT_EQ(2, parser.getResultCount());
   char *buffer = static_cast<char *>(malloc(bufferSize));
   std::memcpy(buffer, origBuffer, bufferSize);
   EXPECT_EQ(true, buffer[0]);
@@ -141,6 +146,10 @@ CUDAQ_TEST(ParserTester, checkFloatingPointValueParsing) {
   EXPECT_TRUE(std::signbit(values[7]));
   EXPECT_TRUE(std::isnan(values[8]));
 }
+
+//===----------------------------------------------------------------------===//
+// Ordered and labeled containers
+//===----------------------------------------------------------------------===//
 
 CUDAQ_TEST(ParserTester, checkArrayOrdered) {
   const std::string log = "OUTPUT\tARRAY\t2\n"
@@ -276,15 +285,6 @@ CUDAQ_TEST(ParserTester, checkTupleOrdered) {
   origBuffer = nullptr;
 }
 
-CUDAQ_TEST(ParserTester, checkTupleLabeled) {
-  const std::string log = "OUTPUT\tTUPLE\t3\ttuple<i1, i32, f64>\n"
-                          "OUTPUT\tBOOL\ttrue\t.0\n"
-                          "OUTPUT\tINT\t37\t.1\n"
-                          "OUTPUT\tDOUBLE\t3.1416\t.2\n";
-  cudaq::RecordLogParser parser;
-  EXPECT_ANY_THROW(parser.parse("log"));
-}
-
 CUDAQ_TEST(ParserTester, checkMultipleShots) {
   const std::string log = "HEADER\tschema_id\tlabeled\n"
                           "START\n"
@@ -402,6 +402,10 @@ CUDAQ_TEST(ParserTester, checkTupleWithLayoutAndBool) {
   buffer = nullptr;
   origBuffer = nullptr;
 }
+
+//===----------------------------------------------------------------------===//
+// Grammar, value, and aggregate validation
+//===----------------------------------------------------------------------===//
 
 CUDAQ_TEST(ParserTester, checkFailureCases) {
   cudaq::RecordLogParser parser;
@@ -609,6 +613,10 @@ CUDAQ_TEST(ParserTester, checkTupleLayoutValidation) {
   EXPECT_ANY_THROW(buffer.insertIntoTuple<std::int32_t>(1, 9));
 }
 
+//===----------------------------------------------------------------------===//
+// RESULT normalization and shot filtering
+//===----------------------------------------------------------------------===//
+
 CUDAQ_TEST(ParserTester, checkResultType) {
   const std::string log =
       "HEADER\tschema_id\tlabeled\nHEADER\tschema_version\t1."
@@ -714,7 +722,7 @@ CUDAQ_TEST(ParserTester, checkResultTypeWithRegisterName) {
   origBuffer = nullptr;
 }
 
-CUDAQ_TEST(ParserTester, checkFailedShot_0) {
+CUDAQ_TEST(ParserTester, checkFailedShotProducesNoResult) {
   const std::string log = "START\n"
                           "OUTPUT\tDOUBLE\t0.00\tf64\n"
                           "END\t1\n";
@@ -727,7 +735,7 @@ CUDAQ_TEST(ParserTester, checkFailedShot_0) {
   EXPECT_EQ(nullptr, origBuffer);
 }
 
-CUDAQ_TEST(ParserTester, checkFailedShot_1) {
+CUDAQ_TEST(ParserTester, checkFailedArrayShotIsDiscarded) {
   const std::string log = "HEADER\tschema_id\tlabeled\n"
                           "START\n"
                           "OUTPUT\tARRAY\t2\tarray<i16 x 2>\n"
@@ -768,39 +776,7 @@ CUDAQ_TEST(ParserTester, checkFailedShot_1) {
   origBuffer = nullptr;
 }
 
-CUDAQ_TEST(ParserTester, checkFailedShot_2) {
-  std::string log =
-      "HEADER\tschema_id\tlabeled\nHEADER\tschema_version\t1."
-      "0\nSTART\nMETADATA\tentry_point\nMETADATA\toutput_labeling_"
-      "schema\tschema_id\nMETADATA\tqir_profiles\tadaptive_"
-      "profile\nMETADATA\trequired_num_qubits\t2\nMETADATA\trequired_num_"
-      "results\t2\nOUTPUT\tINT\t0\ti64\nEND\t1\nSTART\nOUTPUT\tINT\t2\ti64\nE"
-      "ND\t0\nSTART\nOUTPUT\tINT\t0\ti64\nEND\t0\nSTART\nOUTPUT\tINT\t0\ti64"
-      "\nEND\t5\nSTART\nOUTPUT\tINT\t0\ti64\nEND\t0\nSTART\nOUTPUT\tINT\t2\ti"
-      "64\nEND\t127\nSTART\nOUTPUT\tINT\t0\ti64\nEND\t0";
-
-  cudaq::RecordLogParser parser;
-  parser.parse(log);
-  auto *origBuffer = parser.getBufferPtr();
-  std::size_t bufferSize = parser.getBufferSize();
-  char *buffer = static_cast<char *>(malloc(bufferSize));
-  std::memcpy(buffer, origBuffer, bufferSize);
-  cudaq::detail::RunResultSpan span = {buffer, bufferSize};
-  std::vector<std::int64_t> results = {
-      reinterpret_cast<std::int64_t *>(span.data),
-      reinterpret_cast<std::int64_t *>(span.data + span.lengthInBytes)};
-  // Only 4 successful shots
-  EXPECT_EQ(4, results.size());
-  for (const auto &result : results) {
-    // Result should be either 0 or 2
-    EXPECT_TRUE(result == 0 || result == 2);
-  }
-  free(buffer);
-  buffer = nullptr;
-  origBuffer = nullptr;
-}
-
-CUDAQ_TEST(ParserTester, checkFailedShot_3) {
+CUDAQ_TEST(ParserTester, checkFailedResultShotIsDiscarded) {
   std::string log =
       "HEADER\tschema_id\tlabeled\nHEADER\tschema_version\t1."
       "0\nSTART\nMETADATA\tentry_point\nMETADATA\toutput_labeling_"
@@ -1010,17 +986,76 @@ CUDAQ_TEST(ParserTester, checkResultTypeWithArray) {
   origBuffer = nullptr;
 }
 
-CUDAQ_TEST(ParserTester, checkShotCountBufferConsistency) {
-  // 5 shots recorded, 1 fails (END 1). Parser produces buffer for 4
-  // successful shots of int64 → 32 bytes. This validates the mathematical
-  // invariant that runTheKernel relies on: bufferSize % shots == 0 when the
-  // number of results matches, and bufferSize % shots != 0 when it doesn't.
+//===----------------------------------------------------------------------===//
+// Containment regressions
+//===----------------------------------------------------------------------===//
+
+CUDAQ_TEST(ParserTester, checkEmptySuccessfulShot) {
+  cudaq::RecordLogParser parser;
+  EXPECT_NO_THROW(parser.parse("START\nEND\t0"));
+  EXPECT_EQ(nullptr, parser.getBufferPtr());
+  EXPECT_EQ(0, parser.getBufferSize());
+  EXPECT_EQ(0, parser.getResultCount());
+}
+
+CUDAQ_TEST(ParserTester, checkAggregateCompleteness) {
+  const std::vector<std::string> invalidLogs = {
+      // A duplicate array index must not count as a second element.
+      "OUTPUT\tARRAY\t2\tarray<i32 x 2>\n"
+      "OUTPUT\tINT\t1\t[0]\n"
+      "OUTPUT\tINT\t2\t[0]\n",
+      // Labeled arrays must provide every declared element.
+      "OUTPUT\tARRAY\t2\tarray<i32 x 2>\n"
+      "OUTPUT\tINT\t1\t[0]\n",
+      // Labeled tuples must provide every declared member.
+      "OUTPUT\tTUPLE\t2\ttuple<i32, f64>\n"
+      "OUTPUT\tINT\t1\t.0\n",
+      // Ordered containers must contain exactly the declared number of values.
+      "OUTPUT\tARRAY\t2\n"
+      "OUTPUT\tINT\t1\ti32\n",
+      // A second result container cannot begin while the first is incomplete.
+      "OUTPUT\tARRAY\t2\tarray<i32 x 2>\n"
+      "OUTPUT\tINT\t1\t[0]\n"
+      "OUTPUT\tARRAY\t1\tarray<i32 x 1>\n"
+      "OUTPUT\tINT\t2\t[0]\n"};
+
+  for (const auto &log : invalidLogs) {
+    cudaq::RecordLogParser parser;
+    EXPECT_ANY_THROW(parser.parse(log));
+  }
+}
+
+CUDAQ_TEST(ParserTester, checkAggregateAllocationBounds) {
+  const std::vector<std::string> invalidLogs = {
+      // The element-byte calculation must not wrap to a small allocation.
+      "OUTPUT\tARRAY\t4611686018427387905\t"
+      "array<i32 x 4611686018427387905>\n",
+      // A small log must not request a disproportionately large array payload.
+      "OUTPUT\tARRAY\t1000000\tarray<i8 x 1000000>\n",
+      // Reject an oversized tracking vector before allocating it.
+      "OUTPUT\tARRAY\t8000000000\tarray<i8 x 8000000000>\n",
+      // Reject oversized RESULT tracking declared through metadata.
+      "METADATA\trequired_results\t8000000000\n"
+      "OUTPUT\tRESULT\t1\tr00000\n"};
+
+  for (const auto &log : invalidLogs) {
+    cudaq::RecordLogParser parser;
+    EXPECT_ANY_THROW(parser.parse(log));
+  }
+}
+
+CUDAQ_TEST(ParserTester, checkFailedScalarShotsAndResultCount) {
+  // Every nonzero END status marks a failed shot, regardless of its value.
+  // Only the four successfully decoded results contribute to the count and
+  // buffer.
   const std::string log =
       "HEADER\tschema_id\tlabeled\nHEADER\tschema_version\t1.0\n"
+      "START\nOUTPUT\tINT\t0\ti64\nEND\t1\n"
       "START\nOUTPUT\tINT\t2\ti64\nEND\t0\n"
       "START\nOUTPUT\tINT\t4\ti64\nEND\t0\n"
-      "START\nOUTPUT\tINT\t6\ti64\nEND\t1\n"
+      "START\nOUTPUT\tINT\t6\ti64\nEND\t5\n"
       "START\nOUTPUT\tINT\t8\ti64\nEND\t0\n"
+      "START\nOUTPUT\tINT\t9\ti64\nEND\t127\n"
       "START\nOUTPUT\tINT\t10\ti64\nEND\t0\n";
 
   cudaq::RecordLogParser parser;
@@ -1028,16 +1063,8 @@ CUDAQ_TEST(ParserTester, checkShotCountBufferConsistency) {
   auto *origBuffer = parser.getBufferPtr();
   std::size_t bufferSize = parser.getBufferSize();
   ASSERT_NE(origBuffer, nullptr);
-  // 4 successful shots of int64 → 32 bytes
   EXPECT_EQ(32, bufferSize);
-
-  // The condition from runTheKernel: bufferSize % shots != 0 catches mismatch
-  constexpr std::size_t requestedShots = 5;
-  EXPECT_TRUE(bufferSize % requestedShots != 0);
-
-  // With actual shot count, the check passes
-  constexpr std::size_t actualSuccessful = 4;
-  EXPECT_TRUE(bufferSize % actualSuccessful == 0);
+  EXPECT_EQ(4, parser.getResultCount());
 
   // Verify we can read back the correct values
   char *buffer = static_cast<char *>(malloc(bufferSize));


### PR DESCRIPTION
* Follow-up to PR https://github.com/NVIDIA/cuda-quantum/pull/4832
* Hardens QIR output-record parsing against malformed or allocation-amplifying logs. 
* Adds checked allocation accounting, aggregate completeness validation, and accurate successful-result counting
  while preserving partial hardware results. 
* Propagates actual result counts to caller.
* Consolidate parser tests.