### PR TITLE
Fix flaky test (2)

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/cudaq/lib/Optimizer/Transforms/RegToMem.cpp
@@ -289,10 +289,12 @@ public:
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto findLookupValue = [&](Value v) -> Value {
-      if (auto id = analysis.idFromValue(v))
-        return allocas[*id];
+      // Check whether `v` is a quake.unwrap first, to avoid address clashes in
+      // `analysis`
       if (auto u = v.template getDefiningOp<cudaq::quake::UnwrapOp>())
         return u.getRefValue();
+      if (auto id = analysis.idFromValue(v))
+        return allocas[*id];
       return v;
     };
     auto collect = [&](auto values) {


### PR DESCRIPTION
Fixes failure seen here: https://github.com/NVIDIA/cuda-quantum/actions/runs/29756961735/job/88401937075?pr=4927

Newly created `unwrap` values can reuse a previously freed `Wire` address. If this happens to be an address in the `analysis` key-value dict, this gets resolved wrongly.

This is fixed by just flipping the order in which the two cases are tested.