### PR TITLE
Fixing macOS xdist port collisions in backend mock-server tests

### DIFF
--- a/python/tests/backends/test_IQM.py
+++ b/python/tests/backends/test_IQM.py
@@ -24,6 +24,8 @@ iqm_client = pytest.importorskip("iqm.iqm_client")
 from utils.mock_qpu.iqm import startServer
 from utils.mock_qpu.iqm.mock_iqm_cortex_cli import write_a_mock_tokens_file
 
+pytestmark = pytest.mark.xdist_group("iqm_mock")
+
 # Define the port for the mock server
 port = 62443
 

--- a/python/tests/backends/test_IonQ.py
+++ b/python/tests/backends/test_IonQ.py
@@ -14,6 +14,8 @@ from multiprocessing import Process
 from network_utils import check_server_connection
 from utils.mock_qpu.ionq import startServer
 
+pytestmark = pytest.mark.xdist_group("ionq_mock")
+
 # Define the port for the mock server
 port = 62441
 

--- a/python/tests/backends/test_OQC.py
+++ b/python/tests/backends/test_OQC.py
@@ -18,6 +18,8 @@ import numpy as np
 
 from utils.mock_qpu.oqc import startServer
 
+pytestmark = pytest.mark.xdist_group("oqc_mock")
+
 # Define the port for the mock server
 port = 62442
 

--- a/python/tests/backends/test_QCI.py
+++ b/python/tests/backends/test_QCI.py
@@ -17,6 +17,8 @@ from network_utils import check_server_connection
 
 from utils.mock_qpu.qci import startServer
 
+pytestmark = pytest.mark.xdist_group("qci_mock")
+
 # Define the port for the mock server
 port = 62449
 

--- a/python/tests/backends/test_qbraid.py
+++ b/python/tests/backends/test_qbraid.py
@@ -17,6 +17,8 @@ from network_utils import check_server_connection
 
 from utils.mock_qpu.qbraid import startServer
 
+pytestmark = pytest.mark.xdist_group("qbraid_mock")
+
 port = 62454
 
 # Default machine for tests. Mirrors the real qBraid device string format.

--- a/python/tests/backends/test_scaleway_mock.py
+++ b/python/tests/backends/test_scaleway_mock.py
@@ -16,6 +16,8 @@ import numpy as np
 
 qio = pytest.importorskip("qio")
 
+pytestmark = pytest.mark.xdist_group("scaleway_mock")
+
 TEST_PORT = 62450
 TEST_PLATFORM = "EMU-CUDAQ-FAKE"
 TEST_URL = f"http://localhost:{TEST_PORT}"

--- a/python/tests/backends/test_tii_mock.py
+++ b/python/tests/backends/test_tii_mock.py
@@ -22,6 +22,8 @@ skipIfTiiNotInstalled = pytest.mark.skipif(
 
 from utils.mock_qpu.tii import startServer
 
+pytestmark = pytest.mark.xdist_group("tii_mock")
+
 # Define the port for the mock server - make sure this is unique
 # across all tests.
 port = 62451


### PR DESCRIPTION
On macOS the validation suite runs `pytest -n <workers> --dist=loadgroup`. Backend test files that start a scope="session" mock server on a fixed port had no xdist_group marker, so their tests scattered across workers. Each worker's session fixture tried to bind the same port (address already in use), and the surviving shared server leaked stateful test hooks across workers.

So pinned each fixed-port mock-server file to a single worker with `pytestmark = pytest.mark.xdist_group(...)`, matching the existing Quantinuum idiom in conftest.py.

Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/29423986845/job/87387953025?pr=4927#step:7:4447