### PR TITLE
[core] Rename the apply-control-negations pass to better reflect

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -60,18 +60,6 @@ def AssignWireIndices : Pass<"assign-wire-indices", "mlir::func::FuncOp"> {
   }];
 }
 
-def ApplyControlNegations :
-    Pass<"apply-control-negations", "mlir::func::FuncOp"> {
-  let summary =
-    "Replace all `Ops` with negated controls with normal controls and `XOp`s.";
-
-  let description = [{
-    For every quantum operation with a negative control, replace that operation 
-    with an X operation on the control qubit, the controlled operation with
-    positive polarity, and a final X operation on the control qubit. 
-  }];
-}
-
 // ApplyOpSpecialization is a module pass because it may modify the ModuleOp
 // and add new FuncOps.
 def ApplySpecialization : Pass<"apply-op-specialization", "mlir::ModuleOp"> {
@@ -489,6 +477,18 @@ def EraseVectorCopyCtor : Pass<"erase-vector-copy-ctor"> {
     the calling function copying the heap data to a new vector on the stack.
     Since the callee is inlined, none of this is really required. The callee and
     caller share a common stack frame, so one copy is plenty.
+  }];
+}
+
+def ExpandControlNegations :
+    Pass<"expand-control-negations", "mlir::func::FuncOp"> {
+  let summary =
+    "Replace all `Ops` with negated controls with normal controls and `XOp`s.";
+
+  let description = [{
+    For every quantum operation with a negated control, replace that operation 
+    with an X operation on the control qubit, the controlled operation with
+    positive polarity, and a final X operation on the control qubit. 
   }];
 }
 

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -1338,7 +1338,7 @@ struct ExpPauliOpPattern
   matchAndRewrite(cudaq::quake::ExpPauliOp pauli, Base::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = pauli.getLoc();
-    // Make sure that apply-control-negations pass was run.
+    // Make sure that expand-control-negations pass was run.
     if (adaptor.getNegatedQubitControls())
       return pauli->emitOpError("negated control qubits not allowed.");
     SmallVector<Value> controls;
@@ -1821,7 +1821,7 @@ struct QuantumGatePattern : public OpConversionPattern<OP> {
     };
     auto qirFunctionName = M::quakeToFuncName(op);
 
-    // Make sure that apply-control-negations pass was run.
+    // Make sure that expand-control-negations pass was run.
     if (adaptor.getNegatedQubitControls())
       return op.emitOpError("negated control qubits not allowed.");
 

--- a/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -61,7 +61,7 @@ void createCommonTargetCodegenPipeline(
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createLoopUnroll(luo));
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   } else {
-    pm.addNestedPass<func::FuncOp>(cudaq::opt::createApplyControlNegations());
+    pm.addNestedPass<func::FuncOp>(cudaq::opt::createExpandControlNegations());
     cudaq::opt::addAggressiveInlining(pm);
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createUnwindLowering());

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -15,7 +15,6 @@ add_cudaq_library(OptTransforms
   AddMeasurements.cpp
   AddMetadata.cpp
   AggressiveInlining.cpp
-  ApplyControlNegations.cpp
   ApplyOpSpecialization.cpp
   ArgumentSynthesis.cpp
   BasisConversion.cpp
@@ -35,6 +34,7 @@ add_cudaq_library(OptTransforms
   EraseNopCalls.cpp
   EraseQEC.cpp
   EraseVectorCopyCtor.cpp
+  ExpandControlNegations.cpp
   ExpandControlVeqs.cpp
   ExpandMeasurements.cpp
   FactorQuantumAlloc.cpp

--- a/cudaq/lib/Optimizer/Transforms/ExpandControlNegations.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ExpandControlNegations.cpp
@@ -15,7 +15,7 @@
 #include "mlir/Transforms/Passes.h"
 
 namespace cudaq::opt {
-#define GEN_PASS_DEF_APPLYCONTROLNEGATIONS
+#define GEN_PASS_DEF_EXPANDCONTROLNEGATIONS
 #include "cudaq/Optimizer/Transforms/Passes.h.inc"
 } // namespace cudaq::opt
 
@@ -78,10 +78,10 @@ public:
 
 namespace {
 
-struct ApplyControlNegationsPass
-    : public cudaq::opt::impl::ApplyControlNegationsBase<
-          ApplyControlNegationsPass> {
-  using ApplyControlNegationsBase::ApplyControlNegationsBase;
+struct ExpandControlNegationsPass
+    : public cudaq::opt::impl::ExpandControlNegationsBase<
+          ExpandControlNegationsPass> {
+  using ExpandControlNegationsBase::ExpandControlNegationsBase;
 
   void runOnOperation() override {
     auto funcOp = getOperation();

--- a/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
@@ -177,7 +177,7 @@ static void createJITTargetFinalizePipeline(
   if (options.lowerDeviceCalls)
     pm.addPass(cudaq::opt::createDistributedDeviceCall());
   cudaq::opt::addAggressiveInlining(pm);
-  pm.addNestedPass<func::FuncOp>(cudaq::opt::createApplyControlNegations());
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createExpandControlNegations());
   cudaq::opt::createTargetFinalizePipeline(pm);
 }
 


### PR DESCRIPTION
what it does: expand-control-negations.

In a pedantic sense, nothing new is "applied" by this pass. Rather it replaces a denser encoding with an expansion of the IR. The expansion may or may not be required depending on the target.