### PR TITLE
[CI] Exclude build artifacts from HTML spellcheck

### DIFF
--- a/.github/pre-commit/spellcheck_config.yml
+++ b/.github/pre-commit/spellcheck_config.yml
@@ -111,8 +111,8 @@ matrix:
 
 - name: html
   sources:
-  # Exclude third-party code (tpls/) and auto-generated templates
-  - '**/*.html|!tpls/**/*.html|!docs/sphinx/_templates/**/*.html'
+  # Exclude third-party code, build artifacts, and auto-generated templates
+  - '**/*.html|!tpls/**/*.html|!_skbuild/**/*.html|!build/**/*.html|!build_*/**/*.html|!docs/sphinx/_templates/**/*.html'
   glob_flags: N|G|B
   expect_match: true
   aspell:


### PR DESCRIPTION
Exclude HTML files under `build`, `build_*`, and `_skbuild`.