### PR TITLE
External custom QPU plugins for server-side observe

### DIFF
--- a/docs/sphinx/examples/plugins/README.md
+++ b/docs/sphinx/examples/plugins/README.md
@@ -7,7 +7,8 @@ and tests.
 
 | Plugin | Shape | What it demonstrates |
 |--------|-------|---------------------|
-| [`mock_rest/`](mock_rest/README.md) | REST | `ServerHelper` subclass for the built-in `remote_rest` QPU |
+| [`mock_rest/`](mock_rest/README.md) | REST (sample) | `ServerHelper` subclass for the built-in `remote_rest` QPU |
+| [`mock_observe_qpu/`](mock_observe_qpu/README.md) | Custom QPU (observe) | External `QPU` + `ServerHelper` for Fermioniq-style server-side `observe()` |
 
 See each plugin's README for its design, prerequisites, build and test commands,
 installation steps, and runnable examples.

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/CMakeLists.txt
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/CMakeLists.txt
@@ -1,0 +1,85 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+set(plugin_root ${CMAKE_CURRENT_BINARY_DIR})
+set(plugin_lib_dir ${plugin_root}/lib)
+set(plugin_target_dir ${plugin_root}/targets)
+set(plugin_python_package cudaq_example_mock_observe_qpu)
+set(plugin_python_project cudaq-example-mock-observe-qpu)
+set(plugin_python_entry_point mock_observe_qpu)
+set(plugin_python_description
+    "CUDA-Q reference external custom QPU plugin for server-side observe().")
+set(plugin_python_install_name mock-observe-qpu)
+
+file(MAKE_DIRECTORY ${plugin_lib_dir} ${plugin_target_dir})
+configure_file(targets/mock_observe_qpu.yml.in
+               ${plugin_target_dir}/mock_observe_qpu.yml
+               @ONLY)
+configure_file(pyproject.toml.in
+               ${plugin_root}/pyproject.toml
+               @ONLY)
+configure_file(python/__init__.py.in
+               ${plugin_root}/__init__.py
+               @ONLY)
+configure_file(python/__main__.py.in
+               ${plugin_root}/__main__.py
+               @ONLY)
+
+# Single shared library registers both the custom QPU and ServerHelper.
+# Auto-loaded as libcudaq-<platform-qpu>-qpu.so when the target is activated.
+add_library(cudaq-example-qpu-mock_observe_qpu EXCLUDE_FROM_ALL SHARED
+  MockObserveQPU.cpp)
+set_target_properties(cudaq-example-qpu-mock_observe_qpu
+  PROPERTIES
+    OUTPUT_NAME cudaq-mock_observe_qpu-qpu
+    LIBRARY_OUTPUT_DIRECTORY ${plugin_lib_dir}
+    RUNTIME_OUTPUT_DIRECTORY ${plugin_lib_dir}
+    ARCHIVE_OUTPUT_DIRECTORY ${plugin_lib_dir})
+target_include_directories(cudaq-example-qpu-mock_observe_qpu
+  PRIVATE ${PROJECT_SOURCE_DIR}/runtime)
+target_link_libraries(cudaq-example-qpu-mock_observe_qpu
+  PRIVATE
+    cudaq
+    cudaq-common
+    cudaq-logger
+    cudaq-operator
+    cudaq-mlir-runtime
+    cudaq-platform-default
+    nvqir)
+
+if(NOT PYTHON_EXECUTABLE AND Python3_EXECUTABLE)
+  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+endif()
+
+if(LLVM_EXTERNAL_LIT)
+  set(cudaq_mock_observe_qpu_lit ${LLVM_EXTERNAL_LIT})
+else()
+  set(cudaq_mock_observe_qpu_lit ${LLVM_TOOLS_BINARY_DIR}/llvm-lit)
+endif()
+
+set(CUDAQ_PLUGIN_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/lit.site.cfg.py.in
+               ${CMAKE_CURRENT_BINARY_DIR}/tests/lit.site.cfg.py
+               @ONLY)
+
+set(cudaq_mock_observe_qpu_check_depends cudaq-example-qpu-mock_observe_qpu)
+foreach(dep nvq++ cudaq-install-plugin FileCheck CopyPythonFiles
+            CUDAQuantumPythonModules)
+  if(TARGET ${dep})
+    list(APPEND cudaq_mock_observe_qpu_check_depends ${dep})
+  endif()
+endforeach()
+
+add_custom_target(check-mock-observe-qpu
+  COMMAND ${CMAKE_COMMAND} -E env
+          "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+          "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH}"
+          ${cudaq_mock_observe_qpu_lit} ${LLVM_LIT_ARGS}
+          ${CMAKE_CURRENT_BINARY_DIR}/tests
+  DEPENDS ${cudaq_mock_observe_qpu_check_depends}
+  USES_TERMINAL)

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/MockObserveQPU.cpp
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/MockObserveQPU.cpp
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "common/BaseRemoteRESTQPU.h"
+#include "common/ObservableUserData.h"
+#include "common/ServerHelper.h"
+#include "cudaq_internal/compiler/Compiler.h"
+#include "nlohmann/json.hpp"
+#include "cudaq/algorithms/observe/policy.h"
+#include <cstdlib>
+#include <string>
+
+namespace cudaq {
+
+/// Reference ServerHelper for server-side observe plugins.
+/// Reads `user_data["observable"]` and returns a configured expectation value.
+class MockObserveServerHelper : public ServerHelper {
+  std::string url = "http://localhost:62454";
+  double value = 0.41;
+
+public:
+  const std::string name() const override { return "mock_observe_qpu"; }
+
+  void initialize(BackendConfig config) override {
+    backendConfig = std::move(config);
+    parseConfigForCommonParams(backendConfig);
+    if (auto iter = backendConfig.find("url"); iter != backendConfig.end())
+      url = iter->second;
+    if (auto iter = backendConfig.find("shots");
+        iter != backendConfig.end() && !iter->second.empty())
+      setShots(std::stoul(iter->second));
+    if (auto iter = backendConfig.find("value");
+        iter != backendConfig.end() && !iter->second.empty())
+      value = std::stod(iter->second);
+  }
+
+  RestHeaders getHeaders() override { return {}; }
+
+  ServerJobPayload
+  createJob(std::vector<KernelExecution> &circuitCodes) override {
+    if (circuitCodes.size() != 1)
+      throw std::runtime_error(
+          "mock_observe_qpu expects a single preparation circuit");
+
+    auto &circuit = circuitCodes.front();
+    if (!circuit.user_data->contains("observable"))
+      throw std::runtime_error(
+          "mock_observe_qpu requires user_data[\"observable\"]");
+
+    ServerMessage task;
+    task["kernel"] = circuit.name;
+    task["code"] = circuit.code;
+    task["shots"] = shots;
+    task["observable"] = circuit.user_data->at("observable");
+    task["value"] = value;
+
+    return std::make_tuple(url + "/jobs", RestHeaders(),
+                           std::vector<ServerMessage>{std::move(task)});
+  }
+
+  std::string extractJobId(ServerMessage &postResponse) override {
+    if (postResponse.is_array() && !postResponse.empty())
+      return postResponse.front().value("id", "mock-observe-job");
+    return postResponse.value("id", "mock-observe-job");
+  }
+
+  std::string constructGetJobPath(std::string &jobId) override {
+    return url + "/jobs/" + jobId;
+  }
+
+  std::string constructGetJobPath(ServerMessage &postResponse) override {
+    auto jobId = extractJobId(postResponse);
+    return constructGetJobPath(jobId);
+  }
+
+  bool jobIsDone(ServerMessage &getJobResponse) override {
+    const auto status = getJobResponse.value("status", "done");
+    return status == "done" || status == "completed" || status == "succeeded";
+  }
+
+  sample_result processResults(ServerMessage &postJobResponse,
+                               std::string &jobId) override {
+    // Prefer an expectation returned by the mock server; otherwise use the
+    // configured target argument.
+    double expectation = value;
+    if (postJobResponse.contains("value")) {
+      if (postJobResponse["value"].is_number())
+        expectation = postJobResponse["value"].get<double>();
+      else if (postJobResponse["value"].is_string()) {
+        try {
+          expectation = std::stod(postJobResponse["value"].get<std::string>());
+        } catch (...) {
+          // Keep configured value when the echo server returns a bitstring.
+        }
+      }
+    }
+    return sample_result(ExecutionResult(expectation));
+  }
+};
+
+/// Fermioniq-style custom QPU: no Pauli split, full spin_op on the wire.
+class MockObserveQPU : public BaseRemoteRESTQPU {
+public:
+  ~MockObserveQPU() override = default;
+
+  bool isRemote() override { return true; }
+  bool isEmulated() override { return false; }
+
+  void setNoiseModel(const cudaq::noise_model *model) override {
+    if (model)
+      throw std::runtime_error("Noise modeling is not allowed on this backend");
+  }
+
+  using BaseRemoteRESTQPU::getCompileTarget;
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(const observe_policy &policy) override {
+    auto target = BaseRemoteRESTQPU::getCompileTarget(policy);
+    target->pauliTermSplitObservable = std::nullopt;
+    return target;
+  }
+
+  using QPU::launchKernel;
+
+  observe_result launchKernel(const observe_policy &policy,
+                              const CompiledModule &module,
+                              KernelArgs args) override {
+    if (module.getMlirArtifacts().empty())
+      throw std::runtime_error(
+          "QPU does not support launching a CompiledModule without MLIR "
+          "artifacts.");
+
+    cudaq_internal::compiler::Compiler compiler(getCompileTarget(policy));
+    auto codes = compiler.emitKernelExecutions(module);
+    if (codes.size() != 1)
+      throw std::runtime_error(
+          "mock_observe_qpu expects a single preparation circuit");
+
+    attachObservableUserData(codes[0], policy.spin);
+    async_observe_policy asyncPolicy{policy};
+    return completeLaunchKernel(asyncPolicy, module.getName(), std::move(codes))
+        .get();
+  }
+
+  async_observe_result launchKernel(const async_observe_policy &policy,
+                                    const CompiledModule &module,
+                                    KernelArgs args) override {
+    if (module.getMlirArtifacts().empty())
+      throw std::runtime_error(
+          "QPU does not support launching a CompiledModule without MLIR "
+          "artifacts.");
+
+    cudaq_internal::compiler::Compiler compiler(getCompileTarget(policy.inner));
+    auto codes = compiler.emitKernelExecutions(module);
+    if (codes.size() != 1)
+      throw std::runtime_error(
+          "mock_observe_qpu expects a single preparation circuit");
+
+    attachObservableUserData(codes[0], policy.inner.spin);
+    return completeLaunchKernel(policy, module.getName(), std::move(codes));
+  }
+};
+
+} // namespace cudaq
+
+CUDAQ_REGISTER_TYPE(cudaq::QPU, cudaq::MockObserveQPU, mock_observe_qpu)
+CUDAQ_REGISTER_TYPE(cudaq::ServerHelper, cudaq::MockObserveServerHelper,
+                    mock_observe_qpu)

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/README.md
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/README.md
@@ -1,0 +1,85 @@
+# mock_observe_qpu Plugin
+
+`mock_observe_qpu` is a reference **external custom QPU** plugin. It shows how
+to ship a Fermioniq-style server-side `observe()` backend as a pip-installable
+package without modifying the CUDA-Q source tree: a custom `QPU` subclass
+(`platform-qpu: mock_observe_qpu`) plus a `ServerHelper`, registered from one
+shared library that CUDA-Q auto-loads as `libcudaq-<platform-qpu>-qpu.so`.
+
+Unlike `mock_rest` (which reuses stock `remote_rest` and splits Pauli terms
+client-side), this plugin disables Pauli-term splitting, attaches the full
+`spin_op` on `KernelExecution::user_data["observable"]`, and returns an
+expectation-shaped result.
+
+## What It Demonstrates
+
+- External custom QPU registration via `CUDAQ_REGISTER_TYPE(..., QPU, ...)`.
+- Auto-load of `libcudaq-mock_observe_qpu-qpu.so` from the plugin `lib/` directory
+  (no `plugin-libraries` YAML field required).
+- Target YAML with `platform-qpu: mock_observe_qpu` (not `remote_rest`).
+- Full observable attachment for `cudaq.observe` (Fermioniq-compatible JSON).
+- Expectation results via `sample_result(ExecutionResult(double))`.
+- The same Python packaging / `cudaq.backends` / `nvq++` install story as
+  `mock_rest`.
+
+## How It Works
+
+- `targets/mock_observe_qpu.yml.in`: selects the custom QPU and links
+  `-lcudaq-mock_observe_qpu-qpu`.
+- `MockObserveQPU.cpp`: implements `MockObserveQPU` (no Pauli split; attach
+  observable; sync observe through the async executor path) and
+  `MockObserveServerHelper` (reads `user_data["observable"]`, returns the
+  configured `value` expectation).
+- Python packaging mirrors `mock_rest`.
+
+For local testing, the helper can talk to the generic `mock_qpu` echo server
+(`python/tests/utils/start_mock_qpu.py echo`). The configured `value` target
+argument is used as the expectation when the echo payload is not numeric.
+
+## Build
+
+From the CUDA-Q repository root:
+
+```sh
+cmake -B build \
+  -DCUDAQ_EXTERNAL_PROJECTS="mock-observe-qpu" \
+  -DCUDAQ_EXTERNAL_MOCK_OBSERVE_QPU_SOURCE_DIR=$PWD/docs/sphinx/examples/plugins/mock_observe_qpu
+
+ninja -C build cudaq-example-qpu-mock_observe_qpu
+```
+
+The built plugin root is `build/external/mock-observe-qpu`.
+
+## Test
+
+```sh
+ninja -C build check-mock-observe-qpu
+```
+
+## Run
+
+```python
+import cudaq
+
+cudaq.register_backend_path("build/external/mock-observe-qpu")
+cudaq.set_target("mock_observe_qpu",
+                 url="http://localhost:62454",
+                 value="0.41")
+
+@cudaq.kernel
+def bell():
+    q = cudaq.qvector(2)
+    h(q[0])
+    x.ctrl(q[0], q[1])
+
+H = 0.5 * cudaq.spin.z(0) + 0.3 * cudaq.spin.z(0) * cudaq.spin.z(1)
+result = cudaq.observe(bell, H)
+assert abs(result.expectation() - 0.41) < 1e-9
+```
+
+## Install as an End User
+
+```sh
+python3 -m pip install build/external/mock-observe-qpu
+python3 -m cudaq_example_mock_observe_qpu --install-nvqpp
+```

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/pyproject.toml.in
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/pyproject.toml.in
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "@plugin_python_project@"
+version = "0.1.0"
+description = "@plugin_python_description@"
+requires-python = ">=3.9"
+
+[project.entry-points."cudaq.backends"]
+@plugin_python_entry_point@ = "@plugin_python_package@:register"
+
+[tool.setuptools]
+packages = ["@plugin_python_package@"]
+
+[tool.setuptools.package-dir]
+"@plugin_python_package@" = "."
+
+[tool.setuptools.package-data]
+"@plugin_python_package@" = ["targets/*.yml", "lib/*"]

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/python/__init__.py.in
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/python/__init__.py.in
@@ -1,0 +1,18 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+from importlib.resources import files
+
+
+def register():
+    import cudaq
+
+    cudaq.register_backend_path(str(files(__name__)))
+
+
+__all__ = ["register"]

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/python/__main__.py.in
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/python/__main__.py.in
@@ -1,0 +1,19 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+PACKAGE_NAME = "@plugin_python_package@"
+PLUGIN_NAME = "@plugin_python_install_name@"
+
+
+def main() -> int:
+    from cudaq.plugins import install_plugin_for_nvqpp_main
+    return install_plugin_for_nvqpp_main(PACKAGE_NAME, PLUGIN_NAME)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/targets/mock_observe_qpu.yml.in
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/targets/mock_observe_qpu.yml.in
@@ -1,0 +1,30 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+name: mock_observe_qpu
+description: "Reference external custom QPU plugin for server-side observe()."
+cudaq-version: "@CUDA_QUANTUM_VERSION@"
+config:
+  platform-qpu: mock_observe_qpu
+  gen-target-backend: true
+  preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
+  link-libs: ["-lcudaq-mock_observe_qpu-qpu"]
+  codegen-emission: qir-base
+  library-mode: false
+
+target-arguments:
+  - key: url
+    required: false
+    type: string
+    platform-arg: url
+    help-string: "Specify the mock REST service URL."
+  - key: value
+    required: false
+    type: string
+    platform-arg: value
+    help-string: "Expectation value returned by processResults (default 0.41)."

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/tests/check_plugin.cpp
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/tests/check_plugin.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: rm -rf %t.xdg
+// RUN: test -f %cudaq_example_plugins_dir/mock-observe-qpu/targets/mock_observe_qpu.yml
+// RUN: test -f %cudaq_example_plugins_dir/mock-observe-qpu/lib/libcudaq-mock_observe_qpu-qpu%cudaq_plugin_ext
+// RUN: FileCheck %s --check-prefix=MOCK-YAML --input-file=%cudaq_example_plugins_dir/mock-observe-qpu/targets/mock_observe_qpu.yml
+// RUN: env XDG_DATA_HOME=%t.xdg cudaq-install-plugin --copy %cudaq_example_plugins_dir/mock-observe-qpu
+// RUN: env XDG_DATA_HOME=%t.xdg cudaq-install-plugin --list | FileCheck %s --check-prefix=LIST
+// RUN: env XDG_DATA_HOME=%t.xdg nvq++ --list-targets | FileCheck %s --check-prefix=TARGETS
+// RUN: env XDG_DATA_HOME=%t.xdg nvq++ --target mock_observe_qpu %s -o %t.native
+// RUN: env XDG_DATA_HOME=%t.xdg %t.native
+// RUN: PYTHONPATH=%cudaq_target_dir/../python python3 -c "import cudaq; cudaq.register_backend_path('%cudaq_example_plugins_dir/mock-observe-qpu'); cudaq.set_target('mock_observe_qpu'); cudaq.reset_target()"
+// RUN: rm -rf %t.python %t.pip-cache %t.python-xdg
+// RUN: env PIP_CACHE_DIR=%t.pip-cache python3 -m pip install --no-deps --no-build-isolation --target %t.python %cudaq_example_plugins_dir/mock-observe-qpu
+// RUN: env PYTHONPATH=%t.python:%cudaq_target_dir/../python python3 -c "import cudaq; assert cudaq.has_target('mock_observe_qpu'); cudaq.set_target('mock_observe_qpu'); cudaq.reset_target()"
+// RUN: env PYTHONPATH=%t.python:%cudaq_target_dir/../python XDG_DATA_HOME=%t.python-xdg python3 -m cudaq_example_mock_observe_qpu --install-nvqpp
+// RUN: test -L %t.python-xdg/cudaq/plugins/mock-observe-qpu
+// RUN: env XDG_DATA_HOME=%t.python-xdg nvq++ --list-targets | FileCheck %s --check-prefix=TARGETS
+// clang-format on
+
+// MOCK-YAML: name: mock_observe_qpu
+// MOCK-YAML: cudaq-version:
+// MOCK-YAML: platform-qpu: mock_observe_qpu
+// MOCK-YAML-NOT: plugin-libraries
+// MOCK-YAML-NOT: observe-mode
+// MOCK-YAML-NOT: remote_rest
+
+// LIST: user{{[[:space:]]+}}mock-observe-qpu
+
+// TARGETS: mock_observe_qpu
+
+#include <cudaq.h>
+
+__qpu__ void mock_observe_qpu_test_kernel() {
+  cudaq::qubit q;
+  h(q);
+  mz(q);
+}
+
+int main() { return cudaq::get_platform().is_remote() ? 0 : 1; }

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/tests/lit.cfg.py
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/tests/lit.cfg.py
@@ -1,0 +1,31 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Lit configuration for the mock_observe_qpu example plugin test.
+
+import os
+import lit.formats
+import lit.util
+from lit.llvm import llvm_config
+
+config.name = 'mock_observe_qpu plugin'
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.suffixes = ['.cpp']
+config.test_source_root = os.path.dirname(__file__)
+config.test_exec_root = os.path.join(config.cudaq_obj_root, 'test',
+                                     'mock-observe-qpu')
+
+config.substitutions.append(('%cudaq_lib_dir', config.cudaq_lib_dir))
+config.substitutions.append(('%cudaq_target_dir', config.cudaq_target_dir))
+config.substitutions.append(
+    ('%cudaq_example_plugins_dir', config.cudaq_example_plugins_dir))
+config.substitutions.append(('%cudaq_plugin_ext', config.cudaq_plugin_ext))
+
+llvm_config.use_default_substitutions()
+llvm_config.with_environment('PATH', config.cudaq_tools_dir, append_path=True)
+llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)

