### PR TITLE
Remove virtual inheritance for CompileTarget

### DIFF
--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -16,20 +16,7 @@
 namespace cudaq {
 
 /// Target properties used to define the compilation pipeline.
-class CompileTarget {
-public:
-  /// Hook to update the pass pipeline before compilation.
-  virtual void updatePassPipeline(std::string &passPipeline) const {}
-
-  /// Return a hash of this target's configuration, used as a cache key to
-  /// decide whether a previously compiled module can be reused.
-  ///
-  /// A hash of 0 disables caching.
-  ///
-  /// TODO: CompileTarget should be made non-virtual. Once it is, this method
-  /// becomes unnecessary and callers can use std::hash<CompileTarget> directly.
-  virtual std::size_t hash() const;
-
+struct CompileTarget {
   /// Whether to recompile the kernel in the presence of an AOT-compiled module.
   ///
   /// If this is `false` and an AOT-compiled kernel (in the form of a function
@@ -135,14 +122,10 @@ public:
 
   /// Construct a CompileTarget from static and runtime backend configurations.
   CompileTarget(config::TargetConfig targetConfig,
-                std::map<std::string, std::string> runtimeConfig, bool emulate);
+                std::map<std::string, std::string> runtimeConfig, bool emulate,
+                std::map<std::string, std::string> pipelineSubstitutions = {});
 
   CompileTarget() = default;
-  CompileTarget(const CompileTarget &) = default;
-  CompileTarget(CompileTarget &&) = default;
-  CompileTarget &operator=(const CompileTarget &) = default;
-  CompileTarget &operator=(CompileTarget &&) = default;
-  virtual ~CompileTarget() = default;
 };
 
 } // namespace cudaq

--- a/cudaq/lib/Target/CompileTarget.cpp
+++ b/cudaq/lib/Target/CompileTarget.cpp
@@ -45,9 +45,23 @@ static void substitutePipelinePlaceholders(
   }
 }
 
