### PR TITLE
Reuse dominance-safe fixed qvector references

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -174,6 +174,16 @@ class PyScopedSymbolTable(object):
     def scopeRoot(self):
         return self._scope.root
 
+    def getIfAccessible(self, symbol):
+        """Return the value for an accessible `symbol`, otherwise None."""
+        scope = self._scope
+        while scope:
+            value, valid = scope.tryGet(symbol)
+            if value is not None:
+                return value if valid else None
+            scope = scope.parent
+        return None
+
     def __contains__(self, symbol):
         """Returns True if and only if a symbol with the given name is defined
         according to Python scoping rules.
@@ -1431,8 +1441,10 @@ class PyASTBridge(ast.NodeVisitor):
 
         whileBlock = Block.create_at_start(loop.whileRegion, argTypes)
         with InsertionPoint(whileBlock):
+            self.symbolTable.beginBlock()
             condVal = evalCond(whileBlock.arguments)
             cc.ConditionOp(condVal, whileBlock.arguments)
+            self.symbolTable.endBlock()
 
         bodyBlock = Block.create_at_start(loop.bodyRegion, argTypes)
         with InsertionPoint(bodyBlock):
@@ -4936,6 +4948,38 @@ class PyASTBridge(ast.NodeVisitor):
             self.visit(node.value)
             var = self.popValue()
             self.isSubscriptRoot = subscriptRoot
+
+        if (quake.VeqType.isinstance(var.type) and
+                isinstance(node.slice, ast.Constant) and
+                type(node.slice.value) is int and node.slice.value >= 0):
+            if self.pushPointerValue:
+                self.emitFatalError(
+                    "indexing into a qvector does not produce a "
+                    "modifiable value", node)
+
+            # Cache the pure fixed extraction in the scoped symbol table, which
+            # already tracks whether a value's defining block dominates the
+            # current insertion point. The MLIR base value distinguishes
+            # separate allocations/views while allowing source aliases to
+            # share the same reference.
+            cacheKey = ("__cudaq_fixed_qref", var, node.slice.value)
+            cachedRef = self.symbolTable.getIfAccessible(cacheKey)
+            if cachedRef is not None:
+                self.pushValue(cachedRef)
+                return
+
+            ref = quake.ExtractRefOp(self.getRefType(), var,
+                                     node.slice.value).result
+
+            # Preserve the number and timing of diagnostics for a statically
+            # out-of-bounds index by emitting every invalid extraction.
+            staticSize = (quake.VeqType.getSize(var.type)
+                          if quake.VeqType.hasSpecifiedSize(var.type) else None)
+            if staticSize is None or node.slice.value < staticSize:
+                self.symbolTable[cacheKey] = ref
+
+            self.pushValue(ref)
+            return
 
         pushPtr = self.pushPointerValue
         self.pushPointerValue = False

--- a/python/tests/kernel/test_fixed_qref.py
+++ b/python/tests/kernel/test_fixed_qref.py
@@ -1,0 +1,136 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import pytest
+
+import cudaq
+
+
+def count_extract_refs(kernel):
+    kernel.compile()
+    return str(kernel.qkeModule).count("quake.extract_ref")
+
+
+def test_reuses_repeated_fixed_qrefs_by_vector_identity():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(2)
+        alias = q
+        other = cudaq.qvector(1)
+        x(q[0])
+        x(alias[0])
+        x(q[0])
+        x(alias[0])
+        x(other[0])
+        x(other[0])
+
+    assert count_extract_refs(kernel) == 2
+    assert cudaq.sample(kernel).count("000") == 1000
+
+
+def test_fixed_qref_reuse_respects_structured_dominance():
+
+    @cudaq.kernel
+    def outer_definition_dominates(condition: bool):
+        q = cudaq.qvector(1)
+        x(q[0])
+        if condition:
+            x(q[0])
+        else:
+            y(q[0])
+        x(q[0])
+
+    @cudaq.kernel
+    def branch_definitions_do_not_escape(condition: bool):
+        q = cudaq.qvector(1)
+        if condition:
+            x(q[0])
+            x(q[0])
+        else:
+            y(q[0])
+            y(q[0])
+        z(q[0])
+
+    assert count_extract_refs(outer_definition_dominates) == 1
+    assert count_extract_refs(branch_definitions_do_not_escape) == 3
+
+
+def test_fixed_qref_reuse_respects_loop_dominance():
+
+    @cudaq.kernel
+    def outer_definition_dominates(count: int):
+        q = cudaq.qvector(1)
+        x(q[0])
+        for _ in range(count):
+            x(q[0])
+        x(q[0])
+
+    @cudaq.kernel
+    def loop_definition_does_not_escape(count: int):
+        q = cudaq.qvector(1)
+        for _ in range(count):
+            x(q[0])
+            x(q[0])
+        z(q[0])
+
+    @cudaq.kernel
+    def while_condition_definition_does_not_escape():
+        q = cudaq.qvector(1)
+        while mz(q[0]):
+            x(q[0])
+        x(q[0])
+
+    assert count_extract_refs(outer_definition_dominates) == 1
+    assert count_extract_refs(loop_definition_does_not_escape) == 2
+    assert count_extract_refs(while_condition_definition_does_not_escape) == 3
+
+
+def test_dynamic_and_negative_qrefs_are_not_reused():
+
+    @cudaq.kernel
+    def dynamic_index(index: int):
+        q = cudaq.qvector(2)
+        x(q[index])
+        x(q[index])
+
+    @cudaq.kernel
+    def negative_index():
+        q = cudaq.qvector(2)
+        x(q[-1])
+        x(q[-1])
+
+    assert count_extract_refs(dynamic_index) == 2
+    assert count_extract_refs(negative_index) == 2
+    assert cudaq.sample(dynamic_index, 0).count("00") == 1000
+    assert cudaq.sample(dynamic_index, 1).count("00") == 1000
+    assert cudaq.sample(negative_index).count("00") == 1000
+
+
+def test_repeated_out_of_bounds_fixed_qrefs_still_diagnose(capfd):
+
+    @cudaq.kernel
+    def direct():
+        q = cudaq.qvector(2)
+        x(q[2])
+        x(q[2])
+
+    @cudaq.kernel
+    def through_alias():
+        q = cudaq.qvector(2)
+        alias = q
+        x(alias[2])
+        x(alias[2])
+
+    with pytest.raises(RuntimeError, match="could not compile code"):
+        direct.compile()
+    assert "invalid index [2] because >= size [2]" in capfd.readouterr().err
+
+    with pytest.raises(RuntimeError, match="could not compile code"):
+        through_alias.compile()
+    assert "invalid index [2] because >= size [2]" in capfd.readouterr().err

--- a/python/tests/mlir/ast_control_kernel.py
+++ b/python/tests/mlir/ast_control_kernel.py
@@ -36,7 +36,6 @@ def test_control_kernel():
     # CHECK:      %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
     # CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
     # CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-    # CHECK:           %[[VAL_19:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
     # CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
-    # CHECK:           quake.apply %[[VAL_18]] {{\[}}%[[VAL_19]]] %[[VAL_2]] : (!quake.ref, !quake.ref) -> ()
+    # CHECK:           quake.apply %[[VAL_18]] {{\[}}%[[VAL_1]]] %[[VAL_2]] : (!quake.ref, !quake.ref) -> ()
     # CHECK:           return

--- a/python/tests/mlir/control_toffoli.py
+++ b/python/tests/mlir/control_toffoli.py
@@ -35,8 +35,7 @@ def test_tuple_assign():
 # CHECK:           quake.x %[[VAL_2]] : (!quake.ref) -> ()
 # CHECK:           quake.x %[[VAL_3]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<3>) -> !quake.ref
-# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_1]][2] : (!quake.veq<3>) -> !quake.ref
-# CHECK:           quake.apply %[[VAL_0]] {{\[}}%[[VAL_2]]] %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
+# CHECK:           quake.apply %[[VAL_0]] {{\[}}%[[VAL_2]]] %[[VAL_4]], %[[VAL_3]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 # CHECK:           quake.dealloc %[[VAL_1]] : !quake.veq<3>
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/custom_operation.py
+++ b/python/tests/mlir/custom_operation.py
@@ -49,9 +49,8 @@ def test_custom_adjoint():
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.custom_unitary_constant @__nvqpp__mlirgen__custom_h_generator_1.rodata %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
-# CHECK:           quake.custom_unitary_constant @__nvqpp__mlirgen__custom_x_generator_1.rodata {{\[}}%[[VAL_2]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.custom_unitary_constant @__nvqpp__mlirgen__custom_x_generator_1.rodata {{\[}}%[[VAL_1]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.dealloc %[[VAL_0]] : !quake.veq<2>
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/qec_ops.py
+++ b/python/tests/mlir/qec_ops.py
@@ -295,8 +295,7 @@ def test_rep_code_d3():
 # CHECK:             quake.x {{\[}}%[[EXTRACT_REF_0]]] %[[ALLOCA_1]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:             %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_0]][1] : (!quake.veq<3>) -> !quake.ref
 # CHECK:             quake.x {{\[}}%[[EXTRACT_REF_1]]] %[[ALLOCA_1]] : (!quake.ref, !quake.ref) -> ()
-# CHECK:             %[[EXTRACT_REF_2:.*]] = quake.extract_ref %[[ALLOCA_0]][1] : (!quake.veq<3>) -> !quake.ref
-# CHECK:             quake.x {{\[}}%[[EXTRACT_REF_2]]] %[[ALLOCA_2]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:             quake.x {{\[}}%[[EXTRACT_REF_1]]] %[[ALLOCA_2]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:             %[[EXTRACT_REF_3:.*]] = quake.extract_ref %[[ALLOCA_0]][2] : (!quake.veq<3>) -> !quake.ref
 # CHECK:             quake.x {{\[}}%[[EXTRACT_REF_3]]] %[[ALLOCA_2]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:             %[[MZ_0:.*]] = quake.mz %[[ALLOCA_1]] name "s0" : (!quake.ref) -> !cc.measure_handle


### PR DESCRIPTION
 ### Summary

- Reuse fixed `qvector` element references when the lowered base and literal index match and the cached definition dominates the new use.
- Preserve existing behavior for dynamic, negative, and out-of-bounds indices, including while-condition region dominance.
- Add structural and runtime coverage and update the affected golden MLIR.
- Local perf numbers: At 2,000 operations, `Release` compile time improves by 52.3% for repeated `cx` and 44.1% for repeated `x`.