--- a/docs/sphinx/examples/plugins/mock_observe_qpu/tests/lit.site.cfg.py.in
+++ b/docs/sphinx/examples/plugins/mock_observe_qpu/tests/lit.site.cfg.py.in
@@ -1,0 +1,57 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Site config for example plugin tests.  Reuses the cudaq test infrastructure
+# (substitutions, features, paths) but points test_source_root at the plugin's
+# own test directory.
+#
+# NOTE: This file is processed by configure_file(@ONLY), NOT by
+# configure_lit_site_cfg, so @LIT_SITE_CFG_IN_HEADER@ is not available.
+# We provide the path() helper inline.
+
+import os
+import platform
+import sys
+
+def path(p):
+    if not p: return ''
+    if platform.system() == 'Windows':
+        return os.path.abspath(os.path.join(os.path.dirname(__file__), p))
+    else:
+        return os.path.realpath(os.path.join(os.path.dirname(__file__), p))
+
+def cmake_boolvar_to_bool(s):
+    return s == "1" or s.upper() == "TRUE" or s.upper() == "ON"
+
+config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_BINARY_DIR@")
+config.llvm_shlib_dir = lit_config.substitute(path(r"@SHLIBDIR@"))
+config.llvm_plugin_ext = "@LLVM_PLUGIN_EXT@"
+config.llvm_install = config.llvm_tools_dir + "/.."
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.errc_messages = "@LLVM_LIT_ERRC_MESSAGES@"
+config.cudaq_obj_root = "@CUDAQ_BINARY_DIR@"
+config.cudaq_src_dir = "@CUDAQ_SOURCE_DIR@"
+config.cudaq_tools_dir = lit_config.substitute("@CUDAQ_TOOLS_DIR@")
+config.cudaq_intrinsic_modules_dir = "@CUDAQ_INTRINSIC_MODULES_DIR@"
+config.cudaq_llvm_tools_dir = "@CMAKE_BINARY_DIR@/bin"
+config.cudaq_lib_dir = "@CMAKE_BINARY_DIR@/lib"
+config.cudaq_shlib_prefix = "@CMAKE_SHARED_LIBRARY_PREFIX@"
+config.cudaq_shlib_ext = "@CMAKE_SHARED_LIBRARY_SUFFIX@"
+config.cudaq_target_dir = "@CMAKE_BINARY_DIR@/targets"
+config.cudaq_example_plugins_dir = "@CMAKE_BINARY_DIR@/external"
+config.cudaq_plugin_ext = "@LLVM_PLUGIN_EXT@"
+config.python_executable = "@PYTHON_EXECUTABLE@"
+config.cc = "@CMAKE_C_COMPILER@"
+config.targets_to_build = "@TARGETS_TO_BUILD@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the plugin's own lit.cfg.py do the rest.
+lit_config.load_config(config,
+    os.path.join("@CUDAQ_PLUGIN_TEST_SOURCE_DIR@", "lit.cfg.py"))

