### PR TITLE
Block-local qubit identitfier analysis

### DIFF
--- a/cudaq/lib/Optimizer/Analysis/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Analysis/CMakeLists.txt
@@ -7,6 +7,7 @@
 # ============================================================================ #
 
 add_cudaq_library(OptAnalysis
+  QubitIdentityAnalysis.cpp
   UnitaryOpGrouping.cpp
 
   DEPENDS

--- a/cudaq/lib/Optimizer/Analysis/QubitIdentityAnalysis.cpp
+++ b/cudaq/lib/Optimizer/Analysis/QubitIdentityAnalysis.cpp
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "QubitIdentityAnalysis.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include <utility>
+
+using namespace mlir;
+
+using cudaq::quake::detail::QubitIdentityAnalysis;
+using QubitId = QubitIdentityAnalysis::QubitId;
+using BorrowKey = std::pair<Attribute, std::int32_t>;
+
+// Copy an input's known qubit ID to the SSA value that replaces it. An unknown
+// input leaves the result unmapped so later queries remain conservative.
+static void propagateQubitId(llvm::DenseMap<Value, QubitId> &qubitIds,
+                             Value input, Value result) {
+  auto qubitId = qubitIds.find(input);
+  if (qubitId != qubitIds.end())
+    qubitIds.try_emplace(result, qubitId->second);
+}
+
+// Propagate only an unambiguous one-to-one scalar wire correspondence.
+// Reference, aggregate, and malformed shapes leave their results unmapped.
+static void
+propagateQubitIdsThroughWires(llvm::DenseMap<Value, QubitId> &qubitIds,
+                              ValueRange wireInputs, ValueRange wireResults) {
+  if (wireInputs.size() != wireResults.size() ||
+      llvm::any_of(wireInputs,
+                   [](Value input) {
+                     return !isa<cudaq::quake::WireType>(input.getType());
+                   }) ||
+      llvm::any_of(wireResults, [](Value result) {
+        return !isa<cudaq::quake::WireType>(result.getType());
+      }))
+    return;
+  for (auto [input, result] : llvm::zip(wireInputs, wireResults))
+    propagateQubitId(qubitIds, input, result);
+}
+
+// Thread qubit IDs through a value-form operator. Quake returns one wire for
+// each wire control and target in operand order; unsupported result shapes are
+// left unmapped.
+static void
+propagateQubitIdsThroughOperator(llvm::DenseMap<Value, QubitId> &qubitIds,
+                                 cudaq::quake::OperatorInterface op) {
+  llvm::SmallVector<Value> wireInputs;
+  for (Value control : op.getControls())
+    if (isa<cudaq::quake::WireType>(control.getType()))
+      wireInputs.push_back(control);
+  for (Value target : op.getTargets())
+    if (isa<cudaq::quake::WireType>(target.getType()))
+      wireInputs.push_back(target);
+
+  propagateQubitIdsThroughWires(qubitIds, wireInputs, op.getWires());
+}
+
+// Build block-local qubit identities in program order. Block arguments and
+// null wires introduce IDs, repeated borrows reuse their (wire set, identity)
+// ID, and supported conversions and identity-preserving results propagate IDs.
+static void buildQubitIdMap(Block &block,
+                            llvm::DenseMap<Value, QubitId> &qubitIds) {
+  QubitId nextQubitId = 0;
+  llvm::DenseMap<BorrowKey, QubitId> borrowedQubitIds;
+
+  for (BlockArgument argument : block.getArguments())
+    if (isa<cudaq::quake::WireType, cudaq::quake::ControlType>(
+            argument.getType()))
+      qubitIds.try_emplace(argument, nextQubitId++);
+
+  for (Operation &operation : block) {
+    if (auto nullWire = dyn_cast<cudaq::quake::NullWireOp>(operation)) {
+      qubitIds.try_emplace(nullWire.getResult(), nextQubitId++);
+      continue;
+    }
+    if (auto borrowWire = dyn_cast<cudaq::quake::BorrowWireOp>(operation)) {
+      BorrowKey key{borrowWire.getSetNameAttr(), borrowWire.getIdentity()};
+      auto [qubitId, inserted] = borrowedQubitIds.try_emplace(key, nextQubitId);
+      if (inserted)
+        ++nextQubitId;
+      qubitIds.try_emplace(borrowWire.getResult(), qubitId->second);
+      continue;
+    }
+    if (auto toControl = dyn_cast<cudaq::quake::ToControlOp>(operation)) {
+      propagateQubitId(qubitIds, toControl.getQubit(), toControl.getResult());
+      continue;
+    }
+    if (auto fromControl = dyn_cast<cudaq::quake::FromControlOp>(operation)) {
+      propagateQubitId(qubitIds, fromControl.getCtrlbit(),
+                       fromControl.getResult());
+      continue;
+    }
+    if (isa<cudaq::quake::MeasurementInterface, cudaq::quake::ResetOp>(
+            operation)) {
+      propagateQubitIdsThroughWires(
+          qubitIds, cudaq::quake::getQuantumOperands(&operation),
+          cudaq::quake::getQuantumResults(&operation));
+      continue;
+    }
+    if (auto operatorInterface =
+            dyn_cast<cudaq::quake::OperatorInterface>(operation))
+      propagateQubitIdsThroughOperator(qubitIds, operatorInterface);
+  }
+}
+
+QubitIdentityAnalysis::QubitIdentityAnalysis(Block &block) {
+  buildQubitIdMap(block, qubitIds);
+}
+
+std::optional<QubitId>
+QubitIdentityAnalysis::getQubitId(mlir::Value value) const {
+  auto qubitId = qubitIds.find(value);
+  if (qubitId == qubitIds.end())
+    return std::nullopt;
+  return qubitId->second;
+}

--- a/cudaq/lib/Optimizer/Analysis/QubitIdentityAnalysis.h
+++ b/cudaq/lib/Optimizer/Analysis/QubitIdentityAnalysis.h
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "llvm/ADT/DenseMap.h"
+#include "mlir/IR/Value.h"
+#include <cstdint>
+#include <optional>
+
+namespace mlir {
+class Block;
+}
+
+namespace cudaq::quake::detail {
+
+/// Assigns analysis-local identifiers to virtual qubits represented by scalar
+/// `!quake.wire` and `!quake.control` SSA values within one block of valid
+/// Quake value-form IR. Block-local quantum analyses can use these identifiers
+/// to determine whether operations act on the same or disjoint virtual qubits.
+///
+/// Block arguments, `quake.null_wire`, and `quake.borrow_wire` establish local
+/// identities. The analysis propagates them through supported operators,
+/// measurements, resets, and wire/control conversions. Identity does not imply
+/// quantum-state equivalence. For example, measurement and reset preserve the
+/// virtual-qubit identity while changing its state.
+///
+/// The analysis does not propagate identifiers through calls, references,
+/// aggregates, or block edges. Values that cannot be identified unambiguously
+/// remain unidentified. Any mutation of the block invalidates the analysis.
+class QubitIdentityAnalysis {
+public:
+  using QubitId = std::uint32_t;
+
+  explicit QubitIdentityAnalysis(mlir::Block &block);
+
+  /// Return the analysis-local qubit identifier, or no value when identity
+  /// cannot be propagated unambiguously.
+  std::optional<QubitId> getQubitId(mlir::Value value) const;
+
+private:
+  llvm::DenseMap<mlir::Value, QubitId> qubitIds;
+};
+
+} // namespace cudaq::quake::detail

--- a/cudaq/unittests/Optimizer/CMakeLists.txt
+++ b/cudaq/unittests/Optimizer/CMakeLists.txt
@@ -33,12 +33,15 @@ create_cudaq_unittest_check_target("OptimizerUnitTests" "optimizer-unit-tests")
 
 add_cudaq_unittest("AnalysisPassUnitTests" "analysis-passes"
     SOURCES
+        QubitIdentityAnalysisTest.cpp
         UnitaryOpGroupingTest.cpp
     INCLUDES
+        ${CMAKE_SOURCE_DIR}/cudaq/lib/Optimizer/Analysis
     LINKED_LIBS
         MLIRArithDialect
         MLIRFuncDialect
         MLIRIR
+        MLIRParser
         QuakeDialect
         CCDialect
         OptAnalysis

--- a/cudaq/unittests/Optimizer/QubitIdentityAnalysisTest.cpp
+++ b/cudaq/unittests/Optimizer/QubitIdentityAnalysisTest.cpp
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "QubitIdentityAnalysis.h"
+#include "gtest/gtest.h"
+#include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+
+using namespace mlir;
+
+using cudaq::quake::detail::QubitIdentityAnalysis;
+
+TEST(QubitIdentityAnalysisTest, TracksQubitIdentity) {
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.loadDialect<cudaq::cc::CCDialect>();
+  context.loadDialect<cudaq::quake::QuakeDialect>();
+  auto module = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      quake.wire_set @wires[2]
+      func.func private @wire_source() -> !quake.wire
+      func.func @identity(%wireArg: !quake.wire,
+                          %controlArg: !quake.control,
+                          %aggregate: !quake.veq<2>) {
+        %initial = quake.null_wire
+        %x = quake.x %initial : (!quake.wire) -> !quake.wire
+        %reset = quake.reset %x : (!quake.wire) -> !quake.wire
+        %distinct = quake.null_wire
+        %measurement, %measuredInitial, %measuredDistinct =
+            quake.mz %reset, %distinct
+                : (!quake.wire, !quake.wire)
+                  -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire)
+        %control = quake.to_ctrl %measuredInitial
+            : (!quake.wire) -> !quake.control
+        %returned = quake.from_ctrl %control
+            : (!quake.control) -> !quake.wire
+        %mixedWireControl = quake.null_wire
+        %mixedControlWire = quake.null_wire
+        %mixedTarget = quake.null_wire
+        %mixedControl = quake.to_ctrl %mixedControlWire
+            : (!quake.wire) -> !quake.control
+        %mixedResults:2 = quake.x [%mixedWireControl, %mixedControl] %mixedTarget
+            : (!quake.wire, !quake.control, !quake.wire)
+              -> (!quake.wire, !quake.wire)
+
+        %borrow0a = quake.borrow_wire @wires[0] : !quake.wire
+        quake.return_wire %borrow0a : !quake.wire
+        %borrow0b = quake.borrow_wire @wires[0] : !quake.wire
+        quake.return_wire %borrow0b : !quake.wire
+        %borrow1 = quake.borrow_wire @wires[1] : !quake.wire
+        quake.return_wire %borrow1 : !quake.wire
+
+        %call = func.call @wire_source() : () -> !quake.wire
+        %reference = quake.alloca !quake.ref
+        %unwrapped = quake.unwrap %reference : (!quake.ref) -> !quake.wire
+        quake.sink %returned : !quake.wire
+        quake.sink %measuredDistinct : !quake.wire
+        quake.sink %mixedResults#0 : !quake.wire
+        quake.sink %mixedResults#1 : !quake.wire
+        quake.sink %call : !quake.wire
+        quake.sink %wireArg : !quake.wire
+        %controlArgumentWire = quake.from_ctrl %controlArg
+            : (!quake.control) -> !quake.wire
+        quake.sink %controlArgumentWire : !quake.wire
+        quake.wrap %unwrapped to %reference : !quake.wire, !quake.ref
+        return
+      }
+    }
+  )mlir",
+                                            &context);
+
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  auto function = module->lookupSymbol<func::FuncOp>("identity");
+  ASSERT_TRUE(function);
+
+  Block &block = function.front();
+  auto nullWires = llvm::to_vector(block.getOps<cudaq::quake::NullWireOp>());
+  auto xOps = llvm::to_vector(block.getOps<cudaq::quake::XOp>());
+  auto resets = llvm::to_vector(block.getOps<cudaq::quake::ResetOp>());
+  auto measurements = llvm::to_vector(block.getOps<cudaq::quake::MzOp>());
+  auto toControls = llvm::to_vector(block.getOps<cudaq::quake::ToControlOp>());
+  auto fromControls =
+      llvm::to_vector(block.getOps<cudaq::quake::FromControlOp>());
+  auto borrows = llvm::to_vector(block.getOps<cudaq::quake::BorrowWireOp>());
+  auto calls = llvm::to_vector(block.getOps<func::CallOp>());
+  auto unwraps = llvm::to_vector(block.getOps<cudaq::quake::UnwrapOp>());
+  ASSERT_EQ(nullWires.size(), 5u);
+  ASSERT_EQ(xOps.size(), 2u);
+  ASSERT_EQ(resets.size(), 1u);
+  ASSERT_EQ(measurements.size(), 1u);
+  ASSERT_EQ(toControls.size(), 2u);
+  ASSERT_EQ(fromControls.size(), 2u);
+  ASSERT_EQ(borrows.size(), 3u);
+  ASSERT_EQ(calls.size(), 1u);
+  ASSERT_EQ(unwraps.size(), 1u);
+
+  Value initial = nullWires[0].getResult();
+  Value distinct = nullWires[1].getResult();
+  auto x = xOps[0];
+  auto mixedX = xOps[1];
+  auto reset = resets[0];
+  auto measurement = measurements[0];
+  auto control = toControls[0];
+  Value returned = fromControls[0].getResult();
+  Value controlArgumentWire = fromControls[1].getResult();
+  Value borrow0a = borrows[0].getResult();
+  Value borrow0b = borrows[1].getResult();
+  Value borrow1 = borrows[2].getResult();
+  auto call = calls[0];
+  auto unwrapped = unwraps[0];
+
+  QubitIdentityAnalysis analysis(function.front());
+  auto initialId = analysis.getQubitId(initial);
+  ASSERT_TRUE(initialId);
+  // State-changing and control-conversion operations preserve virtual-qubit
+  // identity as they replace their scalar SSA inputs.
+  EXPECT_EQ(initialId, analysis.getQubitId(x.getWires().front()));
+  EXPECT_EQ(initialId, analysis.getQubitId(reset.getWires().front()));
+  EXPECT_EQ(initialId, analysis.getQubitId(measurement.getWires().front()));
+  EXPECT_EQ(initialId, analysis.getQubitId(control));
+  EXPECT_EQ(initialId, analysis.getQubitId(returned));
+
+  // Operator wire results follow wire controls and targets in operand order;
+  // !quake.control operands do not produce replacement wire results.
+  ASSERT_EQ(mixedX.getWires().size(), 2u);
+  ASSERT_TRUE(analysis.getQubitId(mixedX.getWires()[0]));
+  ASSERT_TRUE(analysis.getQubitId(mixedX.getWires()[1]));
+  EXPECT_EQ(analysis.getQubitId(mixedX.getControls()[0]),
+            analysis.getQubitId(mixedX.getWires()[0]));
+  EXPECT_EQ(analysis.getQubitId(mixedX.getTargets()[0]),
+            analysis.getQubitId(mixedX.getWires()[1]));
+
+  // Scalar block arguments and null wires introduce distinct local identities.
+  ASSERT_TRUE(analysis.getQubitId(function.getArgument(0)));
+  ASSERT_TRUE(analysis.getQubitId(function.getArgument(1)));
+  EXPECT_EQ(analysis.getQubitId(function.getArgument(1)),
+            analysis.getQubitId(controlArgumentWire));
+  ASSERT_TRUE(analysis.getQubitId(distinct));
+  EXPECT_NE(initialId, analysis.getQubitId(distinct));
+  EXPECT_EQ(analysis.getQubitId(distinct),
+            analysis.getQubitId(measurement.getWires()[1]));
+
+  // A returned and reborrowed wire retains its wire-set identity, while a
+  // different wire-set index identifies a different virtual qubit.
+  EXPECT_EQ(analysis.getQubitId(borrow0a), analysis.getQubitId(borrow0b));
+  EXPECT_NE(analysis.getQubitId(borrow0a), analysis.getQubitId(borrow1));
+
+  // Identity propagation through aggregates, calls, and references is
+  // deliberately unsupported.
+  EXPECT_FALSE(analysis.getQubitId(function.getArgument(2)));
+  EXPECT_FALSE(analysis.getQubitId(call.getResult(0)));
+  EXPECT_FALSE(analysis.getQubitId(unwrapped.getResult()));
+}


### PR DESCRIPTION
Some pre-work to my commutation analysis. There might be another better way to do this or existing code that could be reused (eg., regtomem or the mapping code does similar but not quite this) and am keen to hear others opinions. At the end of the day the ask is how to know which values output by Quake operators correspond to the same qubit state. 

Adds an analysis that assign stable analysis-local IDs to scalar Quake wire and control values within a value-form block. Propagates that identifier through supported operators, measurements, resets, conversions, and wire-set borrows. 

Does not yet handle references, aggregates, calls, and block edges.

Some ideas how to extend this further to expand commutation analysis coverage:

- Operations using statically indexed elements of a !quake.veq.
- Identity propagated through quake.wrap and quake.unwrap when reference ownership is unambiguous.
- Identity propagated through calls with an exact function summary.
- Identity correlated through successor block arguments and control-flow edges.
- Aggregate or reference operands whose scalar support can be resolved without alias ambiguity.

