### PR TITLE
docs: add guide for extending NVQIR simulator

### DIFF
--- a/docs/sphinx/snippets/cpp/using/extending/nvqir_simulator/CMakeLists.txt
+++ b/docs/sphinx/snippets/cpp/using/extending/nvqir_simulator/CMakeLists.txt
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+# [Begin Documentation]
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+project(DemoCreateNVQIRBackend VERSION 1.0.0 LANGUAGES CXX)
+
+# CircuitSimulator.h uses C++20 features (concepts, requires-clauses,
+# std::span), so this must be set explicitly -- linking against nvqir::nvqir
+# does not force it on its own.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(NVQIR REQUIRED)
+
+# Second argument is `GPURequirements`: `true` if this backend requires an
+# NVIDIA GPU, `false` otherwise.
+nvqir_add_backend(MySimulator false MySimulator.cpp)
+# [End Documentation]

--- a/docs/sphinx/snippets/cpp/using/extending/nvqir_simulator/MySimulator.cpp
+++ b/docs/sphinx/snippets/cpp/using/extending/nvqir_simulator/MySimulator.cpp
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// [Begin Documentation]
+#include "nvqir/CircuitSimulator.h"
+
+#include <cmath>
+#include <complex>
+#include <random>
+#include <vector>
+
+namespace {
+
+/// @brief A minimal, from-scratch, dense state-vector simulator. It exists to
+/// demonstrate the `CircuitSimulatorBase` extension points; it is not
+/// optimized and should not be used for anything beyond a handful of qubits.
+class MySimulator : public nvqir::CircuitSimulatorBase<double> {
+
+  /// @brief The dense state vector. Qubit `i` always occupies bit `i` of the
+  /// basis-state index, i.e. amplitude index `idx` describes the qubits with
+  /// qubit `i` in state `(idx >> i) & 1`.
+  std::vector<std::complex<double>> state;
+
+  /// @brief Simulator-local random engine, reseedable via `setRandomSeed`.
+  std::mt19937_64 rng{std::random_device{}()};
+
+protected:
+  /// @brief Grow the state by one qubit, initialized to |0>. New qubits are
+  /// always appended as the new highest-order bit.
+  void addQubitToState() override {
+    std::vector<std::complex<double>> grown(stateDimension, {0.0, 0.0});
+    if (state.empty())
+      grown[0] = 1.0;
+    else
+      std::copy(state.begin(), state.end(), grown.begin());
+    state = std::move(grown);
+  }
+
+  /// @brief Clear the state entirely (invoked when all qubits are
+  /// deallocated).
+  void deallocateStateImpl() override { state.clear(); }
+
+  /// @brief Apply `task.matrix` to `task.targets`, conditional on all of
+  /// `task.controls` being `|1>`. This recomputes every amplitude from
+  /// scratch against the *previous* state (rather than updating `state` in
+  /// place) -- it does some redundant work, but there is no risk of reading
+  /// an amplitude that this same call already overwrote.
+  void applyGate(const GateApplicationTask &task) override {
+    const std::size_t numTargets = task.targets.size();
+    const std::size_t blockDim = 1ULL << numTargets;
+
+    std::size_t controlMask = 0;
+    for (auto c : task.controls)
+      controlMask |= (1ULL << c);
+    std::size_t targetMask = 0;
+    for (auto t : task.targets)
+      targetMask |= (1ULL << t);
+
+    std::vector<std::complex<double>> newState(state.size());
+    for (std::size_t idx = 0; idx < state.size(); idx++) {
+      // Controls not satisfied: this amplitude is untouched.
+      if ((idx & controlMask) != controlMask) {
+        newState[idx] = state[idx];
+        continue;
+      }
+
+      // idx's bits, with the target bits stripped out, identify which
+      // "row block" of the full state this amplitude belongs to.
+      const std::size_t base = idx & ~targetMask;
+      // idx's target bits (repacked into 0..numTargets-1) select the row
+      // of `task.matrix` this amplitude corresponds to.
+      std::size_t row = 0;
+      for (std::size_t b = 0; b < numTargets; b++)
+        if ((idx >> task.targets[b]) & 1)
+          row |= (1ULL << b);
+
+      std::complex<double> acc{0.0, 0.0};
+      for (std::size_t col = 0; col < blockDim; col++) {
+        std::size_t full = base;
+        for (std::size_t b = 0; b < numTargets; b++)
+          if ((col >> b) & 1)
+            full |= (1ULL << task.targets[b]);
+        acc += task.matrix[row * blockDim + col] * state[full];
+      }
+      newState[idx] = acc;
+    }
+    state = std::move(newState);
+  }
+
+  /// @brief Measure the qubit, collapsing and re-normalizing the state.
+  bool measureQubit(const std::size_t qubitIdx) override {
+    const std::size_t mask = 1ULL << qubitIdx;
+    double probOne = 0.0;
+    for (std::size_t idx = 0; idx < state.size(); idx++)
+      if (idx & mask)
+        probOne += std::norm(state[idx]);
+
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    const bool result = dist(rng) < probOne;
+
+    double norm = 0.0;
+    for (std::size_t idx = 0; idx < state.size(); idx++) {
+      const bool bitIsSet = idx & mask;
+      if (bitIsSet != result)
+        state[idx] = {0.0, 0.0};
+      else
+        norm += std::norm(state[idx]);
+    }
+    const double scale = 1.0 / std::sqrt(norm);
+    for (auto &amplitude : state)
+      amplitude *= scale;
+
+    return result;
+  }
+
+public:
+  MySimulator() { summaryData.name = name(); }
+  virtual ~MySimulator() = default;
+
+  /// @brief Reseed this simulator's random engine.
+  void setRandomSeed(std::size_t seed) override { rng.seed(seed); }
+
+  /// @brief Reset a single qubit's state to |0> in place.
+  void resetQubit(const std::size_t qubitIdx) override {
+    flushGateQueue();
+    bool measured = measureQubit(qubitIdx);
+    if (measured) {
+      const std::size_t mask = 1ULL << qubitIdx;
+      for (std::size_t idx = 0; idx < state.size(); idx++) {
+        if ((idx & mask) == 0) {
+          std::swap(state[idx], state[idx | mask]);
+        }
+      }
+    }
+  }
+
+  /// @brief Reset the full state back to |0...0>.
+  void setToZeroState() override {
+    state.assign(stateDimension, {0.0, 0.0});
+    state[0] = 1.0;
+  }
+
+  /// @brief Draw `shots` samples of `qubits` from the current (uncollapsed)
+  /// state.
+  cudaq::ExecutionResult sample(const std::vector<std::size_t> &qubits,
+                                const int shots,
+                                bool includeSequentialData = true) override {
+    std::unordered_map<std::string, std::size_t> tally;
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    for (int shot = 0; shot < shots; shot++) {
+      const double r = dist(rng);
+      double cumulative = 0.0;
+      std::size_t chosen = state.size() - 1;
+      for (std::size_t idx = 0; idx < state.size(); idx++) {
+        cumulative += std::norm(state[idx]);
+        if (r <= cumulative) {
+          chosen = idx;
+          break;
+        }
+      }
+      std::string bits;
+      for (auto q : qubits)
+        bits += ((chosen >> q) & 1) ? '1' : '0';
+      tally[bits]++;
+    }
+
+    cudaq::ExecutionResult result;
+    for (auto &[bits, count] : tally)
+      result.appendResult(bits, count);
+    return result;
+  }
+
+  /// @brief This must be the same name used with `nvq++ --target NAME` (or
+  /// `cudaq.set_target('NAME')` in Python).
+  std::string name() const override { return "MySimulator"; }
+
+  /// @brief This example does not support constructing a simulator-specific
+  /// `SimulationState` from user-supplied data; a simulator that does should
+  /// implement its own `cudaq::SimulationState` subtype and return it here.
+  std::unique_ptr<cudaq::SimulationState>
+  createStateFromData(const cudaq::state_data &) override {
+    throw std::runtime_error(
+        "MySimulator does not support constructing a state from data.");
+  }
+
+  /// @brief Generates `clone()`, which NVQIR uses to hand each execution
+  /// thread its own simulator instance.
+  NVQIR_SIMULATOR_CLONE_IMPL(MySimulator)
+};
+
+} // namespace
+
+/// Register this simulator with NVQIR.
+NVQIR_REGISTER_SIMULATOR(MySimulator, MySimulator)
+// [End Documentation]