--- a/docs/sphinx/using/extending/backend.rst
+++ b/docs/sphinx/using/extending/backend.rst
@@ -9,9 +9,12 @@ repository. Plugin authors can distribute these plugins as Python packages so
 that end users of the target can install them into their own CUDA-Q
 environments.
 
-This guide covers the most common backend shape: a **REST-style backend** that
-subclasses ``ServerHelper`` to communicate with a provider's REST API, reusing
-the built-in ``remote_rest`` QPU.
+This guide covers two backend shapes:
+
+1. A **REST-style backend** that subclasses ``ServerHelper`` and reuses the
+   built-in ``remote_rest`` QPU (sample / client-side Pauli-split observe).
+2. A **custom QPU backend** that ships its own ``QPU`` shared library (for
+   example Fermioniq-style server-side ``observe()``).
 
 All backends use the same plugin package layout and distribution mechanism
 described in :doc:`packaging`.
@@ -28,7 +31,8 @@ Every backend plugin follows this layout:
     ├── targets/
     │   └── my-backend.yml       # Target configuration
     ├── lib/
-    │   └── libcudaq-serverhelper-my-backend.so
+    │   ├── libcudaq-serverhelper-my-backend.so   # REST-style (or combined)
+    │   └── libcudaq-my-qpu-qpu.so                # Custom QPU (optional)
     └── data/                    # Optional auxiliary files
         └── topology.txt
 
