### PR TITLE
Making run_tests.sh user friendly with -j and better OMP_NUM_THREADS support

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,7 +11,7 @@
 # Run CUDA-Q test suite (ctest + llvm-lit)
 # Used by both Linux and macOS CI, and for local development.
 #
-# Usage: bash scripts/run_tests.sh [-v] [-B build_dir]
+# Usage: bash scripts/run_tests.sh [-v] [-B build_dir] [-j num_jobs]
 #
 # Note: GPU tests will fail gracefully on macOS (no CUDA available)
 
@@ -20,11 +20,21 @@ source "$this_file_dir/set_env_defaults.sh"
 
 build_dir="build"
 verbose=""
+num_jobs=""
 
-while getopts ":vB:" opt; do
+while getopts ":vB:j:" opt; do
   case $opt in
     v) verbose="-v" ;;
     B) build_dir="$OPTARG" ;;
+    j) num_jobs="$OPTARG" ;;
+    :)
+      echo "::error::Option -$OPTARG requires an argument"
+      exit 1
+      ;;
+    \?)
+      echo "::error::Invalid option: -$OPTARG"
+      exit 1
+      ;;
   esac
 done
 
@@ -39,12 +49,27 @@ status_sum=0
 # Set PYTHONPATH to find the built cudaq module
 export PYTHONPATH="$build_dir/python:${PYTHONPATH:-}"
 
-# Determine number of parallel jobs (use all available CPUs)
+# Determine number of parallel jobs (use all available CPUs unless -j is set)
 if [ "$(uname)" = "Darwin" ]; then
-  num_jobs=$(sysctl -n hw.ncpu)
+  max_jobs=$(sysctl -n hw.ncpu)
 else
-  num_jobs=$(nproc --all)
+  # nproc would return OMP_NUM_THREADS if set, which defeats our purpose.
+  # Unset OMP_NUM_THREADS and OMP_THREAD_LIMIT to get the real number of cores.
+  max_jobs=$(env -u OMP_NUM_THREADS -u OMP_THREAD_LIMIT nproc --all)
 fi
+if [ -n "$num_jobs" ]; then
+  if ! [[ "$num_jobs" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::-j requires a positive integer, got: $num_jobs"
+    exit 1
+  fi
+  # Allow some oversubscription to 2 * max_jobs
+  if [ "$num_jobs" -gt $((2 * max_jobs)) ]; then
+    num_jobs=$((2 * max_jobs))
+  fi
+else
+  num_jobs=$max_jobs
+fi
+if [ "$num_jobs" -lt 1 ]; then num_jobs=1; fi
 
 # Thread budget to avoid OpenMP oversubscription.
 # OpenMP-parallel tests (qpp, dm simulators) each use OMP_NUM_THREADS cores.


### PR DESCRIPTION
My motivation is to make run_tests.sh usable on local machines by developers. I ran in a couple issues trying to do that.

1. I typically already have `OMP_NUM_THREADS` set in my environment so that `lit -j` can be called directly. In this scenario `nproc` returns `OMP_NUM_THREADS` which defeats our purpose. 
2. As a user I may want some control of how many cores are used, so I have also added `-j` support to overwrite `nproc`.