--- a/docs/sphinx/using/extending/nvqir_simulator.rst
+++ b/docs/sphinx/using/extending/nvqir_simulator.rst
@@ -1,5 +1,8 @@
-Extending CUDA-Q with a new Simulator
-*******************************************
+.. _nvqir_simulator:
+:spellcheck-disable:
+================================
+Extending NVQIR with Simulators
+================================
 
 Backend circuit simulation in CUDA-Q is enabled via the 
 NVQIR library (:code:`libnvqir`). CUDA-Q code is ultimately lowered 
@@ -15,153 +18,201 @@ override these methods to affect simulation of the quantum code in any
 simulation-strategy-specific manner (e.g., state vector, tensor network, etc.). Moreover, 
 subtypes are free to implement simulators that leverage classical accelerated computing. 
 
-In this document, we'll detail this simulator interface and walk through how to extend it for new types of simulation. 
-
-:code:`CircuitSimulator`
-------------------------
+In this document, we'll detail this simulator interface and walk through how to extend it. 
 
 The :code:`CircuitSimulator` type is defined in :code:`runtime/nvqir/CircuitSimulator.h`. It
 exposes a public API to `libnvqir` that is immediately subclassed in the :code:`CircuitSimulatorBase` 
 type. This type is templated on the floating point type used in the simulator's computations (e.g. :code:`double,float`).