+/// Replace literal placeholder keys in a pipeline stage string.
+static void applyPipelineSubstitutions(
+    std::string &pipeline,
+    const std::map<std::string, std::string> &pipelineSubstitutions) {
+  for (const auto &[key, value] : pipelineSubstitutions) {
+    std::string::size_type pos = 0;
+    while ((pos = pipeline.find(key, pos)) != std::string::npos) {
+      pipeline.replace(pos, key.size(), value);
+      pos += value.size();
+    }
+  }
+}
+
 cudaq::CompileTarget::CompileTarget(
     config::TargetConfig targetConfig,
-    std::map<std::string, std::string> runtimeConfig, bool emulate_)
+    std::map<std::string, std::string> runtimeConfig, bool emulate_,
+    std::map<std::string, std::string> pipelineSubstitutions)
     : emulate(emulate_) {
   if (!targetConfig.BackendConfig.has_value()) {
     pipelineConfig.skipTargetLoweringPipeline = true;
@@ -64,6 +78,7 @@ cudaq::CompileTarget::CompileTarget(
     std::string pipeline = stage;
     if (!pipeline.empty()) {
       substitutePipelinePlaceholders(pipeline, runtimeConfig);
+      applyPipelineSubstitutions(pipeline, pipelineSubstitutions);
       CUDAQ_INFO("{:<27} {}", stageName + ":", pipeline);
     }
     return pipeline;
@@ -131,8 +146,4 @@ std::size_t std::hash<cudaq::CompileTarget>::operator()(
     hash_combine(seed, t.pauliTermSplitObservable->to_string());
 
   return seed;
-}
-
-std::size_t cudaq::CompileTarget::hash() const {
-  return std::hash<cudaq::CompileTarget>{}(*this);
 }

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -727,7 +727,7 @@ pyLaunchModule(const std::string &name, ModuleOp mod,
                cudaq::CompiledModule *cachedModule,
                const std::vector<void *> &rawArgs) {
   auto target = getCompileTargetImpl();
-  auto targetHash = target->hash();
+  auto targetHash = std::hash<cudaq::CompileTarget>{}(*target);
 
   // We don't cache kernels that inline all arguments, as any change to the
   // runtime arguments would invalidate the cache. Currently, synthesis is

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -221,30 +221,6 @@ public:
                                         serverHelper, executor);
   }
 
-  class BaseRemoteRESTQPUCompileTarget : public CompileTarget {
-  public:
-    BaseRemoteRESTQPUCompileTarget(
-        cudaq::ServerHelper *serverHelper,
-        cudaq::config::TargetConfig targetConfig,
-        std::map<std::string, std::string> runtimeConfig, bool emulate)
-        : CompileTarget(targetConfig, runtimeConfig, emulate),
-          serverHelper(serverHelper) {
-      std::filesystem::path cudaqLibPath{cudaq::getCUDAQLibraryPath()};
-      platformPath = cudaqLibPath.parent_path().parent_path() / "targets";
-    }
-
-    void updatePassPipeline(std::string &passPipeline) const override {
-      serverHelper->updatePassPipeline(platformPath, passPipeline);
-    }
-
-    /// Disable compiled-module caching for the remote REST target.
-    std::size_t hash() const override { return 0; }
-
-  private:
-    cudaq::ServerHelper *serverHelper;
-    std::filesystem::path platformPath;
-  };
-
   using QPU::getCompileTarget;
   std::unique_ptr<CompileTarget>
   getCompileTarget(const other_policies &, ExecutionContext *ctx) override {
@@ -253,8 +229,9 @@ public:
           "Remote rest execution can only be performed via cudaq::sample(), "
           "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
 
-    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
-        serverHelper.get(), targetConfig, backendConfig, emulate);
+    auto target = std::make_unique<CompileTarget>(
+        targetConfig, backendConfig, emulate,
+        serverHelper->getPipelineSubstitutions(platformPath));
     target->pipelineConfig.replaceStateWithKernel = true;
     target->overrideAOTCompilation = true;
     if (ctx && ctx->name == "resource-count")
@@ -265,8 +242,9 @@ public:
 
   std::unique_ptr<CompileTarget>
   getCompileTarget(const sample_policy &policy) override {
-    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
-        serverHelper.get(), targetConfig, backendConfig, emulate);
+    auto target = std::make_unique<CompileTarget>(
+        targetConfig, backendConfig, emulate,
+        serverHelper->getPipelineSubstitutions(platformPath));
     target->supportConditionalsOnMeasureResults = !emulate;
     target->pipelineConfig.addMeasurements = true;
     target->storeReorderIdx = true;
@@ -277,8 +255,9 @@ public:
 
   std::unique_ptr<CompileTarget>
   getCompileTarget(const observe_policy &policy) override {
-    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
-        serverHelper.get(), targetConfig, backendConfig, emulate);
+    auto target = std::make_unique<CompileTarget>(
+        targetConfig, backendConfig, emulate,
+        serverHelper->getPipelineSubstitutions(platformPath));
     target->overrideAOTCompilation = true;
     target->pauliTermSplitObservable = policy.spin;
     target->pipelineConfig.replaceStateWithKernel = true;
@@ -288,8 +267,10 @@ public:
   /// Build a local JIT artifact for DEM analysis. No provider target code is
   /// emitted or submitted while this policy is active.
   std::unique_ptr<CompileTarget> getCompileTarget(const dem_policy &) override {
-    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
-        serverHelper.get(), targetConfig, backendConfig, emulate);
+    // Skip pipeline substitutions: this path never builds the lowering pipeline
+    // and should not trigger server-helper side effects (e.g. IQM arch fetch).
+    auto target =
+        std::make_unique<CompileTarget>(targetConfig, backendConfig, emulate);
     target->pipelineConfig.replaceStateWithKernel = true;
     target->overrideAOTCompilation = true;
     target->emitJit = true;

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -19,6 +19,7 @@
 #include "common/RecordLogParser.h"
 #include "cudaq_json.h"
 #include <filesystem>
+#include <map>
 
 namespace cudaq {
 
@@ -133,9 +134,12 @@ public:
   virtual cudaq::sample_result processResults(ServerMessage &postJobResponse,
                                               std::string &jobId) = 0;
 
-  /// @brief Adjust the compiler pass pipeline (if desired)
-  virtual void updatePassPipeline(const std::filesystem::path &platformPath,
-                                  std::string &passPipeline) {}
+  /// @brief Return placeholder substitutions for config-derived pipeline
+  /// stages.
+  virtual std::map<std::string, std::string>
+  getPipelineSubstitutions(const std::filesystem::path &platformPath) {
+    return {};
+  }
 
   /// @brief Set the runtime target information
   void setRuntimeTarget(const RuntimeTarget &target) { runtimeTarget = target; }

--- a/runtime/cudaq/platform/default/rest/helpers/anyon/AnyonServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/anyon/AnyonServerHelper.cpp
@@ -106,9 +106,9 @@ public:
   cudaq::sample_result processResults(ServerMessage &postJobResponse,
                                       std::string &jobID) override;
 
-  /// @brief Update `passPipeline` with architecture-specific pass options
-  void updatePassPipeline(const std::filesystem::path &platformPath,
-                          std::string &passPipeline) override;
+  /// @brief Return architecture-specific pipeline placeholder substitutions.
+  std::map<std::string, std::string>
+  getPipelineSubstitutions(const std::filesystem::path &platformPath) override;
 };
 
 ServerJobPayload
@@ -443,8 +443,8 @@ std::string searchAPIKey(std::string &key, std::string &refreshKey,
   return hwConfig;
 }
 
-void AnyonServerHelper::updatePassPipeline(
-    const std::filesystem::path &platformPath, std::string &passPipeline) {
+std::map<std::string, std::string> AnyonServerHelper::getPipelineSubstitutions(
+    const std::filesystem::path &platformPath) {
   std::string qgate_type = "cgate";
   if (machine.starts_with("berkeley")) {
     qgate_type = "pgate";
@@ -453,13 +453,10 @@ void AnyonServerHelper::updatePassPipeline(
   } else {
     printf("Unidentified machine type %s\n", machine.c_str());
   }
-  passPipeline =
-      std::regex_replace(passPipeline, std::regex("%Q_GATE%"), qgate_type);
 
   std::string pathToFile = platformPath / std::string("mapping/anyon") /
                            (machine + std::string(".txt"));
-  passPipeline =
-      std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), pathToFile);
+  return {{"%Q_GATE%", qgate_type}, {"%QPU_ARCH%", pathToFile}};
 }
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -148,9 +148,9 @@ public:
   cudaq::sample_result processResults(ServerMessage &postJobResponse,
                                       std::string &jobId) override;
 
-  /// @brief Update `passPipeline` with architecture-specific pass options
-  void updatePassPipeline(const std::filesystem::path &platformPath,
-                          std::string &passPipeline) override;
+  /// @brief Return architecture-specific pipeline placeholder substitutions.
+  std::map<std::string, std::string>
+  getPipelineSubstitutions(const std::filesystem::path &platformPath) override;
 
   /// @brief Default destructor removes the dynamic quantum architecture file
   ~IQMServerHelper() {
@@ -429,8 +429,8 @@ IQMServerHelper::generateRequestHeader() const {
  * parameter in the backend string, or even more flexible by setting the
  * environment variable 'IQM_QPU_QA' to the path+filename.
  */
-void IQMServerHelper::updatePassPipeline(
-    const std::filesystem::path &platformPath, std::string &passPipeline) {
+std::map<std::string, std::string> IQMServerHelper::getPipelineSubstitutions(
+    const std::filesystem::path &platformPath) {
   std::string pathToFile;
 
   // For normal operation the dynamic quantum architecture is retrieved from
@@ -461,8 +461,7 @@ void IQMServerHelper::updatePassPipeline(
   // shell glob.
   pathToFile.insert(0, "'").append("'");
 
-  passPipeline =
-      std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), pathToFile);
+  return {{"%QPU_ARCH%", pathToFile}};
 }
 
 /**

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -90,9 +90,9 @@ public:
   cudaq::sample_result processResults(ServerMessage &postJobResponse,
                                       std::string &jobID) override;
 
-  /// @brief Update `passPipeline` with architecture-specific pass options
-  void updatePassPipeline(const std::filesystem::path &platformPath,
-                          std::string &passPipeline) override;
+  /// @brief Return architecture-specific pipeline placeholder substitutions.
+  std::map<std::string, std::string>
+  getPipelineSubstitutions(const std::filesystem::path &platformPath) override;
 };
 
 namespace {
@@ -457,15 +457,14 @@ RestHeaders OQCServerHelper::getHeaders() {
   return headers;
 }
 
-void OQCServerHelper::updatePassPipeline(
-    const std::filesystem::path &platformPath, std::string &passPipeline) {
+std::map<std::string, std::string> OQCServerHelper::getPipelineSubstitutions(
+    const std::filesystem::path &platformPath) {
   auto machine =
       get_from_config(backendConfig, "machine", []() { return Lucy; });
   check_machine_allowed(machine);
   std::string pathToFile = platformPath / std::string("mapping/oqc") /
                            (machine + std::string(".txt"));
-  passPipeline =
-      std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), pathToFile);
+  return {{"%QPU_ARCH%", pathToFile}};
 }
 
 } // namespace cudaq

--- a/runtime/internal/compiler/JITTargetPipeline.cpp
+++ b/runtime/internal/compiler/JITTargetPipeline.cpp
@@ -39,7 +39,6 @@ cudaq_internal::compiler::getPassPipeline(const cudaq::CompileTarget &target) {
 
   if (!pipelineConfig.overridePassPipeline.empty()) {
     passPipeline = pipelineConfig.overridePassPipeline;
-    target.updatePassPipeline(passPipeline);
     return passPipeline;
   }
 
@@ -74,8 +73,6 @@ cudaq_internal::compiler::getPassPipeline(const cudaq::CompileTarget &target) {
                "pipeline to {}",
                passPipeline);
   }
-
-  target.updatePassPipeline(passPipeline);
 
   return passPipeline;
 }

--- a/unittests/nvqpp/backends/quake_backend/FakeQuakeServerHelper.cpp
+++ b/unittests/nvqpp/backends/quake_backend/FakeQuakeServerHelper.cpp
@@ -29,20 +29,20 @@ public:
 
   void initialize(BackendConfig config) override { backendConfig = config; }
 
-  void updatePassPipeline(const std::filesystem::path &,
-                          std::string &passPipeline) override {
+  std::map<std::string, std::string>
+  getPipelineSubstitutions(const std::filesystem::path &) override {
     const auto iter = backendConfig.find("emulate");
     if (iter == backendConfig.end() || iter->second != "true")
-      return;
+      return {{"%QUAKE_EMULATE_SUFFIX%", ""}};
 
     // Remote execution preserves structured control flow in the wire-set
     // payload, then fully unrolls it on the mock server before lowering the
     // wire set directly to QIR. Mirror that execution-time lowering for local
     // emulation without changing the selectively unrolled client payload.
-    passPipeline +=
-        ",func.func(cc-loop-unroll{maximum-iterations=1024 "
-        "signal-failure-if-any-loop-cannot-be-completely-unrolled=true "
-        "allow-early-exit=true},canonicalize),lower-to-cfg";
+    return {{"%QUAKE_EMULATE_SUFFIX%",
+             ",func.func(cc-loop-unroll{maximum-iterations=1024 "
+             "signal-failure-if-any-loop-cannot-be-completely-unrolled=true "
+             "allow-early-exit=true},canonicalize),lower-to-cfg"}};
   }
 
   ServerJobPayload

--- a/unittests/nvqpp/backends/quake_backend/quake_fake.yml
+++ b/unittests/nvqpp/backends/quake_backend/quake_fake.yml
@@ -20,7 +20,7 @@ config:
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "expand-measurements"
   jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
-  jit-low-level-pipeline: "return-to-output-log,symbol-dce"
+  jit-low-level-pipeline: "return-to-output-log,symbol-dce%QUAKE_EMULATE_SUFFIX%"
   # Tell the rest-qpu that we are simply dumping CUDA-Q MLIR code.
   codegen-emission: nop
   # Library mode is only for simulators, physical backends must turn this off


### PR DESCRIPTION
It turns out that all the `updatePassPipeline` implementations in `ServerHelper` do one thing: they apply a regex to replace placeholders in the pipeline definitions with QPU-specific data.

By replacing the `updatePassPipeline` method of the ServerHelper into `getPipelineSubstitutions`, we can turn `CompileTarget` into essentially a C-struct. The pipeline modification that was previously happening within the `ServerHelper` instances is now done at construction time of `CompileTarget`.

This makes `CompileTarget` a much better candidate for a future stable public API as it no longer relies on virtual inheritance.

The disadvantage of this change is that `ServerHelper` loses the (afaict currently unused) ability of modifying compilation pipelines using arbitrary logic.