### PR TITLE
Adding support -E and fixing -MT, -MD, -MF

### DIFF
--- a/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -733,6 +733,12 @@ public:
     std::vector<std::string> targets;
     /// Whether to include system headers (-MD) or omit them (-MMD).
     bool includeSystemHeaders = false;
+    /// Canonical on-disk path of the main input file. clang::tooling maps the
+    /// source to a virtual file named after the (bare) input spelling, so the
+    /// dependency generator would otherwise record the main file under a
+    /// non-existent relative name. When set, that entry is rewritten to this
+    /// path so the emitted rule's prerequisite matches the real source.
+    std::string mainFileRealPath;
   };
 
   /// Constructor. \p depOpts is stored by reference and so must outlive this

--- a/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -13,12 +13,14 @@
 #include "clang/AST/ParentMapContext.h"
 #include "clang/Basic/TargetCXXABI.h"
 #include "clang/Basic/TargetInfo.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/DependencyOutputOptions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/IRMapping.h"
 #include <cxxabi.h>
@@ -37,6 +39,50 @@ using namespace mlir;
 // all, which will avoid any/all random crashes in the MLIR printer.
 llvm::cl::opt<unsigned> debugOpNameOnly("lower-ast-values", llvm::cl::init(0));
 
+namespace {
+/// A DependencyFileGenerator that rewrites every recorded prerequisite to its
+/// canonical on-disk path. cudaq-quake runs the frontend through
+/// clang::tooling, which distorts the paths clang would normally emit:
+///   - The main input is mapped to a virtual file named after the (bare) input
+///     spelling, so it is recorded as e.g. "main.cpp" instead of its real path.
+///   - libstdc++ headers are recorded with the search-directory spelling clang
+///     computed in the tooling context, which carries a bogus empty install
+///     prefix, e.g. "/../lib/gcc/.../../../../include/c++/13/cstddef".
+/// Both spellings still resolve on disk (the second via the /lib -> /usr/lib
+/// symlink), but once Ninja textually canonicalizes them they no longer stat,
+/// so every object is treated as perpetually out of date. Resolving each entry
+/// with real_path, and substituting the real main-file path, yields
+/// prerequisites Ninja can match.
+class CanonicalDependencyFileGenerator : public clang::DependencyFileGenerator {
+public:
+  CanonicalDependencyFileGenerator(const clang::DependencyOutputOptions &opts,
+                                   std::string mainFileVirtualName,
+                                   std::string mainFileRealPath)
+      : clang::DependencyFileGenerator(opts),
+        mainFileVirtualName(std::move(mainFileVirtualName)),
+        mainFileRealPath(std::move(mainFileRealPath)) {}
+
+  void maybeAddDependency(llvm::StringRef filename, bool fromModule,
+                          bool isSystem, bool isModuleFile,
+                          bool isMissing) override {
+    llvm::SmallString<256> resolved;
+    if (!mainFileRealPath.empty() && filename == mainFileVirtualName) {
+      resolved.assign(mainFileRealPath);
+    } else if (llvm::sys::fs::real_path(filename, resolved)) {
+      // real_path failed (e.g. a genuinely missing header): keep the original
+      // spelling so an -MP phony target is still emitted for it.
+      resolved.assign(filename);
+    }
+    clang::DependencyFileGenerator::maybeAddDependency(
+        resolved, fromModule, isSystem, isModuleFile, isMissing);
+  }
+
+private:
+  std::string mainFileVirtualName;
+  std::string mainFileRealPath;
+};
+} // namespace
+
 void cudaq::ASTBridgeAction::attachDependencyFileGenerator(
     clang::CompilerInstance &ci) {
   if (dependencyFileOptions.outputFile.empty())
@@ -53,7 +99,15 @@ void cudaq::ASTBridgeAction::attachDependencyFileGenerator(
     depOpts.Targets.push_back(dependencyFileOptions.outputFile);
   else
     depOpts.Targets = dependencyFileOptions.targets;
-  auto gen = std::make_shared<clang::DependencyFileGenerator>(depOpts);
+  // The virtual name clang::tooling mapped the main source to; used to rewrite
+  // that entry to the real path (see CanonicalDependencyFileGenerator).
+  std::string mainFileVirtualName;
+  const auto &inputs = ci.getFrontendOpts().Inputs;
+  if (!inputs.empty() && inputs.front().isFile())
+    mainFileVirtualName = inputs.front().getFile().str();
+  auto gen = std::make_shared<CanonicalDependencyFileGenerator>(
+      depOpts, std::move(mainFileVirtualName),
+      dependencyFileOptions.mainFileRealPath);
   gen->attachToPreprocessor(ci.getPreprocessor());
   ci.addDependencyCollector(gen);
 }

--- a/cudaq/test/NVQPP/depfile.cpp
+++ b/cudaq/test/NVQPP/depfile.cpp
@@ -16,6 +16,10 @@
 // RUN: nvq++ -c %s -o %t/default_md.o -MD -MT %t/default_md.o -MF %t/default_md.d -I%S/Inputs 
 // RUN: [ -e %t/default_md.o ] && [ -e %t/default_md.d ] 
 // RUN: cat %t/default_md.d | FileCheck %s --check-prefix=DEFAULT-MD
+// Guard against the non-canonical spellings clang::tooling would otherwise emit
+// (a bare relative main-file name and "/../"-prefixed system headers), which
+// stat as missing under Ninja and cause every object to rebuild forever.
+// RUN: not grep -F '/../' %t/default_md.d
 
 // Default target (cudaq-quake path): -MMD with a single -MT/-MF.
 // RUN: nvq++ -c %s -o %t/default_mmd.o -MMD -MT %t/default_mmd.o -MF %t/default_mmd.d -I%S/Inputs 
@@ -49,10 +53,13 @@
 
 int plain_old_function() { return cudaq_test_dep_value(); }
 
+// The main-file and project-header prerequisites must be recorded as absolute
+// paths (not the bare virtual name clang::tooling maps the in-memory source to,
+// nor a non-canonical spelling), so Ninja can stat them.
 // DEFAULT-MD: default_md.o:
-// DEFAULT-MD-DAG: depfile.cpp
+// DEFAULT-MD-DAG: {{ /[^ ]*depfile\.cpp }}
 // DEFAULT-MD-DAG: __stddef
-// DEFAULT-MD-DAG: Inputs/dep_header.h
+// DEFAULT-MD-DAG: {{ /[^ ]*Inputs/dep_header\.h}}
 
 // DEFAULT-MMD: default_mmd.o:
 // DEFAULT-MMD-DAG: depfile.cpp

--- a/cudaq/test/NVQPP/preprocess.cpp
+++ b/cudaq/test/NVQPP/preprocess.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Verify nvq++ -E (preprocess-only) delegates to the host preprocessor on both
+// compile paths: the default target (cudaq-quake) and orca-photonics library
+// mode.
+
+// RUN: rm -rf %t && mkdir -p %t
+
+// Default target: -E to stdout.
+// RUN: nvq++ -E %s -I%S/Inputs | FileCheck %s --check-prefix=STDOUT
+
+// Default target: -E with -o.
+// RUN: nvq++ -E %s -o %t/out.ii -I%S/Inputs
+// RUN: [ -e %t/out.ii ]
+// RUN: cat %t/out.ii | FileCheck %s --check-prefix=FILE
+
+// Orca-photonics (library mode): -E with -o.
+// RUN: nvq++ --target orca-photonics -E %s -o %t/orca.ii -I%S/Inputs
+// RUN: [ -e %t/orca.ii ]
+// RUN: cat %t/orca.ii | FileCheck %s --check-prefix=ORCA
+
+#include "dep_header.h"
+#include <cudaq.h>
+
+int plain_old_function() { return cudaq_test_dep_value(); }
+
+// STDOUT: # {{[0-9]+}} {{.*}}preprocess.cpp
+// STDOUT-DAG: plain_old_function
+// STDOUT-DAG: cudaq_test_dep_value
+
+// FILE: # {{[0-9]+}} {{.*}}preprocess.cpp
+// FILE-DAG: plain_old_function
+// FILE-DAG: cudaq_test_dep_value
+
+// ORCA: # {{[0-9]+}} {{.*}}preprocess.cpp
+// ORCA-DAG: plain_old_function
+// ORCA-DAG: cudaq_test_dep_value

--- a/cudaq/tools/cudaq-quake/cudaq-quake.cpp
+++ b/cudaq/tools/cudaq-quake/cudaq-quake.cpp
@@ -333,6 +333,16 @@ int main(int argc, char **argv) {
     else
       depFileOpts.targets.assign(dependencyTargets.begin(),
                                  dependencyTargets.end());
+    // The frontend runs through clang::tooling on an in-memory copy of the
+    // source mapped to a virtual (bare) name, so the dependency generator would
+    // record the main file under a non-existent relative path. Capture the real
+    // path here so that entry can be rewritten (see ASTBridge.cpp).
+    if (!isStdinInput(inputFilename)) {
+      SmallString<256> mainReal;
+      if (sys::fs::real_path(inputFilename, mainReal))
+        mainReal.assign(inputFilename);
+      depFileOpts.mainFileRealPath = std::string(mainReal);
+    }
   }
 
   ErrorOr<std::unique_ptr<MemoryBuffer>> fileOrError =

--- a/cudaq/tools/nvqpp/nvq++.in
+++ b/cudaq/tools/nvqpp/nvq++.in
@@ -289,6 +289,10 @@ function show_help {
 -c
 	Compile only. Do not link.
 
+-E
+	Preprocess only; do not compile, assemble, or link. Writes preprocessed
+	output to stdout, or to the file given by -o.
+
 -Wl<opt>
 	Linker options to be passed to the linker.
 
@@ -438,6 +442,7 @@ DEP_OUTPUT_FILE=
 DEP_TARGETS=
 MAPPING_FILE=
 DO_LINK=true
+PREPROCESS_ONLY=false
 SHOW_VERSION=false
 ENABLE_ARRAY_CONVERSION=true
 ENABLE_VARIABLE_COALESCE=true
@@ -719,6 +724,14 @@ while [ $# -ne 0 ]; do
 	-c)
 		DO_LINK=false
 		;;
+	-E)
+		# Preprocess only. ccache probes the compiler this way to build its
+		# manifest / hash the preprocessed TU. Handle it explicitly so it does
+		# not fall through to the catch-all (which would run the full
+		# quake+compile+link pipeline). Actual delegation happens below.
+		PREPROCESS_ONLY=true
+		DO_LINK=false
+		;;
 	-L* | -Wl* |-shared|-static)
 		LINKER_FLAGS="${LINKER_FLAGS} $1"
 		;;