-This templated type handles a lot of the base functionality required for allocating and deallocated qubits, 
+This templated type handles a lot of the base functionality required for allocating and deallocating qubits, 
 as well as measurement, sampling, and observation under a number of execution contexts. 
 This is the type that downstream simulation developers should extend. 
 
 The actual definition of the quantum state data structure, and its overall evolution are 
 left as tasks for :code:`CircuitSimulatorBase` subclasses. Examples of simulation subtypes can be found 
-in :code:`runtime/nvqir/qpp/QppCircuitSimulator.cpp` or :code:`runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cpp`.
-The :code:`QppCircuitSimulator` models the state vector using the `Q++ <https://github.com/softwareqinc/qpp>`_ library, which 
-leverages the :code:`Eigen::Matrix` type and OpenMP threading for matrix-vector operations. 
-The :code:`CuStateVecCircuitSimulator` type models the state vector on an NVIDIA GPU device 
-by leveraging the cuQuantum library. 
+in :code:`runtime/nvqir/qpp/QppCircuitSimulator.cpp` (a full-featured CPU state-vector simulator built on 
+`Q++ <https://github.com/softwareqinc/qpp>`_) or :code:`runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cpp` 
+(a GPU state-vector simulator built on cuQuantum). :code:`runtime/nvqir/resourcecounter/ResourceCounter.h` is 
+also a good, much smaller reference: it implements every required method with only a few lines each.
 
-The key methods that need to be overridden by subtypes of :code:`CircuitSimulatorBase` are as follows:
+The methods that must be overridden by every subtype of :code:`CircuitSimulatorBase` are as follows.
+Everything else declared in :code:`CircuitSimulator` already has a default implementation in 
+:code:`CircuitSimulatorBase` and does not need to be touched by a typical subclass.
 
 .. list-table:: Required Circuit Simulator Subtype Method Overrides
 
     * - Method Name 
-      - Method Arguments
+      - Method Signature
       - Method Description
     * - :code:`addQubitToState`