@@ -36,6 +40,13 @@ The ``targets/`` directory contains one or more YAML target configurations.
 The ``lib/`` directory contains the shared libraries that implement the backend.
 The optional ``data/`` directory holds auxiliary files (device topologies, noise
 models, calibration data, etc.).
+
+When a target is activated, CUDA-Q ``dlopen``\ s:
+
+- every entry in optional YAML ``plugin-libraries``
+- ``libcudaq-serverhelper-<target>.so`` if present
+- ``libcudaq-<platform-qpu>-qpu.so`` if ``platform-qpu`` is set and the file
+  exists (custom QPU plugins)
 
 
 REST-Style Backends (Server Helper)
@@ -212,6 +223,52 @@ For the full list of recognized YAML fields see the mapping traits in
 For a complete working example of a REST-style plugin, see the
 `mock_rest reference plugin <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples/plugins/mock_rest>`_.
 
+
+Custom QPU Backends (Server-Side Observe)
+=========================================
+
+Use a custom ``QPU`` subclass when the remote API must receive the **full**
+multi-term observable (for example error-mitigated expectation services). The
+in-tree Fermioniq backend follows this pattern; external plugins can ship the
+same shape without modifying CUDA-Q.
+
+Requirements:
+
+1. Subclass ``BaseRemoteRESTQPU`` (or ``QPU``) and register it with
+   ``CUDAQ_REGISTER_TYPE(cudaq::QPU, MyQPU, my_qpu)``.
+2. Override ``getCompileTarget(observe_policy)`` to set
+   ``pauliTermSplitObservable = std::nullopt`` so CUDA-Q emits one preparation
+   circuit.
+3. In ``launchKernel`` for observe, attach the full ``spin_op`` with
+   ``attachObservableUserData`` (see ``runtime/common/ObservableUserData.h``)
+   and submit through the executor path.
+4. Implement a ``ServerHelper`` (registered under the **target** name) that
+   reads ``user_data["observable"]`` and returns
+   ``sample_result(ExecutionResult(expectation))``.
+5. Ship ``libcudaq-<platform-qpu>-qpu.so`` in the plugin ``lib/`` directory
+   (auto-loaded when the target is activated). Optionally also ship a separate
+   ``libcudaq-serverhelper-<target>.so``, or register both types from the same
+   QPU library.
+
+Target YAML:
+
+.. code-block:: yaml
+
+    name: my_qpu
+    description: "Server-side observe backend."
+    cudaq-version: "@CUDA_QUANTUM_VERSION@"
+    config:
+      platform-qpu: my_qpu
+      link-libs: ["-lcudaq-my_qpu-qpu"]
+      codegen-emission: qasm2
+      library-mode: false
+
+Synchronous ``cudaq.observe`` should route through the async executor and
+``.get()`` so remote create/poll completes (see the
+`mock_observe_qpu <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples/plugins/mock_observe_qpu>`_
+reference). Custom job life cycles (for example create → estimate → start →
+poll) stay in a vendor ``Executor`` registered under the same target name.
+
 CMake Build File
 ----------------
 
