### PR TITLE
Validate operator metadata and Pauli words

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
@@ -94,10 +94,7 @@ inline std::optional<std::size_t> getVeqSize(mlir::Value v) {
     return veqTy.getSize();
   if (auto relaxOp = v.getDefiningOp<cudaq::quake::RelaxSizeOp>()) {
     // RelaxSizeOp verifier guarantees input is VeqType when result is VeqType.
-    auto innerTy =
-        mlir::cast<cudaq::quake::VeqType>(relaxOp.getInputVec().getType());
-    if (innerTy.hasSpecifiedSize())
-      return innerTy.getSize();
+    return getVeqSize(relaxOp.getInputVec());
   }
   return std::nullopt;
 }

--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -9,9 +9,11 @@
 #pragma once
 
 #include "cudaq/Support/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
+#include <optional>
 
 //===----------------------------------------------------------------------===//
 // Generated logic
@@ -21,6 +23,15 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h.inc"
 
 namespace cudaq::quake {
+/// A single factor in a Pauli tensor product.
+enum class Pauli { I, X, Y, Z };
+
+/// An ordered Pauli tensor-product word.
+using PauliWord = llvm::SmallVector<Pauli>;
+
+/// Convert a word containing only `I`, `X`, `Y`, and `Z` to Pauli symbols.
+std::optional<PauliWord> symbolizePauliWord(llvm::StringRef value);
+
 /// \returns true if \p `ty` is a quantum value or reference.
 inline bool isQuantumType(mlir::Type ty) {
   // NB: this intentionally excludes MeasureType.

--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cudaq/Optimizer/Dialect/Traits.h"
 #include "cudaq/Support/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -70,14 +71,14 @@ inline bool isQuantumValueType(mlir::Type ty) {
 /// number of quantum references.
 bool isConstantQuantumRefType(mlir::Type ty);
 
+/// Get the number of qubits represented by \p ty when it is statically known.
+/// \p ty must be a quantum type.
+std::optional<std::size_t> getQubitCount(mlir::Type ty);
+
 /// Get the number of references in \p ty. \p ty must be a reference type.
 std::size_t getAllocationSize(mlir::Type ty);
 
 /// Get the number of wires in \p ty. \p ty must be a value type.
-inline std::size_t getWireCount(mlir::Type ty) {
-  if (isa<cudaq::quake::WireType, cudaq::quake::ControlType>(ty))
-    return 1;
-  return cast<cudaq::quake::CableType>(ty).getSize();
-}
+std::size_t getWireCount(mlir::Type ty);
 
 } // namespace cudaq::quake

--- a/cudaq/include/cudaq/Optimizer/Dialect/Traits.h
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Traits.h
@@ -9,12 +9,6 @@
 #pragma once
 
 #include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/Types.h"
-
-namespace mlir::TypeTrait {
-template <typename ConcreteType>
-class SSIType : public TraitBase<ConcreteType, SSIType> {};
-} // namespace mlir::TypeTrait
 
 namespace cudaq::quake {
 mlir::LogicalResult verifyWireArityAndCoarity(mlir::Operation *op);

--- a/cudaq/include/cudaq/Optimizer/Dialect/Traits.h
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Traits.h
@@ -9,6 +9,12 @@
 #pragma once
 
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Types.h"
+
+namespace mlir::TypeTrait {
+template <typename ConcreteType>
+class SSIType : public TraitBase<ConcreteType, SSIType> {};
+} // namespace mlir::TypeTrait
 
 namespace cudaq::quake {
 mlir::LogicalResult verifyWireArityAndCoarity(mlir::Operation *op);

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -60,6 +60,37 @@ static LogicalResult verifyWireResultsAreLinear(Operation *op) {
   return success();
 }
 
+// Verify invariants shared by Quake operators: control polarity metadata must
+// align with control operands, and value-form wire results must remain linear.
+static LogicalResult
+verifyOperator(cudaq::quake::OperatorInterface operatorInterface) {
+  auto controlPolarities = operatorInterface.getNegatedControls();
+  if (controlPolarities &&
+      controlPolarities->size() != operatorInterface.getControls().size())
+    return operatorInterface->emitOpError(
+        "control polarity count must match control operand count");
+  return verifyWireResultsAreLinear(operatorInterface.getOperation());
+}
+
+// Return the total number of target qubits when every target has a known size.
+// Target operand count is insufficient because one fixed-size veq operand may
+// represent multiple qubits. Dynamic veq sizes keep the count unknown.
+static std::optional<std::size_t>
+getStaticTargetQubitCount(ValueRange targets) {
+  std::size_t count = 0;
+  for (Value target : targets) {
+    if (isa<cudaq::quake::WireType, cudaq::quake::RefType>(target.getType())) {
+      ++count;
+      continue;
+    }
+    auto size = cudaq::quake::getVeqSize(target);
+    if (!size)
+      return std::nullopt;
+    count += *size;
+  }
+  return count;
+}
+
 /// When a quake operation is in value form, the number of wire arguments (wire
 /// arity) must be the same as the number of wires returned as results (wire
 /// coarity). This function verifies that this property is true.
@@ -562,13 +593,19 @@ LogicalResult cudaq::quake::ExpPauliOp::verify() {
   if (getPauliLiteralAttr()) {
     if (getPauli())
       return emitOpError("cannot have both a literal and a value Pauli word");
+    if (!symbolizePauliWord(*getPauliLiteral()))
+      return emitOpError("literal Pauli word must contain only I, X, Y, or Z");
+    auto targetQubitCount = getStaticTargetQubitCount(getTargets());
+    if (targetQubitCount && getPauliLiteral()->size() != *targetQubitCount)
+      return emitOpError(
+          "literal Pauli word length must match target qubit count");
   } else {
     if (!getPauli())
       return emitOpError("must have either a literal or a value Pauli word");
   }
   if (!(getParameters().empty() || getParameters().size() == 1))
     return emitOpError("can only have 0 or 1 parameter");
-  return verifyWireResultsAreLinear(getOperation());
+  return verifyOperator(cast<cudaq::quake::OperatorInterface>(getOperation()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1194,7 +1231,7 @@ LogicalResult cudaq::quake::CustomUnitaryCallOp::verify() {
   auto fn = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this, gen);
   if (!fn)
     return emitOpError("symbol must be a func.func");
-  return verifyWireResultsAreLinear(getOperation());
+  return verifyOperator(cast<cudaq::quake::OperatorInterface>(getOperation()));
 }
 
 void cudaq::quake::CustomUnitaryConstantOp::getOperatorMatrix(Matrix &matrix) {
@@ -1283,7 +1320,7 @@ LogicalResult cudaq::quake::CustomUnitaryConstantOp::verify() {
           "Invalid matrix size, required 2^N * 2^N for N-qubit operation");
   }
 
-  return verifyWireResultsAreLinear(getOperation());
+  return verifyOperator(cast<cudaq::quake::OperatorInterface>(getOperation()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1402,9 +1439,14 @@ QUANTUM_OPS(INSTANTIATE_CALLBACKS)
     return verifyWireResultsAreLinear(getOperation());                         \
   }
 
-#define VERIFY_OPS(MACRO) BUILTIN_GATE_OPS(MACRO) WIRE_OPS(MACRO)
+#define INSTANTIATE_OPERATOR_VERIFY(Op)                                        \
+  LogicalResult cudaq::quake::Op::verify() {                                   \
+    return verifyOperator(                                                     \
+        cast<cudaq::quake::OperatorInterface>(getOperation()));                \
+  }
 
-VERIFY_OPS(INSTANTIATE_LINEAR_TYPE_VERIFY)
+BUILTIN_GATE_OPS(INSTANTIATE_OPERATOR_VERIFY)
+WIRE_OPS(INSTANTIATE_LINEAR_TYPE_VERIFY)
 
 //===----------------------------------------------------------------------===//
 // Generated logic

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include <limits>
 #include <unordered_set>
 
 using namespace mlir;
@@ -72,21 +73,34 @@ verifyOperator(cudaq::quake::OperatorInterface operatorInterface) {
   return verifyWireResultsAreLinear(operatorInterface.getOperation());
 }
 
+static std::optional<std::size_t> checkedAdd(std::size_t lhs, std::size_t rhs) {
+  if (std::numeric_limits<std::size_t>::max() - lhs < rhs)
+    return std::nullopt;
+  return lhs + rhs;
+}
+
 // Return the total number of target qubits when every target has a known size.
-// Target operand count is insufficient because one fixed-size veq operand may
-// represent multiple qubits. Dynamic veq sizes keep the count unknown.
+// Target operand count is insufficient because one fixed-size aggregate operand
+// may represent multiple qubits. With dynamic sizes, the count is unknown.
+static std::optional<std::size_t> getStaticTargetQubitCount(Value target) {
+  if (auto count = cudaq::quake::getQubitCount(target.getType()))
+    return count;
+  if (auto relaxOp = target.getDefiningOp<cudaq::quake::RelaxSizeOp>())
+    return getStaticTargetQubitCount(relaxOp.getInputVec());
+  return std::nullopt;
+}
+
 static std::optional<std::size_t>
 getStaticTargetQubitCount(ValueRange targets) {
   std::size_t count = 0;
   for (Value target : targets) {
-    if (isa<cudaq::quake::WireType, cudaq::quake::RefType>(target.getType())) {
-      ++count;
-      continue;
-    }
-    auto size = cudaq::quake::getVeqSize(target);
-    if (!size)
+    auto targetCount = getStaticTargetQubitCount(target);
+    if (!targetCount)
       return std::nullopt;
-    count += *size;
+    auto updatedCount = checkedAdd(count, *targetCount);
+    if (!updatedCount)
+      return std::nullopt;
+    count = *updatedCount;
   }
   return count;
 }

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/DialectImplementation.h"
 
 using namespace mlir;
+using cudaq::quake::Pauli;
 
 //===----------------------------------------------------------------------===//
 // Generated logic
@@ -20,6 +21,34 @@ using namespace mlir;
 
 #define GET_TYPEDEF_CLASSES
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.cpp.inc"
+
+static std::optional<Pauli> symbolizePauli(char value) {
+  switch (value) {
+  case 'I':
+    return Pauli::I;
+  case 'X':
+    return Pauli::X;
+  case 'Y':
+    return Pauli::Y;
+  case 'Z':
+    return Pauli::Z;
+  default:
+    return std::nullopt;
+  }
+}
+
+std::optional<cudaq::quake::PauliWord>
+cudaq::quake::symbolizePauliWord(llvm::StringRef value) {
+  PauliWord result;
+  result.reserve(value.size());
+  for (char character : value) {
+    auto pauli = symbolizePauli(character);
+    if (!pauli)
+      return std::nullopt;
+    result.push_back(*pauli);
+  }
+  return result;
+}
 
 //===----------------------------------------------------------------------===//
 // Veq's custom parser and pretty printing.

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -13,7 +13,6 @@
 #include "mlir/IR/DialectImplementation.h"
 
 using namespace mlir;
-using cudaq::quake::Pauli;
 
 //===----------------------------------------------------------------------===//
 // Generated logic
@@ -22,16 +21,16 @@ using cudaq::quake::Pauli;
 #define GET_TYPEDEF_CLASSES
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.cpp.inc"
 
-static std::optional<Pauli> symbolizePauli(char value) {
+static std::optional<cudaq::quake::Pauli> symbolizePauli(char value) {
   switch (value) {
   case 'I':
-    return Pauli::I;
+    return cudaq::quake::Pauli::I;
   case 'X':
-    return Pauli::X;
+    return cudaq::quake::Pauli::X;
   case 'Y':
-    return Pauli::Y;
+    return cudaq::quake::Pauli::Y;
   case 'Z':
-    return Pauli::Z;
+    return cudaq::quake::Pauli::Z;
   default:
     return std::nullopt;
   }
@@ -39,7 +38,7 @@ static std::optional<Pauli> symbolizePauli(char value) {
 
 std::optional<cudaq::quake::PauliWord>
 cudaq::quake::symbolizePauliWord(llvm::StringRef value) {
-  PauliWord result;
+  cudaq::quake::PauliWord result;
   result.reserve(value.size());
   for (char character : value) {
     auto pauli = symbolizePauli(character);

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -11,6 +11,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include <limits>
 
 using namespace mlir;
 
@@ -47,6 +48,12 @@ cudaq::quake::symbolizePauliWord(llvm::StringRef value) {
     result.push_back(*pauli);
   }
   return result;
+}
+
+static std::optional<std::size_t> checkedAdd(std::size_t lhs, std::size_t rhs) {
+  if (std::numeric_limits<std::size_t>::max() - lhs < rhs)
+    return std::nullopt;
+  return lhs + rhs;
 }
 
 //===----------------------------------------------------------------------===//
@@ -117,23 +124,7 @@ bool cudaq::quake::StruqType::hasSpecifiedSize() const {
 }
 
 std::optional<std::size_t> cudaq::quake::StruqType::getArity() const {
-  if (getMembers().empty())
-    return {0};
-  std::size_t res = 0;
-  for (auto ty : getMembers()) {
-    if (ty == RefType::get(getContext())) {
-      res++;
-    } else if (auto veqTy = llvm::dyn_cast<VeqType>(ty)) {
-      if (veqTy.hasSpecifiedSize())
-        res += veqTy.getSize();
-      else
-        return std::nullopt;
-    } else {
-      // NB: This is a bug. Should not have anything but Ref and Veq types.
-      return std::nullopt;
-    }
-  }
-  return {res};
+  return getQubitCount(*this);
 }
 
 void cudaq::quake::StruqType::print(AsmPrinter &printer) const {
@@ -146,42 +137,51 @@ void cudaq::quake::StruqType::print(AsmPrinter &printer) const {
 
 //===----------------------------------------------------------------------===//
 
-// This recursive function returns true if and only if \p ty is a quake
-// type in the set \e R, `{ ref, veq, struq }`, (loosely known as "reference"
-// types) and the number of qubits is a compile-time known constant. This
-// function returns false for any type not in the set \e R or if the composition
-// of types contains a `veq` of unspecified size.
-static bool isConstQuantumBits(Type ty) {
-  if (isa<cudaq::quake::RefType>(ty))
-    return true;
-  if (auto t = dyn_cast<cudaq::quake::StruqType>(ty)) {
-    for (auto m : t.getMembers())
-      if (!isConstQuantumBits(m))
-        return false;
-    return true;
-  }
-  if (auto t = dyn_cast<cudaq::quake::VeqType>(ty))
-    if (t.hasSpecifiedSize())
-      return true;
-  return false;
+bool cudaq::quake::isConstantQuantumRefType(Type ty) {
+  if (!isQuantumReferenceType(ty))
+    return false;
+  return getQubitCount(ty).has_value();
 }
 
-bool cudaq::quake::isConstantQuantumRefType(Type ty) {
-  return isConstQuantumBits(ty);
+std::optional<std::size_t> cudaq::quake::getQubitCount(Type ty) {
+  assert(isQuantumType(ty) && "expected a quantum type");
+  if (isa<RefType, WireType, ControlType>(ty))
+    return 1;
+  if (auto veqTy = dyn_cast<VeqType>(ty)) {
+    if (!veqTy.hasSpecifiedSize())
+      return std::nullopt;
+    return veqTy.getSize();
+  }
+  if (auto cableTy = dyn_cast<CableType>(ty))
+    return cableTy.getSize();
+  auto struqTy = cast<StruqType>(ty);
+  std::size_t count = 0;
+  for (auto member : struqTy.getMembers()) {
+    if (!isa<RefType, VeqType>(member))
+      return std::nullopt;
+    auto memberCount = getQubitCount(member);
+    if (!memberCount)
+      return std::nullopt;
+    auto updatedCount = checkedAdd(count, *memberCount);
+    if (!updatedCount)
+      return std::nullopt;
+    count = *updatedCount;
+  }
+  return count;
 }
 
 std::size_t cudaq::quake::getAllocationSize(Type ty) {
-  if (isa<cudaq::quake::RefType>(ty))
-    return 1;
-  if (auto stq = dyn_cast<cudaq::quake::StruqType>(ty)) {
-    std::size_t size = 0;
-    for (auto m : stq.getMembers())
-      size += getAllocationSize(m);
-    return size;
-  }
-  auto veq = cast<cudaq::quake::VeqType>(ty);
-  assert(veq.hasSpecifiedSize() && "veq type must have constant size");
-  return veq.getSize();
+  assert(isQuantumReferenceType(ty) && "expected a quantum reference type");
+  auto count = getQubitCount(ty);
+  assert(count && "quantum reference type must have constant size");
+  return *count;
+}
+
+std::size_t cudaq::quake::getWireCount(Type ty) {
+  assert(isQuantumValueType(ty) && "expected a quantum value type");
+  auto count = getQubitCount(ty);
+  assert(count && "quantum value type must have constant size");
+  return *count;
 }
 
 //===----------------------------------------------------------------------===//

--- a/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -9,6 +9,7 @@
 #include "DecompositionPatterns.h"
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Builder/Factory.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/TypeName.h"
@@ -422,9 +423,6 @@ struct ExpPauliDecomposition
     auto theta = expPauliOp.getParameter();
     auto pauliWord = expPauliOp.getPauli();
 
-    if (expPauliOp.isAdj())
-      theta = arith::NegFOp::create(rewriter, loc, theta);
-
     std::optional<std::string> optPauliWordStr;
     if (!pauliWord) {
       optPauliWordStr = expPauliOp.getPauliLiteral()->str();
@@ -517,21 +515,31 @@ struct ExpPauliDecomposition
     if (size > 0 && pauliWordStr[size - 1] == '\0')
       size--;
 
+    auto maybePaulis = cudaq::quake::symbolizePauliWord(
+        StringRef(pauliWordStr).take_front(size));
+    if (!maybePaulis)
+      return expPauliOp.emitOpError(
+          "Pauli word must contain only I, X, Y, or Z");
+    const auto &paulis = *maybePaulis;
+
+    if (expPauliOp.isAdj())
+      theta = arith::NegFOp::create(rewriter, loc, theta);
+
     SmallVector<Value> qubitSupport;
-    for (std::size_t i = 0; i < size; i++) {
+    for (auto [i, pauli] : llvm::enumerate(paulis)) {
       Value index = arith::ConstantIntOp::create(rewriter, loc, i, 64);
       Value qubitI =
           cudaq::quake::ExtractRefOp::create(rewriter, loc, qubits, index);
-      if (pauliWordStr[i] != 'I')
+      if (pauli != cudaq::quake::Pauli::I)
         qubitSupport.push_back(qubitI);
 
-      if (pauliWordStr[i] == 'Y') {
+      if (pauli == cudaq::quake::Pauli::Y) {
         APFloat d(M_PI_2);
         Value param = arith::ConstantFloatOp::create(rewriter, loc,
                                                      rewriter.getF64Type(), d);
         cudaq::quake::RxOp::create(rewriter, loc, ValueRange{param},
                                    ValueRange{}, ValueRange{qubitI});
-      } else if (pauliWordStr[i] == 'X') {
+      } else if (pauli == cudaq::quake::Pauli::X) {
         cudaq::quake::HOp::create(rewriter, loc, ValueRange{qubitI});
       }
     }
@@ -562,19 +570,19 @@ struct ExpPauliDecomposition
     for (auto &[i, j] : toReverse)
       cudaq::quake::XOp::create(rewriter, loc, ValueRange{i}, ValueRange{j});
 
-    for (std::size_t i = 0; i < pauliWordStr.size(); i++) {
-      std::size_t k = pauliWordStr.size() - 1 - i;
+    for (std::size_t i = 0; i < paulis.size(); i++) {
+      std::size_t k = paulis.size() - 1 - i;
       Value index = arith::ConstantIntOp::create(rewriter, loc, k, 64);
       Value qubitK =
           cudaq::quake::ExtractRefOp::create(rewriter, loc, qubits, index);
 
-      if (pauliWordStr[k] == 'Y') {
+      if (paulis[k] == cudaq::quake::Pauli::Y) {
         APFloat d(-M_PI_2);
         Value param = arith::ConstantFloatOp::create(rewriter, loc,
                                                      rewriter.getF64Type(), d);
         cudaq::quake::RxOp::create(rewriter, loc, ValueRange{param},
                                    ValueRange{}, ValueRange{qubitK});
-      } else if (pauliWordStr[k] == 'X') {
+      } else if (paulis[k] == cudaq::quake::Pauli::X) {
         cudaq::quake::HOp::create(rewriter, loc, ValueRange{qubitK});
       }
     }

--- a/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -9,6 +9,7 @@
 #include "DecompositionPatterns.h"
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Builder/Factory.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Error.h"
@@ -419,7 +420,6 @@ struct ExpPauliDecomposition
                                 PatternRewriter &rewriter) const override {
     auto loc = expPauliOp.getLoc();
     auto module = expPauliOp->getParentOfType<ModuleOp>();
-    auto qubits = expPauliOp.getTarget();
     auto theta = expPauliOp.getParameter();
     auto pauliWord = expPauliOp.getPauli();
 
@@ -522,14 +522,42 @@ struct ExpPauliDecomposition
           "Pauli word must contain only I, X, Y, or Z");
     const auto &paulis = *maybePaulis;
 
+    // Flatten variadic targets into individual refs before lowering.
+    SmallVector<Value> qubits;
+    auto targets = expPauliOp.getTargets();
+    for (Value target : targets) {
+      auto targetTy = target.getType();
+      if (isa<cudaq::quake::RefType>(targetTy)) {
+        qubits.push_back(target);
+        continue;
+      }
+      if (!isa<cudaq::quake::VeqType>(targetTy))
+        return failure();
+      auto maybeSize = cudaq::quake::getVeqSize(target);
+      if (!maybeSize) {
+        // The Pauli-word length cannot determine boundaries between dynamic
+        // targets.
+        if (targets.size() != 1)
+          return failure();
+        maybeSize = paulis.size();
+      }
+      for (std::size_t i = 0; i < *maybeSize; ++i) {
+        Value index = arith::ConstantIntOp::create(rewriter, loc, i, 64);
+        qubits.push_back(
+            cudaq::quake::ExtractRefOp::create(rewriter, loc, target, index));
+      }
+    }
+
+    if (qubits.size() != paulis.size())
+      return expPauliOp.emitOpError(
+          "Pauli word length must match target qubit count");
+
     if (expPauliOp.isAdj())
       theta = arith::NegFOp::create(rewriter, loc, theta);
 
     SmallVector<Value> qubitSupport;
     for (auto [i, pauli] : llvm::enumerate(paulis)) {
-      Value index = arith::ConstantIntOp::create(rewriter, loc, i, 64);
-      Value qubitI =
-          cudaq::quake::ExtractRefOp::create(rewriter, loc, qubits, index);
+      Value qubitI = qubits[i];
       if (pauli != cudaq::quake::Pauli::I)
         qubitSupport.push_back(qubitI);
 
@@ -572,9 +600,7 @@ struct ExpPauliDecomposition
 
     for (std::size_t i = 0; i < paulis.size(); i++) {
       std::size_t k = paulis.size() - 1 - i;
-      Value index = arith::ConstantIntOp::create(rewriter, loc, k, 64);
-      Value qubitK =
-          cudaq::quake::ExtractRefOp::create(rewriter, loc, qubits, index);
+      Value qubitK = qubits[k];
 
       if (paulis[k] == cudaq::quake::Pauli::Y) {
         APFloat d(-M_PI_2);

--- a/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -522,13 +522,20 @@ struct ExpPauliDecomposition
           "Pauli word must contain only I, X, Y, or Z");
     const auto &paulis = *maybePaulis;
 
-    // Flatten variadic targets into individual refs before lowering.
-    SmallVector<Value> qubits;
+    // Determine target cardinalities before creating any IR. Pattern failure
+    // must leave the operation unchanged so that the greedy driver can stop
+    // cleanly instead of repeatedly matching a partially rewritten operation.
+    SmallVector<std::size_t> targetSizes;
     auto targets = expPauliOp.getTargets();
+    std::size_t qubitCount = 0;
     for (Value target : targets) {
       auto targetTy = target.getType();
       if (isa<cudaq::quake::RefType>(targetTy)) {
-        qubits.push_back(target);
+        if (qubitCount == paulis.size())
+          return expPauliOp.emitOpError(
+              "Pauli word length must match target qubit count");
+        targetSizes.push_back(1);
+        ++qubitCount;
         continue;
       }
       if (!isa<cudaq::quake::VeqType>(targetTy))
@@ -541,16 +548,30 @@ struct ExpPauliDecomposition
           return failure();
         maybeSize = paulis.size();
       }
-      for (std::size_t i = 0; i < *maybeSize; ++i) {
+      if (*maybeSize > paulis.size() - qubitCount)
+        return expPauliOp.emitOpError(
+            "Pauli word length must match target qubit count");
+      targetSizes.push_back(*maybeSize);
+      qubitCount += *maybeSize;
+    }
+
+    if (qubitCount != paulis.size())
+      return expPauliOp.emitOpError(
+          "Pauli word length must match target qubit count");
+
+    // Flatten variadic targets into individual refs before lowering.
+    SmallVector<Value> qubits;
+    for (auto [target, targetSize] : llvm::zip(targets, targetSizes)) {
+      if (isa<cudaq::quake::RefType>(target.getType())) {
+        qubits.push_back(target);
+        continue;
+      }
+      for (std::size_t i = 0; i < targetSize; ++i) {
         Value index = arith::ConstantIntOp::create(rewriter, loc, i, 64);
         qubits.push_back(
             cudaq::quake::ExtractRefOp::create(rewriter, loc, target, index));
       }
     }
-
-    if (qubits.size() != paulis.size())
-      return expPauliOp.emitOpError(
-          "Pauli word length must match target qubit count");
 
     if (expPauliOp.isAdj())
       theta = arith::NegFOp::create(rewriter, loc, theta);

--- a/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
+++ b/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=ExpPauliDecomposition})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=ExpPauliDecomposition})' %s -split-input-file -verify-diagnostics | FileCheck %s
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_ZZ4mainENK3$_0clEd"}} {
 
@@ -101,4 +101,14 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 // CHECK:           quake.h %[[VAL_9]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
+}
+
+// -----
+
+func.func @invalid_adjoint_dynamic_word(%theta : f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %qubits = quake.alloca !quake.veq<2>
+  %word = cc.string_literal "Xa" : !cc.ptr<!cc.array<i8 x 3>>
+  // expected-error@+1 {{Pauli word must contain only I, X, Y, or Z}}
+  quake.exp_pauli<adj> (%theta) %qubits to %word : (f64, !quake.veq<2>, !cc.ptr<!cc.array<i8 x 3>>) -> ()
+  return
 }

--- a/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
+++ b/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
@@ -42,12 +42,12 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 // CHECK:           quake.x %[[VAL_11]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_8]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_1]]] : (!quake.veq<4>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_13]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_14:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_2]]] : (!quake.veq<4>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_14]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_3]]] : (!quake.veq<4>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_15]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_4]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           quake.h %[[VAL_13]] : (!quake.ref) -> ()
+// CHECK:           quake.h %[[VAL_14]] : (!quake.ref) -> ()
+// CHECK:           quake.h %[[VAL_15]] : (!quake.ref) -> ()
 // CHECK:           quake.rx (%[[VAL_5]]) %[[VAL_16]] : (f64, !quake.ref) -> ()
 // CHECK:           quake.x {{\[}}%[[VAL_13]]] %[[VAL_14]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           quake.x {{\[}}%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
@@ -57,14 +57,10 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 // CHECK:           quake.x {{\[}}%[[VAL_15]]] %[[VAL_16]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           quake.x {{\[}}%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           quake.x {{\[}}%[[VAL_13]]] %[[VAL_14]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           %[[VAL_18:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_4]]] : (!quake.veq<4>, i64) -> !quake.ref
-// CHECK:           quake.rx (%[[VAL_7]]) %[[VAL_18]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_19:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_3]]] : (!quake.veq<4>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_19]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_2]]] : (!quake.veq<4>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_20]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_21:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_1]]] : (!quake.veq<4>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_21]] : (!quake.ref) -> ()
+// CHECK:           quake.rx (%[[VAL_7]]) %[[VAL_16]] : (f64, !quake.ref) -> ()
+// CHECK:           quake.h %[[VAL_15]] : (!quake.ref) -> ()
+// CHECK:           quake.h %[[VAL_14]] : (!quake.ref) -> ()
+// CHECK:           quake.h %[[VAL_13]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -89,16 +85,36 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant -1.5707963267948966 : f64
 // CHECK-DAG:       %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_0]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_6]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           quake.h %[[VAL_6]] : (!quake.ref) -> ()
 // CHECK:           quake.rx (%[[VAL_2]]) %[[VAL_7]] : (f64, !quake.ref) -> ()
 // CHECK:           quake.x {{\[}}%[[VAL_6]]] %[[VAL_7]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           quake.rz (%[[VAL_3]]) %[[VAL_7]] : (f64, !quake.ref) -> ()
 // CHECK:           quake.x {{\[}}%[[VAL_6]]] %[[VAL_7]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:           quake.rx (%[[VAL_4]]) %[[VAL_8]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_0]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:           quake.h %[[VAL_9]] : (!quake.ref) -> ()
+// CHECK:           quake.rx (%[[VAL_4]]) %[[VAL_7]] : (f64, !quake.ref) -> ()
+// CHECK:           quake.h %[[VAL_6]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+  func.func @multi_target_exp_pauli(%theta : f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+    %0 = quake.alloca !quake.ref
+    %1 = quake.alloca !quake.veq<2>
+    %2 = quake.alloca !quake.ref
+    quake.exp_pauli (%theta) %0, %1, %2 to "XYZX" : (f64, !quake.ref, !quake.veq<2>, !quake.ref) -> ()
+    return
+  }
+
+// CHECK-LABEL:   func.func @multi_target_exp_pauli(
+// CHECK-SAME:                                      %[[ARG_0:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-NOT:       quake.exp_pauli
+// CHECK:           %[[REF_0:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VEQ:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[REF_1:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VEQ_0:.*]] = quake.extract_ref %[[VEQ]]
+// CHECK:           %[[VEQ_1:.*]] = quake.extract_ref %[[VEQ]]
+// CHECK:           quake.h %[[REF_0]] : (!quake.ref) -> ()
+// CHECK:           quake.rx {{.*}} %[[VEQ_0]] : (f64, !quake.ref) -> ()
+// CHECK:           quake.rz {{.*}} %[[REF_1]] : (f64, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 }

--- a/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
+++ b/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
@@ -128,3 +128,13 @@ func.func @invalid_adjoint_dynamic_word(%theta : f64) attributes {"cudaq-entrypo
   quake.exp_pauli<adj> (%theta) %qubits to %word : (f64, !quake.veq<2>, !cc.ptr<!cc.array<i8 x 3>>) -> ()
   return
 }
+
+// -----
+
+func.func @invalid_dynamic_word_length(%theta : f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %qubits = quake.alloca !quake.veq<3>
+  %word = cc.string_literal "XY" : !cc.ptr<!cc.array<i8 x 3>>
+  // expected-error@+1 {{Pauli word length must match target qubit count}}
+  quake.exp_pauli (%theta) %qubits to %word : (f64, !quake.veq<3>, !cc.ptr<!cc.array<i8 x 3>>) -> ()
+  return
+}

--- a/cudaq/test/Transforms/exp_pauli-1.qke
+++ b/cudaq/test/Transforms/exp_pauli-1.qke
@@ -11,7 +11,7 @@
 func.func @ep_0() {
   %0 = quake.alloca !quake.ref
   %1 = arith.constant 2.0 : f64
-  quake.exp_pauli (%1) %0 to "XYZ" : (f64, !quake.ref) -> ()
+  quake.exp_pauli (%1) %0 to "X" : (f64, !quake.ref) -> ()
   quake.mz %0 : (!quake.ref) -> !quake.measure
   return
 }
@@ -19,15 +19,14 @@ func.func @ep_0() {
 func.func @ep_1() {
   %0 = quake.alloca !quake.ref
   %1 = arith.constant 2.0 : f64
-  %2 = cc.string_literal "XYZ" : !cc.ptr<!cc.array<i8 x 4>>
-  quake.exp_pauli (%1) %0 to %2 : (f64, !quake.ref, !cc.ptr<!cc.array<i8 x 4>>) -> ()
+  %2 = cc.string_literal "X" : !cc.ptr<!cc.array<i8 x 2>>
+  quake.exp_pauli (%1) %0 to %2 : (f64, !quake.ref, !cc.ptr<!cc.array<i8 x 2>>) -> ()
   quake.mz %0 : (!quake.ref) -> !quake.measure
   return
 }
 
 // CHECK-LABEL:   func.func @ep_0() {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 8 : i32
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 3 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i64
@@ -36,12 +35,12 @@ func.func @ep_1() {
 // CHECK:           %[[VAL_7:.*]] = call @__quantum__rt__array_create_1d(%[[VAL_0]], %[[VAL_4]]) : (i32, i64) -> !cc.ptr<!llvm.struct<"Array", opaque>>
 // CHECK:           %[[VAL_8:.*]] = call @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]], %[[VAL_2]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
-// CHECK:           %[[VAL_9:.*]] = cc.address_of @cstr.58595A00 : !cc.ptr<!llvm.array<4 x i8>>
-// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!llvm.array<4 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = cc.address_of @cstr.5800 : !cc.ptr<!llvm.array<2 x i8>>
+// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!llvm.array<2 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_5]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i64>
-// CHECK:           cc.store %[[VAL_1]], %[[VAL_12]] : !cc.ptr<i64>
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_12]] : !cc.ptr<i64>
 // CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i8>
 // CHECK:           call @__quantum__qis__exp_pauli__body(%[[VAL_3]], %[[VAL_7]], %[[VAL_13]]) : (f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>) -> ()
 // CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_2]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
@@ -54,21 +53,20 @@ func.func @ep_1() {
 
 // CHECK-LABEL:   func.func @ep_1() {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 8 : i32
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 3 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca !cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_2]] : (i64) -> !cc.ptr<!llvm.struct<"Qubit", opaque>>
-// CHECK:           %[[VAL_7:.*]] = cc.string_literal "XYZ" : !cc.ptr<!cc.array<i8 x 4>>
+// CHECK:           %[[VAL_7:.*]] = cc.string_literal "X" : !cc.ptr<!cc.array<i8 x 2>>
 // CHECK:           %[[VAL_8:.*]] = call @__quantum__rt__array_create_1d(%[[VAL_0]], %[[VAL_4]]) : (i32, i64) -> !cc.ptr<!llvm.struct<"Array", opaque>>
 // CHECK:           %[[VAL_9:.*]] = call @__quantum__rt__array_get_element_ptr_1d(%[[VAL_8]], %[[VAL_2]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_9]] : !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
-// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<i8 x 2>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_5]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i64>
-// CHECK:           cc.store %[[VAL_1]], %[[VAL_12]] : !cc.ptr<i64>
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_12]] : !cc.ptr<i64>
 // CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i8>
 // CHECK:           call @__quantum__qis__exp_pauli__body(%[[VAL_3]], %[[VAL_8]], %[[VAL_13]]) : (f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>) -> ()
 // CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_2]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>

--- a/cudaq/test/Transforms/exp_pauli-1.qke
+++ b/cudaq/test/Transforms/exp_pauli-1.qke
@@ -17,11 +17,12 @@ func.func @ep_0() {
 }
 
 func.func @ep_1() {
-  %0 = quake.alloca !quake.ref
+  %0 = quake.alloca !quake.veq<3>
   %1 = arith.constant 2.0 : f64
-  %2 = cc.string_literal "X" : !cc.ptr<!cc.array<i8 x 2>>
-  quake.exp_pauli (%1) %0 to %2 : (f64, !quake.ref, !cc.ptr<!cc.array<i8 x 2>>) -> ()
-  quake.mz %0 : (!quake.ref) -> !quake.measure
+  %2 = cc.string_literal "XYZ" : !cc.ptr<!cc.array<i8 x 4>>
+  quake.exp_pauli (%1) %0 to %2 : (f64, !quake.veq<3>, !cc.ptr<!cc.array<i8 x 4>>) -> ()
+  %3 = quake.extract_ref %0[0] : (!quake.veq<3>) -> !quake.ref
+  quake.mz %3 : (!quake.ref) -> !quake.measure
   return
 }
 
@@ -52,27 +53,25 @@ func.func @ep_1() {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @ep_1() {
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 8 : i32
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2.000000e+00 : f64
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca !cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>
-// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_2]] : (i64) -> !cc.ptr<!llvm.struct<"Qubit", opaque>>
-// CHECK:           %[[VAL_7:.*]] = cc.string_literal "X" : !cc.ptr<!cc.array<i8 x 2>>
-// CHECK:           %[[VAL_8:.*]] = call @__quantum__rt__array_create_1d(%[[VAL_0]], %[[VAL_4]]) : (i32, i64) -> !cc.ptr<!llvm.struct<"Array", opaque>>
-// CHECK:           %[[VAL_9:.*]] = call @__quantum__rt__array_get_element_ptr_1d(%[[VAL_8]], %[[VAL_2]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
-// CHECK:           cc.store %[[VAL_6]], %[[VAL_9]] : !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
-// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<i8 x 2>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_5]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i64>
-// CHECK:           cc.store %[[VAL_4]], %[[VAL_12]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i8>
-// CHECK:           call @__quantum__qis__exp_pauli__body(%[[VAL_3]], %[[VAL_8]], %[[VAL_13]]) : (f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>) -> ()
-// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_2]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
-// CHECK:           call @__quantum__qis__mz__body(%[[VAL_6]], %[[VAL_14]]) {registerName = "r00000"} : (!cc.ptr<!llvm.struct<"Qubit", opaque>>, !cc.ptr<!llvm.struct<"Result", opaque>>) -> ()
-// CHECK:           %[[VAL_15:.*]] = cc.address_of @cstr.72303030303000 : !cc.ptr<!llvm.array<7 x i8>>
-// CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!llvm.array<7 x i8>>) -> !cc.ptr<i8>
-// CHECK:           call @__quantum__rt__result_record_output(%[[VAL_14]], %[[VAL_16]]) {ResultIndex = 0 : i64, registerName = "r00000"} : (!cc.ptr<!llvm.struct<"Result", opaque>>, !cc.ptr<i8>) -> ()
+// CHECK-DAG:       %[[ZERO:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[THREE:.*]] = arith.constant 3 : i64
+// CHECK-DAG:       %[[THETA:.*]] = arith.constant 2.000000e+00 : f64
+// CHECK-DAG:       %[[WORD_STORAGE:.*]] = cc.alloca !cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>
+// CHECK:           %[[QUBIT_ARRAY_ADDR:.*]] = cc.address_of @ep_1.rodata_0 : !cc.ptr<!cc.array<i64 x 3>>
+// CHECK:           %[[QUBIT_ARRAY:.*]] = cc.cast %[[QUBIT_ARRAY_ADDR]] : (!cc.ptr<!cc.array<i64 x 3>>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
+// CHECK:           %[[WORD:.*]] = cc.string_literal "XYZ" : !cc.ptr<!cc.array<i8 x 4>>
+// CHECK:           %[[WORD_DATA:.*]] = cc.cast %[[WORD]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[WORD_DATA_ADDR:.*]] = cc.cast %[[WORD_STORAGE]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           cc.store %[[WORD_DATA]], %[[WORD_DATA_ADDR]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[WORD_SIZE_ADDR:.*]] = cc.compute_ptr %[[WORD_STORAGE]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i64>
+// CHECK:           cc.store %[[THREE]], %[[WORD_SIZE_ADDR]] : !cc.ptr<i64>
+// CHECK:           %[[WORD_ARG:.*]] = cc.cast %[[WORD_STORAGE]] : (!cc.ptr<!cc.array<!cc.struct<{!cc.ptr<i8>, i64}> x 1>>) -> !cc.ptr<i8>
+// CHECK:           call @__quantum__qis__exp_pauli__body(%[[THETA]], %[[QUBIT_ARRAY]], %[[WORD_ARG]]) : (f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>) -> ()
+// CHECK:           %[[QUBIT:.*]] = cc.cast %[[ZERO]] : (i64) -> !cc.ptr<!llvm.struct<"Qubit", opaque>>
+// CHECK:           %[[RESULT:.*]] = cc.cast %[[ZERO]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           call @__quantum__qis__mz__body(%[[QUBIT]], %[[RESULT]]) {registerName = "r00000"} : (!cc.ptr<!llvm.struct<"Qubit", opaque>>, !cc.ptr<!llvm.struct<"Result", opaque>>) -> ()
+// CHECK:           %[[REGISTER_ADDR:.*]] = cc.address_of @cstr.72303030303000 : !cc.ptr<!llvm.array<7 x i8>>
+// CHECK:           %[[REGISTER:.*]] = cc.cast %[[REGISTER_ADDR]] : (!cc.ptr<!llvm.array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           call @__quantum__rt__result_record_output(%[[RESULT]], %[[REGISTER]]) {ResultIndex = 0 : i64, registerName = "r00000"} : (!cc.ptr<!llvm.struct<"Result", opaque>>, !cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/invalid.qke
+++ b/cudaq/test/Transforms/invalid.qke
@@ -308,3 +308,31 @@ module {
   }
   cc.global constant private @int_mat (dense<[0, 1, 1, 0]> : tensor<4xi64>) : !cc.array<i64 x 4>
 }
+
+// -----
+
+func.func @invalid_exp_pauli_literal(%theta : f64) {
+  %qubits = quake.alloca !quake.veq<2>
+  // expected-error@+1 {{literal Pauli word must contain only I, X, Y, or Z}}
+  quake.exp_pauli (%theta) %qubits to "XA" : (f64, !quake.veq<2>) -> ()
+  return
+}
+
+// -----
+
+func.func @invalid_control_polarity_count() {
+  %control = quake.alloca !quake.ref
+  %target = quake.alloca !quake.ref
+  // expected-error@+1 {{control polarity count must match control operand count}}
+  quake.x [%control neg [true, false]] %target : (!quake.ref, !quake.ref) -> ()
+  return
+}
+
+// -----
+
+func.func @invalid_exp_pauli_literal_length(%theta : f64) {
+  %qubits = quake.alloca !quake.veq<2>
+  // expected-error@+1 {{literal Pauli word length must match target qubit count}}
+  quake.exp_pauli (%theta) %qubits to "X" : (f64, !quake.veq<2>) -> ()
+  return
+}

--- a/cudaq/test/Transforms/invalid.qke
+++ b/cudaq/test/Transforms/invalid.qke
@@ -67,7 +67,8 @@ func.func @test_struq() {
 // -----
 
 func.func @test_struq() {
-  // expected-error@+1 {{invalid struq member type}}
+  // expected-error@+2 {{invalid struq member type}}
+  // expected-error@+1 {{struq type must have specified size}}
   %0 = quake.alloca !quake.struq<!quake.struq<!quake.veq<3>, !quake.ref>, !quake.veq<7>>
   return
 }
@@ -334,5 +335,36 @@ func.func @invalid_exp_pauli_literal_length(%theta : f64) {
   %qubits = quake.alloca !quake.veq<2>
   // expected-error@+1 {{literal Pauli word length must match target qubit count}}
   quake.exp_pauli (%theta) %qubits to "X" : (f64, !quake.veq<2>) -> ()
+  return
+}
+
+// -----
+
+func.func @invalid_exp_pauli_multi_target_literal_length(%theta : f64) {
+  %scalar = quake.alloca !quake.ref
+  %vector = quake.alloca !quake.veq<2>
+  // expected-error@+1 {{literal Pauli word length must match target qubit count}}
+  quake.exp_pauli (%theta) %scalar, %vector to "XY" : (f64, !quake.ref, !quake.veq<2>) -> ()
+  return
+}
+
+// -----
+
+func.func @invalid_exp_pauli_relaxed_literal_length(%theta : f64) {
+  %targets = quake.alloca !quake.veq<2>
+  %relaxed = quake.relax_size %targets : (!quake.veq<2>) -> !quake.veq<?>
+  // expected-error@+1 {{literal Pauli word length must match target qubit count}}
+  quake.exp_pauli (%theta) %relaxed to "X" : (f64, !quake.veq<?>) -> ()
+  return
+}
+
+// -----
+
+func.func @invalid_exp_pauli_nested_relaxed_literal_length(%theta : f64) {
+  %targets = quake.alloca !quake.veq<2>
+  %relaxed0 = quake.relax_size %targets : (!quake.veq<2>) -> !quake.veq<?>
+  %relaxed1 = quake.relax_size %relaxed0 : (!quake.veq<?>) -> !quake.veq<?>
+  // expected-error@+1 {{literal Pauli word length must match target qubit count}}
+  quake.exp_pauli (%theta) %relaxed1 to "X" : (f64, !quake.veq<?>) -> ()
   return
 }

--- a/cudaq/test/Transforms/reify_span-1.qke
+++ b/cudaq/test/Transforms/reify_span-1.qke
@@ -10,8 +10,8 @@
 
 func.func @covered_wagon() {
   %cst = arith.constant 3.300000e+00 : f64
-  %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
-  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
+  %0 = cc.const_array [["X", "Z"], ["I", "Y"]] : !cc.array<!cc.array<!cc.array<i8 x 2> x 2> x 2>
+  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 2> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
   %2 = cc.stdvec_data %1 : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
   %4 = cc.load %3 : !cc.ptr<!cc.stdvec<!cc.charspan>>
@@ -26,4 +26,4 @@ func.func @covered_wagon() {
 // CHECK-LABEL: func.func @covered_wagon
 // CHECK: %[[VAL_0:.*]] = arith.constant 3.300000e+00 : f64
 // CHECK: %[[VAL_1:.*]] = quake.alloca !quake.ref
-// CHECK: quake.exp_pauli (%[[VAL_0]]) %[[VAL_1]] to "IZ" : (f64, !quake.ref) -> ()
+// CHECK: quake.exp_pauli (%[[VAL_0]]) %[[VAL_1]] to "I" : (f64, !quake.ref) -> ()

--- a/cudaq/test/Transforms/reify_span-1.qke
+++ b/cudaq/test/Transforms/reify_span-1.qke
@@ -10,20 +10,20 @@
 
 func.func @covered_wagon() {
   %cst = arith.constant 3.300000e+00 : f64
-  %0 = cc.const_array [["X", "Z"], ["I", "Y"]] : !cc.array<!cc.array<!cc.array<i8 x 2> x 2> x 2>
-  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 2> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
+  %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
+  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
   %2 = cc.stdvec_data %1 : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
   %4 = cc.load %3 : !cc.ptr<!cc.stdvec<!cc.charspan>>
   %5 = cc.stdvec_data %4 : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
   %6 = cc.cast %5 : (!cc.ptr<!cc.array<!cc.charspan x ?>>) -> !cc.ptr<!cc.charspan>
-  %7 = quake.alloca !quake.ref
+  %7 = quake.alloca !quake.veq<2>
   %8 = cc.load %6 : !cc.ptr<!cc.charspan>
-  quake.exp_pauli (%cst) %7 to %8 : (f64, !quake.ref, !cc.charspan) -> ()
+  quake.exp_pauli (%cst) %7 to %8 : (f64, !quake.veq<2>, !cc.charspan) -> ()
   return
 }
 
 // CHECK-LABEL: func.func @covered_wagon
 // CHECK: %[[VAL_0:.*]] = arith.constant 3.300000e+00 : f64
-// CHECK: %[[VAL_1:.*]] = quake.alloca !quake.ref
-// CHECK: quake.exp_pauli (%[[VAL_0]]) %[[VAL_1]] to "I" : (f64, !quake.ref) -> ()
+// CHECK: %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
+// CHECK: quake.exp_pauli (%[[VAL_0]]) %[[VAL_1]] to "IZ" : (f64, !quake.veq<2>) -> ()

--- a/cudaq/test/Transforms/roundtrip-ops.qke
+++ b/cudaq/test/Transforms/roundtrip-ops.qke
@@ -174,7 +174,6 @@ func.func @quantum_ops() {
 cc.global constant private @quantum_ops.rodata_synth_0 (dense<[(0.707106769,0.000000e+00), (0.707106769,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00
 ,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f32>>) : !cc.array<complex<f32> x 8>
 
-
 // CHECK-LABEL:   func.func @quantum_ops() {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
@@ -297,6 +296,55 @@ cc.global constant private @quantum_ops.rodata_synth_0 (dense<[(0.707106769,0.00
 // CHECK:           %[[VAL_67:.*]] = quake.create_state %[[VAL_62]], %[[VAL_61]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
 // CHECK:           quake.delete_state %[[VAL_67]] : !cc.ptr<!quake.state>
 // CHECK:           return
+// CHECK:         }
+
+func.func @exp_pauli_targets(%dynamic : !quake.veq<?>, %wire : !quake.wire) -> !quake.wire {
+  %theta = arith.constant 1.0 : f64
+
+  // Mixed fixed-size targets.
+  %ref = quake.alloca !quake.ref
+  %vector = quake.alloca !quake.veq<2>
+  quake.exp_pauli (%theta) %ref, %vector to "XYZ" : (f64, !quake.ref, !quake.veq<2>) -> ()
+
+  // A known zero-size target.
+  %empty = quake.alloca !quake.veq<0>
+  quake.exp_pauli (%theta) %empty to "" : (f64, !quake.veq<0>) -> ()
+
+  // Controls do not contribute to the Pauli-word length.
+  %control = quake.alloca !quake.veq<2>
+  quake.exp_pauli (%theta) [%control] %ref to "Z" : (f64, !quake.veq<2>, !quake.ref) -> ()
+
+  // Nested relax_size preserves recoverable cardinality.
+  %fixed = quake.alloca !quake.veq<2>
+  %relaxed0 = quake.relax_size %fixed : (!quake.veq<2>) -> !quake.veq<?>
+  %relaxed1 = quake.relax_size %relaxed0 : (!quake.veq<?>) -> !quake.veq<?>
+  quake.exp_pauli (%theta) %relaxed1 to "XY" : (f64, !quake.veq<?>) -> ()
+
+  // Dynamic cardinality defers the length check.
+  quake.exp_pauli (%theta) %dynamic to "XYZ" : (f64, !quake.veq<?>) -> ()
+
+  // Value-form target.
+  %result = quake.exp_pauli (%theta) %wire to "Y" : (f64, !quake.wire) -> !quake.wire
+  return %result : !quake.wire
+}
+
+// CHECK-LABEL:   func.func @exp_pauli_targets(
+// CHECK-SAME:        %[[DYNAMIC:.*]]: !quake.veq<?>, %[[WIRE:.*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[THETA:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:           %[[REF:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VECTOR:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           quake.exp_pauli (%[[THETA]]) %[[REF]], %[[VECTOR]] to "XYZ" : (f64, !quake.ref, !quake.veq<2>) -> ()
+// CHECK:           %[[EMPTY:.*]] = quake.alloca !quake.veq<0>
+// CHECK:           quake.exp_pauli (%[[THETA]]) %[[EMPTY]] to "" : (f64, !quake.veq<0>) -> ()
+// CHECK:           %[[CONTROL:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           quake.exp_pauli (%[[THETA]]) {{\[}}%[[CONTROL]]] %[[REF]] to "Z" : (f64, !quake.veq<2>, !quake.ref) -> ()
+// CHECK:           %[[FIXED:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[RELAXED_0:.*]] = quake.relax_size %[[FIXED]] : (!quake.veq<2>) -> !quake.veq<?>
+// CHECK:           %[[RELAXED_1:.*]] = quake.relax_size %[[RELAXED_0]] : (!quake.veq<?>) -> !quake.veq<?>
+// CHECK:           quake.exp_pauli (%[[THETA]]) %[[RELAXED_1]] to "XY" : (f64, !quake.veq<?>) -> ()
+// CHECK:           quake.exp_pauli (%[[THETA]]) %[[DYNAMIC]] to "XYZ" : (f64, !quake.veq<?>) -> ()
+// CHECK:           %[[RESULT:.*]] = quake.exp_pauli (%[[THETA]]) %[[WIRE]] to "Y" : (f64, !quake.wire) -> !quake.wire
+// CHECK:           return %[[RESULT]] : !quake.wire
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @quake_op1(


### PR DESCRIPTION
Some pre-work to my commutation analysis.

Reject malformed control-polarity metadata and invalid static ExpPauli literals during IR verification. Represent Pauli words as typed symbols so decomposition and later analyses share one validated interpretation instead of repeating string comparisons.