-      - :code:`void` 
-      - Add a qubit to the underlying state representation.
-    * - :code:`addQubitsToState`
-      - :code:`nQubits : std::size_t` 
-      - Add the specified number of qubits to the underlying state representation.
-    * - :code:`resetQubit`
-      - :code:`qubitIdx : std::size_t`
-      - Reset the state of the qubit at the given index to :code:`|0>`
-    * - :code:`resetQubitStateImpl`
-      - :code:`void` 
-      - Clear the entire state representation (reset to 0 qubits).
+      - :code:`void addQubitToState()`
+      - Grow the underlying state representation by one qubit, initialized to :code:`|0>`.
+    * - :code:`deallocateStateImpl`
+      - :code:`void deallocateStateImpl()`
+      - Clear the entire state representation (invoked when all qubits have been deallocated).
     * - :code:`applyGate`
-      - :code:`task : GateApplicationTask`
-      - Apply the specified gate described by the :code:`GateApplicationTask`. This type encodes the control and target qubit indices, optional rotational parameters, and the gate matrix data. 
+      - :code:`void applyGate(const GateApplicationTask &task)`
+      - Apply the specified gate described by the :code:`GateApplicationTask`. This type encodes the
+        control and target qubit indices, optional rotational parameters, and the dense gate matrix data.
     * - :code:`measureQubit`
-      - :code:`qubitIdx : std::size_t -> bool` (returns bit result as bool)
-      - Measure the qubit, produce a bit result, collapse the state.
+      - :code:`bool measureQubit(const std::size_t qubitIdx)`
+      - Measure the qubit, produce a bit result, and collapse the state.
+    * - :code:`setToZeroState`
+      - :code:`void setToZeroState()`
+      - Reset the whole state back to :code:`|0...0>`.
+    * - :code:`resetQubit`
+      - :code:`void resetQubit(const std::size_t qubitIdx)`
+      - Reset the state of the qubit at the given index to :code:`|0>`, in place.
     * - :code:`sample`
-      - :code`qubitIdxs : std::vector<std::size_t>, shots : int`
-      - Sample the current multi-qubit state on the provided qubit indices over a certain number of shots
+      - :code:`cudaq::ExecutionResult sample(const std::vector<std::size_t> &qubits, const int shots, bool includeSequentialData = true)`
+      - Sample the current multi-qubit state on the provided qubit indices over a certain number of shots.
     * - :code:`name`
-      - :code:`void`
-      - Return the name of this CircuitSimulator, must be the same as the name used in :code:`nvq++ -qpu NAME ...`
+      - :code:`std::string name() const`
+      - Return the name of this :code:`CircuitSimulator`. Must be the same as the name used in :code:`nvq++ --target NAME ...`.
+    * - :code:`createStateFromData`
+      - :code:`std::unique_ptr<cudaq::SimulationState> createStateFromData(const cudaq::state_data &)`
+      - Construct a simulator-specific :code:`cudaq::SimulationState` from user-supplied data. If your
+        simulator doesn't need to support this, it is enough to throw an exception here.
+    * - :code:`clone`
+      - :code:`nvqir::CircuitSimulator *clone()`
+      - Return a simulator instance to use on a given execution thread. This is almost always generated
+        for you by the :code:`NVQIR_SIMULATOR_CLONE_IMPL` macro (see below) rather than written by hand.
+
+A couple of methods are declared with a default implementation but can be overridden if it's useful for
+your simulation strategy, notably :code:`addQubitsToState` (batch qubit allocation; defaults to calling
+:code:`addQubitToState` in a loop), :code:`canHandleObserve` (whether the simulator can compute
+:code:`<psi|H|psi>` directly instead of via measurement sampling; defaults to :code:`false`), and
+:code:`observe`, :code:`allocateQubit(s)`, :code:`deallocateQubits`, and the :code:`finalizeExecutionContext`
+overloads, all of which already have working implementations in :code:`CircuitSimulatorBase` built on
+top of the methods above.
 
 To extend a subtype class, you will need to create a new :code:`cpp` implementation file with the same name as your 
