### PR TITLE
Introducing run_policy. Removing invocationResultBuffer.

### DIFF
--- a/python/runtime/common/py_ExecutionContext.cpp
+++ b/python/runtime/common/py_ExecutionContext.cpp
@@ -42,8 +42,6 @@ void bindExecutionContext(nanobind::module_ &mod) {
               &cudaq::ExecutionContext::numberTrajectories)
       .def_rw("explicitMeasurements",
               &cudaq::ExecutionContext::explicitMeasurements)
-      .def_ro("invocationResultBuffer",
-              &cudaq::ExecutionContext::invocationResultBuffer)
       .def("setSpinOperator",
            [](cudaq::ExecutionContext &ctx, cudaq::spin_op &spin) {
              ctx.spin = spin;

--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -96,14 +96,14 @@ pyRunTheKernel(const std::string &name, quantum_platform &platform,
   }
   auto layoutInfo =
       cudaq_internal::compiler::getLayoutInfo(name, mod.getOperation());
-  auto results = detail::runTheKernel(
+  cudaq::run_result runResult = detail::launchRun(
       [&]() mutable {
         [[maybe_unused]] auto result =
             clean_launch_module(name, mod, opaques, compiled);
       },
-      platform, name, name, shots_count, layoutInfo, qpu_id);
+      platform, name, shots_count, qpu_id);
 
-  return results;
+  return detail::convertToRunResultSpan(runResult.outputLog, layoutInfo);
 }
 
 static std::vector<nanobind::object>
@@ -154,7 +154,7 @@ namespace {
 // `results` and `error` are owned by the struct; the deferred future captures
 // non-owning raw pointers to them, which stay valid for the future's lifetime
 // because the future is destroyed before these members.
-struct async_run_result {
+struct PyAsyncRunResult {
   std::unique_ptr<std::vector<nanobind::object>> results;
   std::unique_ptr<std::string> error;
   std::future<void> ready;
@@ -162,7 +162,7 @@ struct async_run_result {
 } // namespace
 
 /// @brief Run `cudaq::run_async` on the provided kernel.
-static async_run_result
+static PyAsyncRunResult
 run_async_impl(const std::string &shortName, MlirModule module,
                std::size_t shots_count, std::optional<noise_model> noise_model,
                std::size_t qpu_id, nanobind::args runtimeArgs) {
@@ -181,7 +181,7 @@ run_async_impl(const std::string &shortName, MlirModule module,
     throw std::runtime_error(
         "Noise model is not supported on remote platforms.");
 
-  async_run_result result;
+  PyAsyncRunResult result;
   result.results = std::make_unique<std::vector<nanobind::object>>();
   result.error = std::make_unique<std::string>();
 
@@ -278,10 +278,10 @@ Returns:
 
 /// @brief Bind the run_async cudaq function.
 void cudaq::bindPyRunAsync(nanobind::module_ &mod) {
-  nanobind::class_<async_run_result>(mod, "AsyncRunResultImpl", "")
+  nanobind::class_<PyAsyncRunResult>(mod, "AsyncRunResultImpl", "")
       .def(
           "get",
-          [](async_run_result &self) {
+          [](PyAsyncRunResult &self) {
             {
               // Release the GIL so the async task's MLIR worker threads
               // can call PyGILState_Ensure without deadlocking on us.

--- a/python/tests/backends/test_QCI.py
+++ b/python/tests/backends/test_QCI.py
@@ -225,6 +225,33 @@ def test_run():
     assert non_zero_count > 0
 
 
+def test_run_async():
+
+    @cudaq.kernel
+    def simple(numQubits: int) -> int:
+        qubits = cudaq.qvector(numQubits)
+        h(qubits.front())
+        for i, qubit in enumerate(qubits.front(numQubits - 1)):
+            x.ctrl(qubit, qubits[i + 1])
+        result = 0
+        for i in range(numQubits):
+            if mz(qubits[i]):
+                result += 1
+        return result
+
+    shots = 100
+    qubitCount = 4
+    future = cudaq.run_async(simple, qubitCount, shots_count=shots)
+    results = future.get()
+    assert len(results) == shots
+    non_zero_count = 0
+    for result in results:
+        assert result == 0 or result == qubitCount  # 00..0 or 1...11
+        if result == qubitCount:
+            non_zero_count += 1
+    assert non_zero_count > 0
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)

--- a/python/tests/backends/test_Quantinuum_ng_kernel.py
+++ b/python/tests/backends/test_Quantinuum_ng_kernel.py
@@ -205,6 +205,34 @@ def test_run():
     assert non_zero_count > 0
 
 
+def test_run_async():
+
+    @cudaq.kernel
+    def simple(numQubits: int) -> int:
+        qubits = cudaq.qvector(numQubits)
+        h(qubits.front())
+        for i, qubit in enumerate(qubits.front(numQubits - 1)):
+            x.ctrl(qubit, qubits[i + 1])
+        result = 0
+        for i in range(numQubits):
+            if mz(qubits[i]):
+                result += 1
+        return result
+
+    shots = 100
+    qubitCount = 4
+    future = cudaq.run_async(simple, qubitCount, shots_count=shots)
+    results = future.get()
+    print(results)
+    assert len(results) == shots
+    non_zero_count = 0
+    for result in results:
+        assert result == 0 or result == qubitCount  # 00..0 or 1...11
+        if result == qubitCount:
+            non_zero_count += 1
+    assert non_zero_count > 0
+
+
 def test_quantinuum_state_preparation():
 
     @cudaq.kernel

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -264,6 +264,14 @@ public:
     return target;
   }
 
+  std::unique_ptr<CompileTarget> getCompileTarget(const run_policy &) override {
+    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
+        serverHelper.get(), targetConfig, backendConfig, emulate);
+    target->pipelineConfig.replaceStateWithKernel = true;
+    target->overrideAOTCompilation = true;
+    return target;
+  }
+
   /// Build a local JIT artifact for DEM analysis. No provider target code is
   /// emitted or submitted while this policy is active.
   std::unique_ptr<CompileTarget> getCompileTarget(const dem_policy &) override {
@@ -325,77 +333,67 @@ public:
       return;
     }
 
-    // Get the current execution context and number of shots
-    std::size_t localShots = 1000;
-    if (executionContext->shots != std::numeric_limits<std::size_t>::max() &&
-        executionContext->shots != 0)
-      localShots = executionContext->shots;
+    return;
+  }
 
-    executor->setShots(localShots);
-    assert(executionContext && executionContext->name == "run");
+  run_result completeLaunchKernel(const run_policy &policy,
+                                  const std::string &kernelName,
+                                  std::vector<cudaq::KernelExecution> &&codes) {
+    // The synchronous run policy is only ever used for the emulation path;
+    // remote execution is dispatched through async_run_policy and the executor.
+    assert(emulate);
 
-    // If emulation requested, then just grab the function and invoke it with
-    // the simulator
-    cudaq::detail::future future;
-    if (emulate) {
+    // Seed the simulator RNG for reproducibility. If seed is 0, then it has
+    // not been set.
+    std::size_t seed = cudaq::get_random_seed();
+    if (seed > 0)
+      cudaq::set_random_seed(seed);
 
-      // TODO: This assert demonstrates that we are never expected to return a
-      // future in emulation mode. We are launching a new thread just to wait
-      // for its execution to finish below. We need to make this work without
-      // the thread as the executionContext is crossing the thread boundary
-      // which is not thread safe in the general case.
-      assert(!executionContext->asyncExec);
+    // cudaq::run kernels should only generate one JIT'ed kernel, which we
+    // invoke once per shot and let the execution manager collect the QIR
+    // output log.
+    assert(codes.size() == 1 && codes[0].jit);
+    return cudaq::ExecutionManager::with_default_em(policy, [&] {
+      // Run each shot with the thread-local execution context cleared.
+      // CircuitSimulator::deallocateQubits skips deallocation while an
+      // execution context is set, so if the context stays set across the whole
+      // shot loop the per-shot qubits allocated by the kernel accumulate and
+      // blow up the simulator state (OOM). Clearing it lets each shot fully
+      // deallocate, matching the pre-policy behavior where the shot loop ran on
+      // a separate thread with no execution context.
+      auto *savedContext = cudaq::getExecutionContext();
+      cudaq::detail::resetExecutionContext();
+      cudaq::detail::try_finally(
+          [&] {
+            for (std::size_t shot = 0; shot < policy.shots; shot++)
+              codes[0].jit->run(kernelName);
+          },
+          [&] {
+            if (savedContext)
+              cudaq::detail::setExecutionContext(savedContext);
+          });
+    });
+  }
 
-      // Fetch the thread-specific seed outside and then pass it inside.
-      std::size_t seed = cudaq::get_random_seed();
-
-      // Launch the execution of the simulated jobs asynchronously
-      future = cudaq::detail::future(
-          std::async(std::launch::async,
-                     [&, codes, localShots, kernelName,
-                      seed]() mutable -> cudaq::sample_result {
-                       std::vector<cudaq::ExecutionResult> results;
-
-                       // If seed is 0, then it has not been set.
-                       if (seed > 0)
-                         cudaq::set_random_seed(seed);
-
-                       // Validate the execution logic: cudaq::run kernels
-                       // should only generate one JIT'ed kernel.
-                       assert(codes.size() == 1 && codes[0].jit);
-                       executor->setShots(1); // run one shot at a time
-
-                       // If this is executed via cudaq::run, then you have to
-                       // run the code localShots times
-                       for (std::size_t shot = 0; shot < localShots; shot++)
-                         codes[0].jit->run(kernelName);
-
-                       // Get QIR output log
-                       const auto qirOutputLog = nvqir::getQirOutputLog();
-                       executionContext->invocationResultBuffer.assign(
-                           qirOutputLog.begin(), qirOutputLog.end());
-                       return cudaq::sample_result();
-                     }));
-
-    } else {
-      // Execute the codes produced in quake lowering
-      // Allow developer to disable remote sending (useful for debugging IR)
-      if (getEnvBool("DISABLE_REMOTE_SEND", false))
-        return;
-
-      future =
-          executor->execute(codes, cudaq::detail::ExecutionContextType::run,
-                            &executionContext->invocationResultBuffer);
+  async_run_result
+  completeLaunchKernel(const async_run_policy &policy,
+                       const std::string &kernelName,
+                       std::vector<cudaq::KernelExecution> &&codes) {
+    executor->setShots(policy.inner.shots);
+    assert(!emulate);
+    if (getEnvBool("DISABLE_REMOTE_SEND", false)) {
+      auto rawOutput = std::make_shared<std::vector<char>>();
+      std::promise<sample_result> promise;
+      auto future = promise.get_future();
+      promise.set_value({});
+      return async_run_result(cudaq::detail::future(std::move(future)),
+                              std::move(rawOutput));
     }
 
-    // Keep this asynchronous if requested
-    if (executionContext->asyncExec) {
-      executionContext->futureResult = future;
-      return;
-    }
-
-    // Otherwise make this synchronous
-    executionContext->result = future.get();
+    auto rawOutput = std::make_shared<std::vector<char>>();
+    auto future = executor->execute(
+        codes, cudaq::detail::ExecutionContextType::run, rawOutput.get());
+    return async_run_result(std::move(future), std::move(rawOutput));
   }
 
   async_sample_result
@@ -433,8 +431,6 @@ public:
     if (policy.options.shots != std::numeric_limits<std::size_t>::max() &&
         policy.options.shots != 0)
       localShots = policy.options.shots;
-
-    executor->setShots(localShots);
 
     // If emulation requested, then just grab the function and invoke it with
     // the simulator
@@ -503,7 +499,6 @@ public:
     if (policy.options.shots > 0)
       localShots = static_cast<std::size_t>(policy.options.shots);
 
-    executor->setShots(localShots);
     assert(emulate);
 
     std::size_t seed = cudaq::get_random_seed();

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -265,8 +265,9 @@ public:
   }
 
   std::unique_ptr<CompileTarget> getCompileTarget(const run_policy &) override {
-    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
-        serverHelper.get(), targetConfig, backendConfig, emulate);
+    auto target = std::make_unique<CompileTarget>(
+        targetConfig, backendConfig, emulate,
+        serverHelper->getPipelineSubstitutions(platformPath));
     target->pipelineConfig.replaceStateWithKernel = true;
     target->overrideAOTCompilation = true;
     return target;

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -112,11 +112,6 @@ public:
   /// @brief The ID of the QPU that this execution context is running on.
   std::size_t qpuId = 0;
 
-  /// @brief A buffer containing the return value of a kernel invocation.
-  /// Note: this is only needed for invocation not able to return a
-  /// `sample_result`.
-  std::vector<char> invocationResultBuffer;
-
   /// @brief The number of trajectories to be used for an expectation
   /// calculation on simulation backends that support trajectory simulation.
   std::optional<std::size_t> numberTrajectories = std::nullopt;

--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -13,8 +13,15 @@
 #include <functional>
 #include <future>
 #include <map>
+#include <memory>
 
 namespace cudaq {
+
+/// @brief Raw output produced by a runnable kernel. Defined fully in
+/// cudaq/algorithms/run/policy.h; forward-declared here to break the include
+/// cycle between the run policy header and this header.
+struct run_result;
+
 namespace detail {
 
 /// @brief The execution context of a server job.
@@ -118,6 +125,9 @@ protected:
   /// @brief A spin operator, used for observe future tasks
   std::optional<spin_op> spinOp;
 
+  /// @brief Raw output storage used for asynchronous run tasks.
+  std::shared_ptr<std::vector<char>> rawOutput;
+
 public:
   async_result() = default;
   async_result(const spin_op *s) {
@@ -133,6 +143,9 @@ public:
       spinOp.value().canonicalize();
     }
   }
+  async_result(detail::future &&f,
+               std::shared_ptr<std::vector<char>> rawOutputIn)
+      : result(std::move(f)), rawOutput(std::move(rawOutputIn)) {}
 
   virtual ~async_result() = default;
   async_result(async_result &&) = default;
@@ -178,6 +191,13 @@ public:
       return observe_result(sum, *spinOp, data);
     }
 
+    if constexpr (std::is_same_v<T, run_result>) {
+      if (!rawOutput)
+        throw std::runtime_error(
+            "Returning a run_result requires raw output storage.");
+      return {std::string(rawOutput->begin(), rawOutput->end())};
+    }
+
     return T();
   }
 
@@ -203,6 +223,9 @@ using async_observe_result = async_result<observe_result>;
 
 /// @brief Return type for asynchronous sampling.
 using async_sample_result = async_result<sample_result>;
+
+/// @brief Return type for asynchronous runnable kernel execution.
+using async_run_result = async_result<run_result>;
 
 /// @brief Wrapper for a policy to return an async_result.
 template <typename InnerPolicy>

--- a/runtime/cudaq/algorithms/launch.h
+++ b/runtime/cudaq/algorithms/launch.h
@@ -27,7 +27,7 @@ namespace cudaq_internal::compiler {
 cudaq::CompiledModule
 compileModule(std::unique_ptr<cudaq::CompileTarget> target,
               const cudaq::SourceModule &src, cudaq::KernelArgs args,
-              bool isEntryPoint = true);
+              bool isEntryPoint);
 } // namespace cudaq_internal::compiler
 #endif
 
@@ -80,7 +80,8 @@ auto launch(const Policy &policy, std::size_t qpu_id, ExecutionContext &ctx,
         target = cudaq::get_compile_target(policy);
       }
       compiled = cudaq_internal::compiler::compileModule(std::move(target),
-                                                         *source, args);
+                                                         *source, args,
+                                                         /*isEntryPoint=*/true);
 #endif
     } else {
       CUDAQ_INFO("Found compiled module. Skipping compilation.");

--- a/runtime/cudaq/algorithms/policies.h
+++ b/runtime/cudaq/algorithms/policies.h
@@ -11,6 +11,7 @@
 #include "cudaq/algorithms/dem/policy.h"
 #include "cudaq/algorithms/msm/policy.h"
 #include "cudaq/algorithms/observe/policy.h"
+#include "cudaq/algorithms/run/policy.h"
 #include "cudaq/algorithms/sample/policy.h"
 #include "cudaq/ptsbe/policy.h"
 

--- a/runtime/cudaq/algorithms/policy_dispatch.h
+++ b/runtime/cudaq/algorithms/policy_dispatch.h
@@ -81,6 +81,7 @@ decltype(auto) withPolicy(std::string_view name, Func &&func) {
   static const Entry registry[] = {
       {"sample", [](FuncRef f) -> Ret { return f(sample_policy{}); }},
       {"observe", [](FuncRef f) -> Ret { return f(observe_policy{}); }},
+      {"run", [](FuncRef f) -> Ret { return f(run_policy{}); }},
       {"dem", [](FuncRef f) -> Ret { return f(dem_policy{}); }},
       {"msm_size", [](FuncRef f) -> Ret { return f(msm_size_policy{}); }},
       {"msm", [](FuncRef f) -> Ret { return f(msm_policy{}); }},

--- a/runtime/cudaq/algorithms/run.cpp
+++ b/runtime/cudaq/algorithms/run.cpp
@@ -16,7 +16,6 @@
 cudaq::detail::RunResultSpan cudaq::detail::convertToRunResultSpan(
     const std::string &outputLog,
     const cudaq_internal::compiler::LayoutInfoType &layoutInfo) {
-  ScopedTraceWithContext(cudaq::TIMING_RUN, "runTheKernel");
 
   // 1. Pass the outputLog to the parser (target-specific?)
   cudaq::RecordLogParser parser(layoutInfo);

--- a/runtime/cudaq/algorithms/run.cpp
+++ b/runtime/cudaq/algorithms/run.cpp
@@ -9,50 +9,20 @@
 #include "run.h"
 #include "common/RecordLogParser.h"
 #include "common/Timing.h"
+#include "cudaq/algorithms/launch.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/simulators.h"
 
-cudaq::detail::RunResultSpan cudaq::detail::runTheKernel(
-    std::function<void()> &&kernel, quantum_platform &platform,
-    const std::string &kernel_name, const std::string &original_name,
-    std::size_t shots,
-    const cudaq_internal::compiler::LayoutInfoType &layoutInfo,
-    std::size_t qpu_id) {
+cudaq::detail::RunResultSpan cudaq::detail::convertToRunResultSpan(
+    const std::string &outputLog,
+    const cudaq_internal::compiler::LayoutInfoType &layoutInfo) {
   ScopedTraceWithContext(cudaq::TIMING_RUN, "runTheKernel");
-  // 1. Clear the outputLog.
-  auto *circuitSimulator = nvqir::getCircuitSimulatorInternal();
-  circuitSimulator->outputLog.clear();
 
-  // Some platforms do not support run yet, emit error.
-  if (!platform.get_codegen_config().outputLog)
-    throw std::runtime_error("`run` is not yet supported on this target.");
-
-  // 2. Launch the kernel on the QPU.
-  if (platform.is_remote() || platform.is_emulated()) {
-    // In a remote simulator execution or hardware emulation environment, set
-    // the `run` context name and number of iterations (shots)
-    cudaq::ExecutionContext ctx("run", shots, qpu_id);
-    // Launch the kernel a single time to post the 'run' request to the remote
-    // server or emulation executor.
-    platform.with_execution_context(ctx, std::move(kernel));
-    // Retrieve the result output log.
-    std::string remoteOutputLog(ctx.invocationResultBuffer.begin(),
-                                ctx.invocationResultBuffer.end());
-    circuitSimulator->outputLog.swap(remoteOutputLog);
-  } else {
-    cudaq::ExecutionContext ctx("run", 1, qpu_id);
-    for (std::size_t i = 0; i < shots; ++i) {
-      // Set the execution context since as noise model is attached to this
-      // context.
-      platform.with_execution_context(ctx, std::move(kernel));
-    }
-  }
-
-  // 3. Pass the outputLog to the parser (target-specific?)
+  // 1. Pass the outputLog to the parser (target-specific?)
   cudaq::RecordLogParser parser(layoutInfo);
-  parser.parse(circuitSimulator->outputLog);
+  parser.parse(outputLog);
 
-  // 4. Get the buffer and length of buffer (in bytes) from the parser.
+  // 2. Get the buffer and length of buffer (in bytes) from the parser.
   auto *origBuffer = parser.getBufferPtr();
   std::size_t bufferSize = parser.getBufferSize();
   std::size_t resultCount = parser.getResultCount();
@@ -71,10 +41,7 @@ cudaq::detail::RunResultSpan cudaq::detail::runTheKernel(
     std::memcpy(buffer, origBuffer, bufferSize);
   }
 
-  // 5. Clear the outputLog (?)
-  circuitSimulator->outputLog.clear();
-
-  // 6. Pass the span back as a RunResultSpan. NB: it is the responsibility of
+  // 3. Pass the span back as a RunResultSpan. NB: it is the responsibility of
   // the caller to free the buffer.
   return {buffer, bufferSize, resultCount};
 }

--- a/runtime/cudaq/algorithms/run.h
+++ b/runtime/cudaq/algorithms/run.h
@@ -10,7 +10,10 @@
 
 #include "common/ExecutionContext.h"
 #include "common/SampleResult.h"
+#include "common/Timing.h"
 #include "cudaq/algorithms/broadcast.h"
+#include "cudaq/algorithms/launch.h"
+#include "cudaq/algorithms/run/policy.h"
 #include "cudaq/concepts.h"
 #include "cudaq/host_config.h"
 #include "cudaq/platform.h"
@@ -53,12 +56,66 @@ struct RunResultSpan {
 // executions with nonzero END status are omitted, so the returned span may
 // contain fewer than \p shots results and reports its actual count.
 
-RunResultSpan
-runTheKernel(std::function<void()> &&kernel, quantum_platform &platform,
-             const std::string &kernel_name, const std::string &original_name,
-             std::size_t shots,
-             const cudaq_internal::compiler::LayoutInfoType &layoutInfo,
-             std::size_t qpu_id = 0);
+// Parse a `cudaq::run` output log into a RunResultSpan. The parsing step is
+// kept out of line (in libcudaq) so the RecordLogParser is not instantiated at
+// every call site. The kernel launch that produces \p outputLog happens in the
+// caller's scope (see `launchRun`) so that the JIT compiler dependency is only
+// linked when the user compiles with nvq++.
+RunResultSpan convertToRunResultSpan(
+    const std::string &outputLog,
+    const cudaq_internal::compiler::LayoutInfoType &layoutInfo);
+
+// Launch a runnable \p kernel \p shots times and return the raw output log.
+//
+// This is deliberately defined in the header so that the `detail::launch`
+// machinery (which references the JIT `compileModule`) is instantiated in the
+// caller's translation unit rather than in libcudaq, which does not link the
+// JIT compiler runtime.
+inline run_result launchRun(std::function<void()> kernel,
+                            quantum_platform &platform,
+                            const std::string &kernel_name, std::size_t shots,
+                            std::size_t qpu_id) {
+  ScopedTraceWithContext(cudaq::TIMING_RUN, "launchRun");
+
+  // Some platforms do not support run yet, emit error.
+  if (!platform.get_codegen_config().outputLog)
+    throw std::runtime_error("`run` is not yet supported on this target.");
+
+  run_result result;
+  run_policy policy;
+  policy.kernelName = kernel_name;
+  policy.noiseModel = platform.get_noise(qpu_id);
+  if (platform.is_remote()) {
+    cudaq::ExecutionContext ctx("run", shots, qpu_id);
+    ctx.kernelName = kernel_name;
+    ctx.noiseModel = policy.noiseModel;
+    policy.shots = shots;
+    async_run_policy asyncPolicy;
+    asyncPolicy.inner = policy;
+    result =
+        detail::launch(asyncPolicy, qpu_id, ctx, platform, std::move(kernel))
+            .get();
+  } else if (platform.is_emulated()) {
+    // In a remote simulator execution or hardware emulation environment, set
+    // the `run` context name and number of iterations (shots)
+    cudaq::ExecutionContext ctx("run", shots, qpu_id);
+    ctx.kernelName = kernel_name;
+    ctx.noiseModel = policy.noiseModel;
+    policy.shots = shots;
+    // Launch the kernel a single time to post the 'run' request to the remote
+    // server or emulation executor.
+    result = detail::launch(policy, qpu_id, ctx, platform, std::move(kernel));
+  } else {
+    cudaq::ExecutionContext ctx("run", 1, qpu_id);
+    ctx.kernelName = kernel_name;
+    ctx.noiseModel = policy.noiseModel;
+    for (std::size_t i = 0; i < shots; ++i) {
+      auto shotResult = detail::launch(policy, qpu_id, ctx, platform, kernel);
+      result.outputLog += shotResult.outputLog;
+    }
+  }
+  return result;
+}
 
 // Template to transfer the ownership of the buffer in a RunResultSpan to a
 // `std::vector<T>` object. This special code is required because a
@@ -133,24 +190,33 @@ run(std::size_t shots, QuantumKernel &&kernel, ARGS &&...args) {
   auto &platform = get_platform();
 #ifdef CUDAQ_LIBRARY_MODE
   cudaq::ExecutionContext ctx("run", 1);
+  run_policy policy;
+  policy.kernelName = detail::getKernelName(kernel);
+  policy.noiseModel = platform.get_noise();
   // Direct kernel invocation loop for library mode
   results.reserve(shots);
   for (std::size_t i = 0; i < shots; ++i) {
-    results.emplace_back(platform.with_execution_context(
-        ctx, std::forward<QuantumKernel>(kernel), std::forward<ARGS>(args)...));
+    std::optional<ResultTy> result;
+    detail::launch(policy, 0, ctx, platform, [&] {
+      result.emplace(std::invoke(std::forward<QuantumKernel>(kernel),
+                                 std::forward<ARGS>(args)...));
+    });
+    results.emplace_back(std::move(*result));
   }
 #else
   // Launch the kernel in the appropriate context.
   std::string kernelName{detail::getKernelName(kernel)};
   cudaq_internal::compiler::LayoutInfoType layoutInfo =
       cudaq_internal::compiler::getLayoutInfo(kernelName, nullptr);
-  detail::RunResultSpan span = detail::runTheKernel(
+  cudaq::run_result runResult = detail::launchRun(
       [&]() mutable {
         auto *runKernel =
             detail::get_run_entry_point(qkernel{kernel}, kernelName);
         (*runKernel)(std::forward<ARGS>(args)...);
       },
-      platform, kernelName, kernelName, shots, layoutInfo);
+      platform, kernelName, shots, /*qpu_id=*/0);
+  detail::RunResultSpan span =
+      detail::convertToRunResultSpan(runResult.outputLog, layoutInfo);
   detail::resultSpanToVectorViaOwnership<ResultTy>(results, span);
 #endif
   return results;
@@ -185,10 +251,17 @@ run(std::size_t shots, cudaq::noise_model &noise_model, QuantumKernel &&kernel,
   // Direct kernel invocation loop for library mode
   platform.set_noise(&noise_model);
   cudaq::ExecutionContext ctx("run", 1);
+  run_policy policy;
+  policy.kernelName = detail::getKernelName(kernel);
+  policy.noiseModel = &noise_model;
   results.reserve(shots);
   for (std::size_t i = 0; i < shots; ++i) {
-    results.emplace_back(platform.with_execution_context(
-        ctx, std::forward<QuantumKernel>(kernel), std::forward<ARGS>(args)...));
+    std::optional<ResultTy> result;
+    detail::launch(policy, 0, ctx, platform, [&] {
+      result.emplace(std::invoke(std::forward<QuantumKernel>(kernel),
+                                 std::forward<ARGS>(args)...));
+    });
+    results.emplace_back(std::move(*result));
   }
   platform.reset_noise();
 #else
@@ -197,14 +270,16 @@ run(std::size_t shots, cudaq::noise_model &noise_model, QuantumKernel &&kernel,
   std::string kernelName{detail::getKernelName(kernel)};
   cudaq_internal::compiler::LayoutInfoType layoutInfo =
       cudaq_internal::compiler::getLayoutInfo(kernelName, nullptr);
-  detail::RunResultSpan span = detail::runTheKernel(
+  cudaq::run_result runResult = detail::launchRun(
       [&]() mutable {
         auto *runKernel =
             detail::get_run_entry_point(qkernel{kernel}, kernelName);
         (*runKernel)(std::forward<ARGS>(args)...);
       },
-      platform, kernelName, kernelName, shots, layoutInfo);
+      platform, kernelName, shots, /*qpu_id=*/0);
   platform.reset_noise();
+  detail::RunResultSpan span =
+      detail::convertToRunResultSpan(runResult.outputLog, layoutInfo);
   detail::resultSpanToVectorViaOwnership<ResultTy>(results, span);
 #endif
   return results;
@@ -248,24 +323,32 @@ run_async(std::size_t qpu_id, std::size_t shots, QuantumKernel &&kernel,
         // Direct kernel invocation loop for library mode
         std::vector<ResultTy> res;
         cudaq::ExecutionContext ctx("run", 1, qpu_id);
+        run_policy policy;
+        policy.kernelName = detail::getKernelName(kernel);
+        policy.noiseModel = platform.get_noise(qpu_id);
         res.reserve(shots);
         for (std::size_t i = 0; i < shots; ++i) {
-          res.emplace_back(platform.with_execution_context(
-              ctx, std::forward<QuantumKernel>(kernel),
-              std::forward<ARGS>(args)...));
+          std::optional<ResultTy> result;
+          detail::launch(policy, qpu_id, ctx, platform, [&] {
+            result.emplace(std::invoke(std::forward<QuantumKernel>(kernel),
+                                       std::forward<ARGS>(args)...));
+          });
+          res.emplace_back(std::move(*result));
         }
         p.set_value(std::move(res));
 #else
         const std::string kernelName{detail::getKernelName(kernel)};
         cudaq_internal::compiler::LayoutInfoType layoutInfo =
             cudaq_internal::compiler::getLayoutInfo(kernelName, nullptr);
-        detail::RunResultSpan span = detail::runTheKernel(
+        cudaq::run_result runResult = detail::launchRun(
             [&]() mutable {
               auto *runKernel =
                   detail::get_run_entry_point(qkernel{kernel}, kernelName);
               (*runKernel)(std::forward<ARGS>(args)...);
             },
-            platform, kernelName, kernelName, shots, layoutInfo, qpu_id);
+            platform, kernelName, shots, qpu_id);
+        detail::RunResultSpan span =
+            detail::convertToRunResultSpan(runResult.outputLog, layoutInfo);
         std::vector<ResultTy> results;
         detail::resultSpanToVectorViaOwnership<ResultTy>(results, span);
         p.set_value(std::move(results));
@@ -317,12 +400,18 @@ run_async(std::size_t qpu_id, std::size_t shots,
         // Direct kernel invocation loop for library mode
         platform.set_noise(&noise_model);
         cudaq::ExecutionContext ctx("run", 1, qpu_id);
+        run_policy policy;
+        policy.kernelName = detail::getKernelName(kernel);
+        policy.noiseModel = &noise_model;
         std::vector<ResultTy> res;
         res.reserve(shots);
         for (std::size_t i = 0; i < shots; ++i) {
-          res.emplace_back(platform.with_execution_context(
-              ctx, std::forward<QuantumKernel>(kernel),
-              std::forward<ARGS>(args)...));
+          std::optional<ResultTy> result;
+          detail::launch(policy, qpu_id, ctx, platform, [&] {
+            result.emplace(std::invoke(std::forward<QuantumKernel>(kernel),
+                                       std::forward<ARGS>(args)...));
+          });
+          res.emplace_back(std::move(*result));
         }
         platform.reset_noise();
         p.set_value(std::move(res));
@@ -331,14 +420,16 @@ run_async(std::size_t qpu_id, std::size_t shots,
         const std::string kernelName{detail::getKernelName(kernel)};
         cudaq_internal::compiler::LayoutInfoType layoutInfo =
             cudaq_internal::compiler::getLayoutInfo(kernelName, nullptr);
-        detail::RunResultSpan span = detail::runTheKernel(
+        cudaq::run_result runResult = detail::launchRun(
             [&]() mutable {
               auto *runKernel =
                   detail::get_run_entry_point(qkernel{kernel}, kernelName);
               (*runKernel)(std::forward<ARGS>(args)...);
             },
-            platform, kernelName, kernelName, shots, layoutInfo, qpu_id);
+            platform, kernelName, shots, qpu_id);
         platform.reset_noise();
+        detail::RunResultSpan span =
+            detail::convertToRunResultSpan(runResult.outputLog, layoutInfo);
         std::vector<ResultTy> results;
         detail::resultSpanToVectorViaOwnership<ResultTy>(results, span);
         p.set_value(std::move(results));

--- a/runtime/cudaq/algorithms/run/policy.h
+++ b/runtime/cudaq/algorithms/run/policy.h
@@ -1,0 +1,56 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "common/Future.h"
+#include <cstddef>
+#include <string>
+
+namespace nvqir {
+class CircuitSimulator;
+}
+
+namespace cudaq {
+
+class ExecutionManager;
+class ExecutionContext;
+class noise_model;
+
+/// @brief Raw output produced by a runnable kernel.
+struct run_result {
+  std::string outputLog;
+};
+
+/// @brief Tag and inputs for executing a runnable kernel.
+struct run_policy {
+  /// @brief The name of the policy.
+  static constexpr char name[] = "run";
+
+  /// Associated result type for synchronous APIs keyed off this policy.
+  using result_type = run_result;
+
+  /// @brief The name of the kernel being executed.
+  std::string kernelName;
+
+  /// @brief The number of kernel executions requested.
+  std::size_t shots = 1;
+
+  mutable const noise_model *noiseModel = nullptr;
+
+  friend run_result finalize_execution_manager_impl(ExecutionManager &mgr,
+                                                    const run_policy &policy,
+                                                    ExecutionContext &ctx);
+  friend run_result
+  finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
+                                   const run_policy &policy);
+};
+
+using async_run_policy = async_policy_wrapper<run_policy>;
+
+} // namespace cudaq

--- a/runtime/cudaq/platform.h
+++ b/runtime/cudaq/platform.h
@@ -57,6 +57,8 @@ getDefaultCompileTarget(const sample_policy &policy);
 std::unique_ptr<cudaq::CompileTarget>
 getDefaultCompileTarget(const observe_policy &policy);
 std::unique_ptr<cudaq::CompileTarget>
+getDefaultCompileTarget(const run_policy &policy);
+std::unique_ptr<cudaq::CompileTarget>
 getDefaultCompileTarget(const dem_policy &policy);
 std::unique_ptr<cudaq::CompileTarget>
 getDefaultCompileTarget(const other_policies &policy,

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -77,6 +77,24 @@ cudaq::DefaultQPU::launchKernel(const cudaq::observe_policy &policy,
       [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
 }
 
+cudaq::run_result
+cudaq::DefaultQPU::launchKernel(const cudaq::run_policy &policy,
+                                const cudaq::CompiledModule &module,
+                                cudaq::KernelArgs args) {
+  CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
+  return cudaq::ExecutionManager::with_default_em(
+      policy,
+      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+}
+
+cudaq::async_run_policy::result_type
+cudaq::DefaultQPU::launchKernel(const async_run_policy &policy,
+                                const cudaq::CompiledModule &module,
+                                cudaq::KernelArgs args) {
+  throw std::runtime_error(
+      "DefaultQPU does not support launching the async_run_policy.");
+}
+
 cudaq::msm_dimensions
 cudaq::DefaultQPU::launchKernel(const cudaq::msm_size_policy &policy,
                                 const cudaq::CompiledModule &module,
@@ -132,6 +150,11 @@ cudaq::DefaultQPU::getCompileTarget(const sample_policy &policy) {
 
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::DefaultQPU::getCompileTarget(const observe_policy &policy) {
+  return getDefaultCompileTarget(policy);
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::DefaultQPU::getCompileTarget(const run_policy &policy) {
   return getDefaultCompileTarget(policy);
 }
 

--- a/runtime/cudaq/platform/default/DefaultQPU.h
+++ b/runtime/cudaq/platform/default/DefaultQPU.h
@@ -36,6 +36,14 @@ public:
                               const CompiledModule &module,
                               KernelArgs args) override;
 
+  run_result launchKernel(const run_policy &policy,
+                          const CompiledModule &module,
+                          KernelArgs args) override;
+
+  async_run_policy::result_type launchKernel(const async_run_policy &policy,
+                                             const CompiledModule &module,
+                                             KernelArgs args) override;
+
   msm_dimensions launchKernel(const msm_size_policy &policy,
                               const CompiledModule &module,
                               KernelArgs args) override;
@@ -62,6 +70,9 @@ public:
 
   std::unique_ptr<CompileTarget>
   getCompileTarget(const observe_policy &policy) override;
+
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(const run_policy &policy) override;
 
   std::unique_ptr<CompileTarget>
   getCompileTarget(const dem_policy &policy) override;

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -55,6 +55,26 @@ observe_result RemoteRESTQPU::launchKernel(const observe_policy &policy,
   return completeLaunchKernel(policy, module.getName(), std::move(codes));
 }
 
+run_result RemoteRESTQPU::launchKernel(const run_policy &policy,
+                                       const CompiledModule &module,
+                                       KernelArgs args) {
+  CUDAQ_INFO("RemoteRESTQPU::launchKernel {}", policy.name);
+
+  auto target = getCompileTarget(policy);
+  auto codes = runCodegen(module, std::move(target));
+  return completeLaunchKernel(policy, module.getName(), std::move(codes));
+}
+
+async_run_result RemoteRESTQPU::launchKernel(const async_run_policy &policy,
+                                             const CompiledModule &module,
+                                             KernelArgs args) {
+  CUDAQ_INFO("RemoteRESTQPU::launchKernel async {}", policy.inner.name);
+
+  auto target = getCompileTarget(policy.inner);
+  auto codes = runCodegen(module, std::move(target));
+  return completeLaunchKernel(policy, module.getName(), std::move(codes));
+}
+
 async_observe_result
 RemoteRESTQPU::launchKernel(const async_observe_policy &policy,
                             const CompiledModule &module, KernelArgs args) {

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
@@ -46,6 +46,14 @@ public:
                               const CompiledModule &module,
                               KernelArgs args) override;
 
+  run_result launchKernel(const run_policy &policy,
+                          const CompiledModule &module,
+                          KernelArgs args) override;
+
+  async_run_result launchKernel(const async_run_policy &policy,
+                                const CompiledModule &module,
+                                KernelArgs args) override;
+
   async_observe_result launchKernel(const async_observe_policy &policy,
                                     const CompiledModule &module,
                                     KernelArgs args) override;

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -52,6 +52,20 @@ observe_result cudaq::QPU::launchKernel(const observe_policy &policy,
       "This QPU does not support launching the observe_policy.");
 }
 
+run_result cudaq::QPU::launchKernel(const run_policy &policy,
+                                    const CompiledModule &module,
+                                    KernelArgs args) {
+  throw std::runtime_error(
+      "This QPU does not support launching the run_policy.");
+}
+
+async_run_policy::result_type
+cudaq::QPU::launchKernel(const async_run_policy &policy,
+                         const CompiledModule &module, KernelArgs args) {
+  throw std::runtime_error(
+      "This QPU does not support launching the async_run_policy.");
+}
+
 msm_dimensions cudaq::QPU::launchKernel(const msm_size_policy &policy,
                                         const CompiledModule &module,
                                         KernelArgs args) {
@@ -169,6 +183,12 @@ cudaq::QPU::getCompileTarget(const sample_policy &) {
 
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::QPU::getCompileTarget(const observe_policy &) {
+  // Fall back to policy-agnostic compile target.
+  return getCompileTarget(other_policies{}, nullptr);
+}
+
+std::unique_ptr<cudaq::CompileTarget>
+cudaq::QPU::getCompileTarget(const run_policy &) {
   // Fall back to policy-agnostic compile target.
   return getCompileTarget(other_policies{}, nullptr);
 }

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -173,6 +173,14 @@ public:
                                       const CompiledModule &module,
                                       KernelArgs args);
 
+  virtual run_result launchKernel(const run_policy &policy,
+                                  const CompiledModule &module,
+                                  KernelArgs args);
+
+  virtual async_run_policy::result_type
+  launchKernel(const async_run_policy &policy, const CompiledModule &module,
+               KernelArgs args);
+
   virtual msm_dimensions launchKernel(const msm_size_policy &policy,
                                       const CompiledModule &module,
                                       KernelArgs args);
@@ -203,6 +211,8 @@ public:
   getCompileTarget(const sample_policy &policy);
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(const observe_policy &policy);
+  [[nodiscard]] virtual std::unique_ptr<CompileTarget>
+  getCompileTarget(const run_policy &policy);
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(const msm_size_policy &policy);
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -135,6 +135,12 @@ getDefaultCompileTarget(const observe_policy &) {
   return ct;
 }
 std::unique_ptr<cudaq::CompileTarget>
+getDefaultCompileTarget(const run_policy &) {
+  auto ct = getDefaultPythonCompileTargetImpl();
+  ct->overrideAOTCompilation = false;
+  return ct;
+}
+std::unique_ptr<cudaq::CompileTarget>
 getDefaultCompileTarget(const dem_policy &) {
   auto ct = getDefaultPythonCompileTargetImpl();
   ct->overrideAOTCompilation = false;

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -58,6 +58,10 @@ void ExecutionManager::configureExecutionContext(const observe_policy &policy) {
   nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
 }
 
+void ExecutionManager::configureExecutionContext(const run_policy &policy) {
+  nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
+}
+
 void ExecutionManager::configureExecutionContext(
     const msm_size_policy &policy) {
   nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
@@ -85,6 +89,7 @@ void ExecutionManager::finalizeExecutionContext(ExecutionContext &ctx) {
           ctx.result = r.raw_data();
           ctx.expectationValue = r.expectation();
         },
+        [&](run_result &&r) {},
         [&](msm_dimensions &&r) { ctx.msm_dimensions = std::move(r); },
         [&](msm_result &&r) {
           ctx.result = std::move(r.samples);

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -121,6 +121,7 @@ public:
   /// Configure the execution context before an execution.
   void configureExecutionContext(const sample_policy &policy);
   void configureExecutionContext(const observe_policy &policy);
+  void configureExecutionContext(const run_policy &policy);
   void configureExecutionContext(const msm_size_policy &policy);
   void configureExecutionContext(const msm_policy &policy);
   void configureExecutionContext(const dem_policy &policy);
@@ -137,6 +138,11 @@ public:
 
   virtual observe_result
   finalizeExecutionContext(const observe_policy &policy) = 0;
+
+  virtual run_result finalizeExecutionContext(const run_policy &policy) {
+    throw std::runtime_error(
+        "This execution manager does not support run execution.");
+  }
 
   virtual msm_dimensions
   finalizeExecutionContext(const msm_size_policy &policy) = 0;
@@ -269,6 +275,12 @@ inline observe_result
 finalize_execution_manager_impl(ExecutionManager &mgr,
                                 const observe_policy &policy,
                                 ExecutionContext &ctx) {
+  return mgr.finalizeExecutionContext(policy);
+}
+
+inline run_result finalize_execution_manager_impl(ExecutionManager &mgr,
+                                                  const run_policy &policy,
+                                                  ExecutionContext &ctx) {
   return mgr.finalizeExecutionContext(policy);
 }
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -174,6 +174,11 @@ protected:
     return simulator()->finalizeExecutionContext(policy);
   }
 
+  run_result finalizeExecutionContext(const run_policy &policy) override {
+    finalizeExecutionContextImpl();
+    return simulator()->finalizeExecutionContext(policy);
+  }
+
   msm_dimensions
   finalizeExecutionContext(const msm_size_policy &policy) override {
     finalizeExecutionContextImpl();

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -1153,11 +1153,11 @@ protected:
   cudaq::run_result
   finalizeExecutionContext(const cudaq::run_policy &policy) override {
     finalizeExecutionContextImpl();
-    // Capture the output log for this run and reset it so the simulator is
-    // ready for the next invocation.
-    cudaq::run_result result{this->outputLog};
-    this->outputLog.clear();
-    return result;
+    // Capture the output log for this run. Do not clear it here: the log is
+    // reset at the start of each run in configureExecutionContext(run_policy),
+    // The getAndClearOutputLog helper used by the mock QPUs) read the
+    // simulator's output log *after* finalization.
+    return cudaq::run_result{this->outputLog};
   }
 
   cudaq::observe_result

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -1154,8 +1154,8 @@ protected:
   finalizeExecutionContext(const cudaq::run_policy &policy) override {
     finalizeExecutionContextImpl();
     // Capture the output log for this run. Do not clear it here: the log is
-    // reset at the start of each run in configureExecutionContext(run_policy),
-    // The getAndClearOutputLog helper used by the mock QPUs) read the
+    // reset at the start of each run in configureExecutionContext(run_policy).
+    // The getAndClearOutputLog helper used by the mock QPUs reads the
     // simulator's output log *after* finalization.
     return cudaq::run_result{this->outputLog};
   }

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -296,6 +296,7 @@ public:
             ctx.result = r.raw_data();
             ctx.expectationValue = r.expectation();
           },
+          [&](cudaq::run_result &&r) {},
           [&](cudaq::msm_dimensions &&r) { ctx.msm_dimensions = std::move(r); },
           [&](cudaq::msm_result &&r) {
             ctx.result = std::move(r.samples);
@@ -312,6 +313,8 @@ public:
   finalizeExecutionContext(const cudaq::observe_policy &policy) = 0;
   virtual cudaq::sample_result
   finalizeExecutionContext(const cudaq::sample_policy &policy) = 0;
+  virtual cudaq::run_result
+  finalizeExecutionContext(const cudaq::run_policy &policy) = 0;
   virtual cudaq::msm_dimensions
   finalizeExecutionContext(const cudaq::msm_size_policy &policy) {
     throw std::runtime_error("This target does not support policy " +
@@ -346,6 +349,14 @@ public:
   virtual void configureExecutionContext(const cudaq::observe_policy &policy) {
     configureExecutionContextImpl(policy);
     policy.canHandleObserve = canHandleObserve();
+  }
+
+  /// @brief Set the execution context
+  virtual void configureExecutionContext(const cudaq::run_policy &policy) {
+    configureExecutionContextImpl(policy);
+    // Start each run with a clean output log so results are not accumulated
+    // across invocations.
+    outputLog.clear();
   }
 
   /// @brief Set the execution context
@@ -1139,6 +1150,16 @@ protected:
     flushGateQueue();
   }
 
+  cudaq::run_result
+  finalizeExecutionContext(const cudaq::run_policy &policy) override {
+    finalizeExecutionContextImpl();
+    // Capture the output log for this run and reset it so the simulator is
+    // ready for the next invocation.
+    cudaq::run_result result{this->outputLog};
+    this->outputLog.clear();
+    return result;
+  }
+
   cudaq::observe_result
   finalizeExecutionContext(const cudaq::observe_policy &policy) override {
     finalizeExecutionContextImpl();
@@ -1614,6 +1635,11 @@ namespace cudaq {
 inline sample_result
 finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
                                  const sample_policy &policy) {
+  return sim.finalizeExecutionContext(policy);
+}
+
+inline run_result finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
+                                                   const run_policy &policy) {
   return sim.finalizeExecutionContext(policy);
 }
 


### PR DESCRIPTION
## Introduce `run_policy` for `cudaq::run` / `run_async`

### Summary
Migrates `cudaq::run` and `cudaq::run_async` onto the same policy-based launch
dispatch already used by `sample` and `observe`, and removes the `run` dependence
on `ExecutionContext::invocationResultBuffer`. Unlike `sample` and `observe` the return
result is templated based on the kernel's return type. This is why the  raw QIR output log,
is made the return type of the policy and is converted in the user launch.

This continues the effort to make kernel results flow through typed policy objects 
rather than the global execution context.

### What changed
- **New `run_policy` / `async_run_policy`** (`runtime/cudaq/algorithms/run/policy.h`),
  plus a `run_result` type that carries the raw QIR output log. Wired into policy
  dispatch (`policies.h`, `policy_dispatch.h`).
- **QPU dispatch overloads** for the new policies across `QPU`, `DefaultQPU`, and
  `RemoteRESTQPU` (`launchKernel` + `getCompileTarget`), with matching
  `ExecutionManager` / `CircuitSimulator` hooks (`configureExecutionContext` /
  `finalizeExecutionContext`).
- **`run` result-handling refactor**: `detail::runTheKernel` (`run.cpp`) is now
  parse-only (it takes an already-produced output log). Kernel launching moved into
  an inline `detail::launchRun` helper in `run.h`, so the JIT `compileModule`
  dependency is instantiated in the caller's translation unit (nvq++/Python) rather
  than in `libcudaq`.
- **Removed `invocationResultBuffer` usage for run**: results are returned through
  the policy path; dropped the vestigial Python binding in `py_ExecutionContext.cpp`.
  Python `run` bindings updated to launch-then-parse.
- Covers full parity: C++ and Python, local / emulated / remote, sync and async.