@@ -980,6 +993,17 @@ if ${DEP_GEN} && [ -n "${DEP_OUTPUT_FILE}" ]; then
 	if ${DEP_SYSTEM_HEADERS}; then
 		CUDAQ_QUAKE_DEP_ARGS="${CUDAQ_QUAKE_DEP_ARGS} --dependency-system-headers"
 	fi
+fi
+
+# Preprocess-only mode (-E). Delegate to the host preprocessor with the same
+# defines/includes/args the real compile uses (mirrors the library-mode compile
+# at the top of the loop, minus -c/-o, plus -E). This makes ccache's
+# preprocessor probe succeed so it can cache nvq++ object output. All source
+# files are passed in one invocation to match clang's -E semantics (stdout when
+# no -o; clang itself errors on -o with multiple sources).
+if ${PREPROCESS_ONLY}; then
+	run ${CXX} ${CLANG_VERBOSE} ${CLANG_RESOURCE_DIR} ${COMPILER_FLAGS} ${PREPROCESSOR_DEFINES} ${INCLUDES} ${ARGS} -E ${OUTPUTOPTS} ${SRCS}
+	exit 0
 fi
 
 for i in ${SRCS}; do


### PR DESCRIPTION
With these changes, we are 

1. Adding support to `-E` (used by ccache) 
   This currently does not stop the compilation. With these changes, only `clang -E` is run, library mode or not.
 
2. Fixing the creation of dependency files.
    These were created using relative paths that the cmake based dependency checking may not be able to find resulting in always recompiling files. 