@@ -295,6 +352,7 @@ For REST-style backends, CUDA-Q provides a mock QPU server framework under
 See the reference plugins' ``tests/`` directories for concrete examples:
 
 - `mock_rest/tests/ <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples/plugins/mock_rest/tests>`_
+- `mock_observe_qpu/tests/ <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples/plugins/mock_observe_qpu/tests>`_
 
 
 Example Usage

--- a/docs/sphinx/using/extending/packaging.rst
+++ b/docs/sphinx/using/extending/packaging.rst
@@ -20,7 +20,8 @@ Every plugin follows the same directory convention:
     ├── targets/
     │   └── my-backend.yml          # Target YAML configuration
     ├── lib/
-    │   └── libcudaq-serverhelper-my-backend.so  # Backend shared library
+    │   ├── libcudaq-serverhelper-my-backend.so  # REST-style ServerHelper
+    │   └── libcudaq-my-qpu-qpu.so               # Custom QPU (optional)
     ├── data/                        # Optional auxiliary files
     │   └── topology.txt
     ├── pyproject.toml               # Python package metadata
@@ -29,6 +30,13 @@ Every plugin follows the same directory convention:
 
 The ``targets/`` and ``lib/`` directories are required. The ``data/`` directory
 is optional and holds any auxiliary files your backend needs at runtime.
+
+Library auto-load conventions (when the target is activated):
+
+- ``libcudaq-serverhelper-<target>.so``
+- ``libcudaq-<platform-qpu>-qpu.so`` when ``platform-qpu`` is set
+
+You may also list libraries explicitly under YAML ``plugin-libraries``.
 
 
 Target YAML Reference (Plugin Fields)
@@ -93,7 +101,7 @@ modifying any in-tree files:
       -DCUDAQ_EXTERNAL_PROJECTS="my-backend" \
       -DCUDAQ_EXTERNAL_MY_BACKEND_SOURCE_DIR=/path/to/my-backend
 
-    ninja -C build cudaq-serverhelper-my-backend   # or cudaq-qpu-my-backend
+    ninja -C build cudaq-serverhelper-my-backend   # or cudaq-my-qpu-qpu
 
 The plugin output lands in ``build/external/my-backend/`` with the standard
 ``targets/``, ``lib/``, and packaging files ready to use.