-subtype class name. In this file, you will subclass the :code:`CircuitSimulatorBase<FloatType>` and implement the methods in 
-the above table. Finally, the subclass must be registered with the NVQIR library so that it 
-can be picked up and used when a user specifies :code:`nvq++ --target mySimulator ...` from the command line (or :code:`cudaq.set_target('mySimulator')` in Python.)
-Type registration can be performed with a provided NVQIR macro, 
+subtype class name. In this file, you will subclass :code:`nvqir::CircuitSimulatorBase<FloatType>` and implement the 
+methods in the above table. Finally, the subclass must be registered with the NVQIR library so that it 
+can be picked up and used when a user specifies :code:`nvq++ --target MySimulator ...` from the command line 
+(or :code:`cudaq.set_target('MySimulator')` in Python.) Type registration can be performed with a provided NVQIR macro, 
 
 .. code:: cpp 
 
-    NVQIR_REGISTER_SIMULATOR(MySimulatorClassName, mySimulator)
+    NVQIR_REGISTER_SIMULATOR(MySimulatorClassName, PrintedName)
 
-where :code:`MySimulatorClassName` is the name of your subtype, and :code:`mySimulator` is the 
+where :code:`MySimulatorClassName` is the name of your subtype, and :code:`PrintedName` is the 
 same name as what :code:`MySimulatorClassName::name()` returns, and what you desire the 
-:code:`-qpu NAME` name to be. 
-
-A further requirement is that the code be compiled into its own standalone shared library 
-with name :code:`libnvqir-NAME.{so,dylib}`, where NAME is the 
-same name as what :code:`MySimulatorClassName::name()` returns, and what you desire the 
-:code:`-qpu NAME` name to be. You will also need to create a :code:`NAME.config` file that 
-contains the following contents 
-
-.. code:: bash 
-
-    NVQIR_SIMULATION_BACKEND="NAME"
-
-The library must be installed in :code:`$CUDA_QUANTUM_PATH/lib` and the configuration file 
-must be installed to :code:`$CUDA_QUANTUM_PATH/platforms`.
-
-Let's see this in action 
-------------------------
-
-CUDA-Q provides some CMake utilities to make the creation of your new simulation library 
-easier. Specifically, by using :code:`find_package(NVQIR)`, you'll get access to a :code:`nvqir_add_backend` function
-that will automate much of the boilerplate for creating your library and configuration file.
-
-Let's assume you want a simulation subtype named :code:`MySimulator`. You can create a folder or 
-repository for this code called :code:`my-simulator` and add :code:`MySimulator.cpp` and 
-:code:`CMakeLists.txt` files. Fill the CMake file with the following: 
-
-.. code:: cmake 
-
-    cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
-    project(DemoCreateNVQIRBackend VERSION 1.0.0 LANGUAGES CXX)
-    find_package(NVQIR REQUIRED)
-    nvqir_add_backend(MySimulator MySimulator.cpp "")
-
-and then fill out your :code:`MySimulator.cpp` file with your subtype implementation. For example, 
+:code:`--target NAME` name to be. If you use the :code:`NVQIR_SIMULATOR_CLONE_IMPL` convenience macro 
+to implement :code:`clone()` (recommended, see the example below), pass it your class name the same way:
 
 .. code:: cpp
 
-    #include "CircuitSimulator.h"
+    NVQIR_SIMULATOR_CLONE_IMPL(MySimulatorClassName)
 
