### PR TITLE
Fix mapped terminal measurement result ordering in QIR lowering

### DIFF
--- a/cudaq/include/cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h
+++ b/cudaq/include/cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h
@@ -1,0 +1,40 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "nlohmann/json.hpp"
+#include <cstddef>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace cudaq::opt {
+
+/// Map of result id to its (qubit index, register name) pair.
+using ResultQubitVals =
+    std::map<std::size_t, std::pair<std::size_t, std::string>>;
+
+/// Build output_names entries of the form
+/// [resultId, [qubitNum, registerName, outputPosition]]. Output positions are
+/// the dense ranks of the measured qubits' output order.
+///
+/// \param resultQubitVals Maps each QIR result id to the measured qubit id and
+/// its output register name. The qubit id is preserved as qubitNum in the
+/// emitted metadata.
+/// \param qubitToOutputOrder Optional lookup from qubit id to its
+/// user-visible logical order. An empty lookup, or a qubit id outside its
+/// bounds, falls back to the qubit id itself.
+/// \return The entries wrapped in the single-element outer array expected by
+/// the runtime output_names parser.
+nlohmann::json buildEnrichedOutputNamesJson(
+    const ResultQubitVals &resultQubitVals,
+    const std::vector<std::size_t> &qubitToOutputOrder);
+
+} // namespace cudaq::opt

--- a/cudaq/include/cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h
+++ b/cudaq/include/cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h
@@ -15,11 +15,23 @@
 #include <utility>
 #include <vector>
 
+namespace mlir {
+class Operation;
+}
+
 namespace cudaq::opt {
 
 /// Map of result id to its (qubit index, register name) pair.
 using ResultQubitVals =
     std::map<std::size_t, std::pair<std::size_t, std::string>>;
+
+/// Read an operation's `mapping_v2p` attribute.
+///
+/// \param operation Operation carrying mapping metadata.
+/// \return A lookup indexed by virtual qubit id whose values are final
+/// physical QIR qubit ids, or an empty lookup when the attribute is absent.
+std::vector<std::size_t>
+getVirtualToPhysicalMapping(mlir::Operation *operation);
 
 /// Build output_names entries of the form
 /// [resultId, [qubitNum, registerName, outputPosition]]. Output positions are
@@ -36,5 +48,20 @@ using ResultQubitVals =
 nlohmann::json buildEnrichedOutputNamesJson(
     const ResultQubitVals &resultQubitVals,
     const std::vector<std::size_t> &qubitToOutputOrder);
+
+/// Build `output_names` entries of the form
+/// [resultId, [qubitNum, registerName, outputPosition]], accounting for a
+/// virtual-to-physical qubit mapping. The physical qubit number remains in
+/// qubitNum, while outputPosition follows the original virtual-qubit order.
+///
+/// \param resultQubitVals Maps each QIR result id to the measured physical
+/// qubit id and its output register name.
+/// \param virtualToPhysical Maps each original virtual qubit id to its final
+/// physical QIR qubit id. An empty mapping preserves identity ordering.
+/// \return The entries wrapped in the single-element outer array expected by
+/// the runtime `output_names` parser.
+nlohmann::json buildEnrichedOutputNamesJsonFromV2PMapping(
+    const ResultQubitVals &resultQubitVals,
+    const std::vector<std::size_t> &virtualToPhysical);
 
 } // namespace cudaq::opt

