### PR TITLE
[CI] add internal apt proxy cache

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -246,7 +246,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Log in to DockerHub
         uses: docker/login-action@v4

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -174,7 +174,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Build Open MPI
         id: docker_build
@@ -337,7 +337,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Set up ccache and ORAS
         uses: ./.github/actions/ccache-setup
@@ -609,7 +609,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Set up ccache and ORAS
         uses: ./.github/actions/ccache-setup

--- a/.github/workflows/generate_cc.yml
+++ b/.github/workflows/generate_cc.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Build CUDA Quantum
         id: cudaq_build

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Set up ccache and ORAS
         uses: ./.github/actions/ccache-setup
@@ -291,7 +291,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Log in to DockerHub
         uses: docker/login-action@v4

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -484,7 +484,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Extract cuda-quantum metadata
         id: metadata
@@ -654,7 +654,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Build installer
         uses: docker/build-push-action@v7
@@ -797,7 +797,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Build cuda-quantum wheel
         id: build_wheel

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Build wheel
         id: wheel_build

--- a/.github/workflows/realtime_integration_ci.yml
+++ b/.github/workflows/realtime_integration_ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Determine build cache
         id: cache
@@ -259,7 +259,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Determine build cache
         id: cache

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Build CUDA Quantum
         id: build
@@ -254,7 +254,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: false
+          enable-apt: true
 
       - name: Set up dev environment
         id: dev_env


### PR DESCRIPTION
Two merge-queue runs failed when the arm64 Ubuntu ports mirrors
returned 503s / became unreachable. Re-enable the proxy cache
(reverts https://github.com/NVIDIA/cuda-quantum/pull/4487) so package installs have a path that does not
depend on public mirror uptime.