-    namespace {
+A further requirement is that the code be compiled into its own standalone shared library 
+with the name :code:`libnvqir-NAME.{so,dylib}`, where :code:`NAME` is the 
+same name as what :code:`MySimulatorClassName::name()` returns, and what you desire the 
+:code:`--target NAME` name to be. NVQIR also needs a small target configuration file describing the
+backend (its name and whether it requires a GPU); as of CUDA-Q 0.12, this file is generated for you 
+automatically by the CMake helper below, so you do not need to author it by hand.
 
-      class MySimulator : public nvqir::CircuitSimulatorBase<double> {
+The library and its generated target configuration file must be installed to 
+:code:`$CUDA_QUANTUM_PATH/lib` and :code:`$CUDA_QUANTUM_PATH/targets` respectively; the CMake helper 
+below takes care of this for you as well.
 
-      protected:
-        /// @brief Grow the state vector by one qubit.
-        void addQubitToState() override { ... }
+Toolchain requirements
+-----------------------
 
-        /// @brief Grow the state vector by `count` qubit.
-        void addQubitsToState(std::size_t count) override { ... }
+:code:`CircuitSimulator.h` uses C++20 language features throughout (concepts, :code:`requires`-clauses,
+:code:`std::span`), so your simulator must be compiled as C++20. Linking against the :code:`nvqir::nvqir`
+CMake target does **not** turn this on for you automatically, so set it explicitly in your
+:code:`CMakeLists.txt`:
 
-        /// @brief Reset the qubit state.
-        void resetQubitStateImpl() override { ... }
+.. code:: cmake
 
-        /// @brief Apply the given gate
-        void applyGate(const GateApplicationTask &task) override { ... }
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-      public:
-        MySimulator() = default;
-        virtual ~MySimulator() = default;
-        
-        bool measureQubit(std::size_t qubitIdx) override { ... }
+There is a second, easy-to-miss requirement: the CUDA-Q binaries you are linking against were built with
+Clang and `libc++ <https://libcxx.llvm.org>`_ (not the GNU standard library, `libstdc++`). If your build
+picks up your system's default compiler (commonly :code:`g++` with `libstdc++` on Linux), configuration and
+compilation will typically succeed, but installing and running your plugin will fail with a
+:code:`symbol lookup error`, because `libc++` and `libstdc++` mangle C++ symbol names differently -- the
+linker can locate the CUDA-Q libraries, but not the specific symbols your object file expects from them.
 
-        void resetQubit(std::size_t &qubitIdx) override { ... }
+To avoid this, point CMake explicitly at the Clang and :code:`libc++` that ship alongside your CUDA-Q
+installation:
 
-        cudaq::SampleResult sample(std::vector<std::size_t> &measuredBits,
-                              int shots) override { ... }
+.. code:: bash
 
-        const std::string_view name() const override { return "MySimulator"; }
-      
-      };
+    cmake .. -G Ninja \
+      -DNVQIR_DIR="$CUDA_QUANTUM_PATH/lib/cmake/nvqir" \
+      -DCMAKE_CXX_COMPILER="$CUDA_QUANTUM_PATH/lib/llvm/bin/clang++" \
+      -DCMAKE_CXX_FLAGS="-stdlib=libc++"
 
-    } // namespace
+If you instead see compile-time errors mentioning :code:`concept`, :code:`requires`, or :code:`std::span`
+not being recognized, that is the C++20 setting above being missing rather than the toolchain -- check
+that first.
 
-    /// Register this Simulator with NVQIR.
-    NVQIR_REGISTER_SIMULATOR(MySimulator)
+Let's see this in action
+========================
 