--- a/cudaq/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -24,6 +24,7 @@ add_cudaq_library(OptCodeGen
   OptUtils.cpp
   Passes.cpp
   Pipelines.cpp
+  QIRCodeGenUtils.cpp
   QirInsertArrayRecord.cpp
   QuakeToCodegen.cpp
   QuakeToExecMgr.cpp

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -1785,8 +1785,12 @@ struct AnnotateKernelsWithMeasurementStringsPattern
     if (nameMap.empty())
       return failure();
 
+    const auto virtualToPhysical =
+        cudaq::opt::getVirtualToPhysicalMapping(func.getOperation());
+
     nlohmann::json outputNames =
-        cudaq::opt::buildEnrichedOutputNamesJson(nameMap, {});
+        cudaq::opt::buildEnrichedOutputNamesJsonFromV2PMapping(
+            nameMap, virtualToPhysical);
     std::string outputNamesStr = outputNames.dump();
     SmallVector<Attribute> funcAttrs(passthru.begin(), passthru.end());
     funcAttrs.push_back(

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -14,6 +14,7 @@
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/CodeGen/QIRAttributeNames.h"
+#include "cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h"
 #include "cudaq/Optimizer/CodeGen/QIRFunctionNames.h"
 #include "cudaq/Optimizer/CodeGen/QIROpaqueStructTypes.h"
 #include "cudaq/Optimizer/CodeGen/QuakeToExecMgr.h"
@@ -1784,10 +1785,8 @@ struct AnnotateKernelsWithMeasurementStringsPattern
     if (nameMap.empty())
       return failure();
 
-    // Append the name map. Use a `const T&` to introduce another layer of
-    // brackets here to maintain backwards compatibility.
-    const auto &outputNameMapRef = nameMap;
-    nlohmann::json outputNames{outputNameMapRef};
+    nlohmann::json outputNames =
+        cudaq::opt::buildEnrichedOutputNamesJson(nameMap, {});
     std::string outputNamesStr = outputNames.dump();
     SmallVector<Attribute> funcAttrs(passthru.begin(), passthru.end());
     funcAttrs.push_back(

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
@@ -227,8 +227,12 @@ struct AddFuncAttribute : public OpRewritePattern<LLVM::LLVMFuncOp> {
     assert(iter != infoMap.end());
     rewriter.startOpModification(op);
     const auto &info = iter->second;
+    const auto virtualToPhysical =
+        cudaq::opt::getVirtualToPhysicalMapping(op.getOperation());
+
     auto resultQubitJSON =
-        cudaq::opt::buildEnrichedOutputNamesJson(info.resultQubitVals, {});
+        cudaq::opt::buildEnrichedOutputNamesJsonFromV2PMapping(
+            info.resultQubitVals, virtualToPhysical);
     bool isAdaptive = convertTo == "qir-adaptive";
     const char *profileName = isAdaptive ? "adaptive_profile" : "base_profile";
 

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
@@ -12,6 +12,7 @@
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/CodeGen/Peephole.h"
 #include "cudaq/Optimizer/CodeGen/QIRAttributeNames.h"
+#include "cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h"
 #include "cudaq/Todo.h"
 #include "llvm/ADT/SmallSet.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
@@ -226,7 +227,8 @@ struct AddFuncAttribute : public OpRewritePattern<LLVM::LLVMFuncOp> {
     assert(iter != infoMap.end());
     rewriter.startOpModification(op);
     const auto &info = iter->second;
-    nlohmann::json resultQubitJSON{info.resultQubitVals};
+    auto resultQubitJSON =
+        cudaq::opt::buildEnrichedOutputNamesJson(info.resultQubitVals, {});
     bool isAdaptive = convertTo == "qir-adaptive";
     const char *profileName = isAdaptive ? "adaptive_profile" : "base_profile";
 

--- a/cudaq/lib/Optimizer/CodeGen/QIRCodeGenUtils.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/QIRCodeGenUtils.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h"
+#include <algorithm>
+#include <numeric>
+
+nlohmann::json cudaq::opt::buildEnrichedOutputNamesJson(
+    const ResultQubitVals &resultQubitVals,
+    const std::vector<std::size_t> &qubitToOutputOrder) {
+  std::vector<std::size_t> resultIds;
+  std::vector<std::size_t> outputOrders;
+  resultIds.reserve(resultQubitVals.size());
+  outputOrders.reserve(resultQubitVals.size());
+  // Resolve each measured qubit to its logical output order. Keep the result
+  // ids in a parallel vector so equal output orders have a deterministic
+  // result-id tie-breaker below.
+  for (const auto &[resultId, qubitAndName] : resultQubitVals) {
+    const auto qubit = qubitAndName.first;
+    auto outputOrder = qubit;
+    if (!qubitToOutputOrder.empty() && qubit < qubitToOutputOrder.size())
+      outputOrder = qubitToOutputOrder[qubit];
+
+    resultIds.push_back(resultId);
+    outputOrders.push_back(outputOrder);
+  }
+
+  // Sort entry indices instead of the entries themselves. This preserves the
+  // result-id order used when the JSON entries are emitted.
+  std::vector<std::size_t> rank(resultIds.size());
+  std::iota(rank.begin(), rank.end(), 0);
+  std::sort(rank.begin(), rank.end(), [&](std::size_t lhs, std::size_t rhs) {
+    if (outputOrders[lhs] != outputOrders[rhs])
+      return outputOrders[lhs] < outputOrders[rhs];
+    return resultIds[lhs] < resultIds[rhs];
+  });
+
+  // Invert the sorted index permutation. Its ordinal is the dense output
+  // position, so partial measurements never leave gaps in the global result.
+  std::vector<std::size_t> outputPositions(resultIds.size());
+  for (std::size_t position = 0; position < rank.size(); ++position)
+    outputPositions[rank[position]] = position;
+
+  // Emit entries in result-id order, attaching the independently computed
+  // user-visible position as the third output-location element.
+  auto entries = nlohmann::json::array();
+  std::size_t entryIndex = 0;
+  for (const auto &[resultId, qubitAndName] : resultQubitVals) {
+    entries.push_back({resultId,
+                       {qubitAndName.first, qubitAndName.second,
+                        outputPositions[entryIndex]}});
+    ++entryIndex;
+  }
+  return nlohmann::json::array({std::move(entries)});
+}

--- a/cudaq/lib/Optimizer/CodeGen/QIRCodeGenUtils.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/QIRCodeGenUtils.cpp
@@ -7,8 +7,24 @@
  ******************************************************************************/
 
 #include "cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
 #include <algorithm>
 #include <numeric>
+
+std::vector<std::size_t>
+cudaq::opt::getVirtualToPhysicalMapping(mlir::Operation *operation) {
+  std::vector<std::size_t> mapping;
+  const auto mappingAttr =
+      operation->getAttrOfType<mlir::ArrayAttr>("mapping_v2p");
+  if (!mappingAttr)
+    return mapping;
+
+  mapping.reserve(mappingAttr.size());
+  for (const auto attr : mappingAttr)
+    mapping.push_back(mlir::cast<mlir::IntegerAttr>(attr).getInt());
+  return mapping;
+}
 
 nlohmann::json cudaq::opt::buildEnrichedOutputNamesJson(
     const ResultQubitVals &resultQubitVals,
@@ -57,4 +73,29 @@ nlohmann::json cudaq::opt::buildEnrichedOutputNamesJson(
     ++entryIndex;
   }
   return nlohmann::json::array({std::move(entries)});
+}
+
+nlohmann::json cudaq::opt::buildEnrichedOutputNamesJsonFromV2PMapping(
+    const ResultQubitVals &resultQubitVals,
+    const std::vector<std::size_t> &virtualToPhysical) {
+  // Size the inverse lookup for every physical qubit referenced by either the
+  // measurements or `mapping_v2p`.
+  std::size_t numQubits = 0;
+  for (const auto &resultQubitVal : resultQubitVals)
+    numQubits = std::max(numQubits, resultQubitVal.second.first + 1);
+  for (const auto physicalQubit : virtualToPhysical)
+    numQubits = std::max(numQubits, physicalQubit + 1);
+
+  // The enriched metadata needs the inverse direction: physical QIR qubit id
+  // to original virtual-qubit order. Start with identity so an absent mapping,
+  // or a physical qubit not represented in it, retains the legacy behavior.
+  std::vector<std::size_t> qubitToOutputOrder(numQubits);
+  std::iota(qubitToOutputOrder.begin(), qubitToOutputOrder.end(), 0);
+  for (std::size_t virtualQubit = 0; virtualQubit < virtualToPhysical.size();
+       ++virtualQubit)
+    qubitToOutputOrder[virtualToPhysical[virtualQubit]] = virtualQubit;
+
+  // The common builder densely ranks measured logical orders and emits the
+  // entries in QIR result-id order.
+  return buildEnrichedOutputNamesJson(resultQubitVals, qubitToOutputOrder);
 }

--- a/cudaq/lib/Optimizer/CodeGen/QIRCodeGenUtils.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/QIRCodeGenUtils.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h"
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Operation.h"
 #include <algorithm>
@@ -65,12 +66,11 @@ nlohmann::json cudaq::opt::buildEnrichedOutputNamesJson(
   // Emit entries in result-id order, attaching the independently computed
   // user-visible position as the third output-location element.
   auto entries = nlohmann::json::array();
-  std::size_t entryIndex = 0;
-  for (const auto &[resultId, qubitAndName] : resultQubitVals) {
+  for (auto &&[entryIndex, resultQubitVal] : llvm::enumerate(resultQubitVals)) {
+    const auto &[resultId, qubitAndName] = resultQubitVal;
     entries.push_back({resultId,
                        {qubitAndName.first, qubitAndName.second,
                         outputPositions[entryIndex]}});
-    ++entryIndex;
   }
   return nlohmann::json::array({std::move(entries)});
 }
@@ -78,13 +78,13 @@ nlohmann::json cudaq::opt::buildEnrichedOutputNamesJson(
 nlohmann::json cudaq::opt::buildEnrichedOutputNamesJsonFromV2PMapping(
     const ResultQubitVals &resultQubitVals,
     const std::vector<std::size_t> &virtualToPhysical) {
-  // Size the inverse lookup for every physical qubit referenced by either the
-  // measurements or `mapping_v2p`.
-  std::size_t numQubits = 0;
-  for (const auto &resultQubitVal : resultQubitVals)
-    numQubits = std::max(numQubits, resultQubitVal.second.first + 1);
-  for (const auto physicalQubit : virtualToPhysical)
-    numQubits = std::max(numQubits, physicalQubit + 1);
+  // Only mapped physical qubits need lookup entries. The common builder uses
+  // identity ordering for a measured qubit outside this range.
+  const std::size_t numQubits =
+      virtualToPhysical.empty() ? 0
+                                : *std::max_element(virtualToPhysical.begin(),
+                                                    virtualToPhysical.end()) +
+                                      1;
 
   // The enriched metadata needs the inverse direction: physical QIR qubit id
   // to original virtual-qubit order. Start with identity so an absent mapping,

--- a/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
@@ -19,6 +19,7 @@
 #include "cudaq/Optimizer/CodeGen/QIROpaqueStructTypes.h"
 #include "cudaq/Optimizer/CodeGen/QuakeToExecMgr.h"
 #include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassOptions.h"
@@ -457,14 +458,12 @@ struct WireSetToProfileQIRPass
     // this pipeline. Preserve that sparse physical coordinate space while
     // tracking both its required size and the allocation-order fallback.
     std::optional<std::uint32_t> highestIdentity;
-    std::vector<std::uint32_t> borrowOrder;
+    llvm::SmallSetVector<std::uint32_t, 16> borrowOrder;
     op.walk([&](cudaq::quake::BorrowWireOp op) {
       highestIdentity = highestIdentity
                             ? std::max(*highestIdentity, op.getIdentity())
                             : op.getIdentity();
-      if (std::find(borrowOrder.begin(), borrowOrder.end(), op.getIdentity()) ==
-          borrowOrder.end())
-        borrowOrder.push_back(op.getIdentity());
+      borrowOrder.insert(op.getIdentity());
     });
     const bool hasVirtualToPhysicalMapping = op->hasAttr("mapping_v2p");
     const auto virtualToPhysical =

--- a/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
@@ -14,6 +14,7 @@
 #include "cudaq/Optimizer/CodeGen/CudaqFunctionNames.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/CodeGen/QIRAttributeNames.h"
+#include "cudaq/Optimizer/CodeGen/QIRCodeGenUtils.h"
 #include "cudaq/Optimizer/CodeGen/QIRFunctionNames.h"
 #include "cudaq/Optimizer/CodeGen/QIROpaqueStructTypes.h"
 #include "cudaq/Optimizer/CodeGen/QuakeToExecMgr.h"
@@ -24,6 +25,9 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include <algorithm>
+#include <numeric>
+#include <vector>
 
 #define DEBUG_TYPE "wireset-to-profile-qir"
 
@@ -449,12 +453,44 @@ struct WireSetToProfileQIRPass
       else
         regNameMap[disc.getOperation()] = "?";
     });
+    // Borrowed wire identities are lowered directly to QIR qubit indices in
+    // this pipeline. Preserve that sparse physical coordinate space while
+    // tracking both its required size and the allocation-order fallback.
     std::optional<std::uint32_t> highestIdentity;
+    std::vector<std::uint32_t> borrowOrder;
     op.walk([&](cudaq::quake::BorrowWireOp op) {
       highestIdentity = highestIdentity
                             ? std::max(*highestIdentity, op.getIdentity())
                             : op.getIdentity();
+      if (std::find(borrowOrder.begin(), borrowOrder.end(), op.getIdentity()) ==
+          borrowOrder.end())
+        borrowOrder.push_back(op.getIdentity());
     });
+    // Build the lookup consumed by enriched `output_names`: QIR qubit index to
+    // user-visible output order. Identity initialization preserves the legacy
+    // behavior for qubits not mentioned by the mapping.
+    std::vector<std::size_t> qirQubitToOutputOrder;
+    if (highestIdentity) {
+      qirQubitToOutputOrder.resize(*highestIdentity + 1);
+      std::iota(qirQubitToOutputOrder.begin(), qirQubitToOutputOrder.end(), 0);
+      if (auto mappingAttr =
+              dyn_cast_if_present<ArrayAttr>(op->getAttr("mapping_v2p"))) {
+        // `mapping_v2p[virtual]` is the final physical qubit. Invert it so a
+        // measurement against a physical QIR qubit recovers its original
+        // virtual-qubit order after placement and routing.
+        for (auto [virtualQubit, physicalAttr] : llvm::enumerate(mappingAttr)) {
+          const auto physicalQubit = static_cast<std::size_t>(
+              cast<IntegerAttr>(physicalAttr).getInt());
+          if (physicalQubit < qirQubitToOutputOrder.size())
+            qirQubitToOutputOrder[physicalQubit] = virtualQubit;
+        }
+      } else {
+        // Without mapping metadata, first borrow appearance is the available
+        // allocation-order signal for an explicitly constructed wire set.
+        for (auto &&[outputOrder, qubit] : llvm::enumerate(borrowOrder))
+          qirQubitToOutputOrder[qubit] = outputOrder;
+      }
+    }
     if (highestIdentity)
       op->setAttr(cudaq::opt::qir0_1::RequiredQubitsAttrName,
                   builder.getStringAttr(std::to_string(*highestIdentity + 1)));
@@ -489,7 +525,10 @@ struct WireSetToProfileQIRPass
       signalPassFailure();
 
     if (resultCounter > 0) {
-      nlohmann::json resultQubitJSON{resultQubitVals};
+      // The helper densely ranks only measured qubits. Partial terminal
+      // measurements therefore remain compact while retaining logical order.
+      auto resultQubitJSON = cudaq::opt::buildEnrichedOutputNamesJson(
+          resultQubitVals, qirQubitToOutputOrder);
       op->setAttr(cudaq::opt::QIROutputNamesAttrName,
                   builder.getStringAttr(resultQubitJSON.dump()));
     }

--- a/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
@@ -466,30 +466,19 @@ struct WireSetToProfileQIRPass
           borrowOrder.end())
         borrowOrder.push_back(op.getIdentity());
     });
-    // Build the lookup consumed by enriched `output_names`: QIR qubit index to
-    // user-visible output order. Identity initialization preserves the legacy
-    // behavior for qubits not mentioned by the mapping.
+    const bool hasVirtualToPhysicalMapping = op->hasAttr("mapping_v2p");
+    const auto virtualToPhysical =
+        cudaq::opt::getVirtualToPhysicalMapping(op.getOperation());
+
+    // Without mapping metadata, first borrow appearance is the available
+    // allocation-order signal for an explicitly constructed wire set. Build
+    // the QIR-qubit-to-output-order lookup used by the generic metadata helper.
     std::vector<std::size_t> qirQubitToOutputOrder;
-    if (highestIdentity) {
+    if (highestIdentity && !hasVirtualToPhysicalMapping) {
       qirQubitToOutputOrder.resize(*highestIdentity + 1);
       std::iota(qirQubitToOutputOrder.begin(), qirQubitToOutputOrder.end(), 0);
-      if (auto mappingAttr =
-              dyn_cast_if_present<ArrayAttr>(op->getAttr("mapping_v2p"))) {
-        // `mapping_v2p[virtual]` is the final physical qubit. Invert it so a
-        // measurement against a physical QIR qubit recovers its original
-        // virtual-qubit order after placement and routing.
-        for (auto [virtualQubit, physicalAttr] : llvm::enumerate(mappingAttr)) {
-          const auto physicalQubit = static_cast<std::size_t>(
-              cast<IntegerAttr>(physicalAttr).getInt());
-          if (physicalQubit < qirQubitToOutputOrder.size())
-            qirQubitToOutputOrder[physicalQubit] = virtualQubit;
-        }
-      } else {
-        // Without mapping metadata, first borrow appearance is the available
-        // allocation-order signal for an explicitly constructed wire set.
-        for (auto &&[outputOrder, qubit] : llvm::enumerate(borrowOrder))
-          qirQubitToOutputOrder[qubit] = outputOrder;
-      }
+      for (auto &&[outputOrder, qubit] : llvm::enumerate(borrowOrder))
+        qirQubitToOutputOrder[qubit] = outputOrder;
     }
     if (highestIdentity)
       op->setAttr(cudaq::opt::qir0_1::RequiredQubitsAttrName,
@@ -527,8 +516,12 @@ struct WireSetToProfileQIRPass
     if (resultCounter > 0) {
       // The helper densely ranks only measured qubits. Partial terminal
       // measurements therefore remain compact while retaining logical order.
-      auto resultQubitJSON = cudaq::opt::buildEnrichedOutputNamesJson(
-          resultQubitVals, qirQubitToOutputOrder);
+      const auto resultQubitJSON =
+          !hasVirtualToPhysicalMapping
+              ? cudaq::opt::buildEnrichedOutputNamesJson(resultQubitVals,
+                                                         qirQubitToOutputOrder)
+              : cudaq::opt::buildEnrichedOutputNamesJsonFromV2PMapping(
+                    resultQubitVals, virtualToPhysical);
       op->setAttr(cudaq::opt::QIROutputNamesAttrName,
                   builder.getStringAttr(resultQubitJSON.dump()));
     }

--- a/cudaq/test/Transforms/qir_base_profile.qke
+++ b/cudaq/test/Transforms/qir_base_profile.qke
@@ -70,7 +70,7 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
   }
 }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_grover._Z6groverv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, passthrough = ["entry_point", ["qir_profiles", "base_profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "7"], ["requiredResults", "4"], ["output_names", "{{\[\[}}[0,[2,\22r00000\22]],[1,[3,\22r00001\22]],[2,[4,\22r00002\22]],[3,[5,\22r00003\22]]]]"]], "qir-api"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_grover._Z6groverv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, passthrough = ["entry_point", ["qir_profiles", "base_profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "7"], ["requiredResults", "4"], ["output_names", "{{\[\[}}[0,[2,\22r00000\22,0]],[1,[3,\22r00001\22,1]],[2,[4,\22r00002\22,2]],[3,[5,\22r00003\22,3]]]]"]], "qir-api"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 4 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 3 : i64

--- a/cudaq/test/Transforms/wireset_output_order.qke
+++ b/cudaq/test/Transforms/wireset_output_order.qke
@@ -1,0 +1,54 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --wireset-to-profile-qir-prep --wireset-to-profile-qir --symbol-dce %s | FileCheck %s
+// `mapping_v2p` maps logical qubits 0, 1, and 2 to physical qubits 5, 9,
+// and 1. Verify that wire-set QIR lowering inverts this mapping when building
+// enriched `output_names`, so each result retains its physical QIR qubit while
+// its output position follows logical-qubit order. The partial case also
+// verifies that output positions are densely ranked over the measured subset.
+
+// This matches the default-sampling convention, as validated in
+// `test_explicit_measurements.py::test_measurement_order`:
+// measured bits follow qubit allocation order, not `mz` execution order.
+
+quake.wire_set @phys[10]
+
+func.func @reversed_terminal_order() attributes {"cudaq-entrypoint", "cudaq-kernel", mapping_v2p = [5, 9, 1]} {
+  %q2 = quake.borrow_wire @phys[1] : !quake.wire
+  %q0 = quake.borrow_wire @phys[5] : !quake.wire
+  %q1 = quake.borrow_wire @phys[9] : !quake.wire
+  %m2, %w2 = quake.mz %q2 name "r2" : (!quake.wire) -> (!quake.measure, !quake.wire)
+  %m0, %w0 = quake.mz %q0 name "r0" : (!quake.wire) -> (!quake.measure, !quake.wire)
+  %m1, %w1 = quake.mz %q1 name "r1" : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.return_wire %w0 : !quake.wire
+  quake.return_wire %w1 : !quake.wire
+  quake.return_wire %w2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL: func.func @reversed_terminal_order() attributes
+// Inverse mapping: physical [1, 5, 9] -> logical/output positions [2, 0, 1].
+// CHECK-SAME: output_names = "{{\[\[}}[0,[1,\22r2\22,2]],[1,[5,\22r0\22,0]],[2,[9,\22r1\22,1]]]]"
+
+func.func @partial_terminal_measurement() attributes {"cudaq-entrypoint", "cudaq-kernel", mapping_v2p = [5, 9, 1]} {
+  %q2 = quake.borrow_wire @phys[1] : !quake.wire
+  %q0 = quake.borrow_wire @phys[5] : !quake.wire
+  %q1 = quake.borrow_wire @phys[9] : !quake.wire
+  %m2, %w2 = quake.mz %q2 name "r2" : (!quake.wire) -> (!quake.measure, !quake.wire)
+  %m0, %w0 = quake.mz %q0 name "r0" : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.return_wire %w0 : !quake.wire
+  quake.return_wire %q1 : !quake.wire
+  quake.return_wire %w2 : !quake.wire
+  return
+}
+
+// CHECK-LABEL: func.func @partial_terminal_measurement() attributes
+// Measured inverse mapping: physical [1, 5] -> logical [2, 0].
+// Dense ranking of that logical subset gives output positions [1, 0].
+// CHECK-SAME: output_names = "{{\[\[}}[0,[1,\22r2\22,1]],[1,[5,\22r0\22,0]]]]"

--- a/cudaq/test/Translate/array_record_insert.qke
+++ b/cudaq/test/Translate/array_record_insert.qke
@@ -47,7 +47,7 @@ func.func @__nvqpp__mlirgen__function_multi_vector._Z12multi_vectorv() attribute
   return
 }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_bell_pair._Z9bell_pairv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, passthrough = ["entry_point", ["qir_profiles", "{{base_}}profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "2"], ["requiredResults", "2"], ["output_names", "{{\[\[}}[0,[0,\22r00000\22]],[1,[1,\22r00001\22]]]]"]], "qir-api"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_bell_pair._Z9bell_pairv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, passthrough = ["entry_point", ["qir_profiles", "{{base_}}profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "2"], ["requiredResults", "2"], ["output_names", "{{\[\[}}[0,[0,\22r00000\22,0]],[1,[1,\22r00001\22,1]]]]"]], "qir-api"} {
 // CHECK-DAG:       %[[C2:.*]] = arith.constant 2 : i64
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : i64
@@ -71,7 +71,7 @@ func.func @__nvqpp__mlirgen__function_multi_vector._Z12multi_vectorv() attribute
 // CHECK:           return
 // CHECK:         }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_one_qubit._Z9one_qubitv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, passthrough = ["entry_point", ["qir_profiles", "base_profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "1"], ["requiredResults", "1"], ["output_names", "{{\[\[}}[0,[0,\22r00000\22]]]]"]], "qir-api"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_one_qubit._Z9one_qubitv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, passthrough = ["entry_point", ["qir_profiles", "base_profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "1"], ["requiredResults", "1"], ["output_names", "{{\[\[}}[0,[0,\22r00000\22,0]]]]"]], "qir-api"} {
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[C0]] : (i64) -> !cc.ptr<!llvm.struct<"Qubit", opaque>>
@@ -87,7 +87,7 @@ func.func @__nvqpp__mlirgen__function_multi_vector._Z12multi_vectorv() attribute
 // CHECK:           return
 // CHECK:         }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_multi_vector._Z12multi_vectorv() attributes {"cudaq-entrypoint", "cudaq-kernel", mapping_reorder_idx = [0, 1, 2, 3], mapping_v2p = [0, 1, 2, 3], no_this, passthrough = ["entry_point", ["qir_profiles", "base_profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "4"], ["requiredResults", "4"], ["output_names", "{{\[\[}}[0,[0,\22r00000\22]],[1,[1,\22r00001\22]],[2,[2,\22r00002\22]],[3,[3,\22r00003\22]]]]"]], "qir-api"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_multi_vector._Z12multi_vectorv() attributes {"cudaq-entrypoint", "cudaq-kernel", mapping_reorder_idx = [0, 1, 2, 3], mapping_v2p = [0, 1, 2, 3], no_this, passthrough = ["entry_point", ["qir_profiles", "base_profile"], ["output_labeling_schema", "schema_id"], ["requiredQubits", "4"], ["requiredResults", "4"], ["output_names", "{{\[\[}}[0,[0,\22r00000\22,0]],[1,[1,\22r00001\22,1]],[2,[2,\22r00002\22,2]],[3,[3,\22r00003\22,3]]]]"]], "qir-api"} {
 // CHECK-DAG:       %[[C4:.*]] = arith.constant 4 : i64
 // CHECK-DAG:       %[[C3:.*]] = arith.constant 3 : i64
 // CHECK-DAG:       %[[C2:.*]] = arith.constant 2 : i64

--- a/cudaq/test/Translate/base_profile-1.qke
+++ b/cudaq/test/Translate/base_profile-1.qke
@@ -43,4 +43,4 @@ func.func @__nvqpp__mlirgen__ghz() attributes {"cudaq-kernel"} {
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK:       = { "output_labeling_schema"="schema_id" "output_names"="{{\[\[\[}}0,[0,\22r00000\22]],[1,[1,\22r00001\22]],[2,[2,\22r00002\22]]]]" "qir_profiles"="base_profile" "requiredQubits"="3" "requiredResults"="3" }
+// CHECK:       = { "output_labeling_schema"="schema_id" "output_names"="{{\[\[\[}}0,[0,\22r00000\22,0]],[1,[1,\22r00001\22,1]],[2,[2,\22r00002\22,2]]]]" "qir_profiles"="base_profile" "requiredQubits"="3" "requiredResults"="3" }

--- a/cudaq/test/Translate/base_profile-2.qke
+++ b/cudaq/test/Translate/base_profile-2.qke
@@ -26,4 +26,4 @@ func.func @__nvqpp__mlirgen__t1() attributes {"cudaq-kernel"} {
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK:       = { "output_labeling_schema"="schema_id" "output_names"="{{\[\[\[}}0,[1,\22r00000\22]]]]" "qir_profiles"="base_profile" "requiredQubits"="2" "requiredResults"="1" }
+// CHECK:       = { "output_labeling_schema"="schema_id" "output_names"="{{\[\[\[}}0,[1,\22r00000\22,0]]]]" "qir_profiles"="base_profile" "requiredQubits"="2" "requiredResults"="1" }

--- a/cudaq/test/Translate/base_profile-3.qke
+++ b/cudaq/test/Translate/base_profile-3.qke
@@ -26,4 +26,4 @@ func.func @__nvqpp__mlirgen__t1() attributes {"cudaq-kernel"} {
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK:       = { "output_labeling_schema"="schema_id" "output_names"="{{\[\[\[}}0,[1,\22Bob\22]]]]" "qir_profiles"="base_profile" "requiredQubits"="2" "requiredResults"="1" }
+// CHECK:       = { "output_labeling_schema"="schema_id" "output_names"="{{\[\[\[}}0,[1,\22Bob\22,0]]]]" "qir_profiles"="base_profile" "requiredQubits"="2" "requiredResults"="1" }

--- a/cudaq/test/Translate/mapped_output_order.qke
+++ b/cudaq/test/Translate/mapped_output_order.qke
@@ -1,0 +1,30 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --convert-to-qir-api=api=base-profile %s | FileCheck --check-prefix=API %s
+// RUN: cudaq-translate --convert-to=qir-base %s | FileCheck --check-prefix=PROFILE %s
+
+// The mapped physical QIR qubits remain [0, 2, 1], while enriched output
+// positions recover the original virtual-qubit order [0, 1, 2].
+
+func.func @mapped_terminal_measurements() attributes {"cudaq-entrypoint", "cudaq-kernel", mapping_reorder_idx = [0, 2, 1], mapping_v2p = [0, 2, 1]} {
+  %qubits = quake.alloca !quake.veq<3>
+  %q0 = quake.extract_ref %qubits[0] : (!quake.veq<3>) -> !quake.ref
+  %q2 = quake.extract_ref %qubits[2] : (!quake.veq<3>) -> !quake.ref
+  %q1 = quake.extract_ref %qubits[1] : (!quake.veq<3>) -> !quake.ref
+  %m0 = quake.mz %q0 : (!quake.ref) -> !quake.measure
+  %m1 = quake.mz %q2 : (!quake.ref) -> !quake.measure
+  %m2 = quake.mz %q1 : (!quake.ref) -> !quake.measure
+  quake.dealloc %qubits : !quake.veq<3>
+  return
+}
+
+// API-LABEL: func.func @mapped_terminal_measurements() attributes
+// API-SAME: ["output_names", "{{\[\[}}[0,[0,\22r00000\22,0]],[1,[2,\22r00001\22,1]],[2,[1,\22r00002\22,2]]]]"
+// PROFILE-LABEL: define void @mapped_terminal_measurements()
+// PROFILE: "output_names"="{{\[\[\[}}0,[0,\22r00000\22,0]],[1,[2,\22r00001\22,1]],[2,[1,\22r00002\22,2]]]]"

--- a/runtime/common/CMakeLists.txt
+++ b/runtime/common/CMakeLists.txt
@@ -22,6 +22,7 @@ set(COMMON_RUNTIME_SRC
   Future.cpp
   NoiseModel.cpp
   RecordLogParser.cpp
+  ResultReconstruction.cpp
   Resources.cpp
   RuntimeTarget.cpp
   SampleResult.cpp

--- a/runtime/common/ResultReconstruction.cpp
+++ b/runtime/common/ResultReconstruction.cpp
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "ResultReconstruction.h"
+#include "nlohmann/json.hpp"
+#include <algorithm>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace {
+
+struct OutputTarget {
+  std::string outputName;
+  std::size_t globalPosition = 0;
+  std::size_t localPosition = 0;
+  std::size_t resultIndex = 0;
+};
+
+struct OutputLayout {
+  std::vector<OutputTarget> targets;
+  std::unordered_map<std::string, std::size_t> outputWidths;
+  std::size_t globalWidth = 0;
+};
+
+OutputLayout buildOutputLayout(const cudaq::ResultOutputMap &resultMap) {
+  OutputLayout layout;
+  std::unordered_map<std::string, std::vector<std::size_t>> targetIdsByOutput;
+  std::unordered_set<std::size_t> globalPositions;
+
+  // Every measured bit must have one unambiguous destination in the global
+  // allocation-ordered bitstring.
+  for (const auto &entry : resultMap.outputs) {
+    if (!globalPositions.insert(entry.outputPosition).second)
+      throw std::invalid_argument(
+          "result output map contains duplicate output positions");
+    const auto targetId = layout.targets.size();
+
+    layout.targets.push_back(
+        {entry.outputName, entry.outputPosition, 0, entry.resultIndex});
+    targetIdsByOutput[entry.outputName].push_back(targetId);
+    layout.globalWidth = std::max(layout.globalWidth, entry.outputPosition + 1);
+  }
+
+  // A named register is a projection of the global result. Rank its bits by
+  // global allocation order so metadata or `mz` traversal order cannot leak
+  // into that register's user-visible bitstring.
+  for (auto &[outputName, targetIds] : targetIdsByOutput) {
+    std::sort(targetIds.begin(), targetIds.end(),
+              [&](std::size_t lhs, std::size_t rhs) {
+                return layout.targets[lhs].globalPosition <
+                       layout.targets[rhs].globalPosition;
+              });
+    for (std::size_t localPosition = 0; localPosition < targetIds.size();
+         ++localPosition)
+      layout.targets[targetIds[localPosition]].localPosition = localPosition;
+    layout.outputWidths[outputName] = targetIds.size();
+  }
+
+  return layout;
+}
+
+void validateBit(char bit) {
+  if (bit != '0' && bit != '1')
+    throw std::invalid_argument("returned measurement bit must be '0' or '1'");
+}
+
+std::unordered_map<std::string, std::string>
+makeInitialNamedBits(const OutputLayout &layout) {
+  std::unordered_map<std::string, std::string> namedBits;
+  for (const auto &[name, width] : layout.outputWidths)
+    namedBits.emplace(name, std::string(width, '0'));
+  return namedBits;
+}
+
+cudaq::sample_result reconstructSampleResultFromCounts(
+    const cudaq::CountsDictionary &counts,
+    const cudaq::ResultOutputMap &resultMap,
+    const std::vector<std::string> &sequentialData) {
+  // Without enriched metadata there is no source-to-destination mapping, so
+  // preserve the provider bitstrings and their existing ordering.
+  if (resultMap.outputs.empty()) {
+    cudaq::ExecutionResult result{counts};
+    result.sequentialData = sequentialData;
+    return cudaq::sample_result(std::move(result));
+  }
+
+  // Map each compact QIR result index to its allocation-ordered global
+  // position and to its position within the corresponding named result.
+  const auto layout = buildOutputLayout(resultMap);
+  cudaq::CountsDictionary globalCounts;
+  std::unordered_map<std::string, cudaq::CountsDictionary> namedCounts;
+
+  // Apply exactly the same source-to-destination mapping to aggregated counts
+  // and to each per-shot bitstring.
+  const auto reconstructBits = [&](const std::string &bitstring) {
+    std::string globalBits(layout.globalWidth, '0');
+    auto namedBits = makeInitialNamedBits(layout);
+    for (const auto &target : layout.targets) {
+      if (target.resultIndex >= bitstring.size())
+        throw std::invalid_argument(
+            "bitstring is shorter than a mapped result index");
+      const char bit = bitstring[target.resultIndex];
+      validateBit(bit);
+      globalBits[target.globalPosition] = bit;
+      namedBits[target.outputName][target.localPosition] = bit;
+    }
+    return std::pair{std::move(globalBits), std::move(namedBits)};
+  };
+
+  for (const auto &[bitstring, count] : counts) {
+    if (count == 0)
+      continue;
+
+    auto [globalBits, namedBits] = reconstructBits(bitstring);
+    globalCounts[globalBits] += count;
+    for (const auto &[name, bits] : namedBits)
+      namedCounts[name][bits] += count;
+  }
+
+  std::vector<std::string> globalSequentialData;
+  globalSequentialData.reserve(sequentialData.size());
+  std::unordered_map<std::string, std::vector<std::string>> namedSequentialData;
+  for (const auto &bitstring : sequentialData) {
+    auto [globalBits, namedBits] = reconstructBits(bitstring);
+    globalSequentialData.push_back(std::move(globalBits));
+    for (auto &[name, bits] : namedBits)
+      namedSequentialData[name].push_back(std::move(bits));
+  }
+
+  std::vector<cudaq::ExecutionResult> executionResults;
+  cudaq::ExecutionResult globalResult{globalCounts, cudaq::GlobalRegisterName};
+  globalResult.sequentialData = std::move(globalSequentialData);
+  executionResults.push_back(std::move(globalResult));
+  for (auto &[name, countsByBits] : namedCounts) {
+    cudaq::ExecutionResult namedResult{std::move(countsByBits), name};
+    if (auto iter = namedSequentialData.find(name);
+        iter != namedSequentialData.end())
+      namedResult.sequentialData = std::move(iter->second);
+    executionResults.push_back(std::move(namedResult));
+  }
+  return cudaq::sample_result(executionResults);
+}
+
+} // namespace
+
+cudaq::ResultOutputMap cudaq::makeResultOutputMapFromEnrichedOutputNames(
+    const nlohmann::json &outputNames) {
+  ResultOutputMap resultMap;
+  if (outputNames.is_null() || outputNames.empty())
+    return resultMap;
+
+  // QIR stores output locations inside the first schema array. Each entry maps
+  // a compact result id to a physical qubit, a register name, and, when
+  // enriched, the allocation-ordered output position.
+  resultMap.outputs.reserve(outputNames.at(0).size());
+  std::size_t denseResultIndex = 0;
+  for (const auto &entry : outputNames.at(0)) {
+    const auto resultIndex = entry.at(0).get<std::size_t>();
+    const auto &outputLocation = entry.at(1);
+    auto outputName = outputLocation.at(1).get<std::string>();
+    // Older metadata has no destination field. Dense result order preserves
+    // its historical behavior; enriched producers provide the semantic order.
+    std::size_t outputPosition = denseResultIndex;
+    if (outputLocation.size() > 2)
+      outputPosition = outputLocation.at(2).get<std::size_t>();
+    resultMap.outputs.push_back(
+        {resultIndex, std::move(outputName), outputPosition});
+    ++denseResultIndex;
+  }
+  return resultMap;
+}
+
+cudaq::sample_result
+cudaq::reconstructSampleResultFromResultIndexedMeasurements(
+    const CountsDictionary &counts, const ResultOutputMap &resultMap,
+    const std::vector<std::string> &sequentialData) {
+  return reconstructSampleResultFromCounts(counts, resultMap, sequentialData);
+}

--- a/runtime/common/ResultReconstruction.h
+++ b/runtime/common/ResultReconstruction.h
@@ -1,0 +1,57 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+#include "SampleResult.h"
+#include "nlohmann/json_fwd.hpp"
+#include <string>
+#include <vector>
+
+namespace cudaq {
+
+/// Describes how one compact QIR result moves into a user-visible default
+/// `sample` result.
+struct ResultOutputEntry {
+  /// Compact QIR result index. QIR-style backend bitstrings place this result
+  /// at this source position, which commonly follows `mz` emission order.
+  std::size_t resultIndex = 0;
+
+  /// Name of the measurement register that receives this bit.
+  std::string outputName;
+
+  /// Dense destination position in the global result bitstring. For default
+  /// `sample`, the compiler assigns this by measured-qubit allocation order,
+  /// independently of the order in which `mz` operations execute.
+  std::size_t outputPosition = 0;
+};
+
+/// Complete reconstruction map for the measured results of one kernel.
+struct ResultOutputMap {
+  std::vector<ResultOutputEntry> outputs;
+};
+
+/// Build a reconstruction map from QIR `output_names` metadata encoded as
+/// `[[[resultIndex, [deviceQubit, outputName, outputPosition]], ...]]`.
+///
+/// The physical `deviceQubit` field remains part of the QIR schema, but compact
+/// QIR responses are indexed by `resultIndex`. `outputPosition` is the
+/// enriched field that separates this source coordinate from the
+/// allocation-ordered destination coordinate. Legacy two-field output
+/// locations omit it and fall back to dense metadata order.
+ResultOutputMap
+makeResultOutputMapFromEnrichedOutputNames(const nlohmann::json &outputNames);
+
+/// Reconstruct aggregated QIR-style counts using compact result indices as
+/// source positions and allocation order as the global destination order.
+/// When provided, `sequentialData` contains per-shot bitstrings in the same
+/// compact result order and is reconstructed for the global and named results.
+sample_result reconstructSampleResultFromResultIndexedMeasurements(
+    const CountsDictionary &counts, const ResultOutputMap &resultMap,
+    const std::vector<std::string> &sequentialData = {});
+
+} // namespace cudaq

--- a/runtime/common/ServerHelper.cpp
+++ b/runtime/common/ServerHelper.cpp
@@ -13,6 +13,32 @@
 
 namespace cudaq {
 
+std::optional<ResultOutputMap>
+ServerHelper::resultMapForJob(const std::string &jobId) const {
+  const auto iter = outputNames.find(jobId);
+  if (iter == outputNames.end() || iter->second.empty())
+    return std::nullopt;
+
+  ResultOutputMap resultMap;
+  resultMap.outputs.reserve(iter->second.size());
+  for (const auto &[result, info] : iter->second)
+    resultMap.outputs.push_back({.resultIndex = result,
+                                 .outputName = info.registerName,
+                                 .outputPosition = info.outputPosition});
+  return resultMap;
+}
+
+std::optional<sample_result>
+ServerHelper::tryReconstructFromResultIndexedCounts(
+    const std::string &jobId, const CountsDictionary &counts,
+    const std::vector<std::string> &sequentialData) {
+  const auto resultMap = resultMapForJob(jobId);
+  if (!resultMap)
+    return std::nullopt;
+  return reconstructSampleResultFromResultIndexedMeasurements(
+      counts, *resultMap, sequentialData);
+}
+
 void ServerHelper::parseConfigForCommonParams(const BackendConfig &config) {
   // Parse common parameters for each job and place into member variables
   for (auto &[key, val] : config) {
@@ -28,11 +54,18 @@ void ServerHelper::parseConfigForCommonParams(const BackendConfig &config) {
       // LowerToQIRProfile.cpp for an example of how this was populated.
       OutputNamesType jobOutputNames;
       nlohmann::json outputNamesJSON = nlohmann::json::parse(val);
+      std::size_t denseResultIndex = 0;
       for (const auto &el : outputNamesJSON[0]) {
-        auto result = el[0].get<std::size_t>();
-        auto qubitNum = el[1][0].get<std::size_t>();
-        auto registerName = el[1][1].get<std::string>();
-        jobOutputNames[result] = {qubitNum, registerName};
+        const auto result = el[0].get<std::size_t>();
+        const auto &outputLocation = el[1];
+        const auto qubitNum = outputLocation[0].get<std::size_t>();
+        auto registerName = outputLocation[1].get<std::string>();
+        std::size_t outputPosition = denseResultIndex;
+        if (outputLocation.size() > 2)
+          outputPosition = outputLocation[2].get<std::size_t>();
+        jobOutputNames[result] = {qubitNum, std::move(registerName),
+                                  outputPosition};
+        ++denseResultIndex;
       }
 
       this->outputNames[newKey] = jobOutputNames;

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -14,11 +14,13 @@
 #include "KernelExecution.h"
 #include "Registry.h"
 #include "Resources.h"
+#include "ResultReconstruction.h"
 #include "RuntimeTarget.h"
 #include "SampleResult.h"
 #include "common/RecordLogParser.h"
 #include "cudaq_json.h"
 #include <filesystem>
+#include <optional>
 
 namespace cudaq {
 
@@ -44,6 +46,7 @@ using ServerJobPayload =
 struct ResultInfoType {
   std::size_t qubitNum;
   std::string registerName;
+  std::size_t outputPosition = 0;
 };
 
 /// @brief Results information, indexed by 0-based result number
@@ -72,6 +75,15 @@ protected:
 
   /// @brief Reordering indices indexed by jobID/taskID (used by mapping pass)
   std::map<std::string, std::vector<std::size_t>> reorderIdx;
+
+  /// Build the output map for a job from enriched output_names.
+  std::optional<ResultOutputMap>
+  resultMapForJob(const std::string &jobId) const;
+
+  /// Reconstruct QIR-style counts whose bit positions are compact result ids.
+  std::optional<sample_result> tryReconstructFromResultIndexedCounts(
+      const std::string &jobId, const CountsDictionary &counts,
+      const std::vector<std::string> &sequentialData = {});
 
   /// @brief  Information about the runtime target managing this server helper.
   RuntimeTarget runtimeTarget;

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -154,6 +154,7 @@ void OQCServerHelper::initialize(BackendConfig config) {
   auto machine = get_from_config(config, "machine", []() { return Lucy; });
   check_machine_allowed(machine);
   config["machine"] = machine;
+  parseConfigForCommonParams(config);
   const auto emulate_it = config.find("emulate");
   if (emulate_it != config.end() && emulate_it->second == "true") {
     CUDAQ_INFO("Emulation is enabled, ignore all oqc connection specific "
@@ -181,7 +182,6 @@ void OQCServerHelper::initialize(BackendConfig config) {
 
   // Construct the API job path
   config["job_path"] = std::string("/") + dev_id + "/tasks";
-  parseConfigForCommonParams(config);
 
   // Move the passed config into the member variable backendConfig
   backendConfig = std::move(config);
@@ -372,14 +372,11 @@ OQCServerHelper::processResults(ServerMessage &postJobResponse,
     }
   }
 
+  // OQC result bits are indexed by compact QIR result number. Without the
+  // corresponding output metadata, their user-visible order cannot be
+  // reconstructed reliably.
   if (outputNames.find(jobId) == outputNames.end())
     throw std::runtime_error("Could not find output names for job " + jobId);
-
-  auto &output_names = outputNames[jobId];
-  for (auto &[result, info] : output_names) {
-    CUDAQ_INFO("Qubit {} Result {} Name {}", info.qubitNum, result,
-               info.registerName);
-  }
 
   CountsDictionary countsDict;
   if (hasResultNames) {
@@ -409,38 +406,10 @@ OQCServerHelper::processResults(ServerMessage &postJobResponse,
     sampleResult.append(executionResult);
   }
 
-  // First reorder the global register by QIR qubit number.
-  std::vector<std::size_t> qirQubitMeasurements;
-  qirQubitMeasurements.reserve(output_names.size());
-  for (auto &[result, info] : output_names)
-    qirQubitMeasurements.push_back(info.qubitNum);
-
-  std::vector<std::size_t> idx(output_names.size());
-  std::iota(idx.begin(), idx.end(), 0);
-  std::sort(idx.begin(), idx.end(), [&](std::size_t i1, std::size_t i2) {
-    return qirQubitMeasurements[i1] < qirQubitMeasurements[i2];
-  });
-  CUDAQ_INFO("Reordering global result to map QIR result order to QIR qubit "
-             "allocation order is {}",
-             idx);
-  sampleResult.reorder(idx);
-
-  // Now reorder according to reorderIdx[]. This sorts the global bitstring in
-  // original user qubit allocation order.
-  auto thisJobReorderIdxIt = reorderIdx.find(jobId);
-  if (thisJobReorderIdxIt != reorderIdx.end()) {
-    auto &thisJobReorderIdx = thisJobReorderIdxIt->second;
-    if (!thisJobReorderIdx.empty())
-      sampleResult.reorder(thisJobReorderIdx);
-  }
-
-  // We will also make registers for each result using output_names.
-  for (auto &[result, info] : output_names) {
-    sample_result singleBitResult = sampleResult.get_marginal({result});
-    ExecutionResult executionResult{singleBitResult.to_map(),
-                                    info.registerName};
-    sampleResult.append(executionResult);
-  }
+  // Reconstruct the user-visible result order and named registers from the
+  // enriched output_names.
+  if (auto result = tryReconstructFromResultIndexedCounts(jobId, countsDict))
+    return *result;
 
   return sampleResult;
 }

--- a/runtime/cudaq/platform/default/rest/helpers/qci/QCIServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/qci/QCIServerHelper.cpp
@@ -276,7 +276,11 @@ QCIServerHelper::processResults(ServerMessage &postJobResponse,
   CUDAQ_INFO("jobId: {}", jobId);
   auto outputPath = postJobResponse.at("outputUrl").get<std::string>();
   auto qirResults = getOutputLog(outputPath);
-  return createSampleResultFromQirOutput(qirResults);
+  auto sampleResult = createSampleResultFromQirOutput(qirResults);
+  if (auto result = tryReconstructFromResultIndexedCounts(
+          jobId, sampleResult.to_map(), sampleResult.sequential_data()))
+    return *result;
+  return sampleResult;
 }
 
 std::map<std::string, std::string>

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
@@ -629,7 +629,11 @@ QuantinuumServerHelper::processResults(ServerMessage &jobResponse,
         resultResponse["data"]["attributes"]["results"];
     CUDAQ_DBG("Count result data: {}", qirResults);
 
-    return createSampleResultFromQirOutput(qirResults);
+    auto sampleResult = createSampleResultFromQirOutput(qirResults);
+    if (auto result = tryReconstructFromResultIndexedCounts(
+            jobId, sampleResult.to_map(), sampleResult.sequential_data()))
+      return *result;
+    return sampleResult;
   }
 }
 

--- a/targettests/execution/reordered_terminal_measurements.cpp
+++ b/targettests/execution/reordered_terminal_measurements.cpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: if %oqc_avail; then nvq++ --target oqc --emulate %s -o %t && %t; fi
+// RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t; fi
+// RUN: nvq++ --target quantinuum --quantinuum-machine Helios-1SC --emulate %s -o %t && %t
+// clang-format on
+
+#include <cudaq.h>
+
+__qpu__ void reordered_terminal_measurements() {
+  cudaq::qvector qubits(3);
+  x(qubits[0]);
+  x(qubits[2]);
+
+  // Measure out of allocation order so the provider reports compact QIR
+  // results as "110" while CUDA-Q must present the global result as "101".
+  mz(qubits[2]);
+  mz(qubits[0]);
+  mz(qubits[1]);
+}
+
+int main() {
+  const auto result = cudaq::sample(100, reordered_terminal_measurements);
+
+  // Default sampling follows the allocation-order convention, as validated in
+  // `test_explicit_measurements.py::test_measurement_order`.
+  return result.most_probable() == "101" ? 0 : 1;
+}

--- a/targettests/oqc/reordered_terminal_measurements.cpp
+++ b/targettests/oqc/reordered_terminal_measurements.cpp
@@ -1,0 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: echo skipping
+#include "../execution/reordered_terminal_measurements.cpp"

--- a/targettests/qci/reordered_terminal_measurements.cpp
+++ b/targettests/qci/reordered_terminal_measurements.cpp
@@ -1,0 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: echo skipping
+#include "../execution/reordered_terminal_measurements.cpp"

--- a/targettests/quantinuum_ng/reordered_terminal_measurements.cpp
+++ b/targettests/quantinuum_ng/reordered_terminal_measurements.cpp
@@ -1,0 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: echo skipping
+#include "../execution/reordered_terminal_measurements.cpp"

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -246,6 +246,16 @@ target_link_libraries(test_exec_ctx_thread
   gtest_main)
 cudaq_gtest_discover_tests(test_exec_ctx_thread DISCOVERY_TIMEOUT 120)
 
+# Focused tests for provider result-coordinate reconstruction.
+add_executable(test_result_reconstruction main.cpp
+  nvqpp/common/ResultReconstructionTester.cpp)
+target_include_directories(test_result_reconstruction PRIVATE
+  ${CMAKE_SOURCE_DIR}/runtime)
+target_link_libraries(test_result_reconstruction PRIVATE
+  cudaq-common
+  gtest_main)
+cudaq_gtest_discover_tests(test_result_reconstruction DISCOVERY_TIMEOUT 120)
+
 add_subdirectory(nvqpp)
 add_subdirectory(output_record)
 add_subdirectory(target_config)

--- a/unittests/nvqpp/backends/oqc/OQCTester.cpp
+++ b/unittests/nvqpp/backends/oqc/OQCTester.cpp
@@ -7,6 +7,8 @@
  ******************************************************************************/
 
 #include "CUDAQTestUtils.h"
+#include "common/ServerHelper.h"
+#include "nlohmann/json.hpp"
 #include "cudaq/algorithm.h"
 #include <fstream>
 #include <gtest/gtest.h>
@@ -63,6 +65,48 @@ CUDAQ_TEST(OQCTester, checkSampleAsyncLoadFromFile) {
   EXPECT_EQ(counts.size(), 2);
 
   std::remove("saveMe.json");
+}
+
+// Provider-specific parsing: OQC returns counts under a "results" object with
+// a sibling "task_error". Verify that processResults uses enriched output_names
+// to reconstruct compact QIR results into user-visible terminal order.
+// This matches the default-sampling convention, as validated in
+// `test_explicit_measurements.py::test_measurement_order`:
+// measured bits follow qubit allocation order, not `mz` execution order.
+CUDAQ_TEST(OQCTester, processResultsParsesProviderResponse) {
+  auto serverHelper = cudaq::registry::get<cudaq::ServerHelper>("oqc");
+  ASSERT_TRUE(serverHelper);
+
+  cudaq::BackendConfig config;
+  config["emulate"] = "true";
+  config["output_names.oqc-parse-job-id"] =
+      R"([[[0, [2, "r00000", 2]], [1, [0, "r00001", 0]], [2, [1, "r00002", 1]]]])";
+  serverHelper->initialize(config);
+
+  cudaq::ServerMessage response = {{"results", {{"110", 1000}}},
+                                   {"task_error", nullptr}};
+  std::string jobId = "oqc-parse-job-id";
+  auto result = serverHelper->processResults(response, jobId);
+
+  EXPECT_EQ(result.count("101"), 1000);
+  EXPECT_EQ(result.count("1", "r00000"), 1000);
+  EXPECT_EQ(result.count("1", "r00001"), 1000);
+  EXPECT_EQ(result.count("0", "r00002"), 1000);
+}
+
+CUDAQ_TEST(OQCTester, processResultsRequiresOutputNames) {
+  auto serverHelper = cudaq::registry::get<cudaq::ServerHelper>("oqc");
+  ASSERT_TRUE(serverHelper);
+
+  cudaq::BackendConfig config;
+  config["emulate"] = "true";
+  serverHelper->initialize(config);
+
+  cudaq::ServerMessage response = {{"results", {{"0", 1}}},
+                                   {"task_error", nullptr}};
+  std::string jobId = "oqc-missing-output-names";
+
+  EXPECT_ANY_THROW(serverHelper->processResults(response, jobId));
 }
 
 CUDAQ_TEST(OQCTester, checkObserveSync) {

--- a/unittests/nvqpp/backends/oqc/OQCTester.cpp
+++ b/unittests/nvqpp/backends/oqc/OQCTester.cpp
@@ -94,6 +94,39 @@ CUDAQ_TEST(OQCTester, processResultsParsesProviderResponse) {
   EXPECT_EQ(result.count("0", "r00002"), 1000);
 }
 
+// The OQC compilation of `x(q[0]); swap(q[0], q[2]); mz(q)` maps virtual
+// qubits [0, 1, 2] to physical qubits [0, 2, 1]. The QIR results therefore
+// retain physical qubit ids [0, 2, 1], while their enriched output positions
+// recover the original virtual-qubit order [0, 1, 2]. Verify that the remote
+// provider response path reconstructs the CUDA-Q bit string from that metadata
+// without applying the legacy non-identity `reorderIdx` a second time.
+CUDAQ_TEST(OQCTester, processResultsMappedTerminalMeasurements) {
+  auto serverHelper = cudaq::registry::get<cudaq::ServerHelper>("oqc");
+  ASSERT_TRUE(serverHelper);
+
+  cudaq::BackendConfig config;
+  config["entry_url"] = "http://localhost:62442";
+  config["auth_token"] = "fake_auth_token";
+  config["device"] = "qpu:uk:-1:1234567890";
+  config["output_names.oqc-mapped-job-id"] =
+      R"([[[0, [0, "r00000", 0]], [1, [2, "r00001", 1]], [2, [1, "r00002", 2]]]])";
+  config["reorderIdx.oqc-mapped-job-id"] = R"([0, 2, 1])";
+  serverHelper->initialize(config);
+
+  cudaq::ServerMessage response = {{"results", {{"001", 1000}}},
+                                   {"task_error", nullptr}};
+  std::string jobId = "oqc-mapped-job-id";
+  auto result = serverHelper->processResults(response, jobId);
+
+  // Although `mapping_v2p` is [0, 2, 1], `mz(q)` assigns QIR result ids in
+  // logical measurement order. The corrected output positions [0, 1, 2]
+  // therefore preserve the raw provider count "001" as the global result.
+  EXPECT_EQ(result.count("001"), 1000);
+  EXPECT_EQ(result.count("0", "r00000"), 1000);
+  EXPECT_EQ(result.count("0", "r00001"), 1000);
+  EXPECT_EQ(result.count("1", "r00002"), 1000);
+}
+
 CUDAQ_TEST(OQCTester, processResultsRequiresOutputNames) {
   auto serverHelper = cudaq::registry::get<cudaq::ServerHelper>("oqc");
   ASSERT_TRUE(serverHelper);

--- a/unittests/nvqpp/backends/qci/QCITester.cpp
+++ b/unittests/nvqpp/backends/qci/QCITester.cpp
@@ -29,6 +29,35 @@ CUDAQ_TEST(QCITester, checkSampleSync) {
   EXPECT_EQ(counts.size(), 2);
 }
 
+// The terminal-order and partial-measurement tests below match the
+// default-sampling ordering convention, as validated in
+// `test_explicit_measurements.py::test_measurement_order`:
+// measured bits follow qubit allocation order, not `mz` execution order.
+CUDAQ_TEST(QCITester, terminalMeasurementOutputOrder) {
+  auto kernel = cudaq::make_kernel();
+  auto qubits = kernel.qalloc(3);
+  kernel.x(qubits[0]);
+  kernel.x(qubits[2]);
+  kernel.mz(qubits[2]);
+  kernel.mz(qubits[0]);
+  kernel.mz(qubits[1]);
+
+  auto counts = cudaq::sample(32, kernel);
+  EXPECT_EQ(counts.count("101"), 32);
+}
+
+CUDAQ_TEST(QCITester, partialTerminalMeasurement) {
+  auto kernel = cudaq::make_kernel();
+  auto qubits = kernel.qalloc(3);
+  kernel.x(qubits[0]);
+  kernel.x(qubits[1]);
+  kernel.mz(qubits[2]);
+  kernel.mz(qubits[0]);
+
+  auto counts = cudaq::sample(32, kernel);
+  EXPECT_EQ(counts.count("10"), 32);
+}
+
 CUDAQ_TEST(QCITester, checkSampleAsync) {
 
   auto kernel = cudaq::make_kernel();

--- a/unittests/nvqpp/backends/quake_backend/CMakeLists.txt
+++ b/unittests/nvqpp/backends/quake_backend/CMakeLists.txt
@@ -17,6 +17,15 @@ add_library(fake_quake_backend_device_funcs SHARED backend_lib.cpp)
 configure_file(QuakeStartServerAndTest.sh.in QuakeStartServerAndTest.sh @ONLY)
 
 add_test(NAME quake-remote-backend-tests
-  COMMAND bash QuakeStartServerAndTest.sh
+  COMMAND bash QuakeStartServerAndTest.sh mock
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+add_test(NAME quake-emulation-backend-tests
+  COMMAND bash QuakeStartServerAndTest.sh emulation
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+# Account for the concurrent `nvq++` and Python processes in CTest's scheduler.
+set_tests_properties(quake-remote-backend-tests PROPERTIES PROCESSORS 6)
+set_tests_properties(quake-emulation-backend-tests PROPERTIES PROCESSORS 5)

--- a/unittests/nvqpp/backends/quake_backend/FakeQuakeServerHelper.cpp
+++ b/unittests/nvqpp/backends/quake_backend/FakeQuakeServerHelper.cpp
@@ -27,7 +27,10 @@ public:
 
   RestHeaders getHeaders() override { return RestHeaders(); }
 
-  void initialize(BackendConfig config) override { backendConfig = config; }
+  void initialize(BackendConfig config) override {
+    backendConfig = config;
+    parseConfigForCommonParams(config);
+  }
 
   void updatePassPipeline(const std::filesystem::path &,
                           std::string &passPipeline) override {
@@ -87,7 +90,20 @@ public:
 
   cudaq::sample_result processResults(ServerMessage &postJobResponse,
                                       std::string &jobId) override {
-    return cudaq::sample_result();
+    auto sampleResult = createSampleResultFromQirOutput(
+        extractOutputLog(postJobResponse, jobId));
+    const auto &response = postJobResponse[0];
+    if (response.contains("output_names") &&
+        !response["output_names"].empty()) {
+      const auto resultMap =
+          makeResultOutputMapFromEnrichedOutputNames(response["output_names"]);
+      return reconstructSampleResultFromResultIndexedMeasurements(
+          sampleResult.to_map(), resultMap);
+    }
+    if (auto result =
+            tryReconstructFromResultIndexedCounts(jobId, sampleResult.to_map()))
+      return *result;
+    return sampleResult;
   }
 };
 

--- a/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
+++ b/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
@@ -45,6 +45,33 @@ done
 
 echo "Server started successfully"
 test_err_sum=0
+runMappedSampleTest() {
+  local mode="$1"
+  local topology_name="$2"
+  local device="$3"
+  local executable="test_mapping_app_${mode}_${topology_name}"
+  local compile_args=(--target quake_fake --quake_fake-device "$device")
+
+  if [ "$mode" = "emulation" ]; then
+    compile_args+=(--emulate)
+  fi
+
+  PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ "${compile_args[@]}" @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_mapping_app.cpp -o "$executable"
+  if [ $? -ne 0 ]; then
+    echo ":x: nvq++ compilation failed for mapped $mode test ($topology_name)"
+    test_err_sum=$((test_err_sum+1))
+    return
+  fi
+
+  ./"$executable"
+  if [ $? -ne 0 ]; then
+    echo ":x: Mapped $mode test failed ($topology_name)"
+    test_err_sum=$((test_err_sum+1))
+  else
+    echo ":white_check_mark: Successfully ran mapped $mode test ($topology_name)"
+  fi
+}
+
 # Test the app nvq++ (remote execution on the mock server)
 PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ --target quake_fake @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.cpp -o test_app
 if [ $? -ne 0 ]; then
@@ -90,6 +117,10 @@ else
   fi
 fi
 
+runMappedSampleTest mock path3 "path(3)"
+runMappedSampleTest mock offset_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_line.txt)"
+runMappedSampleTest mock noncontiguous_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_noncontiguous_line.txt)"
+
 # Emulation test
 # Note: for emulation, we need to link in the device library. 
 PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ --target quake_fake --emulate @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.cpp -o test_app @CMAKE_BINARY_DIR@/unittests/nvqpp/backends/quake_backend/libfake_quake_backend_device_funcs.$LIB_EXT
@@ -124,6 +155,10 @@ else
     echo ":white_check_mark: Successfully ran test_loop_app (emulation)"
   fi
 fi
+
+runMappedSampleTest emulation path3 "path(3)"
+runMappedSampleTest emulation offset_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_line.txt)"
+runMappedSampleTest emulation noncontiguous_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_noncontiguous_line.txt)"
 
 # Run the Python test
 PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.py

--- a/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
+++ b/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
@@ -8,8 +8,31 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+mode="$1"
+if [ "$mode" != "mock" ] && [ "$mode" != "emulation" ]; then
+  echo "Usage: $0 {mock|emulation}"
+  exit 2
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  LIB_EXT="dylib"
+else
+  LIB_EXT="so"
+fi
+
+test_err_sum=0
+server_pid=""
+compile_pids=()
+compile_executables=()
+topology_names=(
+  path3
+  offset_island
+  noncontiguous_island
+)
+
+
 checkServerConnection() {
-  PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ - << EOF
+  PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ - << EOF_PYTHON
 import socket
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -17,180 +40,217 @@ try:
     s.close()
 except Exception:
     exit(1)
-EOF
+EOF_PYTHON
 }
 
-# Launch the fake server
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  LIB_EXT="dylib"
-else
-  LIB_EXT="so"
-fi
-
-
-PYTHONPATH=@CMAKE_BINARY_DIR@/python:@CMAKE_SOURCE_DIR@/python/tests/utils/mock_qpu @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/mock_server.py -device-lib @CMAKE_BINARY_DIR@/unittests/nvqpp/backends/quake_backend/libfake_quake_backend_device_funcs.$LIB_EXT &
-# we'll need the process id to kill it
-pid=$(echo "$!")
-n=0
-while ! checkServerConnection; do
-  sleep 1
-  n=$((n+1))
-  if [ "$n" -eq "60" ]; then
-    echo "Failed to start the server after 20 seconds"
-    # kill the server
-    kill -INT $pid
-    exit 99
+stopServer() {
+  if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+    kill -INT "$server_pid"
+    wait "$server_pid" 2>/dev/null
   fi
-done
+}
+trap stopServer EXIT
 
-echo "Server started successfully"
-test_err_sum=0
-runMappedSampleTest() {
-  local mode="$1"
-  local topology_name="$2"
-  local device="$3"
-  local executable="test_mapping_app_${mode}_${topology_name}"
-  local compile_args=(--target quake_fake --quake_fake-device "$device")
+startServer() {
+  PYTHONPATH=@CMAKE_BINARY_DIR@/python:@CMAKE_SOURCE_DIR@/python/tests/utils/mock_qpu \
+    @Python_EXECUTABLE@ \
+    @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/mock_server.py \
+    -device-lib \
+    @CMAKE_BINARY_DIR@/unittests/nvqpp/backends/quake_backend/libfake_quake_backend_device_funcs.$LIB_EXT &
+  server_pid=$!
+}
 
-  if [ "$mode" = "emulation" ]; then
-    compile_args+=(--emulate)
+waitForServer() {
+  local attempt=0
+  while ! checkServerConnection; do
+    sleep 1
+    attempt=$((attempt+1))
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+      echo "The mock server exited before accepting connections"
+      exit 99
+    fi
+    if [ "$attempt" -eq 60 ]; then
+      echo "Failed to start the server after 60 seconds"
+      exit 99
+    fi
+  done
+  echo "Server started successfully"
+}
+
+# Run independent nvq++ invocations concurrently. Each compiler writes to a
+# separate log so diagnostics remain readable if one of them fails.
+queueCompilation() {
+  local executable="$1"
+  shift
+  rm -f "$executable" "$executable.compile.out"
+  (
+    PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ "$@" -o "$executable" \
+      > "$executable.compile.out" 2>&1
+  ) &
+  compile_pids+=("$!")
+  compile_executables+=("$executable")
+}
+
+waitForCompilations() {
+  local index
+  for ((index = 0; index < ${#compile_pids[@]}; ++index)); do
+    local executable="${compile_executables[$index]}"
+    if wait "${compile_pids[$index]}"; then
+      echo ":white_check_mark: Successfully compiled $executable with nvq++"
+      rm -f "$executable.compile.out"
+    else
+      echo ":x: nvq++ compilation failed for $executable"
+      cat "$executable.compile.out"
+      test_err_sum=$((test_err_sum+1))
+    fi
+  done
+}
+
+queueMappedSampleTests() {
+  local topology_devices=(
+    "path(3)"
+    "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_line.txt)"
+    "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_noncontiguous_line.txt)"
+  )
+  local index
+  for ((index = 0; index < ${#topology_names[@]}; ++index)); do
+    local executable="test_mapping_app_${mode}_${topology_names[$index]}"
+    local compile_args=(
+      --target quake_fake
+      --quake_fake-device "${topology_devices[$index]}"
+    )
+    if [ "$mode" = "emulation" ]; then
+      compile_args+=(--emulate)
+    fi
+    queueCompilation "$executable" "${compile_args[@]}" \
+      @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_mapping_app.cpp
+  done
+}
+
+runTest() {
+  local description="$1"
+  local executable="$2"
+  if [ ! -x "$executable" ]; then
+    return
   fi
-
-  PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ "${compile_args[@]}" @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_mapping_app.cpp -o "$executable"
-  if [ $? -ne 0 ]; then
-    echo ":x: nvq++ compilation failed for mapped $mode test ($topology_name)"
+  if ./"$executable"; then
+    echo ":white_check_mark: Successfully ran $description"
+  else
+    echo ":x: $description failed"
     test_err_sum=$((test_err_sum+1))
+  fi
+}
+
+runMappedSampleTests() {
+  local topology_name
+  for topology_name in "${topology_names[@]}"; do
+    runTest "mapped $mode test ($topology_name)" \
+      "test_mapping_app_${mode}_${topology_name}"
+  done
+}
+
+runLoopTest() {
+  local executable="test_loop_app_$mode"
+  if [ ! -x "$executable" ]; then
     return
   fi
 
-  ./"$executable"
-  if [ $? -ne 0 ]; then
-    echo ":x: Mapped $mode test failed ($topology_name)"
-    test_err_sum=$((test_err_sum+1))
-  else
-    echo ":white_check_mark: Successfully ran mapped $mode test ($topology_name)"
-  fi
-}
+  if [ "$mode" = "mock" ]; then
+    CUDAQ_DUMP_JIT_IR=1 ./"$executable" > "$executable.out" 2>&1
+    if [ $? -ne 0 ]; then
+      echo ":x: $executable failed"
+      cat "$executable.out"
+      test_err_sum=$((test_err_sum+1))
+      return
+    fi
 
-# Test the app nvq++ (remote execution on the mock server)
-PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ --target quake_fake @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.cpp -o test_app
-if [ $? -ne 0 ]; then
-  echo ":x: nvq++ compilation failed"
-  test_err_sum=$((test_err_sum+1))
-else
-  echo ":white_check_mark: Successfully compiled test_app with nvq++"
-  # Run the test app
-  ./test_app
-  if [ $? -ne 0 ]; then
-    echo ":x: test_app failed"
-    test_err_sum=$((test_err_sum+1))
-  else
-    echo ":white_check_mark: Successfully ran test_app"
-  fi
-fi
-
-# Loop remote execution test. CUDAQ_DUMP_JIT_IR validates that the client
-# preserves cc.loop operations, and the mock server validates and executes the
-# submitted payload.
-PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ --target quake_fake @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_loop_app.cpp -o test_loop_app
-if [ $? -ne 0 ]; then
-  echo ":x: nvq++ compilation failed for test_loop_app"
-  test_err_sum=$((test_err_sum+1))
-else
-  echo ":white_check_mark: Successfully compiled test_loop_app with nvq++"
-  CUDAQ_DUMP_JIT_IR=1 ./test_loop_app > test_loop_app.out 2>&1
-  if [ $? -ne 0 ]; then
-    echo ":x: test_loop_app failed"
-    cat test_loop_app.out
-    test_err_sum=$((test_err_sum+1))
-  else
-    loop_count=$(grep -c "cc.loop" test_loop_app.out)
+    local loop_count
+    loop_count=$(grep -c "cc.loop" "$executable.out")
     # Expected loops: the nested for lowers to two cc.loop ops, and the while
     # lowers to one.
     if [ "$loop_count" -lt 3 ]; then
-      echo ":x: test_loop_app client IR did not preserve expected cc.loop ops"
-      cat test_loop_app.out
+      echo ":x: $executable client IR did not preserve expected cc.loop ops"
+      cat "$executable.out"
+      test_err_sum=$((test_err_sum+1))
+      return
+    fi
+    echo ":white_check_mark: Successfully ran $executable with preserved client loops"
+    return
+  fi
+
+  runTest "$executable" "$executable"
+}
+
+runPythonTests() {
+  PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ \
+    @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.py
+  if [ $? -ne 0 ]; then
+    echo ":x: Python test_app.py failed"
+    test_err_sum=$((test_err_sum+1))
+  else
+    echo ":white_check_mark: Successfully ran Python test_app.py"
+  fi
+
+  # CUDAQ_DUMP_JIT_IR validates that Python's nop codegen path preserves the
+  # three structured loops in the client IR.
+  CUDAQ_DUMP_JIT_IR=1 PYTHONPATH=@CMAKE_BINARY_DIR@/python \
+    @Python_EXECUTABLE@ \
+    @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_loop_app.py \
+    > test_loop_app_python.out 2>&1
+  if [ $? -ne 0 ]; then
+    echo ":x: Python test_loop_app.py failed"
+    cat test_loop_app_python.out
+    test_err_sum=$((test_err_sum+1))
+  else
+    local loop_count
+    loop_count=$(grep -c "cc.loop" test_loop_app_python.out)
+    if [ "$loop_count" -lt 3 ]; then
+      echo ":x: Python test_loop_app.py client IR did not preserve expected cc.loop ops"
+      cat test_loop_app_python.out
       test_err_sum=$((test_err_sum+1))
     else
-      echo ":white_check_mark: Successfully ran test_loop_app with preserved client loops"
+      echo ":white_check_mark: Successfully ran Python test_loop_app.py with preserved client loops"
     fi
   fi
+}
+
+if [ "$mode" = "mock" ]; then
+  # Python mock execution below overlaps only the independent C++ compilations.
+  startServer
+  waitForServer
 fi
 
-runMappedSampleTest mock path3 "path(3)"
-runMappedSampleTest mock offset_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_line.txt)"
-runMappedSampleTest mock noncontiguous_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_noncontiguous_line.txt)"
-
-# Emulation test
-# Note: for emulation, we need to link in the device library. 
-PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ --target quake_fake --emulate @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.cpp -o test_app @CMAKE_BINARY_DIR@/unittests/nvqpp/backends/quake_backend/libfake_quake_backend_device_funcs.$LIB_EXT
-if [ $? -ne 0 ]; then
-  echo ":x: nvq++ compilation failed"
-  test_err_sum=$((test_err_sum+1))
-else
-  echo ":white_check_mark: Successfully compiled test_app (emulation) with nvq++"
-  # Run the test app
-  ./test_app
-  if [ $? -ne 0 ]; then
-    echo ":x: test_app failed"
-    test_err_sum=$((test_err_sum+1))
-  else
-    echo ":white_check_mark: Successfully ran test_app (emulation)"
-  fi
+common_compile_args=(--target quake_fake)
+if [ "$mode" = "emulation" ]; then
+  common_compile_args+=(--emulate)
 fi
 
-# Loop emulation test. This covers structured control flow that survives the
-# target pipeline before local wire-set-to-QIR lowering.
-PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ --target quake_fake --emulate @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_loop_app.cpp -o test_loop_app_emulate
-if [ $? -ne 0 ]; then
-  echo ":x: nvq++ compilation failed for test_loop_app (emulation)"
-  test_err_sum=$((test_err_sum+1))
-else
-  echo ":white_check_mark: Successfully compiled test_loop_app (emulation) with nvq++"
-  ./test_loop_app_emulate
-  if [ $? -ne 0 ]; then
-    echo ":x: test_loop_app failed (emulation)"
-    test_err_sum=$((test_err_sum+1))
-  else
-    echo ":white_check_mark: Successfully ran test_loop_app (emulation)"
-  fi
+app_compile_args=(
+  "${common_compile_args[@]}"
+  @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.cpp
+)
+if [ "$mode" = "emulation" ]; then
+  app_compile_args+=(
+    @CMAKE_BINARY_DIR@/unittests/nvqpp/backends/quake_backend/libfake_quake_backend_device_funcs.$LIB_EXT
+  )
+fi
+queueCompilation "test_app_$mode" "${app_compile_args[@]}"
+queueCompilation "test_loop_app_$mode" "${common_compile_args[@]}" \
+  @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_loop_app.cpp
+queueMappedSampleTests
+if [ "$mode" = "mock" ]; then
+  runPythonTests
 fi
 
-runMappedSampleTest emulation path3 "path(3)"
-runMappedSampleTest emulation offset_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_line.txt)"
-runMappedSampleTest emulation noncontiguous_island "file(@CMAKE_SOURCE_DIR@/cudaq/test/Transforms/mapping_disconnected_noncontiguous_line.txt)"
+waitForCompilations
 
-# Run the Python test
-PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_app.py
-if [ $? -ne 0 ]; then
-  echo ":x: Python test_app.py failed"
-  test_err_sum=$((test_err_sum+1))
-else
-  echo ":white_check_mark: Successfully ran Python test_app.py"
-fi
+# Executions remain sequential: mock jobs share one server, while emulation
+# runtime is small compared with compilation and gains little from concurrency.
+runTest "test_app ($mode)" "test_app_$mode"
+runLoopTest
+runMappedSampleTests
 
-# Python loop remote execution test. CUDAQ_DUMP_JIT_IR validates that the Python
-# client preserves cc.loop operations for the nop codegen path.
-CUDAQ_DUMP_JIT_IR=1 PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_loop_app.py > test_loop_app.py.out 2>&1
-if [ $? -ne 0 ]; then
-  echo ":x: Python test_loop_app.py failed"
-  cat test_loop_app.py.out
-  test_err_sum=$((test_err_sum+1))
-else
-  loop_count=$(grep -c "cc.loop" test_loop_app.py.out)
-  if [ "$loop_count" -lt 3 ]; then
-    echo ":x: Python test_loop_app.py client IR did not preserve expected cc.loop ops"
-    cat test_loop_app.py.out
-    test_err_sum=$((test_err_sum+1))
-  else
-    echo ":white_check_mark: Successfully ran Python test_loop_app.py with preserved client loops"
-  fi
-fi
-
-# kill the server
-kill -INT $pid
-# return success / failure
-if [ ! $test_err_sum -eq 0 ]; then
+if [ "$test_err_sum" -ne 0 ]; then
   echo "::error::${test_err_sum} tests failed."
   exit 1
 fi

--- a/unittests/nvqpp/backends/quake_backend/mock_server.py
+++ b/unittests/nvqpp/backends/quake_backend/mock_server.py
@@ -8,7 +8,7 @@
 
 import cudaq
 from fastapi import FastAPI, HTTPException, Request
-import uvicorn, uuid, base64, ctypes, sys, re
+import uvicorn, uuid, base64, ctypes, sys, re, json
 from llvmlite import binding as llvm
 from preallocated_qubits_context import PreallocatedQubitsContext
 from cudaq.mlir.passmanager import PassManager
@@ -112,6 +112,25 @@ def getNumRequiredResults(function):
                     "\"", "").replace("'", ""))
 
 
+def getOutputNames(function):
+    for attribute in function.attributes:
+        # `llvmlite` may expose function attributes as either bytes or a
+        # string-like object, so normalize them before inspecting the text.
+        value = (attribute.decode("utf-8")
+                 if isinstance(attribute, bytes) else str(attribute))
+        # The enriched JSON is stored in the QIR function's `output_names`
+        # string attribute.
+        marker = 'output_names\"=\"'
+        if marker not in value:
+            continue
+        # Quotes within an LLVM string attribute are encoded as `\22`. The
+        # next ordinary quote therefore terminates the attribute value.
+        encoded = value.split(marker, 1)[1].split('\"', 1)[0]
+        return json.loads(encoded.replace('\\22', '"'))
+    # Some QIR entry points do not carry result metadata.
+    return []
+
+
 def getKernelFunction(module):
     for f in module.functions:
         if not f.is_declaration:
@@ -191,6 +210,7 @@ async def postJob(request: Request):
         raise Exception("Could not find kernel function")
     numQubitsRequired = getNumRequiredQubits(function)
     numResultsRequired = getNumRequiredResults(function)
+    outputNames = getOutputNames(function)
     kernelFunctionName = function.name
 
     # Job ID
@@ -217,7 +237,7 @@ async def postJob(request: Request):
         qir_log += "END\t0\n"
 
     engine.remove_module(m)
-    createdJobs[newId] = qir_log
+    createdJobs[newId] = {"qir_output": qir_log, "output_names": outputNames}
     # Job "created", return the id
     return ({"id": newId}, 201)
 
@@ -228,10 +248,10 @@ async def getJob(jobId: str):
         raise HTTPException(status_code=404, detail="Job ID not found")
 
     job_output = createdJobs[jobId]
-    if job_output.startswith("FAILURE:"):
-        res = ({"status": "error", "message": job_output}, 200)
+    if job_output["qir_output"].startswith("FAILURE:"):
+        res = ({"status": "error", "message": job_output["qir_output"]}, 200)
     else:
-        res = ({"status": "done", "qir_output": job_output}, 201)
+        res = ({"status": "done", **job_output}, 201)
     return res
 
 

--- a/unittests/nvqpp/backends/quake_backend/quake_fake.yml
+++ b/unittests/nvqpp/backends/quake_backend/quake_fake.yml
@@ -8,6 +8,14 @@
 
 name: quake_fake
 description: "CUDA-Q target for Quake fake target."
+
+target-arguments:
+  - key: device
+    required: false
+    type: string
+    platform-arg: device
+    help-string: "Device topology for mapped backend tests. Defaults to bypass."
+
 config:
   # Tell DefaultQuantumPlatform what QPU subtype to use
   platform-qpu: remote_rest
@@ -19,7 +27,7 @@ config:
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "expand-measurements"
-  jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
+  jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass% placement=auto search=sabre raise-fatal-errors=1},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "return-to-output-log,symbol-dce"
   # Tell the rest-qpu that we are simply dumping CUDA-Q MLIR code.
   codegen-emission: nop

--- a/unittests/nvqpp/backends/quake_backend/test_mapping_app.cpp
+++ b/unittests/nvqpp/backends/quake_backend/test_mapping_app.cpp
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include <cudaq.h>
+
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace {
+
+constexpr std::size_t shots = 4;
+
+template <typename Kernel>
+bool sampleAndCheck(std::string_view name, Kernel &&kernel,
+                    std::string_view expected) {
+  auto result = cudaq::sample(shots, std::forward<Kernel>(kernel));
+  const auto counts = result.to_map(cudaq::GlobalRegisterName);
+  const auto expectedIter = counts.find(std::string(expected));
+  const bool passed = counts.size() == 1 && expectedIter != counts.end() &&
+                      expectedIter->second == shots;
+
+  if (passed) {
+    std::cout << "PASS " << name << ": " << expected << '\n';
+    return true;
+  }
+
+  std::cerr << "FAIL " << name << ": expected " << expected << '\n';
+  result.dump();
+  return false;
+}
+
+} // namespace
+
+int main() {
+  bool passed = true;
+
+  auto terminalVector = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    x(q[2]);
+    mz(q);
+  };
+  passed &= sampleAndCheck("terminal-vector", terminalVector, "101");
+
+  auto implicitMeasurements = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    x(q[2]);
+  };
+  // q[1] is unused and is eliminated before implicit measurements are added.
+  passed &= sampleAndCheck("implicit-measurements", implicitMeasurements, "11");
+
+  auto terminalRouting = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    x(q[1]);
+    x<cudaq::ctrl>(q[0], q[1]);
+    x<cudaq::ctrl>(q[0], q[2]);
+    x<cudaq::ctrl>(q[1], q[2]);
+    mz(q);
+  };
+  passed &= sampleAndCheck("terminal-routing", terminalRouting, "101");
+
+  auto implicitRouting = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    x(q[1]);
+    x<cudaq::ctrl>(q[0], q[1]);
+    x<cudaq::ctrl>(q[0], q[2]);
+    x<cudaq::ctrl>(q[1], q[2]);
+  };
+  passed &= sampleAndCheck("implicit-routing", implicitRouting, "101");
+
+  auto terminalUserSwap = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    swap(q[0], q[2]);
+    mz(q);
+  };
+  passed &= sampleAndCheck("terminal-user-swap", terminalUserSwap, "001");
+
+  auto implicitUserSwap = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    swap(q[0], q[2]);
+  };
+  // q[1] is unused and is eliminated before implicit measurements are added.
+  passed &= sampleAndCheck("implicit-user-swap", implicitUserSwap, "01");
+
+  // These reversed and partial cases extend the default-sampling ordering
+  // convention, as validated in
+  // `test_explicit_measurements.py::test_measurement_order`:
+  // measured bits follow qubit allocation order, not `mz` execution order.
+  auto reversedTerminalOrder = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    x(q[2]);
+    mz(q[2]);
+    mz(q[0]);
+    mz(q[1]);
+  };
+  passed &=
+      sampleAndCheck("reversed-terminal-order", reversedTerminalOrder, "101");
+
+  auto partialTerminalMeasurement = []() __qpu__ {
+    cudaq::qvector q(3);
+    x(q[0]);
+    x(q[1]);
+    mz(q[2]);
+    mz(q[0]);
+  };
+  passed &= sampleAndCheck("partial-terminal-measurement",
+                           partialTerminalMeasurement, "10");
+
+  return passed ? 0 : 1;
+}

--- a/unittests/nvqpp/backends/quantinuum/QuantinuumTester.cpp
+++ b/unittests/nvqpp/backends/quantinuum/QuantinuumTester.cpp
@@ -27,6 +27,35 @@ CUDAQ_TEST(QuantinuumTester, checkSampleSync) {
   EXPECT_EQ(counts.size(), 2);
 }
 
+// The terminal-order and partial-measurement tests below match the
+// default-sampling ordering convention, as validated in
+// `test_explicit_measurements.py::test_measurement_order`:
+// measured bits follow qubit allocation order, not `mz` execution order.
+CUDAQ_TEST(QuantinuumTester, terminalMeasurementOutputOrder) {
+  auto kernel = cudaq::make_kernel();
+  auto qubits = kernel.qalloc(3);
+  kernel.x(qubits[0]);
+  kernel.x(qubits[2]);
+  kernel.mz(qubits[2]);
+  kernel.mz(qubits[0]);
+  kernel.mz(qubits[1]);
+
+  auto counts = cudaq::sample(32, kernel);
+  EXPECT_EQ(counts.count("101"), 32);
+}
+
+CUDAQ_TEST(QuantinuumTester, partialTerminalMeasurement) {
+  auto kernel = cudaq::make_kernel();
+  auto qubits = kernel.qalloc(3);
+  kernel.x(qubits[0]);
+  kernel.x(qubits[1]);
+  kernel.mz(qubits[2]);
+  kernel.mz(qubits[0]);
+
+  auto counts = cudaq::sample(32, kernel);
+  EXPECT_EQ(counts.count("10"), 32);
+}
+
 CUDAQ_TEST(QuantinuumTester, checkSampleAsync) {
   auto kernel = cudaq::make_kernel();
   auto qubit = kernel.qalloc(2);

--- a/unittests/nvqpp/common/ResultReconstructionTester.cpp
+++ b/unittests/nvqpp/common/ResultReconstructionTester.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "common/ResultReconstruction.h"
+#include "nlohmann/json.hpp"
+#include <gtest/gtest.h>
+
+// These compact and partial cases enforce the default-sampling ordering
+// convention, as validated in
+// `test_explicit_measurements.py::test_measurement_order`:
+// measured bits follow qubit allocation order, not `mz` execution order.
+TEST(ResultReconstructionTester, ReordersCompactQirResults) {
+  const nlohmann::json outputNames = {
+      {{0, {2, "r2", 2}}, {1, {0, "r0", 0}}, {2, {1, "r1", 1}}}};
+  const auto resultMap =
+      cudaq::makeResultOutputMapFromEnrichedOutputNames(outputNames);
+  const auto result =
+      cudaq::reconstructSampleResultFromResultIndexedMeasurements({{"110", 7}},
+                                                                  resultMap);
+
+  EXPECT_EQ(result.to_map(), cudaq::CountsDictionary({{"101", 7}}));
+  EXPECT_EQ(result.to_map("r0"), cudaq::CountsDictionary({{"1", 7}}));
+  EXPECT_EQ(result.to_map("r1"), cudaq::CountsDictionary({{"0", 7}}));
+  EXPECT_EQ(result.to_map("r2"), cudaq::CountsDictionary({{"1", 7}}));
+}
+
+TEST(ResultReconstructionTester, ReordersPartialQirResults) {
+  const nlohmann::json outputNames = {{{0, {2, "r2", 1}}, {1, {0, "r0", 0}}}};
+  const auto resultMap =
+      cudaq::makeResultOutputMapFromEnrichedOutputNames(outputNames);
+  const auto result =
+      cudaq::reconstructSampleResultFromResultIndexedMeasurements({{"01", 5}},
+                                                                  resultMap);
+
+  EXPECT_EQ(result.to_map(), cudaq::CountsDictionary({{"10", 5}}));
+}
+
+TEST(ResultReconstructionTester, SupportsLegacyOutputNames) {
+  const nlohmann::json outputNames = {{{0, {9, "r0"}}, {1, {5, "r1"}}}};
+  const auto resultMap =
+      cudaq::makeResultOutputMapFromEnrichedOutputNames(outputNames);
+  const auto result =
+      cudaq::reconstructSampleResultFromResultIndexedMeasurements({{"10", 2}},
+                                                                  resultMap);
+
+  EXPECT_EQ(result.to_map(), cudaq::CountsDictionary({{"10", 2}}));
+}


### PR DESCRIPTION
The default sampling convention is: 

> The order of the bits in the bitstring corresponds to the qubit allocation order specified in the kernel.

 (i.e., not the `mz` order, unless in the explicit measurement mode, which is not supported by default for remote backends.) 

QIR output logs are indexed by measurement result, but `output_names` did not preserve the logical output position. Mapping, reversed terminal measurements, and partial measurements could therefore expose result-index or physical-qubit order.

Hence, extend `output_names` with an output position during QIR lowering and use shared reconstruction logic to rebuild global and named results. 

Note: this PR focuses on the QIR lowering pipeline, both reference and value semantics. 

**Backend validation**: added a new test (`reordered_terminal_measurements`)

- Quantinuum:  https://github.com/NVIDIA/cuda-quantum/actions/runs/29401089009/job/87306082467#step:6:3038

- OQC: https://github.com/NVIDIA/cuda-quantum/actions/runs/29401089009/job/87306082445#step:6:1293 


Note: This is a subset of a larger refactor in https://github.com/NVIDIA/cuda-quantum/pull/4753/changes/cff8b2df6755c444cf1b6c63e8ad5fa80f103ee2#diff-405d40932f874fb6806c3bd7d00ac02f8bb51daf57b77140079b6990cbc9ad94, which also addresses other issues beyond _terminal measurement_ result ordering.

Co-authored-by: Thomas Alexander <talexander@nvidia.com>