### PR TITLE
[iqm] Don't reject user-named measurement registers

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -338,19 +338,26 @@ IQMServerHelper::processResults(ServerMessage &postJobResponse,
     // is used to sort the strings in numerical order and then the bitstrings
     // are ordered accordingly. As result the bitstrings are ordered according
     // to the physical qubit numbering.
+    //
+    // The sort only applies when every key ends in a digit (auto-generated
+    // `r00000`, ...). A user-named register (e.g. `auto result = mz(q)`) has
+    // no position to sort by, so keep the emission order instead of rejecting.
+    bool sortable = true;
     for (std::string key : counts["measurement_keys"]) {
-      // keys must not be empty and end with a digit
       if (key.empty() || !std::isdigit(key.back())) {
-        throw std::runtime_error("Malformed measurement key received: " + key);
+        sortable = false;
+        break;
       }
       mxKeys[key] = i++;
     }
-    mxOrder.reserve(mxKeys.size());
-    i = 0;
-    for (auto [_, idx] : mxKeys) {
-      mxOrder.push_back(idx);
-      if (!reorder && idx != i++)
-        reorder = true;
+    if (sortable) {
+      mxOrder.reserve(mxKeys.size());
+      i = 0;
+      for (auto [_, idx] : mxKeys) {
+        mxOrder.push_back(idx);
+        if (!reorder && idx != i++)
+          reorder = true;
+      }
     }
 
     if (reorder) {

--- a/unittests/nvqpp/backends/iqm/IQMTester.cpp
+++ b/unittests/nvqpp/backends/iqm/IQMTester.cpp
@@ -116,6 +116,31 @@ CUDAQ_TEST(IQMTester, processResultsAppliesReorderIdxFromConfig) {
       << "(see GitHub issue #4621). Got \"" << mostFrequent << "\".";
 }
 
+// A user-named register (e.g. `auto result = mz(q)`) yields a non-numeric
+// measurement key. processResults must accept it, not reject it as malformed.
+// Regression test for the nightly IQM failure from PR #4818.
+CUDAQ_TEST(IQMTester, processResultsAcceptsNonNumericMeasurementKey) {
+  auto serverHelper = cudaq::registry::get<cudaq::ServerHelper>("iqm");
+  ASSERT_TRUE(serverHelper);
+
+  cudaq::BackendConfig config;
+  config["url"] = "http://localhost:62443";
+  serverHelper->initialize(config);
+
+  // Single measurement into a user-named register `result`.
+  cudaq::ServerMessage response = {
+      {{"counts", {{"1", 1000}}}, {"measurement_keys", {"result"}}}};
+
+  std::string jobId = "test-job-id";
+  cudaq::sample_result result;
+  EXPECT_NO_THROW(result = serverHelper->processResults(response, jobId))
+      << "IQMServerHelper rejected a non-numeric measurement key instead of "
+      << "leaving the bitstrings in measurement order.";
+
+  auto counts = result.to_map();
+  EXPECT_EQ(counts["1"], 1000);
+}
+
 // Setting an arbitrary string in the IQM_TOKEN environment variable must
 // trigger the response that the authentication failed.
 CUDAQ_TEST(IQMTester, invalidTokenFromEnvVariable) {


### PR DESCRIPTION
PR #4818 added a numerical sort of the IQM `measurement_keys` to reorder result bitstrings into physical-qubit order, guarded by a check that every key ends in a digit. That assumption only holds for the auto-generated `r00000`, `r00001`, ... register names. A kernel that names its measurement register explicitly (e.g. `auto result = mz(q)`) produces a key such as `result`, which tripped the guard and threw "Malformed measurement key received: result", aborting the job.

The unit tests exercised only digit-suffixed keys via the mock server, so this passed CI at merge time but broke the nightly IQM integration test (targettests/iqm/callable_kernel_arg.cpp) every night since.

Non-numeric keys carry no positional information, so there is nothing to sort by. Skip the reordering in that case and leave the bitstrings in the order the measurements were emitted -- the behavior prior to #4818 -- rather than rejecting the response. Numeric keys keep the #4818 reordering.

Adds a regression test covering a non-numeric measurement key.