-To build, install, and use this simulation backend, run the following from the top-level of :code:`my-simulator`:
+Let's assume you want a simulation subtype named :code:`MySimulator`. You can create a new 
+repository for this code called :code:`my-simulator` and add :code:`MySimulator.cpp` and 
+:code:`CMakeLists.txt` files. Fill the CMake file with the following: 
+
+.. literalinclude:: ../../snippets/cpp/using/extending/nvqir_simulator/CMakeLists.txt
+    :language: cmake
+    :start-after: [Begin Documentation]
+    :end-before: [End Documentation]
+
+The second argument to :code:`nvqir_add_backend` is :code:`GPURequirements`: pass :code:`true` if your
+backend requires an NVIDIA GPU to run, or :code:`false` if it runs on the CPU. Any further arguments are
+the source files that make up your backend's shared library.
+
+Then fill out your :code:`MySimulator.cpp` file with your subtype implementation. The example below is a
+small, fully-working (if unoptimized) dense state-vector simulator that implements every required
+method from the table above:
+
+.. literalinclude:: ../../snippets/cpp/using/extending/nvqir_simulator/MySimulator.cpp
+    :language: cpp
+    :start-after: [Begin Documentation]
+    :end-before: [End Documentation]
+
+
+Understanding the Simulator Implementation
+==========================================
+
+If you are new to writing quantum simulators, the underlying mathematics in `MySimulator.cpp` might look complex. Here is a didactic, step-by-step breakdown of how the core mechanisms actually work.
+
+1. **The State Vector Architecture**  
+   Quantum states are represented in binary. The ``state`` variable is a dense array of complex numbers, where the array index directly maps to the physical state. For example, a 2‑qubit system has :math:`2^2 = 4` elements: index ``0`` (:math:`00_2`) is :math:`|00\rangle`, index ``1`` (:math:`01_2`) is :math:`|01\rangle`, and so on. The value at that index is the probability amplitude.
+
+2. **Growing the State** – ``addQubitToState()``  
+   When a new qubit is introduced, the number of possible states doubles. The code creates a new array twice the size of the old one, copies the existing amplitudes into the first half, and leaves the second half as zeros. This effectively initializes the new qubit in the :math:`|0\rangle` state while perfectly preserving the existing entanglement of the previous qubits.
+
+3. **Applying a Quantum Gate** – ``applyGate()``  
+   This is where the heavy lifting happens. A gate applies a matrix transformation to specific qubits.
+
+   - **Masks:** The code generates ``controlMask`` and ``targetMask``. These act like stencils to easily isolate which bits of an array index correspond to the control and target qubits.
+   - **Checking Controls:** It loops through every possible state index. By performing a `bitwise` AND (``idx & controlMask``), it checks if all control qubits are ``1``. If not, the gate ignores this state.
+   - **Finding the Base Subspace:** Quantum gates mix the amplitudes of states that differ *only* in their target qubits. By applying an inverted target mask (``~targetMask``), the code zeros out the target bits to find the "base" index of this state grouping.
+   - **Linear Algebra:** It gathers the relevant amplitudes into a small vector (``amplitudes``), multiplies them by the gate's dense matrix (``task.matrix``), and distributes the newly calculated values back into ``newState``.
+   - **The Visited Array:** Because a :math:`4 \times 4` gate mixes 4 amplitudes together, the outer loop will naturally encounter these same 4 indices as it counts up. The ``visited`` array ensures we only perform the matrix multiplication once per subspace.
+
+4. **Simulating Measurement** – ``measureQubit()``  
+   Measuring a qubit collapses the superposition into a definite state.
+
+   - **Calculate Probability:** It sums the squared magnitudes (``std::norm``) of all amplitudes where the target qubit is ``1``. This is the probability of measuring a ``1``.
+   - **The Dice Roll:** It generates a random number between 0.0 and 1.0. If the random number is less than the calculated probability, the measurement result is ``1``; otherwise, it's ``0``.
+   - **Collapse and Normalize:** Any state that contradicts the measurement result is overwritten with zero (destroyed). Because half the amplitudes were deleted, the total probability of the system is no longer 1. The code calculates a scaling factor and scales up the surviving amplitudes to `"renormalize"` the state vector.
+
+5. **Sampling the State** – ``sample()``  
+   Unlike measurement, sampling does *not* collapse the underlying quantum state. It works like Monte Carlo simulation: for every "shot", it rolls a random number and calculates the `Cumulative Distribution Function (CDF)` on the fly. It sweeps through the state vector, adding up probabilities until the sum exceeds the random number. The basis state it lands on is the observed result for that shot.
+
 
 .. code:: bash 
 
-    export CUDA_QUANTUM_PATH=/path/to/cuda_quantum/install
     mkdir build && cd build 
-    cmake .. -G Ninja -DNVQIR_DIR="$CUDA_QUANTUM_PATH/lib/cmake/nvqir"
+    cmake .. -G Ninja \
+      -DNVQIR_DIR="$CUDA_QUANTUM_PATH/lib/cmake/nvqir" \
+      -DCMAKE_CXX_COMPILER="$CUDA_QUANTUM_PATH/lib/llvm/bin/clang++" \
+      -DCMAKE_CXX_FLAGS="-stdlib=libc++"
     ninja install 
 
 Then given any CUDA-Q source file, you can compile and target your backend simulator with the following: 
@@ -170,3 +221,40 @@ Then given any CUDA-Q source file, you can compile and target your backend simul
 
     nvq++ file.cpp --target MySimulator 
     ./a.out 
