### PR TITLE
Introducing msm and msm_size policies with generic launch API

### DIFF
--- a/runtime/cudaq/algorithms/launch.h
+++ b/runtime/cudaq/algorithms/launch.h
@@ -12,12 +12,14 @@
 #include "common/CompiledModule.h"
 #include "common/ExecutionContext.h"
 #include "common/KernelArgs.h"
+#include "cudaq/algorithms/msm/policy.h"
 #include "cudaq/platform.h"
 #include "cudaq/platform/qpu.h"
 #include "cudaq/qis/execution_manager.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <stdexcept>
+#include <utility>
 #include <variant>
 
 #ifndef CUDAQ_DISABLE_JIT_COMPILER
@@ -103,4 +105,36 @@ auto launch(const Policy &policy, std::size_t qpu_id, ExecutionContext &ctx,
   return result;
 }
 } // namespace detail
+
+/// @brief Execute the given function with an MSM size policy.
+template <typename Callable, typename... Args>
+msm_dimensions launch(msm_size_policy policy, Callable &&f, Args &&...args) {
+  auto &platform = get_platform();
+  ExecutionContext ctx(msm_size_policy::name);
+  const size_t qpu_id = 0;
+  ctx.qpuId = qpu_id;
+  policy.kernelName = cudaq::getKernelName(f);
+  ctx.kernelName = policy.kernelName;
+  policy.noiseModel = platform.get_noise(qpu_id);
+  ctx.noiseModel = policy.noiseModel;
+  return detail::launch(policy, qpu_id, ctx, platform,
+                        std::forward<Callable>(f), std::forward<Args>(args)...);
+}
+
+/// @brief Execute the given function with an MSM policy.
+template <typename Callable, typename... Args>
+msm_result launch(msm_policy policy, Callable &&f, Args &&...args) {
+  auto &platform = get_platform();
+  ExecutionContext ctx(msm_policy::name);
+  const size_t qpu_id = 0;
+  ctx.qpuId = qpu_id;
+  policy.kernelName = cudaq::getKernelName(f);
+  ctx.kernelName = policy.kernelName;
+  policy.noiseModel = platform.get_noise(qpu_id);
+  ctx.noiseModel = policy.noiseModel;
+  ctx.msm_dimensions = policy.dimensions;
+  return detail::launch(policy, qpu_id, ctx, platform,
+                        std::forward<Callable>(f), std::forward<Args>(args)...);
+}
+
 } // namespace cudaq

--- a/runtime/cudaq/algorithms/msm/policy.h
+++ b/runtime/cudaq/algorithms/msm/policy.h
@@ -1,0 +1,80 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "common/SampleResult.h"
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace nvqir {
+class CircuitSimulator;
+}
+
+namespace cudaq {
+
+class ExecutionManager;
+class ExecutionContext;
+class noise_model;
+
+using msm_dimensions = std::pair<std::size_t, std::size_t>;
+
+struct msm_result {
+  sample_result samples;
+  std::vector<double> probabilities;
+  std::vector<std::size_t> probability_error_ids;
+};
+
+/// @brief Tag and inputs for computing Measurement Syndrome Matrix dimensions.
+struct msm_size_policy {
+  /// @brief The name of the policy.
+  static constexpr char name[] = "msm_size";
+
+  /// Associated result type for synchronous APIs keyed off this policy.
+  using result_type = msm_dimensions;
+
+  /// @brief The name of the kernel being executed.
+  std::string kernelName;
+
+  mutable const noise_model *noiseModel = nullptr;
+
+  friend msm_dimensions
+  finalize_execution_manager_impl(ExecutionManager &mgr,
+                                  const msm_size_policy &policy,
+                                  ExecutionContext &ctx);
+  friend msm_dimensions
+  finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
+                                   const msm_size_policy &policy);
+};
+
+/// @brief Tag and inputs for computing a Measurement Syndrome Matrix.
+struct msm_policy {
+  /// @brief The name of the policy.
+  static constexpr char name[] = "msm";
+
+  /// Associated result type for synchronous APIs keyed off this policy.
+  using result_type = msm_result;
+
+  /// @brief The name of the kernel being executed.
+  std::string kernelName;
+
+  std::optional<msm_dimensions> dimensions;
+
+  mutable const noise_model *noiseModel = nullptr;
+
+  friend msm_result finalize_execution_manager_impl(ExecutionManager &mgr,
+                                                    const msm_policy &policy,
+                                                    ExecutionContext &ctx);
+  friend msm_result
+  finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
+                                   const msm_policy &policy);
+};
+
+} // namespace cudaq

--- a/runtime/cudaq/algorithms/policies.h
+++ b/runtime/cudaq/algorithms/policies.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cudaq/algorithms/dem/policy.h"
+#include "cudaq/algorithms/msm/policy.h"
 #include "cudaq/algorithms/observe/policy.h"
 #include "cudaq/algorithms/sample/policy.h"
 #include "cudaq/ptsbe/policy.h"

