### PR TITLE
[NFC] Move the python uniqued attrbute to the quake dialect namespace.

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Builder/RuntimeNames.h
+++ b/cudaq/include/cudaq/Optimizer/Builder/RuntimeNames.h
@@ -82,6 +82,6 @@ static constexpr const char extractDevPtr[] =
 // Garbage collection for arrays created during kernel execution.
 static constexpr const char cleanupArrays[] = "__nvqpp_cleanup_arrays";
 
-static constexpr const char pythonUniqueAttrName[] = "cc.python_uniqued";
+static constexpr const char pythonUniqueAttrName[] = "quake.python_uniqued";
 
 } // namespace cudaq::runtime

--- a/cudaq/test/Translate/callable_closure.qke
+++ b/cudaq/test/Translate/callable_closure.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-translate --convert-to=qir %s | FileCheck %s
 
-module attributes {cc.python_uniqued = "kernel0..0x7c72351ce620", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", quake.mangled_name_map = {__nvqpp__mlirgen__kernel0..0x7c72351ce620 = "__nvqpp__mlirgen__kernel0..0x7c72351ce620_PyKernelEntryPointRewrite"}} {
+module attributes {quake.python_uniqued = "kernel0..0x7c72351ce620", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", quake.mangled_name_map = {__nvqpp__mlirgen__kernel0..0x7c72351ce620 = "__nvqpp__mlirgen__kernel0..0x7c72351ce620_PyKernelEntryPointRewrite"}} {
   func.func @__nvqpp__mlirgen__kernel0..0x7c72351ce620(%arg0: i64 {quake.pylifted}) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64

--- a/docs/sphinx/examples/python/executing_kernels.ipynb
+++ b/docs/sphinx/examples/python/executing_kernels.ipynb
@@ -336,7 +336,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "module attributes {cc.python_uniqued = \"kernel..0x7193017137d0\", llvm.data_layout = \"e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128\", quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7193017137d0 = \"__nvqpp__mlirgen__kernel..0x7193017137d0_PyKernelEntryPointRewrite\"}} {\n",
+      "module attributes {quake.python_uniqued = \"kernel..0x7193017137d0\", llvm.data_layout = \"e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128\", quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7193017137d0 = \"__nvqpp__mlirgen__kernel..0x7193017137d0_PyKernelEntryPointRewrite\"}} {\n",
       "  func.func @__nvqpp__mlirgen__kernel..0x7193017137d0(%arg0: i64) attributes {\"cudaq-entrypoint\", \"cudaq-kernel\"} {\n",
       "    %c1_i64 = arith.constant 1 : i64\n",
       "    %0 = cc.undef i64\n",

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -118,7 +118,7 @@ class Color:
 
 # Name of module attribute to recover the name of the entry-point for the python
 # kernel decorator.  The associated StringAttr is *without* the `nvqppPrefix`.
-cudaq__unique_attr_name = "cc.python_uniqued"
+cudaq__unique_attr_name = "quake.python_uniqued"
 
 
 def recover_func_op(module, name):


### PR DESCRIPTION
Other ModuleOp attributes are in the quake dialect namespace. This PR just makes this one consistent with the rest.