### PR TITLE
[runtime] Cache groundwork: reusable arg helper + owned closure modules

### DIFF
--- a/runtime/common/ArgumentWrapper.h
+++ b/runtime/common/ArgumentWrapper.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/OwningOpRef.h>
 #include <vector>
 
 namespace cudaq {
@@ -79,12 +80,13 @@ public:
   explicit CallableClosureArgument(const std::string &name, mlir::ModuleOp mod,
                                    std::optional<unsigned> &&startLifted,
                                    OpaqueArguments &&oppy)
-      : short_name{name}, module_op{mod},
+      : short_name{name}, module_op{mod.clone()},
         start_lifted_pos{std::move(startLifted)}, opaque_args{std::move(oppy)} {
   }
 
   const std::string &getShortName() const { return short_name; }
-  mlir::ModuleOp getModule() { return module_op; }
+  // Hands back a non-owning handle; ownership stays with this object.
+  mlir::ModuleOp getModule() { return module_op.get(); }
   const std::optional<unsigned> &getStartLiftedPos() const {
     return start_lifted_pos;
   }
@@ -94,7 +96,10 @@ private:
   CallableClosureArgument() = delete;
 
   std::string short_name;
-  mlir::ModuleOp module_op;
+  // Owns a clone of the callable's module so the closure stays valid after the
+  // source module it was built from is destroyed (e.g. the transient clones
+  // created while computing a compiled-module cache key).
+  mlir::OwningOpRef<mlir::ModuleOp> module_op;
   // Positions of the opaque arguments.
   std::optional<unsigned> start_lifted_pos;
   // Using OpaqueArguments class here since it deals with struct{any}.

--- a/runtime/internal/compiler/ArgumentConversion.cpp
+++ b/runtime/internal/compiler/ArgumentConversion.cpp
@@ -1111,3 +1111,20 @@ bool cudaq_internal::compiler::mergeAllCallableClosures(
   }
   return true;
 }
+
+bool cudaq_internal::compiler::retainCallableArguments(
+    std::span<void *const> &rawArgs, std::vector<void *> &closureArgs,
+    mlir::func::FuncOp funcOp) {
+  bool isFullySpecialized = true;
+
+  FunctionType fromFuncTy = funcOp.getFunctionType();
+  closureArgs = std::vector(rawArgs.begin(), rawArgs.end());
+  for (auto [i, ty] : llvm::enumerate(fromFuncTy.getInputs())) {
+    if (!isa<cudaq::cc::CallableType>(ty)) {
+      isFullySpecialized = false;
+      closureArgs[i] = nullptr;
+    }
+  }
+  rawArgs = closureArgs;
+  return isFullySpecialized;
+}

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -169,23 +169,6 @@ void cudaq_internal::compiler::Compiler::applyPipeline(
     throw std::runtime_error("Remote rest platform Quake lowering failed.");
 }
 
-static bool eraseNonCallableArguments(std::span<void *const> &rawArgs,
-                                      std::vector<void *> &closureArgs,
-                                      mlir::func::FuncOp funcOp) {
-  bool isFullySpecialized = true;
-
-  FunctionType fromFuncTy = funcOp.getFunctionType();
-  closureArgs = std::vector(rawArgs.begin(), rawArgs.end());
-  for (auto [i, ty] : llvm::enumerate(fromFuncTy.getInputs())) {
-    if (!isa<cudaq::cc::CallableType>(ty)) {
-      isFullySpecialized = false;
-      closureArgs[i] = nullptr;
-    }
-  }
-  rawArgs = closureArgs;
-  return isFullySpecialized;
-}
-
 std::tuple<mlir::ModuleOp, mlir::func::FuncOp, bool>
 cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
                                                   mlir::ModuleOp m_module,
@@ -229,15 +212,15 @@ cudaq_internal::compiler::Compiler::prepareModule(const std::string &kernelName,
       const bool boolVecBitPacked = target->isLocalSimulator;
       cudaq_internal::compiler::ArgumentConverter argCon(kernelName, moduleOp,
                                                          boolVecBitPacked);
-      // Must stay in scope as `eraseNonCallableArguments` may populate it
+      // Must stay in scope as `retainCallableArguments` may populate it
       std::vector<void *> closureArgs;
       if (cudaq::opt::factory::isFullySynthesized(epFunc)) {
         // Already fully specialized, nothing to do.
         isFullySpecialized = true;
       } else if (isEntryPoint && !target->fullySpecialize) {
         // We disable specialization by erasing args that should not be inlined
-        isFullySpecialized =
-            eraseNonCallableArguments(*rawArgs, closureArgs, epFunc);
+        isFullySpecialized = cudaq_internal::compiler::retainCallableArguments(
+            *rawArgs, closureArgs, epFunc);
       }
       argCon.gen(*rawArgs);
 

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/ArgumentConversion.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/ArgumentConversion.h
@@ -136,4 +136,14 @@ bool mergeAllCallableClosures(mlir::ModuleOp intoModule,
                               std::span<void *const> rawArgs,
                               std::optional<unsigned> betaRedux = {});
 
+/// Replace every non-callable argument pointer with null so that only callable
+/// closures participate in argument synthesis. Used both to disable
+/// specialization and to derive a compiled-module cache key from just the
+/// callable dependencies. \p rawArgs is re-pointed at \p closureArgs, which
+/// must outlive the call. Returns `true` when every argument is callable, i.e.
+/// the kernel is fully specialized.
+bool retainCallableArguments(std::span<void *const> &rawArgs,
+                             std::vector<void *> &closureArgs,
+                             mlir::func::FuncOp funcOp);
+
 } // namespace cudaq_internal::compiler

--- a/runtime/test/test_argument_conversion.cpp
+++ b/runtime/test/test_argument_conversion.cpp
@@ -11,6 +11,7 @@
 
 // RUN: test_argument_conversion | FileCheck %s
 
+#include "common/ArgumentWrapper.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
@@ -681,6 +682,24 @@ void test_combinations(mlir::MLIRContext *ctx) {
   // clang-format on
 }
 
+// A `CallableClosureArgument` must own (clone) its module so it
+// stays valid after the source module it was constructed from is destroyed.
+void test_callable_closure_argument(mlir::MLIRContext *ctx) {
+  const char *code = R"#(
+func.func @closure_fn() {
+  return
+})#";
+  std::unique_ptr<cudaq::runtime::CallableClosureArgument> closure;
+  {
+    auto source = mlir::parseSourceString<mlir::ModuleOp>(code, ctx);
+    closure = std::make_unique<cudaq::runtime::CallableClosureArgument>(
+        "closure_fn", *source, std::nullopt, cudaq::OpaqueArguments{});
+  }
+  if (closure->getModule().lookupSymbol("closure_fn"))
+    llvm::outs() << "Callable closure owns its module\n";
+  // CHECK: Callable closure owns its module
+}
+
 int main() {
   mlir::DialectRegistry registry;
   cudaq::registerAllDialects(registry);
@@ -692,5 +711,6 @@ int main() {
   test_recursive(&context);
   test_simulation_state(&context);
   test_combinations(&context);
+  test_callable_closure_argument(&context);
   return 0;
 }


### PR DESCRIPTION
### Summary

First step toward making the Python compiled-module cache actually work for kernels with callable dependencies. Today those kernels recompile on every call. This stacked series fixes that. This PR is pure groundwork no caching logic and no behavior change it just makes the next PR's cache-key fingerprint possible and memory-safe.

### Follow-up work

 Stacked series: add the deterministic fingerprint that makes captured kernels cache-hit; add the owned single-flight cache + launch migration; wire the async path (`observe_async`).