### PR TITLE
Add documentation for developing the Cuda-Q MLIR compiler

### DIFF
--- a/cudaq/include/cudaq/Optimizer/CodeGen/CMakeLists.txt
+++ b/cudaq/include/cudaq/Optimizer/CodeGen/CMakeLists.txt
@@ -12,3 +12,5 @@ add_cudaq_dialect_doc(CodeGen codegen)
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name OptCodeGen)
 add_public_tablegen_target(OptCodeGenPassIncGen)
+
+add_cudaq_doc(Passes CodeGenPasses -gen-pass-doc)

--- a/cudaq/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -276,8 +276,8 @@ def ReturnToOutputLog : Pass<"return-to-output-log", "mlir::ModuleOp"> {
   let options = [
     Option<"allowDynamicResult", "allow-dynamic-result", "bool",
            /*default=*/"true",
-           "Allow dynamic-size vector result logging. Set to false for targets"
-           "that require statically-known output record counts (e.g., targets"
+           "Allow dynamic-size vector result logging. Set to false for targets "
+           "that require statically-known output record counts (e.g., targets "
            "that don't support full QIR).">,
   ];
 }

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -392,9 +392,9 @@ def Decomposition : Pass<"decomposition", "mlir::ModuleOp"> {
     patterns, ensuring every gate is decomposed to the specified basis in a
     unique way.
     
-    ## Options
+    #### Pattern selection
 
-    The following options are available and are all optional:
+    Pattern selection can be controlled with the following optional settings:
 
     - `disable-patterns`: used to filter out specific rewrite patterns from the
        selection.
@@ -455,7 +455,7 @@ def DependencyAnalysis : Pass<"dep-analysis", "mlir::ModuleOp"> {
     used. If two virtual qubits have non-overlapping lifetimes, they can be
     assigned to the same physical qubit, as every virtual qubit is assumed to be
     fully reset before release. Failure to fully reset virtual qubits before
-    release is undefinied behavior, and will likely lead to incorrect output
+    release is undefined behavior and will likely lead to incorrect output
     when running DependencyAnalysis.
   }];
 
@@ -466,7 +466,8 @@ def DependencyAnalysis : Pass<"dep-analysis", "mlir::ModuleOp"> {
               "Number of virtual qubits used">,
     Statistic<"numPhysicalQubits", "num-physical-qubits",
               "Number of physical qubits used">,
-    Statistic<"numCycles", "num-cycles", "Length of kernel in cycles">
+    Statistic<"numCycles", "num-cycles",
+              "Length of kernel in cycles">,
   ];
 }
 