--- a/runtime/cudaq/algorithms/policy_dispatch.h
+++ b/runtime/cudaq/algorithms/policy_dispatch.h
@@ -82,6 +82,8 @@ decltype(auto) withPolicy(std::string_view name, Func &&func) {
       {"sample", [](FuncRef f) -> Ret { return f(sample_policy{}); }},
       {"observe", [](FuncRef f) -> Ret { return f(observe_policy{}); }},
       {"dem", [](FuncRef f) -> Ret { return f(dem_policy{}); }},
+      {"msm_size", [](FuncRef f) -> Ret { return f(msm_size_policy{}); }},
+      {"msm", [](FuncRef f) -> Ret { return f(msm_policy{}); }},
       {"ptsbe-sample",
        [](FuncRef f) -> Ret { return f(ptsbe::sample_policy{}); }},
   };

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -77,6 +77,26 @@ cudaq::DefaultQPU::launchKernel(const cudaq::observe_policy &policy,
       [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
 }
 
+cudaq::msm_dimensions
+cudaq::DefaultQPU::launchKernel(const cudaq::msm_size_policy &policy,
+                                const cudaq::CompiledModule &module,
+                                cudaq::KernelArgs args) {
+  CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
+  return cudaq::ExecutionManager::with_default_em(
+      policy,
+      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+}
+
+cudaq::msm_result
+cudaq::DefaultQPU::launchKernel(const cudaq::msm_policy &policy,
+                                const cudaq::CompiledModule &module,
+                                cudaq::KernelArgs args) {
+  CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
+  return cudaq::ExecutionManager::with_default_em(
+      policy,
+      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+}
+
 cudaq::async_observe_result
 cudaq::DefaultQPU::launchKernel(const async_observe_policy &policy,
                                 const cudaq::CompiledModule &module,

--- a/runtime/cudaq/platform/default/DefaultQPU.h
+++ b/runtime/cudaq/platform/default/DefaultQPU.h
@@ -36,6 +36,14 @@ public:
                               const CompiledModule &module,
                               KernelArgs args) override;
 
+  msm_dimensions launchKernel(const msm_size_policy &policy,
+                              const CompiledModule &module,
+                              KernelArgs args) override;
+
+  msm_result launchKernel(const msm_policy &policy,
+                          const CompiledModule &module,
+                          KernelArgs args) override;
+
   async_observe_result launchKernel(const async_observe_policy &policy,
                                     const CompiledModule &module,
                                     KernelArgs args) override;

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
@@ -11,11 +11,6 @@
 #include "common/BaseRemoteRESTQPU.h"
 #include "common/CompiledModule.h"
 
-#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 611
-#endif
-
 namespace cudaq {
 
 /// @brief The RemoteRESTQPU is a subtype of QPU that enables the
@@ -24,7 +19,7 @@ namespace cudaq {
 class RemoteRESTQPU : public BaseRemoteRESTQPU {
 public:
   // Overrides the `sample`/`observe` `launchKernel` overloads but inherits
-  // `launchKernel(dem_policy)` from `BaseRemoteRESTQPU`.
+  // others (eg `launchKernel(dem_policy)`) from `BaseRemoteRESTQPU`.
   using BaseRemoteRESTQPU::launchKernel;
 
   RemoteRESTQPU() : BaseRemoteRESTQPU() {}
@@ -55,9 +50,5 @@ public:
                                     const CompiledModule &module,
                                     KernelArgs args) override;
 };
-
-#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-#pragma nv_diagnostic pop
-#endif
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
@@ -11,6 +11,11 @@
 #include "common/BaseRemoteRESTQPU.h"
 #include "common/CompiledModule.h"
 
+#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 611
+#endif
+
 namespace cudaq {
 
 /// @brief The RemoteRESTQPU is a subtype of QPU that enables the
@@ -50,5 +55,9 @@ public:
                                     const CompiledModule &module,
                                     KernelArgs args) override;
 };
+
+#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+#pragma nv_diagnostic pop
+#endif
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -11,6 +11,11 @@
 #include "common/BaseRemoteRESTQPU.h"
 #include <optional>
 
+#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 611
+#endif
+
 namespace cudaq {
 
 /// @brief The `FermioniqBaseQPU` is a QPU that allows users to
@@ -64,5 +69,9 @@ public:
                                     const CompiledModule &module,
                                     KernelArgs args) override;
 };
+
+#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+#pragma nv_diagnostic pop
+#endif
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -11,11 +11,6 @@
 #include "common/BaseRemoteRESTQPU.h"
 #include <optional>
 
-#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 611
-#endif
-
 namespace cudaq {
 
 /// @brief The `FermioniqBaseQPU` is a QPU that allows users to
@@ -23,7 +18,7 @@ namespace cudaq {
 class FermioniqQPU : public BaseRemoteRESTQPU {
 public:
   // Overrides the `sample`/`observe` `launchKernel` overloads but inherits
-  // `launchKernel(dem_policy)` from `BaseRemoteRESTQPU`.
+  // others (eg `launchKernel(dem_policy)`) from `BaseRemoteRESTQPU`.
   using BaseRemoteRESTQPU::launchKernel;
 
   ~FermioniqQPU() override;
@@ -69,9 +64,5 @@ public:
                                     const CompiledModule &module,
                                     KernelArgs args) override;
 };
-
-#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-#pragma nv_diagnostic pop
-#endif
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -52,6 +52,20 @@ observe_result cudaq::QPU::launchKernel(const observe_policy &policy,
       "This QPU does not support launching the observe_policy.");
 }
 
+msm_dimensions cudaq::QPU::launchKernel(const msm_size_policy &policy,
+                                        const CompiledModule &module,
+                                        KernelArgs args) {
+  throw std::runtime_error(
+      "This QPU does not support launching the msm_size_policy.");
+}
+
+msm_result cudaq::QPU::launchKernel(const msm_policy &policy,
+                                    const CompiledModule &module,
+                                    KernelArgs args) {
+  throw std::runtime_error(
+      "This QPU does not support launching the msm_policy.");
+}
+
 async_observe_result
 cudaq::QPU::launchKernel(const async_observe_policy &policy,
                          const CompiledModule &module, KernelArgs args) {
@@ -163,6 +177,16 @@ std::unique_ptr<cudaq::CompileTarget>
 cudaq::QPU::getCompileTarget(const dem_policy &) {
   throw std::runtime_error(
       "This QPU does not support detector error model generation.");
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::QPU::getCompileTarget(const msm_size_policy &) {
+  return getCompileTarget(other_policies{}, nullptr);
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::QPU::getCompileTarget(const msm_policy &) {
+  return getCompileTarget(other_policies{}, nullptr);
 }
 
 std::unique_ptr<cudaq::CompileTarget>

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -173,6 +173,14 @@ public:
                                       const CompiledModule &module,
                                       KernelArgs args);
 
+  virtual msm_dimensions launchKernel(const msm_size_policy &policy,
+                                      const CompiledModule &module,
+                                      KernelArgs args);
+
+  virtual msm_result launchKernel(const msm_policy &policy,
+                                  const CompiledModule &module,
+                                  KernelArgs args);
+
   virtual async_observe_result launchKernel(const async_observe_policy &policy,
                                             const CompiledModule &module,
                                             KernelArgs args);
@@ -195,6 +203,10 @@ public:
   getCompileTarget(const sample_policy &policy);
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(const observe_policy &policy);
+  [[nodiscard]] virtual std::unique_ptr<CompileTarget>
+  getCompileTarget(const msm_size_policy &policy);
+  [[nodiscard]] virtual std::unique_ptr<CompileTarget>
+  getCompileTarget(const msm_policy &policy);
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(const dem_policy &policy);
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -52,6 +52,9 @@ void ExecutionManager::configureExecutionContext(const sample_policy &policy) {
 }
 
 void ExecutionManager::configureExecutionContext(const observe_policy &policy) {
+  if (auto *ctx = getExecutionContext()) {
+    configureExecutionContext(*ctx);
+  }
   nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
 }
 

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -52,9 +52,15 @@ void ExecutionManager::configureExecutionContext(const sample_policy &policy) {
 }
 
 void ExecutionManager::configureExecutionContext(const observe_policy &policy) {
-  if (auto *ctx = getExecutionContext())
-    configureExecutionContext(*ctx);
+  nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
+}
 
+void ExecutionManager::configureExecutionContext(
+    const msm_size_policy &policy) {
+  nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
+}
+
+void ExecutionManager::configureExecutionContext(const msm_policy &policy) {
   nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
 }
 
@@ -75,6 +81,12 @@ void ExecutionManager::finalizeExecutionContext(ExecutionContext &ctx) {
         [&](observe_result &&r) {
           ctx.result = r.raw_data();
           ctx.expectationValue = r.expectation();
+        },
+        [&](msm_dimensions &&r) { ctx.msm_dimensions = std::move(r); },
+        [&](msm_result &&r) {
+          ctx.result = std::move(r.samples);
+          ctx.msm_probabilities = std::move(r.probabilities);
+          ctx.msm_prob_err_id = std::move(r.probability_error_ids);
         },
         [&](policies::void_result &&r) {});
   });

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -121,6 +121,8 @@ public:
   /// Configure the execution context before an execution.
   void configureExecutionContext(const sample_policy &policy);
   void configureExecutionContext(const observe_policy &policy);
+  void configureExecutionContext(const msm_size_policy &policy);
+  void configureExecutionContext(const msm_policy &policy);
   void configureExecutionContext(const dem_policy &policy);
   void configureExecutionContext(const ptsbe::sample_policy &policy);
   void configureExecutionContext(ExecutionContext &ctx);
@@ -135,6 +137,11 @@ public:
 
   virtual observe_result
   finalizeExecutionContext(const observe_policy &policy) = 0;
+
+  virtual msm_dimensions
+  finalizeExecutionContext(const msm_size_policy &policy) = 0;
+
+  virtual msm_result finalizeExecutionContext(const msm_policy &policy) = 0;
 
   virtual dem_result finalizeExecutionContext(const dem_policy &) {
     throw std::runtime_error(
@@ -262,6 +269,19 @@ inline observe_result
 finalize_execution_manager_impl(ExecutionManager &mgr,
                                 const observe_policy &policy,
                                 ExecutionContext &ctx) {
+  return mgr.finalizeExecutionContext(policy);
+}
+
+inline msm_dimensions
+finalize_execution_manager_impl(ExecutionManager &mgr,
+                                const msm_size_policy &policy,
+                                ExecutionContext &ctx) {
+  return mgr.finalizeExecutionContext(policy);
+}
+
+inline msm_result finalize_execution_manager_impl(ExecutionManager &mgr,
+                                                  const msm_policy &policy,
+                                                  ExecutionContext &ctx) {
   return mgr.finalizeExecutionContext(policy);
 }
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -174,6 +174,17 @@ protected:
     return simulator()->finalizeExecutionContext(policy);
   }
 
+  msm_dimensions
+  finalizeExecutionContext(const msm_size_policy &policy) override {
+    finalizeExecutionContextImpl();
+    return simulator()->finalizeExecutionContext(policy);
+  }
+
+  msm_result finalizeExecutionContext(const msm_policy &policy) override {
+    finalizeExecutionContextImpl();
+    return simulator()->finalizeExecutionContext(policy);
+  }
+
   dem_result finalizeExecutionContext(const dem_policy &policy) override {
     finalizeExecutionContextImpl();
     return simulator()->finalizeExecutionContext(policy);

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -214,6 +214,16 @@ protected:
         "observe policy not supported for this photonics simulator.");
   }
 
+  msm_dimensions finalizeExecutionContext(const msm_size_policy &) override {
+    throw std::runtime_error(
+        "msm_size policy not supported for this photonics simulator.");
+  }
+
+  msm_result finalizeExecutionContext(const msm_policy &) override {
+    throw std::runtime_error(
+        "msm policy not supported for this photonics simulator.");
+  }
+
   void finalizeExecutionContext(const other_policies &policy,
                                 ExecutionContext &ctx) override {
     std::vector<std::size_t> ids;

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -124,6 +124,13 @@ protected:
   /// should be emitted.
   bool warnAboutNamedMeasurements = false;
 
+  template <typename Policy>
+  void configureExecutionContextImpl(Policy policy) {
+    noiseModel = policy.noiseModel;
+    currentCircuitName = policy.kernelName;
+    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+  }
+
 public:
   /// @brief The constructor
   CircuitSimulator() = default;
@@ -161,29 +168,6 @@ public:
   /// previously applied gates have truly been applied by the underlying
   /// simulator.
   virtual void synchronize() {}
-
-  /// @brief For simulators that support generating an MSM, this returns the
-  /// number of rows and columns in the MSM (for a given noisy kernel)
-  virtual std::optional<std::pair<std::size_t, std::size_t>> generateMSMSize() {
-    return std::nullopt;
-  }
-
-  /// @brief For simulators that support generating an MSM, this generates the
-  /// MSM and returns it as an msm_result. The result is only
-  /// valid for a specific kernel with a specific noise profile.
-  /// Note: Measurement Syndrome Matrix is defined in
-  /// https://arxiv.org/pdf/2407.13826.
-  virtual cudaq::msm_result generateMSM() { return {}; }
-
-  /// @brief For simulators that support detector error model (DEM) analysis,
-  /// compute the DEM from the recorded circuit and return it as `.dem` text.
-  ///
-  /// `.dem` is the Detector Error Model text format defined by Stim; only the
-  /// `stim` backend currently implements this.
-  virtual std::string generateDem() {
-    throw std::runtime_error(
-        "Detector error model (DEM) analysis not supported.");
-  }
 
   /// @brief Apply exp(-i theta PauliTensorProd) to the underlying state.
   /// This must be provided by subclasses.
@@ -303,13 +287,19 @@ public:
   virtual cudaq::sample_result
   finalizeExecutionContext(const cudaq::sample_policy &policy) = 0;
   virtual cudaq::msm_dimensions
-  finalizeExecutionContext(const cudaq::msm_size_policy &policy) = 0;
+  finalizeExecutionContext(const cudaq::msm_size_policy &policy) {
+    throw std::runtime_error("This target does not support policy" +
+                             std::string(policy.name));
+  }
   virtual cudaq::msm_result
-  finalizeExecutionContext(const cudaq::msm_policy &policy) = 0;
+  finalizeExecutionContext(const cudaq::msm_policy &policy) {
+    throw std::runtime_error("This target does not support policy" +
+                             std::string(policy.name));
+  }
   virtual cudaq::dem_result
-  finalizeExecutionContext(const cudaq::dem_policy &) {
-    throw std::runtime_error(
-        "This target does not support detector error model generation.");
+  finalizeExecutionContext(const cudaq::dem_policy &policy) {
+    throw std::runtime_error("This target does not support policy" +
+                             std::string(policy.name));
   }
 
   /// @brief Clean up after execution ends.
@@ -322,25 +312,20 @@ public:
 
   /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::sample_policy &policy) {
+    configureExecutionContextImpl(policy);
     warnAboutNamedMeasurements = true;
-    noiseModel = policy.noiseModel;
-    currentCircuitName = policy.kernelName;
-    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
   }
 
   /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::observe_policy &policy) {
-    noiseModel = policy.noiseModel;
-    currentCircuitName = policy.kernelName;
+    configureExecutionContextImpl(policy);
     policy.canHandleObserve = canHandleObserve();
-    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
   }
 
   /// @brief Set the execution context
-  void configureExecutionContext(const cudaq::dem_policy &policy) {
-    noiseModel = policy.noiseModel;
-    currentCircuitName = policy.kernelName;
-    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+  virtual void configureExecutionContext(const cudaq::dem_policy &policy) {
+    throw std::runtime_error("This target does not support policy" +
+                             std::string(policy.name));
   }
 
   /// @brief Set the execution context
@@ -359,16 +344,14 @@ public:
 
   /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::msm_size_policy &policy) {
-    noiseModel = policy.noiseModel;
-    currentCircuitName = policy.kernelName;
-    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+    throw std::runtime_error("This target does not support policy" +
+                             std::string(policy.name));
   }
 
   /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::msm_policy &policy) {
-    noiseModel = policy.noiseModel;
-    currentCircuitName = policy.kernelName;
-    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+    throw std::runtime_error("This target does not support policy" +
+                             std::string(policy.name));
   }
 
   /// @brief Set the execution context
@@ -1249,25 +1232,6 @@ protected:
     currentCircuitName = "";
 
     return internalResult;
-  }
-
-  cudaq::msm_dimensions
-  finalizeExecutionContext(const cudaq::msm_size_policy &policy) override {
-    if (nQubitsAllocated == 0)
-      return {};
-    finalizeExecutionContextImpl();
-    auto dimensions = generateMSMSize();
-    if (!dimensions)
-      throw std::runtime_error("MSM size analysis not supported.");
-    return *dimensions;
-  }
-
-  cudaq::msm_result
-  finalizeExecutionContext(const cudaq::msm_policy &policy) override {
-    if (nQubitsAllocated == 0)
-      return {};
-    finalizeExecutionContextImpl();
-    return generateMSM();
   }
 
   void finalizeExecutionContext(const cudaq::other_policies &policy,

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -288,17 +288,17 @@ public:
   finalizeExecutionContext(const cudaq::sample_policy &policy) = 0;
   virtual cudaq::msm_dimensions
   finalizeExecutionContext(const cudaq::msm_size_policy &policy) {
-    throw std::runtime_error("This target does not support policy" +
+    throw std::runtime_error("This target does not support policy " +
                              std::string(policy.name));
   }
   virtual cudaq::msm_result
   finalizeExecutionContext(const cudaq::msm_policy &policy) {
-    throw std::runtime_error("This target does not support policy" +
+    throw std::runtime_error("This target does not support policy " +
                              std::string(policy.name));
   }
   virtual cudaq::dem_result
   finalizeExecutionContext(const cudaq::dem_policy &policy) {
-    throw std::runtime_error("This target does not support policy" +
+    throw std::runtime_error("This target does not support policy " +
                              std::string(policy.name));
   }
 
@@ -324,7 +324,7 @@ public:
 
   /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::dem_policy &policy) {
-    throw std::runtime_error("This target does not support policy" +
+    throw std::runtime_error("This target does not support policy " +
                              std::string(policy.name));
   }
 
@@ -344,13 +344,13 @@ public:
 
   /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::msm_size_policy &policy) {
-    throw std::runtime_error("This target does not support policy" +
+    throw std::runtime_error("This target does not support policy " +
                              std::string(policy.name));
   }
 
   /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::msm_policy &policy) {
-    throw std::runtime_error("This target does not support policy" +
+    throw std::runtime_error("This target does not support policy " +
                              std::string(policy.name));
   }
 

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -169,11 +169,21 @@ public:
   }
 
   /// @brief For simulators that support generating an MSM, this generates the
-  /// MSM and stores the result in the execution context. The result is only
+  /// MSM and returns it as an msm_result. The result is only
   /// valid for a specific kernel with a specific noise profile.
   /// Note: Measurement Syndrome Matrix is defined in
   /// https://arxiv.org/pdf/2407.13826.
-  virtual void generateMSM() {}
+  virtual cudaq::msm_result generateMSM() { return {}; }
+
+  /// @brief For simulators that support detector error model (DEM) analysis,
+  /// compute the DEM from the recorded circuit and return it as `.dem` text.
+  ///
+  /// `.dem` is the Detector Error Model text format defined by Stim; only the
+  /// `stim` backend currently implements this.
+  virtual std::string generateDem() {
+    throw std::runtime_error(
+        "Detector error model (DEM) analysis not supported.");
+  }
 
   /// @brief Apply exp(-i theta PauliTensorProd) to the underlying state.
   /// This must be provided by subclasses.
@@ -276,6 +286,12 @@ public:
             ctx.result = r.raw_data();
             ctx.expectationValue = r.expectation();
           },
+          [&](cudaq::msm_dimensions &&r) { ctx.msm_dimensions = std::move(r); },
+          [&](cudaq::msm_result &&r) {
+            ctx.result = std::move(r.samples);
+            ctx.msm_probabilities = std::move(r.probabilities);
+            ctx.msm_prob_err_id = std::move(r.probability_error_ids);
+          },
           [&](cudaq::policies::void_result &&r) {});
     });
   }