@@ -304,8 +312,8 @@ Environment variables
 Reference Plugins
 =================
 
-CUDA-Q ships a reference plugin under ``docs/sphinx/examples/plugins/``
-that demonstrates the full plugin lifecycle:
+CUDA-Q ships reference plugins under ``docs/sphinx/examples/plugins/``
+that demonstrate the full plugin lifecycle:
 
 .. list-table::
    :header-rows: 1
@@ -314,10 +322,13 @@ that demonstrates the full plugin lifecycle:
      - Shape
      - What it demonstrates
    * - `mock_rest <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples/plugins/mock_rest>`_
-     - REST
+     - REST (sample)
      - ``ServerHelper`` subclass, ``remote_rest`` QPU, mock server testing
+   * - `mock_observe_qpu <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples/plugins/mock_observe_qpu>`_
+     - Custom QPU (observe)
+     - External ``QPU`` + ``ServerHelper``, no Pauli split, full ``spin_op``, expectation results
 
-Use this as a starter template for new plugins. It includes a complete
+Use these as starter templates for new plugins. Each includes a complete
 build configuration, Python packaging, lit tests, and documentation.
 
 
@@ -326,8 +337,9 @@ Quick-Start Checklist
 
 .. code-block:: text
 
-    □ Implement ServerHelper subclass
+    □ Implement ServerHelper subclass (and custom QPU if needed)
     □ Create targets/<name>.yml with target configuration
+    □ For server-side observe: platform-qpu: <custom>, ship libcudaq-<qpu>-qpu.so
     □ Create CMakeLists.txt (build with CUDAQ_EXTERNAL_PROJECTS)
     □ Add pyproject.toml with cudaq.backends entry point
     □ Add __init__.py with register() function

--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -151,6 +151,11 @@ public:
         throw std::runtime_error(
             "Returning an observe_result requires a spin_op.");
 
+      // Server-side observe backends return a single expectation on the
+      // global register (e.g. Fermioniq / external custom QPU plugins).
+      if (data.has_expectation())
+        return observe_result(data.expectation(), *spinOp, data);
+
       auto checkRegName = spinOp->to_string();
       if (data.has_expectation(checkRegName))
         return observe_result(data.expectation(checkRegName), *spinOp, data);

--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -164,6 +164,11 @@ public:
         throw std::runtime_error(
             "Returning an observe_result requires a spin_op.");
 
+      // Server-side observe backends return a single expectation on the
+      // global register (e.g. Fermioniq / external custom QPU plugins).
+      if (data.has_expectation())
+        return observe_result(data.expectation(), *spinOp, data);
+
       auto checkRegName = spinOp->to_string();
       if (data.has_expectation(checkRegName))
         return observe_result(data.expectation(checkRegName), *spinOp, data);

--- a/runtime/common/ObservableUserData.h
+++ b/runtime/common/ObservableUserData.h
@@ -1,0 +1,46 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// Helpers for attaching a full spin_op to KernelExecution::user_data when a
+/// REST / custom QPU backend evaluates observables server-side (e.g. Fermioniq
+/// or an external plugin that registers its own QPU).
+
+#pragma once
+
+#include "common/KernelExecution.h"
+#include "nlohmann/json.hpp"
+#include "cudaq/runtime/logger/cudaq_fmt.h"
+#include "cudaq/spin_op.h"
+#include <cmath>
+
+namespace cudaq {
+
+/// @brief Attach a full spin observable to a KernelExecution as
+/// `user_data["observable"]` for server-side observe backends.
+///
+/// Format matches Fermioniq / external REST plugins:
+/// `[["Z0", "0.5+0.0j"], ["Z0 Z1", "0.3+0.0j"], ...]`
+inline void attachObservableUserData(KernelExecution &code,
+                                     const spin_op &spin) {
+  nlohmann::json user_data = nlohmann::json::object();
+  nlohmann::json obs = nlohmann::json::array();
+  for (const auto &term : spin) {
+    nlohmann::json terms = nlohmann::json::array();
+    terms.push_back(term.get_term_id());
+    auto coeff = term.evaluate_coefficient();
+    auto coeff_str = cudaq_fmt::format("{}{}{}j", coeff.real(),
+                                       coeff.imag() < 0.0 ? "-" : "+",
+                                       std::fabs(coeff.imag()));
+    terms.push_back(coeff_str);
+    obs.push_back(std::move(terms));
+  }
+  user_data["observable"] = std::move(obs);
+  code.user_data = cudaq_json(std::move(user_data));
+}
+
+} // namespace cudaq

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -7,30 +7,9 @@
  ******************************************************************************/
 
 #include "FermioniqQPU.h"
+#include "common/ObservableUserData.h"
 #include "cudaq_internal/compiler/Compiler.h"
-#include "nlohmann/json.hpp"
 #include "cudaq/algorithms/observe/policy.h"
-#include "cudaq/runtime/logger/cudaq_fmt.h"
-
-namespace {
-void attachFermioniqObservable(cudaq::KernelExecution &code,
-                               const cudaq::spin_op &spin) {
-  auto user_data = nlohmann::json::object();
-  auto obs = nlohmann::json::array();
-  for (const auto &term : spin) {
-    auto terms = nlohmann::json::array();
-    terms.push_back(term.get_term_id());
-    auto coeff = term.evaluate_coefficient();
-    auto coeff_str = cudaq_fmt::format("{}{}{}j", coeff.real(),
-                                       coeff.imag() < 0.0 ? "-" : "+",
-                                       std::fabs(coeff.imag()));
-    terms.push_back(coeff_str);
-    obs.push_back(terms);
-  }
-  user_data["observable"] = obs;
-  code.user_data = user_data;
-}
-} // namespace
 
 cudaq::FermioniqQPU::~FermioniqQPU() = default;
 