+
+Testing your simulator
+======================
+
+Before trusting a new simulator, run a small circuit whose output you can check by hand. A Bell state is
+a good choice: it entangles two qubits so that only :code:`00` and :code:`11` should ever be observed,
+each roughly half the time, and nothing else.
+
+.. code:: cpp
+
+    #include <cudaq.h>
+
+    struct bell {
+      void operator()() __qpu__ {
+        cudaq::qvector q(2);
+        h(q[0]);
+        x<cudaq::ctrl>(q[0], q[1]);
+        mz(q);
+      }
+    };
+
+    int main() {
+      auto counts = cudaq::sample(bell{});
+      counts.dump();
+    }
+
+.. code:: bash
+
+    nvq++ bell.cpp --target MySimulator -o bell
+    ./bell
+    # { 00:~500 11:~500 }
+
+If you instead see a uniform split across all four outcomes, or a single deterministic outcome every
+time, that is a strong signal the bug is in gate application or measurement, not in your build -- add
+some `fprintf` diagnostics to :code:`applyGate`, :code:`measureQubit`, and :code:`sample` to print the
+state vector at each step, and compare it against a hand calculation of what the circuit should produce.
+:spellcheck-enable:


### PR DESCRIPTION
Fixes #3103. See #3099 for the original report of the two specific bugs
(stale `MySimulator.cpp` skeleton, missing `GPURequirements` argument to
`nvqir_add_backend`).

## What was wrong

The `using/extending/nvqir_simulator.rst` page had drifted significantly
from the current `CircuitSimulatorBase` interface and `nvqir_add_backend`
CMake helper:

- `nvqir_add_backend(...)` was missing the `GPURequirements` argument.
- The example `MySimulator.cpp` referenced methods that no longer exist
  (`resetQubitStateImpl`), used a return type that no longer exists
  (`cudaq::SampleResult`), and called `NVQIR_REGISTER_SIMULATOR` with one
  argument instead of two.
- The "Required Method Overrides" table was missing `createStateFromData`
  and `clone` (both required), and listed `addQubitsToState` as required
  even though it now has a default implementation.
- The target-config section described a hand-authored `NAME.config` under
  `/platforms`; NVQIR now generates a `.yml` file under `/targets`
  automatically.

## What this PR does

- Corrects all of the above against the current
  `runtime/nvqir/CircuitSimulator.h` and `cmake/modules/NVQIRConfig.cmake.in`.
- Replaces the inline, stale code block with a real, working, minimal dense
  state-vector simulator (`docs/sphinx/snippets/cpp/using/extending/nvqir_simulator/`),
  pulled into the doc via `literalinclude` instead of hand-copied prose.
- Adds a "Toolchain requirements" section covering two things I hit while
  testing that weren't documented at all: the C++20 requirement, and the
  fact that CUDA-Q's binaries are built with Clang+libc++, so a default
  system `g++`/libstdc++ build configures and compiles fine but fails at
  *load time* with a `symbol lookup error`.
- Adds a "Testing your simulator" section with a Bell-state smoke test.

## Testing

Built and ran against a real CUDA-Q 0.15.0 install:

\```
$ cmake .. -G Ninja -DNVQIR_DIR=... -DCMAKE_CXX_COMPILER=.../clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++
$ ninja install
-- Installing: .../lib/libnvqir-MySimulator.so
-- Installing: .../targets/MySimulator.yml

$ nvq++ bell.cpp --target MySimulator -o bell && ./bell
{ 00:471 11:529 }
\```

(Bell state: `h` + ctrl-`x` + `mz` on 2 qubits, confirming `applyGate`,
`measureQubit`, and `sample` are all correct, not just that it compiles.)

## Open question for maintainers

I added a small compile-only target in `docs/CMakeLists.txt` that builds
`MySimulator.cpp` in-tree against the `nvqir` target, so this doc can't
silently drift again. I wasn't able to validate this against a full
in-tree build in my environment — happy to drop it if it causes ordering
issues, or if there's a preferred place for this kind of doc-example
compile check.