@@ -286,6 +302,10 @@ public:
   finalizeExecutionContext(const cudaq::observe_policy &policy) = 0;
   virtual cudaq::sample_result
   finalizeExecutionContext(const cudaq::sample_policy &policy) = 0;
+  virtual cudaq::msm_dimensions
+  finalizeExecutionContext(const cudaq::msm_size_policy &policy) = 0;
+  virtual cudaq::msm_result
+  finalizeExecutionContext(const cudaq::msm_policy &policy) = 0;
   virtual cudaq::dem_result
   finalizeExecutionContext(const cudaq::dem_policy &) {
     throw std::runtime_error(
@@ -301,7 +321,7 @@ public:
   virtual bool canHandleObserve() { return false; }
 
   /// @brief Set the execution context
-  void configureExecutionContext(const cudaq::sample_policy &policy) {
+  virtual void configureExecutionContext(const cudaq::sample_policy &policy) {
     warnAboutNamedMeasurements = true;
     noiseModel = policy.noiseModel;
     currentCircuitName = policy.kernelName;
@@ -309,7 +329,7 @@ public:
   }
 
   /// @brief Set the execution context
-  void configureExecutionContext(const cudaq::observe_policy &policy) {
+  virtual void configureExecutionContext(const cudaq::observe_policy &policy) {
     noiseModel = policy.noiseModel;
     currentCircuitName = policy.kernelName;
     policy.canHandleObserve = canHandleObserve();
@@ -331,7 +351,28 @@ public:
   }
 
   /// @brief Set the execution context
-  void configureExecutionContext(cudaq::ExecutionContext &context) {
+  void configureExecutionContext(const cudaq::ptsbe::sample_policy &policy) {
+    noiseModel = nullptr;
+    currentCircuitName = policy.kernelName;
+    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+  }
+
+  /// @brief Set the execution context
+  virtual void configureExecutionContext(const cudaq::msm_size_policy &policy) {
+    noiseModel = policy.noiseModel;
+    currentCircuitName = policy.kernelName;
+    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+  }
+
+  /// @brief Set the execution context
+  virtual void configureExecutionContext(const cudaq::msm_policy &policy) {
+    noiseModel = policy.noiseModel;
+    currentCircuitName = policy.kernelName;
+    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+  }
+
+  /// @brief Set the execution context
+  virtual void configureExecutionContext(cudaq::ExecutionContext &context) {
     context.canHandleObserve = canHandleObserve();
     noiseModel = context.noiseModel;
     currentCircuitName = context.kernelName;
@@ -1210,6 +1251,25 @@ protected:
     return internalResult;
   }
 
+  cudaq::msm_dimensions
+  finalizeExecutionContext(const cudaq::msm_size_policy &policy) override {
+    if (nQubitsAllocated == 0)
+      return {};
+    finalizeExecutionContextImpl();
+    auto dimensions = generateMSMSize();
+    if (!dimensions)
+      throw std::runtime_error("MSM size analysis not supported.");
+    return *dimensions;
+  }
+
+  cudaq::msm_result
+  finalizeExecutionContext(const cudaq::msm_policy &policy) override {
+    if (nQubitsAllocated == 0)
+      return {};
+    finalizeExecutionContextImpl();
+    return generateMSM();
+  }
+
   void finalizeExecutionContext(const cudaq::other_policies &policy,
                                 cudaq::ExecutionContext &context) override {
     if (nQubitsAllocated == 0)
@@ -1221,14 +1281,6 @@ protected:
       context.simulationState = getSimulationState();
       // State is no longer valid, so clean up
       deallocateState();
-    }
-
-    if (context.name == "msm_size") {
-      context.msm_dimensions = generateMSMSize();
-    }
-
-    if (context.name == "msm") {
-      generateMSM();
     }
   }
 
@@ -1607,6 +1659,17 @@ namespace cudaq {
 inline sample_result
 finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
                                  const sample_policy &policy) {
+  return sim.finalizeExecutionContext(policy);
+}
+
+inline msm_dimensions
+finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
+                                 const msm_size_policy &policy) {
+  return sim.finalizeExecutionContext(policy);
+}
+
+inline msm_result finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
+                                                   const msm_policy &policy) {
   return sim.finalizeExecutionContext(policy);
 }
 

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -336,13 +336,6 @@ public:
   }
 
   /// @brief Set the execution context
-  void configureExecutionContext(const cudaq::ptsbe::sample_policy &policy) {
-    noiseModel = nullptr;
-    currentCircuitName = policy.kernelName;
-    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
-  }
-
-  /// @brief Set the execution context
   virtual void configureExecutionContext(const cudaq::msm_size_policy &policy) {
     throw std::runtime_error("This target does not support policy " +
                              std::string(policy.name));

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -189,12 +189,11 @@ protected:
 
   /// @brief Return the number of rows and columns needed for a Parity Check
   /// Matrix
-  std::optional<std::pair<std::size_t, std::size_t>>
-  generateMSMSize() override {
+  std::optional<std::pair<std::size_t, std::size_t>> generateMSMSize() {
     return std::make_pair(num_measurements, msm_err_count);
   }
 
-  cudaq::msm_result generateMSM() override {
+  cudaq::msm_result generateMSM() {
     const auto num_cols = getBatchSize();
     stim::simd_bit_table<W> msmSample = sampleSim->m_record.storage;
     // Disabled because it's too verbose, but left here as comments for
@@ -322,6 +321,25 @@ protected:
     if (policy.options.return_measurement_matrices)
       computeMeasurementMatrices(result);
     return result;
+  }
+
+  cudaq::msm_dimensions
+  finalizeExecutionContext(const cudaq::msm_size_policy &policy) override {
+    if (nQubitsAllocated == 0)
+      return {};
+    finalizeExecutionContextImpl();
+    auto dimensions = generateMSMSize();
+    if (!dimensions)
+      throw std::runtime_error("MSM size analysis not supported.");
+    return *dimensions;
+  }
+
+  cudaq::msm_result
+  finalizeExecutionContext(const cudaq::msm_policy &policy) override {
+    if (nQubitsAllocated == 0)
+      return {};
+    finalizeExecutionContextImpl();
+    return generateMSM();
   }
 
   /// @brief Override the default sized allocation of qubits
@@ -675,6 +693,7 @@ protected:
   QubitOrdering getQubitOrdering() const override { return QubitOrdering::msb; }
 
 public:
+  using StimSimulatorBase::configureExecutionContext;
   StimCircuitSimulator() : randomEngine(std::random_device{}()) {
     // Populate the correct name so it is printed correctly during
     // deconstructor.
@@ -861,9 +880,19 @@ public:
   }
 
   void configureExecutionContext(const cudaq::msm_policy &policy) override {
+    StimSimulatorBase::configureExecutionContextImpl(policy);
     is_msm_mode = true;
     activeMsmDimensions = policy.dimensions;
     StimSimulatorBase::configureExecutionContext(policy);
+  }
+
+  void
+  configureExecutionContext(const cudaq::msm_size_policy &policy) override {
+    StimSimulatorBase::configureExecutionContextImpl(policy);
+  }
+
+  void configureExecutionContext(const cudaq::dem_policy &policy) override {
+    StimSimulatorBase::configureExecutionContextImpl(policy);
   }
 
   // TODO - remove after CUDAQX use of the ExecutionContext is removed

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -31,10 +31,12 @@ struct StimNoiseType {
   int num_targets = 1;
 };
 
+using StimSimulatorBase = nvqir::CircuitSimulatorBase<double>;
+
 /// @brief The StimCircuitSimulator implements the CircuitSimulator
 /// base class to provide a simulator delegating to the Stim library from
 /// https://github.com/quantumlib/Stim.
-class StimCircuitSimulator : public nvqir::CircuitSimulatorBase<double> {
+class StimCircuitSimulator : public StimSimulatorBase {
 protected:
   // Follow Stim naming convention (W) for bit width (required for templates).
   static constexpr std::size_t W = stim::MAX_BITWORD_WIDTH;
@@ -53,7 +55,7 @@ protected:
   std::unique_ptr<stim::FrameSimulator<W>> sampleSim;
 
   /// @brief Error counter for MSM generation. This is only used for "msm" and
-  /// "msm_size" execution contexts.
+  /// "msm_size" policies.
   std::size_t msm_err_count = 0;
 
   /// @brief Error ID counter for MSM generation. This is only used for "msm"
@@ -63,6 +65,15 @@ protected:
   /// @brief Whether or not the execution context name is "msm" (value is cached
   /// for speed)
   bool is_msm_mode = false;
+
+  std::optional<cudaq::msm_dimensions> activeMsmDimensions;
+
+  /// @brief Probabilities of each error mechanism, accumulated during MSM
+  /// execution. Only used for "msm" policy.
+  std::vector<double> msmProbabilities;
+
+  /// @brief Error IDs corresponding to each entry in @c msmProbabilities.
+  std::vector<std::size_t> msmProbErrId;
 
   /// @brief Accumulated Stim circuit covering gates, measurements, noise,
   /// detectors, and observables. Reset alongside `num_measurements` in
@@ -171,10 +182,8 @@ protected:
          executionContext->name == "ptsbe-sample") &&
         !executionContext->hasConditionalsOnMeasureResults)
       batch_size = executionContext->shots;
-    else if (executionContext && executionContext->name == "msm")
-      batch_size =
-          executionContext->msm_dimensions.value_or(std::make_pair(1, 1))
-              .second;
+    else if (is_msm_mode)
+      batch_size = activeMsmDimensions.value_or(std::make_pair(1, 1)).second;
     return batch_size;
   }
 
@@ -185,7 +194,7 @@ protected:
     return std::make_pair(num_measurements, msm_err_count);
   }
 
-  void generateMSM() override {
+  cudaq::msm_result generateMSM() override {
     const auto num_cols = getBatchSize();
     stim::simd_bit_table<W> msmSample = sampleSim->m_record.storage;
     // Disabled because it's too verbose, but left here as comments for
@@ -205,9 +214,14 @@ protected:
       counts[aShot]++;
       sequentialData.push_back(std::move(aShot));
     }
-    ExecutionResult result(counts);
-    result.sequentialData = std::move(sequentialData);
-    getExecutionContext()->result = result;
+    ExecutionResult execResult(counts);
+    execResult.sequentialData = std::move(sequentialData);
+
+    cudaq::msm_result result;
+    result.samples = std::move(execResult);
+    result.probabilities = std::move(msmProbabilities);
+    result.probability_error_ids = std::move(msmProbErrId);
+    return result;
   }
 
   /// @brief Populate the measurement matrices in @p result from
@@ -285,8 +299,7 @@ protected:
   void finalizeExecutionContext(const cudaq::other_policies &policy,
                                 cudaq::ExecutionContext &context) override {
     try {
-      nvqir::CircuitSimulatorBase<double>::finalizeExecutionContext(policy,
-                                                                    context);
+      StimSimulatorBase::finalizeExecutionContext(policy, context);
     } catch (...) {
       endExecution();
       throw;
@@ -315,7 +328,6 @@ protected:
   /// here to be a bit more efficient than the default implementation
   void addQubitsToState(std::size_t qubitCount,
                         const void *stateDataIn = nullptr) override {
-    auto executionContext = getExecutionContext();
     if (stateDataIn)
       throw std::runtime_error("The Stim simulator does not support "
                                "initialization of qubits from state data.");
@@ -330,18 +342,16 @@ protected:
           std::mt19937_64(randomEngine), /*num_qubits=*/0, /*sign_bias=*/+0);
     }
     if (!sampleSim) {
-      is_msm_mode = executionContext && executionContext->name == "msm";
       std::size_t anticipated_num_measurements = 0;
       std::size_t num_msm_cols = 0;
       if (is_msm_mode) {
-        auto dims =
-            executionContext->msm_dimensions.value_or(std::make_pair(1, 1));
+        auto dims = activeMsmDimensions.value_or(std::make_pair(1, 1));
         anticipated_num_measurements = dims.first;
         num_msm_cols = dims.second;
-        executionContext->msm_probabilities.emplace();
-        executionContext->msm_probabilities->reserve(num_msm_cols);
-        executionContext->msm_prob_err_id.emplace();
-        executionContext->msm_prob_err_id->reserve(num_msm_cols);
+        msmProbabilities.clear();
+        msmProbabilities.reserve(num_msm_cols);
+        msmProbErrId.clear();
+        msmProbErrId.reserve(num_msm_cols);
       }
 
       // If possible, provide a non-empty stim::CircuitStats in order to avoid
@@ -380,6 +390,9 @@ protected:
     msm_err_count = 0;
     msm_id_counter = 0;
     is_msm_mode = false;
+    activeMsmDimensions = std::nullopt;
+    msmProbabilities.clear();
+    msmProbErrId.clear();
     recordedCircuit.clear();
   }
 
@@ -456,8 +469,6 @@ protected:
     CUDAQ_INFO("[stim] apply kraus channel {}, is_msm_mode = {}",
                channel.get_type_name(), is_msm_mode);
 
-    auto executionContext = getExecutionContext();
-
     // If we have a valid operation, apply it
     if (auto res = isValidStimNoiseChannel(channel)) {
       // A channel acting on `num_targets` qubits is broadcast independently
@@ -498,8 +509,8 @@ protected:
                 sampleSim->x_table[q][shot] ^= res->flips_x[flip_ix];
                 sampleSim->z_table[q][shot] ^= res->flips_z[flip_ix];
               }
-              executionContext->msm_probabilities->push_back(res->params[m]);
-              executionContext->msm_prob_err_id->push_back(msm_id_counter);
+              msmProbabilities.push_back(res->params[m]);
+              msmProbErrId.push_back(msm_id_counter);
               msm_err_count++;
             }
           }
@@ -847,6 +858,19 @@ public:
   createStateFromData(const cudaq::state_data &) override {
     throw std::runtime_error(
         "Simulation data not available for the stim simulator backend.");
+  }
+
+  void configureExecutionContext(const cudaq::msm_policy &policy) override {
+    is_msm_mode = true;
+    activeMsmDimensions = policy.dimensions;
+    StimSimulatorBase::configureExecutionContext(policy);
+  }
+
+  // TODO - remove after CUDAQX use of the ExecutionContext is removed
+  void configureExecutionContext(cudaq::ExecutionContext &context) override {
+    is_msm_mode = context.name == "msm";
+    activeMsmDimensions = context.msm_dimensions;
+    StimSimulatorBase::configureExecutionContext(context);
   }
 
   NVQIR_SIMULATOR_CLONE_IMPL(StimCircuitSimulator)

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -883,7 +883,6 @@ public:
     StimSimulatorBase::configureExecutionContextImpl(policy);
     is_msm_mode = true;
     activeMsmDimensions = policy.dimensions;
-    StimSimulatorBase::configureExecutionContext(policy);
   }
 
   void

