### PR TITLE
Do not pass the invocationResultBuffer for the observe and sample policies

### DIFF
--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -429,7 +429,6 @@ public:
 
     executor->setShots(localShots);
 
-    auto executionContext = cudaq::getExecutionContext();
     // Execute the codes produced in quake lowering
     // Allow developer to disable remote sending (useful for debugging IR)
     assert(!emulate);
@@ -439,8 +438,7 @@ public:
     const cudaq::detail::ExecutionContextType execType =
         cudaq::detail::ExecutionContextType::sample;
 
-    auto future = executor->execute(codes, execType,
-                                    &executionContext->invocationResultBuffer);
+    auto future = executor->execute(codes, execType);
     return async_sample_result(std::move(future));
   }
 
@@ -507,14 +505,12 @@ public:
 
     executor->setShots(localShots);
 
-    auto executionContext = cudaq::getExecutionContext();
     assert(!emulate);
     if (getEnvBool("DISABLE_REMOTE_SEND", false))
       return {};
 
     auto future =
-        executor->execute(codes, cudaq::detail::ExecutionContextType::observe,
-                          &executionContext->invocationResultBuffer);
+        executor->execute(codes, cudaq::detail::ExecutionContextType::observe);
     return async_observe_result(std::move(future), &policy.inner.spin);
   }
 


### PR DESCRIPTION
This is just a clean-up to avoid passing the invocationResultBuffer  whennot needed so it ultimately can be removed from the execution context.