@@ -90,7 +69,7 @@ cudaq::FermioniqQPU::launchKernel(const cudaq::observe_policy &policy,
   if (codes.size() != 1)
     throw std::runtime_error("Provider only allows 1 circuit at a time.");
 
-  attachFermioniqObservable(codes[0], policy.spin);
+  attachObservableUserData(codes[0], policy.spin);
   auto result =
       completeLaunchKernel(policy, module.getName(), std::move(codes));
   auto expectation = result.raw_data().expectation(GlobalRegisterName);
@@ -114,7 +93,7 @@ cudaq::FermioniqQPU::launchKernel(const cudaq::async_observe_policy &policy,
   if (codes.size() != 1)
     throw std::runtime_error("Provider only allows 1 circuit at a time.");
 
-  attachFermioniqObservable(codes[0], policy.inner.spin);
+  attachObservableUserData(codes[0], policy.inner.spin);
   return completeLaunchKernel(policy, module.getName(), std::move(codes));
 }
 

--- a/runtime/cudaq/platform/qpu_utils.cpp
+++ b/runtime/cudaq/platform/qpu_utils.cpp
@@ -138,6 +138,22 @@ void detail::loadTargetPluginLibraries(
     loadTargetPluginLibrary(candidate, targetName);
     break;
   }
+
+  // External custom QPU plugins ship libcudaq-<platform-qpu>-qpu.so (same
+  // naming as in-tree Fermioniq). Load before registry::get<QPU>.
+  if (targetConfig.BackendConfig.has_value() &&
+      !targetConfig.BackendConfig->PlatformQpu.empty()) {
+    const auto qpuLibName = "libcudaq-" +
+                            targetConfig.BackendConfig->PlatformQpu + "-qpu" +
+                            PLATFORM_SHARED_LIBRARY_SUFFIX;
+    for (const auto &candidate :
+         {cudaqLibDir / qpuLibName, pluginLibDir / qpuLibName}) {
+      if (!std::filesystem::exists(candidate))
+        continue;
+      loadTargetPluginLibrary(candidate, targetName);
+      break;
+    }
+  }
 }
 
 bool detail::isAnalogHamiltonianKernel(const std::string &kernelName) {

--- a/runtime/cudaq/platform/qpu_utils.cpp
+++ b/runtime/cudaq/platform/qpu_utils.cpp
@@ -140,6 +140,22 @@ void detail::loadTargetPluginLibraries(
     loadTargetPluginLibrary(candidate, targetName);
     break;
   }
+
+  // External custom QPU plugins ship libcudaq-<platform-qpu>-qpu.so (same
+  // naming as in-tree Fermioniq). Load before registry::get<QPU>.
+  if (targetConfig.BackendConfig.has_value() &&
+      !targetConfig.BackendConfig->PlatformQpu.empty()) {
+    const auto qpuLibName = "libcudaq-" +
+                            targetConfig.BackendConfig->PlatformQpu + "-qpu" +
+                            PLATFORM_SHARED_LIBRARY_SUFFIX;
+    for (const auto &candidate :
+         {cudaqLibDir / qpuLibName, pluginLibDir / qpuLibName}) {
+      if (!std::filesystem::exists(candidate))
+        continue;
+      loadTargetPluginLibrary(candidate, targetName);
+      break;
+    }
+  }
 }
 
 bool detail::isAnalogHamiltonianKernel(const std::string &kernelName) {

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -247,6 +247,19 @@ target_link_libraries(test_exec_ctx_thread
   gtest_main)
 cudaq_gtest_discover_tests(test_exec_ctx_thread DISCOVERY_TIMEOUT 120)
 
+# Server-side observe helpers (Fermioniq / external custom QPU wire format)
+add_executable(test_observable_user_data
+  main.cpp
+  common/ObservableUserDataTester.cpp)
+target_include_directories(test_observable_user_data PRIVATE .)
+target_link_libraries(test_observable_user_data
+  PRIVATE
+  cudaq
+  cudaq-common
+  cudaq-operator
+  gtest_main)
+cudaq_gtest_discover_tests(test_observable_user_data DISCOVERY_TIMEOUT 120)
+
 add_subdirectory(nvqpp)
 add_subdirectory(output_record)
 add_subdirectory(target_config)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -242,6 +242,19 @@ target_link_libraries(test_exec_ctx_thread
   gtest_main)
 cudaq_gtest_discover_tests(test_exec_ctx_thread DISCOVERY_TIMEOUT 120)
 
+# Server-side observe helpers (Fermioniq / external custom QPU wire format)
+add_executable(test_observable_user_data
+  main.cpp
+  common/ObservableUserDataTester.cpp)
+target_include_directories(test_observable_user_data PRIVATE .)
+target_link_libraries(test_observable_user_data
+  PRIVATE
+  cudaq
+  cudaq-common
+  cudaq-operator
+  gtest_main)
+cudaq_gtest_discover_tests(test_observable_user_data DISCOVERY_TIMEOUT 120)
+
 add_executable(test_quantum_platform main.cpp common/QuantumPlatformTester.cpp)
 target_include_directories(test_quantum_platform PRIVATE .)
 target_link_libraries(test_quantum_platform

--- a/unittests/common/ObservableUserDataTester.cpp
+++ b/unittests/common/ObservableUserDataTester.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// Unit tests for server-side observe helpers used by Fermioniq and external
+/// custom QPU plugins.
+
+#include "common/ObservableUserData.h"
+#include "common/SampleResult.h"
+#include "cudaq/operators.h"
+#include <gtest/gtest.h>
+#include <set>
+#include <string>
+
+TEST(ObservableUserDataTester, attachesFermioniqCompatibleObservable) {
+  cudaq::KernelExecution code;
+  auto spin =
+      0.5 * cudaq::spin::z(0) + 0.3 * cudaq::spin::z(0) * cudaq::spin::z(1);
+
+  cudaq::attachObservableUserData(code, spin);
+
+  ASSERT_TRUE(code.user_data->contains("observable"));
+  ASSERT_TRUE(code.user_data->at("observable").is_array());
+  ASSERT_EQ(code.user_data->at("observable").size(), 2u);
+
+  std::set<std::string> termIds;
+  for (const auto &entry : code.user_data->at("observable")) {
+    ASSERT_TRUE(entry.is_array());
+    ASSERT_EQ(entry.size(), 2u);
+    ASSERT_TRUE(entry[0].is_string());
+    ASSERT_TRUE(entry[1].is_string());
+    termIds.insert(entry[0].get<std::string>());
+    // Coefficient strings match Fermioniq: "re±imj"
+    const auto coeff = entry[1].get<std::string>();
+    EXPECT_NE(coeff.find('j'), std::string::npos);
+  }
+  EXPECT_TRUE(termIds.count("Z0"));
+  EXPECT_TRUE(termIds.count("Z0Z1"));
+}
+
+TEST(ObservableUserDataTester, serverSideExpectationUsesGlobalRegister) {
+  // processResults for server-side observe backends return
+  // ExecutionResult(double). async_observe_result::get() must accept
+  // has_expectation() on the global register without requiring
+  // spin_op->to_string() as the register name.
+  cudaq::sample_result data(cudaq::ExecutionResult(/*expVal=*/0.41));
+  EXPECT_TRUE(data.has_expectation());
+  EXPECT_DOUBLE_EQ(data.expectation(), 0.41);
+  EXPECT_TRUE(data.has_expectation(cudaq::GlobalRegisterName));
+}

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -528,6 +528,37 @@ TEST_F(ExternalBackendTester, nativeTargetLoadsPluginLibraries) {
   unsetenv("CUDAQ_DLOPEN_SENTINEL_PATH");
 }
 
+TEST_F(ExternalBackendTester, autoLoadsPlatformQpuLibrary) {
+  auto root = tmpRoot / "qpu-auto-load";
+  auto targetsDir = root / "targets";
+  auto libDir = root / "lib";
+  std::filesystem::create_directories(targetsDir);
+  std::filesystem::create_directories(libDir);
+
+  const auto pluginPath =
+      std::filesystem::path(CUDAQ_DLOPEN_SENTINEL_PLUGIN_PATH);
+  // Convention: libcudaq-<platform-qpu>-qpu.<ext>
+  const auto qpuLibName =
+      std::string("libcudaq-mock_observe_qpu-qpu") +
+      std::filesystem::path(CUDAQ_DLOPEN_SENTINEL_PLUGIN_FILENAME).extension().string();
+  std::filesystem::copy_file(pluginPath, libDir / qpuLibName,
+                             std::filesystem::copy_options::overwrite_existing);
+
+  const auto sentinelPath = tmpRoot / "qpu-auto-load.sentinel";
+  std::filesystem::remove(sentinelPath);
+  setenv("CUDAQ_DLOPEN_SENTINEL_PATH", sentinelPath.c_str(), 1);
+
+  cudaq::config::TargetConfig config;
+  cudaq::config::BackendEndConfigEntry backendConfig;
+  backendConfig.PlatformQpu = "mock_observe_qpu";
+  config.BackendConfig = backendConfig;
+  cudaq::detail::loadTargetPluginLibraries(
+      "mock_observe_qpu", targetsDir / "mock_observe_qpu.yml", config);
+
+  EXPECT_TRUE(std::filesystem::exists(sentinelPath));
+  unsetenv("CUDAQ_DLOPEN_SENTINEL_PATH");
+}
+
 #endif // CUDAQ_ENABLE_PYTHON
 
 TEST(TargetConfigTester, pluginRootTokenSubstitutionReplacesAllOccurrences) {

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -527,6 +527,37 @@ TEST_F(ExternalBackendTester, nativeTargetLoadsPluginLibraries) {
   unsetenv("CUDAQ_DLOPEN_SENTINEL_PATH");
 }
 
+TEST_F(ExternalBackendTester, autoLoadsPlatformQpuLibrary) {
+  auto root = tmpRoot / "qpu-auto-load";
+  auto targetsDir = root / "targets";
+  auto libDir = root / "lib";
+  std::filesystem::create_directories(targetsDir);
+  std::filesystem::create_directories(libDir);
+
+  const auto pluginPath =
+      std::filesystem::path(CUDAQ_DLOPEN_SENTINEL_PLUGIN_PATH);
+  // Convention: libcudaq-<platform-qpu>-qpu.<ext>
+  const auto qpuLibName =
+      std::string("libcudaq-mock_observe_qpu-qpu") +
+      std::filesystem::path(CUDAQ_DLOPEN_SENTINEL_PLUGIN_FILENAME).extension().string();
+  std::filesystem::copy_file(pluginPath, libDir / qpuLibName,
+                             std::filesystem::copy_options::overwrite_existing);
+
+  const auto sentinelPath = tmpRoot / "qpu-auto-load.sentinel";
+  std::filesystem::remove(sentinelPath);
+  setenv("CUDAQ_DLOPEN_SENTINEL_PATH", sentinelPath.c_str(), 1);
+
+  cudaq::config::TargetConfig config;
+  cudaq::config::BackendEndConfigEntry backendConfig;
+  backendConfig.PlatformQpu = "mock_observe_qpu";
+  config.BackendConfig = backendConfig;
+  cudaq::detail::loadTargetPluginLibraries(
+      "mock_observe_qpu", targetsDir / "mock_observe_qpu.yml", config);
+
+  EXPECT_TRUE(std::filesystem::exists(sentinelPath));
+  unsetenv("CUDAQ_DLOPEN_SENTINEL_PATH");
+}
+
 #endif // CUDAQ_ENABLE_PYTHON
 
 TEST(TargetConfigTester, pluginRootTokenSubstitutionReplacesAllOccurrences) {


### PR DESCRIPTION
## Summary

- Auto-load `libcudaq-<platform-qpu>-qpu.so` when a target is activated (alongside the existing ServerHelper convention)
- Add shared `ObservableUserData` helper and Future global-register expectation handling for server-side observe results
- Document the Fermioniq-style external custom QPU contract and add the `mock_observe_qpu` reference plugin

Fixes #4926 (Proposal A). Leaves stock `remote_rest` / `observe-mode` unchanged.

## Test plan

- [ ] `test_target_config` — `autoLoadsPlatformQpuLibrary`
- [ ] `test_observable_user_data` — Fermioniq-compatible observable attachment + global-register expectation
- [ ] Build with `-DCUDAQ_EXTERNAL_PROJECTS=mock-observe-qpu` and run `check-mock-observe-qpu`
- [ ] Consumer smoke: external `platform-qpu: <custom>` plugin activates via `cudaq.set_target` / `nvq++`