--- a/unittests/nvqpp/integration/kernels_tester.cpp
+++ b/unittests/nvqpp/integration/kernels_tester.cpp
@@ -7,6 +7,8 @@
  ******************************************************************************/
 
 #include "CUDAQTestUtils.h"
+#include "cudaq/algorithms/launch.h"
+#include "cudaq/algorithms/msm/policy.h"
 #include "cudaq/builder/kernels.h"
 #include <iostream>
 
@@ -323,30 +325,26 @@ CUDAQ_TEST(KernelsTester, msmTester_mz_only) {
 
   // Stage 1 - get the MSM size by running with "msm_size". The
   // result will be returned in ctx_msm_size.shots.
-  cudaq::ExecutionContext ctx_msm_size("msm_size");
-  auto &platform = cudaq::get_platform();
-  platform.with_execution_context(ctx_msm_size, multi_round_ghz{}, num_qubits,
-                                  num_rounds);
+  auto msm_dimensions = cudaq::launch(
+      cudaq::msm_size_policy{}, multi_round_ghz{}, num_qubits, num_rounds);
 
   // Stage 2 - get the MSM using the size calculated above
   // (ctx_msm_size.msm_dimensions).
-  cudaq::ExecutionContext ctx_msm("msm");
-  ctx_msm.noiseModel = &noise;
-  ctx_msm.msm_dimensions = ctx_msm_size.msm_dimensions;
-  platform.with_execution_context(ctx_msm, multi_round_ghz{}, num_qubits,
-                                  num_rounds);
+  cudaq::msm_policy policy;
+  policy.dimensions = msm_dimensions;
+  auto msm = cudaq::launch(policy, multi_round_ghz{}, num_qubits, num_rounds);
 
   // The MSM is now stored in ctx_msm.result. More precisely, the unfiltered
   // MSM is stored there, but some post-processing may be required to
   // eliminate duplicate columns.
-  auto msm_as_strings = ctx_msm.result.sequential_data();
+  auto msm_as_strings = msm.samples.sequential_data();
   printf("Columns of MSM:\n");
   for (int col = 0; auto x : msm_as_strings) {
     // For this multi_round_ghz, we expect a 15x15 identity matrix.
     std::string expected_string(num_qubits * num_rounds, '0');
     expected_string[col] = '1';
     EXPECT_EQ(expected_string, x);
-    auto p = ctx_msm.msm_probabilities.value()[col];
+    auto p = msm.probabilities[col];
     printf("Column %02d (Prob %.6f): %s\n", col, p, x.c_str());
     EXPECT_EQ(p, noise_bf_prob);
     col++;
@@ -384,23 +382,21 @@ CUDAQ_TEST(KernelsTester, msmTester_mz_and_depol1_corr) {
 
   // Stage 1 - get the MSM size by running with "msm_size". The
   // result will be returned in ctx_msm_size.shots.
-  cudaq::ExecutionContext ctx_msm_size("msm_size");
-  auto &platform = cudaq::get_platform();
-  platform.with_execution_context(ctx_msm_size, multi_round_ghz{}, num_qubits,
-                                  num_rounds, noise_bf_prob);
+  auto msm_dimensions =
+      cudaq::launch(cudaq::msm_size_policy{}, multi_round_ghz{}, num_qubits,
+                    num_rounds, noise_bf_prob);
 
   // Stage 2 - get the MSM using the size calculated above
   // (ctx_msm_size.msm_dimensions).
-  cudaq::ExecutionContext ctx_msm("msm");
-  ctx_msm.noiseModel = &noise;
-  ctx_msm.msm_dimensions = ctx_msm_size.msm_dimensions;
-  platform.with_execution_context(ctx_msm, multi_round_ghz{}, num_qubits,
-                                  num_rounds, noise_bf_prob);
+  cudaq::msm_policy policy;
+  policy.dimensions = msm_dimensions;
+  auto msm = cudaq::launch(policy, multi_round_ghz{}, num_qubits, num_rounds,
+                           noise_bf_prob);
 
   // The MSM is now stored in ctx_msm.result. More precisely, the unfiltered
   // MSM is stored there, but some post-processing may be required to
   // eliminate duplicate columns.
-  auto msm_as_strings = ctx_msm.result.sequential_data();
+  auto msm_as_strings = msm.samples.sequential_data();
   auto msm_transpose = transpose_msm(msm_as_strings);
 
   const std::vector<std::string> expected = {
@@ -438,11 +434,10 @@ CUDAQ_TEST(KernelsTester, msmTester_mz_and_depol1_corr) {
       13, 13, 14, 14, 14, 15, 16, 17, 18, 19, 20, 20, 20, 21, 21,
       21, 22, 22, 22, 23, 23, 23, 24, 24, 24, 25, 26, 27, 28, 29};
   for (std::size_t i = 0; i < expected_probabilities.size(); i++)
-    EXPECT_NEAR(expected_probabilities[i], ctx_msm.msm_probabilities.value()[i],
-                1e-5)
+    EXPECT_NEAR(expected_probabilities[i], msm.probabilities[i], 1e-5)
         << "Mismatch at index " << i;
-  for (std::size_t i = 0; i < ctx_msm.msm_prob_err_id.value().size(); i++)
-    EXPECT_EQ(ctx_msm.msm_prob_err_id.value()[i], expected_err_ids[i])
+  for (std::size_t i = 0; i < msm.probability_error_ids.size(); i++)
+    EXPECT_EQ(msm.probability_error_ids[i], expected_err_ids[i])
         << "Mismatch at index " << i;
 }
 
@@ -484,20 +479,17 @@ get_msm_test(double noise_probability) {
 
   // Stage 1 - get the MSM size by running with "msm_size". The
   // result will be returned in ctx_msm_size.shots.
-  cudaq::ExecutionContext ctx_msm_size("msm_size");
-  auto &platform = cudaq::get_platform();
-  platform.with_execution_context(ctx_msm_size, simple_test{},
-                                  noise_probability);
+  auto msm_dimensions =
+      cudaq::launch(cudaq::msm_size_policy{}, simple_test{}, noise_probability);
 
   // Stage 2 - get the MSM using the size calculated above
   // (ctx_msm_size.msm_dimensions).
-  cudaq::ExecutionContext ctx_msm("msm");
-  ctx_msm.noiseModel = &noise;
-  ctx_msm.msm_dimensions = ctx_msm_size.msm_dimensions;
-  platform.with_execution_context(ctx_msm, simple_test{}, noise_probability);
+  cudaq::msm_policy policy;
+  policy.dimensions = msm_dimensions;
+  auto msm = cudaq::launch(policy, simple_test{}, noise_probability);
 
-  return {transpose_msm(ctx_msm.result.sequential_data()),
-          ctx_msm.msm_probabilities.value(), ctx_msm.msm_prob_err_id.value()};
+  return {transpose_msm(msm.samples.sequential_data()), msm.probabilities,
+          msm.probability_error_ids};
 }
 
 CUDAQ_TEST(KernelsTester, msmTester_depol2) {
@@ -612,30 +604,26 @@ CUDAQ_TEST(KernelsTester, msmTester_two_qubit_depol_broadcast) {
       /*num_controls=*/1);
   cudaq::set_noise(noise);
 
-  cudaq::ExecutionContext ctx_msm_size("msm_size");
-  auto &platform = cudaq::get_platform();
-  platform.with_execution_context(ctx_msm_size, cx_kernel{});
+  auto msm_dimensions = cudaq::launch(cudaq::msm_size_policy{}, cx_kernel{});
 
-  cudaq::ExecutionContext ctx_msm("msm");
-  ctx_msm.noiseModel = &noise;
-  ctx_msm.msm_dimensions = ctx_msm_size.msm_dimensions;
-  platform.with_execution_context(ctx_msm, cx_kernel{});
+  cudaq::msm_policy policy;
+  policy.dimensions = msm_dimensions;
+  auto msm = cudaq::launch(policy, cx_kernel{});
 
-  auto msm_transpose = transpose_msm(ctx_msm.result.sequential_data());
+  auto msm_transpose = transpose_msm(msm.samples.sequential_data());
 
   // Mechanisms {X,Y,Z} on q0 then {X,Y,Z} on q1; only X and Y flip the
   // Z-basis measurement. Row 0 is q0, row 1 is q1.
   const std::vector<std::string> expected = {"11....", "...11."};
   EXPECT_EQ(msm_transpose, expected);
 
-  ASSERT_EQ(ctx_msm.msm_probabilities.value().size(), 6u);
+  ASSERT_EQ(msm.probabilities.size(), 6u);
   for (std::size_t i = 0; i < 6; i++)
-    EXPECT_NEAR(ctx_msm.msm_probabilities.value()[i], p / 3, 1e-5)
-        << "Mismatch at index " << i;
+    EXPECT_NEAR(msm.probabilities[i], p / 3, 1e-5) << "Mismatch at index " << i;
 
   // Each qubit is an independent error source with its own error id.
   const std::vector<std::size_t> expected_err_ids = {0, 0, 0, 1, 1, 1};
-  EXPECT_EQ(ctx_msm.msm_prob_err_id.value(), expected_err_ids);
+  EXPECT_EQ(msm.probability_error_ids, expected_err_ids);
 
   cudaq::unset_noise();
 }
@@ -666,28 +654,24 @@ CUDAQ_TEST(KernelsTester, msmTester_two_qubit_bitflip_broadcast) {
       /*num_controls=*/1);
   cudaq::set_noise(noise);
 
-  cudaq::ExecutionContext ctx_msm_size("msm_size");
-  auto &platform = cudaq::get_platform();
-  platform.with_execution_context(ctx_msm_size, cx_kernel{});
+  auto msm_dimensions = cudaq::launch(cudaq::msm_size_policy{}, cx_kernel{});
 
-  cudaq::ExecutionContext ctx_msm("msm");
-  ctx_msm.noiseModel = &noise;
-  ctx_msm.msm_dimensions = ctx_msm_size.msm_dimensions;
-  platform.with_execution_context(ctx_msm, cx_kernel{});
+  cudaq::msm_policy policy;
+  policy.dimensions = msm_dimensions;
+  auto msm = cudaq::launch(policy, cx_kernel{});
 
-  auto msm_transpose = transpose_msm(ctx_msm.result.sequential_data());
+  auto msm_transpose = transpose_msm(msm.samples.sequential_data());
 
   // Two mechanisms: X on q0 (flips row 0) and X on q1 (flips row 1).
   const std::vector<std::string> expected = {"1.", ".1"};
   EXPECT_EQ(msm_transpose, expected);
 
-  ASSERT_EQ(ctx_msm.msm_probabilities.value().size(), 2u);
+  ASSERT_EQ(msm.probabilities.size(), 2u);
   for (std::size_t i = 0; i < 2; i++)
-    EXPECT_NEAR(ctx_msm.msm_probabilities.value()[i], p, 1e-5)
-        << "Mismatch at index " << i;
+    EXPECT_NEAR(msm.probabilities[i], p, 1e-5) << "Mismatch at index " << i;
 
   const std::vector<std::size_t> expected_err_ids = {0, 1};
-  EXPECT_EQ(ctx_msm.msm_prob_err_id.value(), expected_err_ids);
+  EXPECT_EQ(msm.probability_error_ids, expected_err_ids);
 
   cudaq::unset_noise();
 }

--- a/unittests/nvqpp/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/nvqpp/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -88,6 +88,14 @@ protected:
     throw std::runtime_error("observe is not implemented for SimpleQudit.");
   }
 
+  msm_dimensions finalizeExecutionContext(const msm_size_policy &) override {
+    throw std::runtime_error("msm_size is not implemented for SimpleQudit.");
+  }
+
+  msm_result finalizeExecutionContext(const msm_policy &) override {
+    throw std::runtime_error("msm is not implemented for SimpleQudit.");
+  }
+
   void endExecution() override {
     sampleQudits.clear();
     BasicExecutionManager::endExecution();


### PR DESCRIPTION
The goal of this PR is to transition us from using the execution context for "msm" and "msm_size" and use a generic `launch` API instead that takes in a policy. msm is the first policy for which there is no existing msm options or msm header file API (unlike sample, observe, run...). It makes it a perfect candidate for the generic launch API @amccaskey proposed. 

Below is an example of what this would look like for a user.

Before:
```
  cudaq::ExecutionContext ctx_msm_size("msm_size");
  auto &platform = cudaq::get_platform();
  platform.with_execution_context(ctx_msm_size, cx_kernel{});

  cudaq::ExecutionContext ctx_msm("msm");
  ctx_msm.noiseModel = &noise;
  ctx_msm.msm_dimensions = ctx_msm_size.msm_dimensions;
  platform.with_execution_context(ctx_msm, cx_kernel{});
```

After:
```
  auto msm_dimensions = cudaq::launch(cudaq::msm_size_policy{}, cx_kernel{});

  cudaq::msm_policy policy;
  policy.dimensions = msm_dimensions;
  auto msm = cudaq::launch(policy, cx_kernel{});
```


There is still support for the old style, as to not break CUDAQ-X. Once CUDAQ-X is transitioned to the new API, this will be removed and the execution context will be cleaned up from msm data. 
