### PR TITLE
Default observe `shots_count` to -1 to match C++ and async API

### DIFF
--- a/python/cudaq/runtime/observe.py
+++ b/python/cudaq/runtime/observe.py
@@ -27,7 +27,7 @@ def isValidObserveKernel(kernel):
                                                    decorator.qkeModule)
 
 
-def __broadcastObserve(kernel, spin_operator, *args, shots_count=0, qpu_id=0):
+def __broadcastObserve(kernel, spin_operator, *args, shots_count=-1, qpu_id=0):
     argSet = __createArgumentSet(*args)
     N = len(argSet)
     results = []
@@ -50,7 +50,7 @@ def __broadcastObserve(kernel, spin_operator, *args, shots_count=0, qpu_id=0):
 def observe(kernel,
             spin_operator,
             *args,
-            shots_count=0,
+            shots_count=-1,
             noise_model=None,
             num_trajectories=None,
             execution=None,

--- a/python/cudaq/runtime/observe.py
+++ b/python/cudaq/runtime/observe.py
@@ -32,7 +32,8 @@ def __broadcastObserve(kernel, spin_operator, *args, shots_count=-1, qpu_id=0):
     N = len(argSet)
     results = []
     kernel_name = kernel.name if hasattr(kernel, 'name') else ''
-    ctx = cudaq_runtime.ExecutionContext('observe', shots_count, qpu_id)
+    ctx_shots = shots_count if shots_count > 0 else 0
+    ctx = cudaq_runtime.ExecutionContext('observe', ctx_shots, qpu_id)
     ctx.totalIterations = N
     ctx.setSpinOperator(spin_operator)
     ctx.kernelName = kernel_name


### PR DESCRIPTION
* Not a correctness fix: 0 already mapped to exact mode via `shots_count > 0`.
* Makes the public default match C++, docs, and observe_async/parallel.