@@ -1165,7 +1166,7 @@ def MemToReg : Pass<"memtoreg", "mlir::func::FuncOp"> {
     Option<"classicalValues", "classical", "bool",
       /*default=*/"true", "Promote classical stack slots to values.">,
     Option<"quantumValues", "quantum", "bool",
-      /*default=*/"true", "Promote of quantum values.">
+      /*default=*/"true", "Promote quantum references to wire values.">
   ];
   let statistics = [
     Statistic<"numProcessOpWithRegionsCalls", "process-op-with-regions-calls",
@@ -1179,7 +1180,7 @@ def MultiControlDecomposition :
     Pass<"multicontrol-decomposition", "mlir::func::FuncOp"> {
   let summary = "Break down multi-control quantum operations.";
   let description = [{
-    This pass decomposes multi-control quantum operations. The decompostion
+    This pass decomposes multi-control quantum operations. The decomposition
     involves allocating new qubits to hold intermediate results. The number of
     extra qubits depends on the particular operation being decomposed.
     Pauli-X and Pauli-Z operations add _N_ - 2 qubits, while other operations
@@ -1216,7 +1217,7 @@ def PhaseFolding: Pass<"phase-folding", "mlir::func::FuncOp"> {
     First, a preprocessing step identifies each subcircuit consisting only of
     Swap, NOT, CNOT, and Rz gates. Currently, we restrict this subcircuit to
     only working with `!quake.ref` types directly from `quake.alloca`s, as
-    values extraced from `quake.veq`s via `extract_ref` may have hidden side
+    values extracted from `quake.veq`s via `extract_ref` may have hidden side
     effects that could cause the subcircuits to be incorrect.
 
     At the beginning of the subcircuit, each qubit is assigned a unique phase
@@ -1228,15 +1229,15 @@ def PhaseFolding: Pass<"phase-folding", "mlir::func::FuncOp"> {
     * A CNOT gate sets the phase of the target to the exclusive sum of the
       phase variables in the phases for the control and target qubits.
     * If multiple `rz` ops are found at the same phase, they will be combined
-      by replacing the rotation angle of the latter occuring op to the sum of
+      by replacing the rotation angle of the latter occurring op with the sum of
       the rotation angles of both ops, and removing the prior op.
   }];
 
   let options = [
     Option<"minimumBlockLength", "min-length", "unsigned", /*default=*/"20",
-    "Minimumn subcircuit length to run phase folding">,
+    "Minimum subcircuit length to run phase folding">,
     Option<"minimumrzWeight", "min-rz-weight", "double", /*default=*/"20",
-    "Minimumn percentage of rz ops in subcircuit to run phase folding">,
+    "Minimum percentage of rz ops in subcircuit to run phase folding">,
   ];
 
   let dependentDialects = ["cudaq::cc::CCDialect",
@@ -1253,7 +1254,7 @@ def PromoteRefToVeqAlloc : Pass<"promote-qubit-allocation"> {
 }
 
 def PruneCtrlRelations : Pass<"pruned-ctrl-form", "mlir::func::FuncOp"> {
-  let summary = "Removes artifical control constraints between quantum ops.";
+  let summary = "Removes artificial control constraints between quantum ops.";
   let description = [{
     In the value semantics, quantum gates may be overly constrained in terms of
     control qubits. These constraints can be removed within the IR to get a more
@@ -1307,10 +1308,10 @@ def PySynthCallableBlockArgs :
   let summary =
     "Synthesize / Inline cc.callable_func on function block arguments.";
   let description = [{
-    This pass is leveraged by the Python bindings to synthesize any 
-    cc.callable block arguments. By synthesis we mean replace all uses of the 
-    callable block argument with a specific in-Module function call (func.call) 
-    retrieved at runtime (the name of the function passed to the kernel at the 
+    The Python bindings use this pass to synthesize any
+    cc.callable block arguments. Synthesis replaces all uses of the callable
+    block argument with a specific in-module function call (`func.call`)
+    retrieved at runtime (the name of the function passed to the kernel at the
     cc.callable block argument index).
   }];
 }
@@ -1555,11 +1556,11 @@ def ResourceCountPreprocess :
       }
     ```
 
-    The initial `h(q[0])` will always be run once, so we can precount it and
-    remove it. Similarly, it is trivial to see that the loop will run 10 times,
-    so we can pre count `y(q[i])` ten times as well. However, because `x(q[i])`
-    is gated by `mz(q[i])`, it is not invariant, so it will remain and be
-    counted during simulation.
+    The initial `h(q[0])` will always be run once, so we can count it in advance
+    and remove it. Similarly, it is trivial to see that the loop will run 10
+    times, so we can count `y(q[i])` ten times in advance as well. However,
+    because `x(q[i])` is gated by `mz(q[i])`, it is not invariant, so it will
+    remain and be counted during simulation.
 
     Currently, the detection of "invariance" is purposefully dumb.
 
@@ -1582,16 +1583,15 @@ def ResourceCountPreprocess :
 }
 
 def RunSemanticsHackery : Pass<"run-semantics-hackery", "mlir::ModuleOp"> {
-  let summary = "Run semantics hackery";
+  let summary = "Adapt vector results for cudaq::run entry points.";
   let description = [{
-    The design of the `cudaq::run` feature breaks the semantics of the host
-    language.  While that is a terrible design decision, we strive to work
-    around the inherent flaws. This pass should be used after the
-    `kernel-execution` pass to clean up some of the semantics potholes and
-    brokenness left behind.
-
-    Ideally, we'd just fix the CUDA-Q spec and use first-class output logging
-    functions.
+    `cudaq::run` entry points log kernel results instead of returning them
+    through the host ABI. After the `kernel-execution` pass creates the `.run`
+    wrapper, this pass finds wrappers that call kernels returning `!cc.stdvec`,
+    clones those kernels, removes calls to `__nvqpp_vectorCopyCtor` from the
+    clones, and redirects the wrappers to call the clones. It must run after
+    `kernel-execution`, while both the generated wrapper and original kernel are
+    present.
   }];
 
   let dependentDialects = ["cudaq::cc::CCDialect", "mlir::func::FuncDialect"];

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -307,9 +307,9 @@ def Decomposition : Pass<"decomposition", "mlir::ModuleOp"> {
     patterns, ensuring every gate is decomposed to the specified basis in a
     unique way.
     
-    ## Options
+    #### Pattern selection
 
-    The following options are available and are all optional:
+    Pattern selection can be controlled with the following optional settings:
 
     - `disable-patterns`: used to filter out specific rewrite patterns from the
        selection.
@@ -370,7 +370,7 @@ def DependencyAnalysis : Pass<"dep-analysis", "mlir::ModuleOp"> {
     used. If two virtual qubits have non-overlapping lifetimes, they can be
     assigned to the same physical qubit, as every virtual qubit is assumed to be
     fully reset before release. Failure to fully reset virtual qubits before
-    release is undefinied behavior, and will likely lead to incorrect output
+    release is undefined behavior and will likely lead to incorrect output
     when running DependencyAnalysis.
   }];
 
@@ -380,7 +380,7 @@ def DependencyAnalysis : Pass<"dep-analysis", "mlir::ModuleOp"> {
     Statistic<"numVirtualQubits", "num-virtual-qubits",
               "Number of virtual qubits used">,
     Statistic<"numPhysicalQubits", "num-physical-qubits",
-              "Number of phyiscal qubits used">,
+              "Number of physical qubits used">,
     Statistic<"numCycles", "num-cycles",
               "Length of kernel in cycles">,
   ];
@@ -1081,7 +1081,7 @@ def MemToReg : Pass<"memtoreg", "mlir::func::FuncOp"> {
     Option<"classicalValues", "classical", "bool",
       /*default=*/"true", "Promote classical stack slots to values.">,
     Option<"quantumValues", "quantum", "bool",
-      /*default=*/"true", "Promote of quantum values.">
+      /*default=*/"true", "Promote quantum references to wire values.">
   ];
 }
 
@@ -1089,7 +1089,7 @@ def MultiControlDecomposition :
     Pass<"multicontrol-decomposition", "mlir::func::FuncOp"> {
   let summary = "Break down multi-control quantum operations.";
   let description = [{
-    This pass decomposes multi-control quantum operations. The decompostion
+    This pass decomposes multi-control quantum operations. The decomposition
     involves allocating new qubits to hold intermediate results. The number of
     extra qubits depends on the particular operation being decomposed.
     Pauli-X and Pauli-Z operations add _N_ - 2 qubits, while other operations
@@ -1126,7 +1126,7 @@ def PhaseFolding: Pass<"phase-folding", "mlir::func::FuncOp"> {
     First, a preprocessing step identifies each subcircuit consisting only of
     Swap, NOT, CNOT, and Rz gates. Currently, we restrict this subcircuit to
     only working with `!quake.ref` types directly from `quake.alloca`s, as
-    values extraced from `quake.veq`s via `extract_ref` may have hidden side
+    values extracted from `quake.veq`s via `extract_ref` may have hidden side
     effects that could cause the subcircuits to be incorrect.
 
     At the beginning of the subcircuit, each qubit is assigned a unique phase
@@ -1138,15 +1138,15 @@ def PhaseFolding: Pass<"phase-folding", "mlir::func::FuncOp"> {
     * A CNOT gate sets the phase of the target to the exclusive sum of the
       phase variables in the phases for the control and target qubits.
     * If multiple `rz` ops are found at the same phase, they will be combined
-      by replacing the rotation angle of the latter occuring op to the sum of
+      by replacing the rotation angle of the latter occurring op with the sum of
       the rotation angles of both ops, and removing the prior op.
   }];
 
   let options = [
     Option<"minimumBlockLength", "min-length", "unsigned", /*default=*/"20",
-    "Minimumn subcircuit length to run phase folding">,
+    "Minimum subcircuit length to run phase folding">,
     Option<"minimumrzWeight", "min-rz-weight", "double", /*default=*/"20",
-    "Minimumn percentage of rz ops in subcircuit to run phase folding">,
+    "Minimum percentage of rz ops in subcircuit to run phase folding">,
   ];
 
   let dependentDialects = ["cudaq::cc::CCDialect",
@@ -1163,7 +1163,7 @@ def PromoteRefToVeqAlloc : Pass<"promote-qubit-allocation"> {
 }
 
 def PruneCtrlRelations : Pass<"pruned-ctrl-form", "mlir::func::FuncOp"> {
-  let summary = "Removes artifical control constraints between quantum ops.";
+  let summary = "Removes artificial control constraints between quantum ops.";
   let description = [{
     In the value semantics, quantum gates may be overly constrained in terms of
     control qubits. These constraints can be removed within the IR to get a more
@@ -1217,10 +1217,10 @@ def PySynthCallableBlockArgs :
   let summary =
     "Synthesize / Inline cc.callable_func on function block arguments.";
   let description = [{
-    This pass is leveraged by the Python bindings to synthesize any 
-    cc.callable block arguments. By synthesis we mean replace all uses of the 
-    callable block argument with a specific in-Module function call (func.call) 
-    retrieved at runtime (the name of the function passed to the kernel at the 
+    The Python bindings use this pass to synthesize any
+    cc.callable block arguments. Synthesis replaces all uses of the callable
+    block argument with a specific in-module function call (`func.call`)
+    retrieved at runtime (the name of the function passed to the kernel at the
     cc.callable block argument index).
   }];
 }
@@ -1465,11 +1465,11 @@ def ResourceCountPreprocess :
       }
     ```
 
-    The initial `h(q[0])` will always be run once, so we can precount it and
-    remove it. Similarly, it is trivial to see that the loop will run 10 times,
-    so we can pre count `y(q[i])` ten times as well. However, because `x(q[i])`
-    is gated by `mz(q[i])`, it is not invariant, so it will remain and be
-    counted during simulation.
+    The initial `h(q[0])` will always be run once, so we can count it in advance
+    and remove it. Similarly, it is trivial to see that the loop will run 10
+    times, so we can count `y(q[i])` ten times in advance as well. However,
+    because `x(q[i])` is gated by `mz(q[i])`, it is not invariant, so it will
+    remain and be counted during simulation.
 
     Currently, the detection of "invariance" is purposefully dumb.
 
@@ -1492,16 +1492,15 @@ def ResourceCountPreprocess :
 }
 
 def RunSemanticsHackery : Pass<"run-semantics-hackery", "mlir::ModuleOp"> {
-  let summary = "Run semantics hackery";
+  let summary = "Adapt vector results for cudaq::run entry points.";
   let description = [{
-    The design of the `cudaq::run` feature breaks the semantics of the host
-    language.  While that is a terrible design decision, we strive to work
-    around the inherent flaws. This pass should be used after the
-    `kernel-execution` pass to clean up some of the semantics potholes and
-    brokenness left behind.
-
-    Ideally, we'd just fix the CUDA-Q spec and use first-class output logging
-    functions.
+    `cudaq::run` entry points log kernel results instead of returning them
+    through the host ABI. After the `kernel-execution` pass creates the `.run`
+    wrapper, this pass finds wrappers that call kernels returning `!cc.stdvec`,
+    clones those kernels, removes calls to `__nvqpp_vectorCopyCtor` from the
+    clones, and redirects the wrappers to call the clones. It must run after
+    `kernel-execution`, while both the generated wrapper and original kernel are
+    present.
   }];
 
   let dependentDialects = ["cudaq::cc::CCDialect", "mlir::func::FuncDialect"];

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -131,10 +131,14 @@ if compiler_developer_docs:
     tags.add('compiler_developer_docs')
     rst_epilog = '''
 .. |CUDA-Q dialect documentation| replace:: :doc:`CUDA-Q dialect documentation </using/extending/compiler/dialect_reference>`
+.. |compiler pass development guide| replace:: :doc:`compiler pass development guide </using/extending/compiler/mlir_pass>`
+.. |available compiler passes| replace:: :doc:`available compiler passes </using/extending/compiler/available_passes>`
 '''
 else:
     rst_epilog = '''
 .. |CUDA-Q dialect documentation| replace:: CUDA-Q dialect documentation
+.. |compiler pass development guide| replace:: compiler pass development guide
+.. |available compiler passes| replace:: available compiler passes
 '''
     exclude_patterns.extend([
         'using/extending/compiler/mlir_pass.rst',

--- a/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
+++ b/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
@@ -191,66 +191,66 @@ should produce
     Setting `explicit_measurements` option
     { 0:479 1:521 }
 
-Here we see that we have measured a qubit in a uniform superposition to a 
-register named :code:`reg1`, and followed it with a reset and the application 
-of an NOT operation. By default the :code:`sample_result` returned for this 
-sampling tasks contains the default :code:`__global__` register as well as the 
-user specified :code:`reg1` register. 
+This kernel measures a qubit in a uniform superposition to a register named
+:code:`reg1`, resets it, and applies an X operation. By default, the
+:code:`sample_result` contains the default :code:`__global__` register and the
+user-specified :code:`reg1` register.
 
 The contents of the :code:`__global__` register will depend on how your kernel
 is written:
 
-1. If no measurements appear in the kernel, then the :code:`__global__` 
-   register is formed with implicit measurements being added for *all* the 
-   qubits defined in the kernel, and the measurements all occur at the end of 
-   the kernel. This is not supported when sampling with the 
-   :code:`explicit_measurements` option; kernels executed with 
-   :code:`explicit_measurements` mode must contain measurements.   
+1. If no measurements appear in the kernel, then the :code:`__global__`
+   register is formed with implicit measurements being added for the qubits
+   that remain in the compiled kernel, and the measurements all occur at the
+   end of the kernel. This is not supported when sampling with the
+   :code:`explicit_measurements` option; kernels executed with
+   :code:`explicit_measurements` mode must contain measurements.
    The order of the bits in the bitstring corresponds to the qubit
-   allocation order specified in the kernel.  That is - the :code:`[0]` element
-   in the :code:`__global__` bitstring corresponds with the first declared qubit
-   in the kernel. For example,
+   allocation order specified in the kernel, for qubits that remain in the
+   compiled kernel. That is - the :code:`[0]` element in the
+   :code:`__global__` bitstring corresponds with the first remaining declared
+   qubit in the kernel. For example,
 
-.. tab:: C++ 
+.. tab:: C++
 
    .. code-block:: cpp
 
        auto kernel = []() __qpu__ {
-         cudaq::qubit a, b;
+         cudaq::qubit a;
          x(a);
        };
        cudaq::sample(kernel).dump();
 
-.. tab:: Python 
+.. tab:: Python
 
-  .. code-block:: python 
+  .. code-block:: python
 
-    @cudaq.kernel 
+    @cudaq.kernel
     def kernel():
-        a, b = cudaq.qubit(), cudaq.qubit() 
-        x(a) 
-    
-    cudaq.sample(kernel).dump() 
+        a = cudaq.qubit()
+        x(a)
 
-should produce 
+    cudaq.sample(kernel).dump()
 
-   .. code-block:: bash 
+should produce
 
-       { 
-         __global__ : { 10:1000 }
+   .. code-block:: bash
+
+       {
+         __global__ : { 1:1000 }
        }
 
 2. Conversely, if any measurements appear in the kernel, then only the measured
-   qubits will appear in the :code:`__global__` register. Similar to #1, the 
+   qubits will appear in the :code:`__global__` register. Similar to #1, the
    bitstring corresponds to the qubit allocation order specified in the kernel.
-   Also (again, similar to #1), the values of the sampled qubits always 
-   correspond to the values *at the end of the kernel execution*, unless the 
-   :code:`explicit_measurements` option is enabled. That is - if a qubit is 
+   Also (again, similar to #1), the values of the sampled qubits always
+   correspond to the values *at the end of the kernel execution*, unless the
+   :code:`explicit_measurements` option is enabled. That is - if a qubit is
    measured in the middle of a kernel and subsequent operations change the state
-   of the qubit, the qubit will be implicitly re-measured at the end of the 
-   kernel, and that re-measured value is the value that will appear in the 
-   :code:`__global__` register. If the sampling option :code:`explicit_measurements` 
-   is enabled, then no re-measurements occur, and the global register contains 
+   of the qubit, the qubit will be implicitly re-measured at the end of the
+   kernel, and that re-measured value is the value that will appear in the
+   :code:`__global__` register. If the sampling option :code:`explicit_measurements`
+   is enabled, then no re-measurements occur, and the global register contains
    the concatenated measurements in the order they were executed in the kernel.
 
 .. tab:: C++ 
@@ -300,12 +300,14 @@ should produce
 
 .. note::
 
-  If you don't specify any measurements in your kernel and allow the :code:`nvq++`
-  compiler to perform passes that introduce ancilla qubits into your kernel, it
-  may be difficult to discern which qubits are the ancilla qubits vs which ones
-  are your qubits. In this case, it is recommended that you provide explicit
-  measurements in your kernel in order to only receive measurements from your
-  qubits and silently discard the measurements from the ancillary qubits.
+  Allocating a qubit does not require the compiler to preserve it. For example,
+  if a kernel allocates two qubits but only operates on one, the other qubit
+  may not appear in the implicit measurement results. If a program requires a
+  stable per-shot result format, measure the required qubits, return those
+  measurement values from the kernel, and execute it with :code:`cudaq.run` or
+  :code:`cudaq::run`. Use the :code:`explicit_measurements` option only when
+  measurement results are needed in the order in which they occur in the
+  kernel.
 
 **[8]** The API exposed by the :code:`sample_result` data type allows one to extract
 the information contained at a variety of levels and for each available 

--- a/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
+++ b/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
@@ -191,66 +191,66 @@ should produce
     Setting `explicit_measurements` option
     { 0:479 1:521 }
 
-Here we see that we have measured a qubit in a uniform superposition to a 
-register named :code:`reg1`, and followed it with a reset and the application 
-of an NOT operation. By default the :code:`sample_result` returned for this 
-sampling tasks contains the default :code:`__global__` register as well as the 
-user specified :code:`reg1` register. 
+This kernel measures a qubit in a uniform superposition to a register named
+:code:`reg1`, resets it, and applies an X operation. By default, the
+:code:`sample_result` contains the default :code:`__global__` register and the
+user-specified :code:`reg1` register.
 
 The contents of the :code:`__global__` register will depend on how your kernel
 is written:
 
-1. If no measurements appear in the kernel, then the :code:`__global__` 
-   register is formed with implicit measurements being added for *all* the 
-   qubits defined in the kernel, and the measurements all occur at the end of 
-   the kernel. This is not supported when sampling with the 
-   :code:`explicit_measurements` option; kernels executed with 
-   :code:`explicit_measurements` mode must contain measurements.   
+1. If no measurements appear in the kernel, then the :code:`__global__`
+   register is formed with implicit measurements being added for the qubits
+   that remain in the compiled kernel, and the measurements all occur at the
+   end of the kernel. This is not supported when sampling with the
+   :code:`explicit_measurements` option; kernels executed with
+   :code:`explicit_measurements` mode must contain measurements.
    The order of the bits in the bitstring corresponds to the qubit
-   allocation order specified in the kernel.  That is - the :code:`[0]` element
-   in the :code:`__global__` bitstring corresponds with the first declared qubit
-   in the kernel. For example,
+   allocation order specified in the kernel, for qubits that remain in the
+   compiled kernel. That is - the :code:`[0]` element in the
+   :code:`__global__` bitstring corresponds with the first remaining declared
+   qubit in the kernel. For example,
 
-.. tab:: C++ 
+.. tab:: C++
 
    .. code-block:: cpp
 
        auto kernel = []() __qpu__ {
-         cudaq::qubit a, b;
+         cudaq::qubit a;
          x(a);
        };
        cudaq::sample(kernel).dump();
 
-.. tab:: Python 
+.. tab:: Python
 
-  .. code-block:: python 
+  .. code-block:: python
 
-    @cudaq.kernel 
+    @cudaq.kernel
     def kernel():
-        a, b = cudaq.qubit(), cudaq.qubit() 
-        x(a) 
-    
-    cudaq.sample(kernel).dump() 
+        a = cudaq.qubit()
+        x(a)
 
-should produce 
+    cudaq.sample(kernel).dump()
 
-   .. code-block:: bash 
+should produce
 
-       { 
-         __global__ : { 10:1000 }
+   .. code-block:: bash
+
+       {
+         __global__ : { 1:1000 }
        }
 
 2. Conversely, if any measurements appear in the kernel, then only the measured
-   qubits will appear in the :code:`__global__` register. Similar to #1, the 
+   qubits will appear in the :code:`__global__` register. Similar to #1, the
    bitstring corresponds to the qubit allocation order specified in the kernel.
-   Also (again, similar to #1), the values of the sampled qubits always 
-   correspond to the values *at the end of the kernel execution*, unless the 
-   :code:`explicit_measurements` option is enabled. That is - if a qubit is 
+   Also (again, similar to #1), the values of the sampled qubits always
+   correspond to the values *at the end of the kernel execution*, unless the
+   :code:`explicit_measurements` option is enabled. That is - if a qubit is
    measured in the middle of a kernel and subsequent operations change the state
-   of the qubit, the qubit will be implicitly re-measured at the end of the 
-   kernel, and that re-measured value is the value that will appear in the 
-   :code:`__global__` register. If the sampling option :code:`explicit_measurements` 
-   is enabled, then no re-measurements occur, and the global register contains 
+   of the qubit, the qubit will be implicitly re-measured at the end of the
+   kernel, and that re-measured value is the value that will appear in the
+   :code:`__global__` register. If the sampling option :code:`explicit_measurements`
+   is enabled, then no re-measurements occur, and the global register contains
    the concatenated measurements in the order they were executed in the kernel.
 
 .. tab:: C++ 
@@ -300,12 +300,13 @@ should produce
 
 .. note::
 
-  If you don't specify any measurements in your kernel and allow the :code:`nvq++`
-  compiler to perform passes that introduce ancilla qubits into your kernel, it
-  may be difficult to discern which qubits are the ancilla qubits vs which ones
-  are your qubits. In this case, it is recommended that you provide explicit
-  measurements in your kernel in order to only receive measurements from your
-  qubits and silently discard the measurements from the ancillary qubits.
+  Allocating a qubit does not require the compiler to preserve it. For example,
+  if a kernel allocates two qubits but only operates on one, the other qubit
+  may not appear in the implicit measurement results. If a program requires a
+  stable result format, measure the required qubits explicitly into named
+  registers and read those registers from the :code:`sample_result`. Use the
+  :code:`explicit_measurements` option only when measurement results are needed
+  in the order in which they occur in the kernel.
 
 **[8]** The API exposed by the :code:`sample_result` data type allows one to extract
 the information contained at a variety of levels and for each available 

--- a/docs/sphinx/specification/quake-dialect.md
+++ b/docs/sphinx/specification/quake-dialect.md
@@ -14,8 +14,8 @@ only two distinguishable states, i.e., it is a two-state quantum mechanical
 system such as a spin-1/2 particle.
 
 Conceptually, a _quantum operator_ is an effect that might modify the state
-of a subset of qubits. Most often, this effect is unitary evolution---in
-this case, we say that the operator is a _unitary_.  The number of target
+of a subset of qubits. Most often, this effect is unitary evolution. In this
+case, we say that the operator is a _unitary_.  The number of target
 qubits an operator acts upon is an intrinsic property.
 
 A _quantum instruction_ is the embodiment of a quantum operator when applied
@@ -35,33 +35,36 @@ values. These values are not truly SSA values, however, as operations
 still have side-effects on the value itself and the value cannot be
 copied.
 
-Let's see an example to clarify the distinction between the models.  Take the
+Let's see an example to clarify the distinction between the models. Take the
 following Quake implementation of some toy quantum computation:
 
-```cpp
-func.func foo(%veq : !quake.veq<2>) {
-    // Boilerplate to extract each qubit from the vector
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %q0 = quake.extract_ref %veq[%c0] : (!quake.veq<2>, index) -> !quake.ref
-    %q1 = quake.extract_ref %veq[%c1] : (!quake.veq<2>, index) -> !quake.ref
+```mlir
+func.func @foo(%veq: !quake.veq<2>)
+    -> !cc.stdvec<!quake.measure> {
+  // Boilerplate to extract each qubit from the vector
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %q0 = quake.extract_ref %veq[%c0]
+      : (!quake.veq<2>, index) -> !quake.ref
+  %q1 = quake.extract_ref %veq[%c1]
+      : (!quake.veq<2>, index) -> !quake.ref
 
-    // We apply some operators to those extracted qubits
-    // ... bunch of operators using %q0 and %q1 ...
-    quake.h %q0 : (!quake.ref) -> ()
+  // We apply an operator to the first extracted qubit
+  quake.h %q0 : (!quake.ref) -> ()
 
-    // We decide to measure the vector
-    %result = quake.mz %veq : (!quake.veq<2>) -> cc.stdvec<i1>
+  // We decide to measure the vector
+  %result = quake.mz %veq
+      : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 
-    // And then apply another Hadamard to %q0
-    quake.h %q0 : (!quake.ref) -> ()
-    // ...
+  // And then apply another Hadamard to %q0
+  quake.h %q0 : (!quake.ref) -> ()
+  return %result : !cc.stdvec<!quake.measure>
 }
 ```
 
-Now imagine we want to optimize this code by removing pair of adjacent
-adjoint operators, e.g., if we have a pair Hadamard operations next to each
-other on the same qubit---visually:
+Now imagine we want to optimize this code by removing a pair of adjacent
+adjoint operators. For example, consider a pair of Hadamard operations next to
+each other on the same qubit:
 
 ```text
     ┌───┐ ┌───┐         ┌───┐
@@ -69,15 +72,17 @@ other on the same qubit---visually:
     └───┘ └───┘         └───┘
 ```
 
-Where `I` is the identity operator. Now note that a naive implementation of
-this optimization for Quake would optimize away both `quake.h` operators
-being applied to `%q0`.  Such an implementation would have missed the fact
-that a measurement is being applied to the vector, `%veq`, which contains
-`%q0`.
+Here, `I` is the identity operator. Now note that a naive implementation of
+this optimization for Quake would optimize away both `quake.h` operators being
+applied to `%q0`. Such an implementation would have missed the fact that a
+measurement is being applied to the vector, `%veq`, which contains the qubit
+referenced by `%q0`.
 
 Of course it is possible to correctly implement this optimization for Quake.
-However such an implementation would be quite error-prone and require
-complex analyses.  For this reason, Quake has overloaded gates.
+However such an implementation would be quite error-prone and require complex
+analyses. For this reason, Quake has overloaded gates. Reference and value
+forms can coexist within the same function body and, where supported, on a
+single quantum operation.
 
 In the value model operators consume values and return new values:
 
@@ -95,56 +100,113 @@ We can visualize the difference between memory and value representation as:
         └──┘ └──┘     └──┘                  └──┘       └──┘     └──┘
 ```
 
-If we look at the implementation again, we notice that the problem
-with the naive optimization happens because the Hadamard operators are
-implicitly connected by the same value `%q0`. In value form, all the gates
-are explicitly connected by distinct values, which eliminates the need
-to do further analysis via implicit side-effects.
-The following is the implementation in value form.
+If we look at the implementation again, we notice that the problem with the
+naive optimization happens because the Hadamard operators are implicitly
+connected by the same reference `%q0`, while the measurement reaches that
+reference through `%veq`. In value form, all the gates are explicitly
+connected by distinct values, which eliminates the need to do further analysis
+via implicit side-effects. The following is the implementation in value form.
 
-```text
-func.func @foo(%array : !quake.qvec<2>) {
-    // Boilerplate to extract each qubit
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %r0 = quake.extract_ref %array[%c0] : (!quake.qvec<2>, index) -> !quake.qref
-    %r1 = quake.extract_ref %array[%c1] : (!quake.qvec<2>, index) -> !quake.qref
-
-    // Unwrap the quantum references to expose the wires.
-    %q0 = quake.unwrap %r0 : (!quake.qref) -> !quake.wire
-    %q1 = quake.unwrap %r1 : (!quake.qref) -> !quake.wire
-
-    // Misc. operators applied
-    %q0_M = quake.h %q0_L : (!quake.wire) -> !quake.wire
-
-    // Re-wrap the wire to its original source
-    quake.wrap %q0_M to %r0 : !quake.wire, !quake.qref
-    quake.wrap %q1_X to %r1 : !quake.wire, !quake.qref
-
-    // Measure the entire vector of quantum references
-    %result = quake.mz %array : (!quake.qvec<2>) -> !cc.stdvec<i1>
-
-    // Unwrap the wire for qubit 0 again
-    %q0_P = quake.unwrap %r0 : (!quake.qref) -> !quake.wire
-    ...
-    %q0_Z = quake.h %q0_Y : (!quake.wire) -> !quake.wire
-    // Re-wrap the wire back to the original reference
-    quake.wrap %q0_Z to %r0 : !quake.wire, !quake.qref
-    return
+```mlir
+func.func @foo_value(%q0: !quake.wire, %q1: !quake.wire)
+    -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire) {
+  %q0_after_first_h = quake.h %q0
+      : (!quake.wire) -> !quake.wire
+  %result, %after_measurement:2 = quake.mz %q0_after_first_h, %q1
+      : (!quake.wire, !quake.wire)
+        -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire)
+  %q0_after_second_h = quake.h %after_measurement#0
+      : (!quake.wire) -> !quake.wire
+  return %result, %q0_after_second_h, %after_measurement#1
+      : !cc.stdvec<!quake.measure>, !quake.wire, !quake.wire
 }
 ```
 
-In this code we can more straightforwardly see that the Hadamard
-operators cannot cancel each other.  One way of reasoning about this
-is as follows: In value form we need to follow a chain of values to
-know the qubit operators are being applied to, in this example:
+In this code we can more straightforwardly see that the Hadamard operators
+cannot cancel each other. One way of reasoning about this is as follows: In
+value form we need to follow a chain of values to know which qubit the
+operators are being applied to, in this example:
 
 ```text
-Mmeory                          Value
-    %q0         [%q0_0, %q0_1 ... %q0_L, %q0_M; %q0_P ... %q0_Y, %q0_Z]
-
+%q0
+  -> quake.h  -> %q0_after_first_h
+  -> quake.mz -> %after_measurement#0
+  -> quake.h  -> %q0_after_second_h
 ```
 
-We know that one Hadamard is applied to `%q0_L` and generates `%q0_M`, and
-the other is applied `%q0_Y` and generates `%q0_Z`.  Hence, there is no
-connection between them---which means they cannot cancel each other out.
+We know that one Hadamard is applied to `%q0` and generates
+`%q0_after_first_h`, the measurement consumes that value and generates
+`%after_measurement#0`, and the other Hadamard is applied to
+`%after_measurement#0` and generates `%q0_after_second_h`. Hence, the
+measurement lies between them, which means they cannot cancel each other out.
+
+The example threads each wire from a function argument through every operation
+that uses it and then to a function result. Region-based control-flow
+operations similarly thread wires through their region arguments and return
+updated wires as operation results. For example, a `cc.if` passes `%q` into
+both regions as `%arg`, and each region returns the wire produced by its gate:
+
+```mlir
+func.func @conditional(%condition: i1, %q: !quake.wire) -> !quake.wire {
+  %updated:1 = cc.if (%condition) ((%arg = %q)) -> (!quake.wire) {
+    %then = quake.h %arg : (!quake.wire) -> !quake.wire
+    cc.continue %then : !quake.wire
+  } else {
+    %else = quake.x %arg : (!quake.wire) -> !quake.wire
+    cc.continue %else : !quake.wire
+  }
+  return %updated#0 : !quake.wire
+}
+```
+
+Only the selected region consumes `%arg` at runtime. In a control-flow graph,
+branches instead pass wires as branch operands to successor block arguments. A
+conditional branch may pass the same wire to both successors because only the
+selected path consumes it. Transformations must preserve this threading when
+rewriting control flow.
+
+Value semantics applies when the individual qudits can be represented
+explicitly. Reference semantics remains useful for dynamically sized
+collections and runtime-selected elements. A transformation must account for
+the representation it accepts rather than assume that every program can be
+freely converted between the two forms.
+
+```{only} compiler_developer_docs
+See {ref}`Developing compiler passes <compiler-pass-input-output-ir>` for more
+detail.
+```
+
+## Calling between reference and value forms
+
+`quake.unwrap` obtains the current wire from a `!quake.ref`, and `quake.wrap`
+writes the updated wire back to that reference. A reference-form function can
+use these operations when it calls a value-form function:
+
+```mlir
+func.func private @value_kernel(!quake.wire) -> !quake.wire
+
+func.func @call_value_kernel(%q: !quake.ref) {
+  %wire = quake.unwrap %q : (!quake.ref) -> !quake.wire
+  %updated = call @value_kernel(%wire)
+      : (!quake.wire) -> !quake.wire
+  quake.wrap %updated to %q : !quake.wire, !quake.ref
+  return
+}
+```
+
+In the other direction, `quake.call_by_ref` lets value-form code call a
+function whose quantum parameters use reference semantics. The operation
+returns the updated wire after the call:
+
+```mlir
+func.func private @reference_kernel(!quake.ref)
+
+func.func @call_reference_kernel(%q: !quake.wire) -> !quake.wire {
+  %updated = quake.call_by_ref @reference_kernel(%q)
+      : (!quake.wire) -> !quake.wire
+  return %updated : !quake.wire
+}
+```
+
+For a call with ordinary results, `quake.call_by_ref` appends each updated
+wire or cable to the result list.

--- a/docs/sphinx/using/examples/executing_kernels.rst
+++ b/docs/sphinx/using/examples/executing_kernels.rst
@@ -37,6 +37,12 @@ Quantum states collapse upon measurement and hence need to be sampled many times
 
 Note that there is a subtle difference between how `sample` is executed with the target device set to a simulator or with the target device set to a QPU. In simulation mode, the quantum state is built once and then sampled :math:`s` times where :math:`s` equals the `shots_count`. In hardware execution mode, the quantum state collapses upon measurement and hence needs to be rebuilt over and over again.
 
+When the ``explicit_measurements`` option is not set, ``sample`` reports final
+measurements for the qubits that remain live after the selected target compiles
+the kernel. If your program depends on a stable output bit schema, measure those
+qubits explicitly. See the :ref:`sample specification <cudaq-sample-spec>` for
+details.
+
 There are a number of helpful tools that can be found in the `API docs <https://nvidia.github.io/cuda-quantum/latest/api/languages/python_api>`_ to process the `Sample_Result` object produced by `sample`.
 
 Sample Asynchronous

--- a/docs/sphinx/using/examples/sample_vs_run.rst
+++ b/docs/sphinx/using/examples/sample_vs_run.rst
@@ -52,8 +52,10 @@ before. This includes implicit measurements, explicit measurements without
 conditionals, partial qubit measurement, mid-circuit measurement for
 reset patterns, and the ``explicit_measurements`` option (which concatenates all
 measurement results in execution order rather than re-measuring at the end of
-the kernel -- see the :ref:`sample specification <cudaq-sample-spec>` for
-details).
+the kernel). If your program depends on a stable output bit schema, measure the
+required qubits explicitly rather than relying on the default ``__global__``
+bit positions. See the :ref:`sample specification <cudaq-sample-spec>` for
+details.
 
 .. tab:: Python
 

--- a/docs/sphinx/using/extending/compiler/available_passes.md
+++ b/docs/sphinx/using/extending/compiler/available_passes.md
@@ -1,0 +1,28 @@
+---
+orphan: true
+---
+
+# Available compiler passes
+
+The CUDA-Q compiler pass catalog is generated from the Transform and
+code-generation `Passes.td` definitions during the documentation build. It
+records each built-in pass's textual argument, description, and options.
+Operation anchors and other implementation details remain in the TableGen
+definitions. The catalog does not assign passes to target stages because target
+pipelines compose passes according to their own IR requirements.
+
+See {doc}`Developing compiler passes <mlir_pass>` for the workflow used to
+design, implement, test, and integrate a pass.
+
+## Built-in passes
+
+```{contents} Pass index
+:local:
+:depth: 1
+```
+
+```{include} /_mdgen/Transforms.md
+```
+
+```{include} /_mdgen/CodeGenPasses.md
+```

--- a/docs/sphinx/using/extending/compiler/cudaq_ir.rst
+++ b/docs/sphinx/using/extending/compiler/cudaq_ir.rst
@@ -26,6 +26,13 @@ For an agreed IR change, state the operations and forms that the transformation
 accepts, the properties it preserves, and the IR it produces. Record these
 expectations in the implementation and its tests.
 
+.. only:: compiler_developer_docs
+
+   See the |compiler pass development guide| for guidance on documenting and
+   testing these expectations in a built-in or external pass. The
+   |available compiler passes| page lists the registered CUDA-Q passes and their
+   options.
+
 CUDA-Q dialects
 ===============
 

--- a/docs/sphinx/using/extending/compiler/index.rst
+++ b/docs/sphinx/using/extending/compiler/index.rst
@@ -40,8 +40,15 @@ pipeline.
   see the :doc:`Quake semantic specification
   <../../../specification/quake-dialect>`.
 * See :doc:`pass_plugins` for the existing external pass plugin interface.
-* The opt-in compiler developer build also provides generated operation and
-  type references in the |CUDA-Q dialect documentation|.
+
+.. only:: compiler_developer_docs
+
+   * Browse the |CUDA-Q dialect documentation| for generated operation and type
+     references.
+   * Follow the |compiler pass development guide| to implement, test, and
+     integrate a compiler pass.
+   * Browse |available compiler passes| for the generated catalog of registered
+     CUDA-Q transformation and code generation passes and their options.
 
 .. rubric:: Code organization
 

--- a/docs/sphinx/using/extending/compiler/mlir_pass.rst
+++ b/docs/sphinx/using/extending/compiler/mlir_pass.rst
@@ -1,0 +1,384 @@
+:orphan:
+
+Developing compiler passes
+**************************
+
+CUDA-Q represents its compiler IR using MLIR and uses the MLIR pass manager to
+schedule work over the mixed-dialect IR described in :doc:`cudaq_ir`. A compiler
+pass is a scheduled unit of work over an MLIR operation. It should run at a
+defined IR boundary and clearly document the valid input IR and the IR it leaves
+for the next compiler step. This includes the required operations, types,
+attributes, and structural properties, along with the output guarantees and
+failure conditions.
+
+The `MLIR pass infrastructure <https://mlir.llvm.org/docs/PassManagement/>`_
+defines the scheduling, nesting, analysis, failure, and registration rules used
+by CUDA-Q passes.
+
+Decide whether a new pass is needed
+===================================
+
+Before adding a pass, review the :doc:`pass catalog <available_passes>` and
+check whether the change belongs in an existing pass that already works at the
+same point in the pipeline and on the same form of IR. Extend the existing pass
+when the new behavior is part of the same transformation and should run whenever
+that pass runs. Add a separate pass when the work needs independent scheduling,
+has its own options or diagnostics, is useful in other pipelines, or expects a
+different form of IR. A local simplification that is valid wherever an operation
+appears may be better expressed as folding or canonicalization.
+
+Identify where and when the pass will run
+=========================================
+
+Start with the producer and consumer of the IR rather than a pass name. Capture
+the IR immediately before the proposed transformation and identify the next
+component that depends on its result. Existing pipeline definitions and lit
+tests provide useful inputs, but they do not replace checking the operations,
+types, attributes, symbol relationships, and control flow that are present at
+that boundary.
+
+General-purpose optimization passes should stay within a single block when
+possible and use SSA use-def chains, operation traits, and interfaces to
+understand dependencies. Reading operations in textual order is not enough once
+the IR contains branches, loops, nested regions, or operations with unknown
+effects. Moving, combining, or canceling operations across those boundaries
+requires explicit reasoning about dominance, control flow, and effects. Such a
+pass should document the forms it supports and test branches, loops, joins, and
+multiple exits.
+
+Compilation stages
+------------------
+
+The following sections describe the current working boundaries between
+compiler stages. The CUDA-Q compiler team is still formalizing these stages and
+expanding their documentation.
+
+Frontend IR construction and early cleanup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Passes in this stage remove language-specific details and produce the
+mixed-dialect IR expected by the shared compiler pipelines. Frontend-specific
+passes may handle differences in IR construction, but passes after this
+boundary should accept equivalent C++ and Python kernel forms.
+
+High-level normalization and specialization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Passes in this stage expose calls, arguments, loops, and kernel variants that
+later transformations need. Each pass should state whether it requires calls to
+be inlined, arguments to be constant, loops to be normalized, or a particular
+kernel variant to have been selected.
+
+Quantum transformation and optimization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Passes in this stage change gates, measurements, allocations, and other quantum
+semantics. A pass should state whether it is target-independent or depends on a
+gate set, device topology, execution profile, or another target constraint.
+
+Every quantum optimization must preserve the computation represented by its
+input IR. A transformation with this property is *semantics-preserving*. A
+pass can produce valid IR and reduce gate counts or depth while still changing
+what the program does, so correctness must be considered separately from IR
+validity and optimization quality.
+
+The pass description should explain when the transformation is valid and what
+behavior it preserves. The implementation should apply the transformation only
+when it can establish those conditions from the IR. Other cases should remain
+unchanged or produce a diagnostic when the pipeline requires the
+transformation.
+
+For unitary IR, preserving the computation normally means implementing the same
+unitary. If a pass allows a different relation, such as equivalence up to global
+phase, equivalence under a known qubit mapping, or a bounded approximation, it
+should state that explicitly. Passes involving measurement or other
+non-unitary behavior should describe the observable behavior they preserve.
+
+Quantum optimizations that reason about gate order or quantum dependencies
+should use Quake's value form unless the transformation specifically needs
+Quake's reference semantics, for example to reason about allocation, lifetime,
+or aliasing. ``!quake.wire`` and ``!quake.cable`` are linear types, so their
+use-def chains expose how quantum state flows between operations without
+reconstructing aliases between ``!quake.ref`` and ``!quake.veq`` values. The
+:doc:`Quake semantic specification <../../../specification/quake-dialect>`
+explains the reference and value models and the boundaries formed by
+``quake.unwrap`` and ``quake.wrap``.
+
+Quantum optimization passes should use these value chains and Quake operation
+interfaces instead of reconstructing a circuit by scanning operations. They
+should preserve the exactly-once use of linear values. A pass that crosses a
+branch or region should thread quantum values through the relevant block
+arguments and region results and use the appropriate dominance, control-flow,
+and effect analyses.
+
+Pipeline integration should keep related quantum optimizations together in a
+value-form portion of the pipeline. A quantum optimization should not require
+its own ``memtoreg`` and ``regtomem`` round trip. If a downstream path requires
+reference form, the pipeline should convert after the value-form work is
+complete. A pass that intentionally accepts reference or mixed form should
+document why and test the relevant aliasing and conversion boundaries.
+
+IR form conversion and structural lowering
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Conversion passes move between structured control flow and control-flow graphs,
+memory and value forms, and CUDA-Q or upstream dialects. They should make both
+sides of the conversion explicit and keep semantic optimization separate from
+representation changes unless one requires the other.
+
+Target preparation, lowering, and emission
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Passes in this stage adapt the module to the selected target or execution
+profile and prepare the representation for final code emission. A pass should
+state which target constraints it depends on and what representation it
+produces for the next compiler step or emitter.
+
+.. _compiler-pass-input-output-ir:
+
+Identify the input and output IR
+================================
+
+Write a small before-and-after example that includes the operation containing
+the transformation. Prefer to scope the pass to one operation and its nested
+IR, such as a ``func.func``. Use a ``builtin.module`` pass only when the
+transformation must coordinate symbols or changes across several functions or
+other module-level operations. MLIR operation passes must not inspect or modify
+sibling operations outside their current operation.
+
+Mixed-dialect input is normal. The pass description should identify the
+compiler stage and IR form it expects, the assumptions that affect correctness
+or pipeline placement, and the form it produces. For a quantum optimization,
+this might include whether it consumes Quake reference or value semantics and
+whether it is target-independent. Focus on meaningful boundaries rather than
+enumerating every dialect, operation, or program feature that may appear.
+
+Define expected behavior
+========================
+
+The pass's TableGen ``description`` and regression tests should name the
+accepted input requirements, guaranteed output properties, behavior for input
+outside the match, and conditions that produce a diagnostic. Options need
+defaults and descriptions that make separate pass instances understandable in
+a textual pipeline.
+
+List a dialect in ``dependentDialects`` when the pass may create its operations,
+types, or attributes and that dialect is not otherwise guaranteed to be loaded.
+This lets the pass manager load dependencies before a multithreaded pipeline
+starts. Signal pass failure after emitting a diagnostic when the pass cannot
+produce its stated output. Do not leave invalid IR for a later pass to diagnose.
+
+Analyses are invalidated when a transformation changes IR unless the pass marks
+them preserved. A pass that mutates symbols, regions, types, or control flow
+should make that effect clear in its implementation and tests. Running
+``cudaq-opt`` with ``--verify-each`` is useful while establishing these output
+conditions.
+
+Choose the MLIR transformation mechanism
+========================================
+
+Use an operation's fold hook or canonicalization patterns for a local canonical
+form that is valid whenever the operation appears. For example, the
+``cc.cast`` canonicalizer removes a cast when its operand and result have the
+same type. This rule is local and always valid, so it does not need a dedicated
+pass.
+
+Use a rewrite pattern for a local DAG transformation whose match can decline
+without making the IR illegal. The
+`pattern rewriting framework <https://mlir.llvm.org/docs/PatternRewriter/>`_
+provides greedy and walk-based drivers. Mutate matched IR through the supplied
+``PatternRewriter`` so the driver can maintain its work queue and listeners.
+
+Use
+`dialect conversion <https://mlir.llvm.org/docs/DialectConversion/>`_ when the
+expected output is naturally expressed as legal and illegal operations or when
+types and region signatures must be converted. Choose full, partial, or
+analysis conversion according to the promised output. A full conversion is
+appropriate only when every illegal operation must be removed.
+
+Use an analysis when the work computes information without changing IR. Use an
+`operation or dialect interface <https://mlir.llvm.org/docs/Interfaces/>`_ when
+an algorithm needs behavior supplied by several operation kinds without a
+central type switch. Use a dedicated operation pass when the work must be
+scheduled in a pipeline, expose options, emit diagnostics, or coordinate a
+bounded set of rewrites, conversions, and analyses. These mechanisms are often
+components of the pass rather than alternatives to it.
+
+Implement and register a built-in pass
+======================================
+
+General transformations are declared in
+``cudaq/include/cudaq/Optimizer/Transforms/Passes.td``. Passes whose primary
+responsibility is final lowering and code generation are declared in
+``cudaq/include/cudaq/Optimizer/CodeGen/Passes.td``.
+
+Add a TableGen definition for the pass. The definition identifies its
+command-line name and operation anchor, documents the expected input and output,
+and declares any dependent dialects or options. This example defines a
+``func.func`` pass that can create Quake and control-flow operations:
+
+.. :spellcheck-disable:
+
+.. code:: tablegen
+
+   def ExampleRewrite : Pass<"example-rewrite", "mlir::func::FuncOp"> {
+     let summary = "Rewrite the example form.";
+     let description = [{
+       Describe the accepted input, the guaranteed output, and failure cases.
+     }];
+     let dependentDialects = ["cudaq::quake::QuakeDialect",
+                              "mlir::cf::ControlFlowDialect"];
+     let options = [
+       Option<"strict", "strict", "bool", /*default=*/"false",
+              "Diagnose input outside the supported form.">
+     ];
+   }
+
+.. :spellcheck-enable:
+
+TableGen generates the base class, factories, option storage, registration
+functions, and catalog entry. The implementation selects its generated base in
+the corresponding ``.cpp`` file:
+
+.. :spellcheck-disable:
+
+.. code:: cpp
+
+   #include "PassDetails.h"
+   #include "cudaq/Optimizer/Transforms/Passes.h"
+
+   namespace cudaq::opt {
+   #define GEN_PASS_DEF_EXAMPLEREWRITE
+   #include "cudaq/Optimizer/Transforms/Passes.h.inc"
+   } // namespace cudaq::opt
+
+   namespace {
+   class ExampleRewritePass
+       : public cudaq::opt::impl::ExampleRewriteBase<ExampleRewritePass> {
+   public:
+     using ExampleRewriteBase::ExampleRewriteBase;
+     void runOnOperation() override;
+   };
+
+   void ExampleRewritePass::runOnOperation() {
+     // Check the input requirements, perform the rewrite, and signal failure when
+     // the promised output cannot be produced.
+   }
+   } // namespace
+
+.. :spellcheck-enable:
+
+Add the implementation file to ``OptTransforms`` or ``OptCodeGen`` in the
+corresponding ``cudaq/lib/Optimizer`` CMake file. A normal declarative pass does
+not need a handwritten registration call. ``cudaq-opt`` calls
+``cudaq::registerAllPasses()``, which registers both generated CUDA-Q pass sets
+and the registered CUDA-Q pipelines. Add an explicit declaration to
+``Passes.h`` only when callers need a helper or factory overload that TableGen
+does not generate.
+
+Build and run the pass
+======================
+
+Rebuild the optimizer after changing a TableGen record or implementation:
+
+.. :spellcheck-disable:
+
+.. code:: bash
+
+   cmake --build build --target cudaq-opt -j8
+
+.. :spellcheck-enable:
+
+Run the pass on the smallest IR that exercises its expected behavior. An
+explicit pipeline makes the operation nesting and options visible:
+
+.. :spellcheck-disable:
+
+.. code:: bash
+
+   build/bin/cudaq-opt \
+     --pass-pipeline='builtin.module(func.func(example-rewrite{strict=true}))' \
+     input.qke -o -
+
+.. :spellcheck-enable:
+
+Nest the pass under the operation named by its definition. A module pass runs
+directly under ``builtin.module``. A function pass must run under the matching
+``func.func`` or ``llvm.func`` operation manager. Use
+``--dump-pass-pipeline`` to inspect the resulting pipeline, ``--verify-each``
+to find the first pass that produces invalid IR, and
+``--mlir-print-ir-before=<pass-argument>`` or
+``--mlir-print-ir-after=<pass-argument>`` to examine the IR around a selected
+transformation. The ``--mlir-print-ir-before-all`` and
+``--mlir-print-ir-after-all`` variants print around every pass. ``cudaq-opt
+--help`` lists the passes and pipelines available in the current build. The
+:doc:`available pass catalog <available_passes>` documents CUDA-Q's built-in
+passes and their options.
+
+Test pass behavior
+==================
+
+Compiler pass regressions normally belong under ``cudaq/test/Transforms`` as
+small textual IR tests. Use ``cudaq-opt`` in a ``RUN`` line and ``FileCheck`` to
+verify the relevant IR structure. Include the shortest positive case, important
+input outside the match that must remain unchanged, option-dependent behavior,
+and the boundary forms described by the pass. Check diagnostics with
+``-verify-diagnostics``. ``-split-input-file`` keeps independent positive or
+negative cases in one file when that improves readability.
+
+Validate quantum transformations
+--------------------------------
+
+Tests for a quantum transformation should show both that the intended rewrite
+occurred and that the computation was preserved. Use ``FileCheck`` to check the
+resulting IR. For bounded unitary IR supported by ``CircuitCheck``, use
+``CircuitCheck`` to compare the original and transformed functions. Use
+``--up-to-global-phase`` or ``--up-to-mapping`` only when the pass explicitly
+claims that form of equivalence.
+
+Include representative transformations, the conditions on which they depend,
+and nearby inputs that must remain unchanged. ``CircuitCheck`` does not support
+every form of quantum IR, so transformations outside its scope need tests
+appropriate to the behavior they preserve. Simulation and sampling can expose
+defects, but agreement on selected inputs does not establish correctness for
+every supported input.
+
+Test the pass directly before adding a pipeline test. Add a pipeline-level test
+when correctness depends on a predecessor, successor, option forwarding, or
+operation nesting. A target test is justified when behavior depends on target
+configuration or final emission rather than the pass's textual IR
+boundary. These choices follow the distinction in the
+`MLIR testing guide <https://mlir.llvm.org/getting_started/TestingGuide/>`_
+between focused transformation tests and more expensive integration tests.
+
+The configured build exposes the full lit target and supports filtered local
+runs. Activate the Python environment used to configure CMake before invoking
+``llvm-lit`` directly:
+
+.. :spellcheck-disable:
+
+.. code:: bash
+
+   cmake --build build --target check-cudaq
+   python "$LLVM_INSTALL_PREFIX/bin/llvm-lit" -sv \
+     --filter example-rewrite build/cudaq/test
+
+.. :spellcheck-enable:
+
+Integrate with a pipeline
+=========================
+
+Keep a pass independently runnable even when its production use is in a
+pipeline. Add it to a shared pipeline only when every target using that pipeline
+produces the pass's expected input and needs its output. Test the pass directly
+before adding a pipeline-level test for its surrounding transformations and any
+option forwarding. When placement depends on a target or output format, also
+test the relevant target configuration or final emission path.
+
+Develop an external pass plugin
+===============================
+
+Passes maintained outside the CUDA-Q source tree follow the same design and
+testing guidance, but are built and registered as shared-library plugins. See
+:doc:`External compiler pass plugins <pass_plugins>` for the plugin interface,
+the maintained example, and the ``cudaq-opt`` loading workflow.

--- a/docs/sphinx/using/extending/compiler/pass_plugins.rst
+++ b/docs/sphinx/using/extending/compiler/pass_plugins.rst
@@ -1,97 +1,74 @@
-Create your own CUDA-Q Compiler Pass 
-******************************************
+.. _external-compiler-pass-plugins:
 
-The CUDA-Q IR can be transformed, analyzed, or optimized 
-using standard MLIR patterns and tools. CUDA-Q provides a registration 
-mechanism for the :code:`cudaq-opt` tool that allows one to create, load, and 
-use custom MLIR passes on Quake code. 
+External compiler pass plugins
+******************************
 
-CUDA-Q MLIR Passes can only be created within an existing CUDA-Q 
-development environment. Therefore, you must clone the repository and add your 
-Pass code as part of the existing CUDA-Q CMake system. 
+``cudaq-opt`` can load a custom MLIR operation pass from a shared library. This
+keeps the pass outside CUDA-Q's built-in pass catalog and production pipelines
+while allowing it to transform CUDA-Q IR with the same MLIR APIs used by
+built-in passes.
 
-As an example, clone the repository and add the following directory structure 
-under :code:`lib`, :code:`lib/Plugins/MyCustomPlugin/`. Within this directory create a 
-:code:`CMakeLists.txt` file and a :code:`MyCustomPlugin.cpp` file. In the CMake file, 
-add the following: 
+.. only:: compiler_developer_docs
 
-.. code:: cmake 
+   See the |compiler pass development guide| for guidance on choosing an
+   operation anchor, defining the accepted IR, and testing a transformation.
 
-    add_llvm_pass_plugin(MyCustomPlugin MyCustomPlugin.cpp)
+CUDA-Q currently builds and tests pass plugins within a CUDA-Q development
+build. A plugin must use CUDA-Q, LLVM, and MLIR headers and libraries compatible
+with the ``cudaq-opt`` binary that loads it. Rebuild the plugin when those
+dependencies change.
 
-Creating a CUDA-Q IR pass starts with the implementation of an 
-:code:`mlir::OperationPass`. A full discussion of the MLIR Pass infrastructure 
-is beyond the scope of this document; please see 
-`MLIR Passes <https://mlir.llvm.org/docs/PassManagement>`_. To create such 
-a pass, start with the following template in the :code:`MyCustomPlugin.cpp` file:
+Implement and register the pass
+===============================
 
-.. code:: cpp 
-    
-    #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
-    #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
-    #include "cudaq/Support/Plugin.h"
-    #include "mlir/Rewrite/FrozenRewritePatternSet.h"
-    #include "mlir/Transforms/DialectConversion.h"
+A plugin pass is an MLIR operation pass with a textual argument. Include
+``cudaq/Support/Plugin.h`` and place ``CUDAQ_REGISTER_MLIR_PASS`` at file scope
+after the pass definition. The macro exports the CUDA-Q plugin entry point and
+registers one default-constructible pass.
 
-    // Here is an example MLIR Pass that one can write externally and 
-    // use via the cudaq-opt tool, with the --load-cudaq-plugin flag. 
-    // The pass here is simple, replace Hadamard operations with S operations. 
+The complete example below is included from the source compiled by the plugin
+test target. It replaces each ``quake.h`` operation with
+``quake.s`` so that the regression can observe the transformation. This example
+demonstrates plugin registration and does not preserve circuit semantics.
 
-    using namespace mlir;
+.. literalinclude:: ../../../../../cudaq/test/plugin/CustomPassPlugin.cpp
+   :language: cpp
 
-    namespace {
+Build the plugin
+================
 
-    struct ReplaceH : public OpRewritePattern<cudaq::quake::HOp> {
-      using OpRewritePattern::OpRewritePattern;
-      LogicalResult matchAndRewrite(cudaq::quake::HOp hOp,
-                                    PatternRewriter &rewriter) const override {
-        rewriter.replaceOpWithNewOp<cudaq::quake::SOp>(
-            hOp, hOp.isAdj(), hOp.getParameters(), hOp.getControls(),
-            hOp.getTargets());
-        return success();
-      }
-    };
+The tested CMake target uses LLVM's pass-plugin helper and depends on the
+generated Quake dialect headers:
 
-    class CustomPassPlugin
-        : public PassWrapper<CustomPassPlugin, OperationPass<func::FuncOp>> {
-    public:
-      MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CustomPassPlugin)
-  
-      llvm::StringRef getArgument() const override { return "cudaq-custom-pass"; }
+.. :spellcheck-disable:
 
-      void runOnOperation() override {
-        auto circuit = getOperation();
-        auto ctx = circuit.getContext();
+.. literalinclude:: ../../../../../cudaq/test/plugin/CMakeLists.txt
+   :language: cmake
 
-        RewritePatternSet patterns(ctx);
-        patterns.insert<ReplaceH>(ctx);
-        ConversionTarget target(*ctx);
-        target.addLegalDialect<cudaq::quake::QuakeDialect>();
-        target.addIllegalOp<cudaq::quake::HOp>();
-        if (failed(applyPartialConversion(circuit, target, std::move(patterns)))) {
-          circuit.emitOpError("simple pass failed");
-          signalPassFailure();
-        }
-      }
-    };
+Build that target from a configured CUDA-Q build tree:
 
-    } // namespace
+.. code:: bash
 
-    CUDAQ_REGISTER_MLIR_PASS(CustomPassPlugin)
+   cmake --build build --target CustomPassPlugin
 
-This example serves as a very simple template for creating custom MLIR 
-Passes that analyze the CUDA-Q Quake representation and perform 
-some general transformation. In this example, we create a rewrite pattern 
-that replaces :code:`Hadamard` operations with :code:`S` operations. 
+.. :spellcheck-enable:
 
-Ensure that :code:`add_subdirectory(Plugins)` is in the :code:`lib/CMakeLists.txt` file, 
-and also that there is a :code:`lib/Plugins/CMakeLists.txt` file that adds your 
-plugin directory with :code:`add_subdirectory`.
+Load and test the plugin
+========================
 
-Then build CUDA-Q and you will have a :code:`MyCustomPlugin.so` plugin library 
-in the install. You can load the plugin and use it with :code:`cudaq-opt` as follows: 
+Load the shared library before naming its registered pass. This Linux command
+uses the paths produced by the in-tree build:
 
-.. code:: bash 
+.. :spellcheck-disable:
 
-    cudaq-opt --load-cudaq-plugin MyCustomPlugin.so file.qke -cudaq-custom-pass
+.. code:: bash
 
+   build/bin/cudaq-opt input.qke \
+     --load-cudaq-plugin build/lib/CustomPassPlugin.so \
+     --cudaq-custom-pass
+
+.. :spellcheck-enable:
+
+A corresponding regression test loads the plugin into ``cudaq-opt`` and checks
+the transformed IR. The pass is registered only for that invocation and is not
+added to a CUDA-Q compilation pipeline.

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -72,6 +72,7 @@ doxygen_output_dir="$docs_build_output/doxygen"
 dialect_output_dir="$docs_build_output/Dialects"
 dialect_reference_names=(Quake CC QEC CodeGen)
 build_compiler_developer_docs="${CUDAQ_BUILD_COMPILER_DEVELOPER_DOCS:-0}"
+compiler_pass_reference_names=(Transforms CodeGenPasses)
 rm -rf "$docs_build_output"
 
 # Check if the cudaq Python package is installed and if not, build and install it
@@ -104,6 +105,13 @@ if [ ! "$cmake_exit_code" -eq "0" ]; then
     echo "CMake exit code: $cmake_exit_code"
     docs_exit_code=10
 elif [ "$build_compiler_developer_docs" = "1" ]; then
+    for pass_reference_name in "${compiler_pass_reference_names[@]}"; do
+        pass_reference_file="$docs_build_output/$pass_reference_name.md"
+        if [ ! -f "$pass_reference_file" ]; then
+            echo "Failed to generate the $pass_reference_name pass reference at $pass_reference_file."
+            docs_exit_code=10
+        fi
+    done
     for dialect_name in "${dialect_reference_names[@]}"; do
         dialect_reference_file="$dialect_output_dir/$dialect_name.md"
         if [ ! -f "$dialect_reference_file" ]; then
@@ -196,6 +204,13 @@ build_sphinx_docs() (
     fi
     if [ "$build_compiler_developer_docs" = "1" ]; then
         mkdir -p sphinx/_mdgen/Dialects
+        for pass_reference_name in "${compiler_pass_reference_names[@]}"; do
+            pass_reference_file="$docs_build_output/$pass_reference_name.md"
+            if ! cp "$pass_reference_file" "sphinx/_mdgen/$pass_reference_name.md"; then
+                echo "Failed to stage the $pass_reference_name pass reference."
+                return 10
+            fi
+        done
         for dialect_name in "${dialect_reference_names[@]}"; do
             dialect_reference_file="$dialect_output_dir/$dialect_name.md"
             if ! cp "$dialect_reference_file" "sphinx/_mdgen/Dialects/$dialect_name.md"; then


### PR DESCRIPTION
Closes #5016. This PR is based on #4930. 

It introduces developer guidance for developing on the CUDA-Q compiler. The intent is that this will be guidance for both human *and* agent developers. A pass development skill will soon follow that will refer to this documentation. We should provide guidance about best practice and how to develop. This is only a starting place but we should build on this as we go to improve and standardize development.

It introduces:
- A compiler development section to the extending subsection of the documentation (Should we rename this to developer guide?)
- A high-level introduction to the compiler.
- A section introducing the IRs.
- Hosted docs for the generated IR and pass documentations.
- A guide for writing passes.
- Updated for the Quake section of the specification docs to bring it up to date with current value/reference semantics.

Fixes #5016
