### PR TITLE
Automatically label pull requests based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,94 @@
+# Used by workflows/label_prs.yml: a PR gets every label (must already
+# exist in the repo) whose globs match at least one changed file.
+
+core compiler:
+  - changed-files:
+    - any-glob-to-any-file:
+      - cudaq/**
+
+'driver (nvq++)':
+  - changed-files:
+    - any-glob-to-any-file:
+      - cudaq/tools/nvqpp/**
+
+c++ bridge:
+  - changed-files:
+    - any-glob-to-any-file:
+      - cudaq/lib/Frontend/**
+      - cudaq/tools/cudaq-quake/**
+
+codegen:
+  - changed-files:
+    - any-glob-to-any-file:
+      - cudaq/lib/Target/**
+      - cudaq/tools/cudaq-translate/**
+
+python-lang:
+  - changed-files:
+    - any-glob-to-any-file:
+      - python/**
+
+python bridge:
+  - changed-files:
+    - any-glob-to-any-file:
+      - python/cudaq/kernel/**
+      - python/cudaq/mlir/**
+      - python/extension/**
+
+kernel builder:
+  - changed-files:
+    - any-glob-to-any-file:
+      - runtime/cudaq/builder/**
+      - python/cudaq/kernel/kernel_builder.py
+
+runtime:
+  - changed-files:
+    - any-glob-to-any-file:
+      - runtime/**
+
+simulation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - runtime/nvqir/**
+
+dynamics:
+  - changed-files:
+    - any-glob-to-any-file:
+      - python/cudaq/dynamics/**
+      - python/runtime/cudaq/dynamics/**
+      - python/tests/dynamics/**
+      - runtime/cudaq/dynamics_integrators.h
+      - runtime/nvqir/cudensitymat/**
+
+ptsbe:
+  - changed-files:
+    - any-glob-to-any-file:
+      - runtime/cudaq/ptsbe/**
+
+realtime:
+  - changed-files:
+    - any-glob-to-any-file:
+      - realtime/**
+      - runtime/cudaq/realtime.h
+      - runtime/cudaq/realtime.cpp
+      - runtime/cudaq/realtime/**
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - docs/**
+      - '*.md'
+
+applications:
+  - changed-files:
+    - any-glob-to-any-file:
+      - docs/sphinx/applications/**
+      - examples/**
+
+build:
+  - changed-files:
+    - any-glob-to-any-file:
+      - cmake/**
+      - docker/**
+      - scripts/**
+      - CMakeLists.txt

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -1,0 +1,33 @@
+name: Labeling new pull requests
+
+# pull_request_target is safe here: no code from the PR branch is checked
+# out or executed; actions/labeler only reads changed file paths via the API.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  label-prs:
+    name: Apply labels based on changed files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    # Skip drafts (labeled once ready for review) and PRs with many
+    # commits, which are usually rebase accidents touching every path.
+    if: >
+      github.repository == 'NVIDIA/cuda-quantum' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.commits < 10
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
Mimic llvm-project's PR auto-labeling: run actions/labeler on pull_request_target with a path-glob to label mapping in .github/labeler.yml. Only changed file paths are inspected via the GitHub API; no code from the PR branch is checked out or executed.

Maps 15 existing repository labels (core compiler, runtime, python-lang, documentation, etc.) to the directories they cover, to make filtering pull requests by area easier.