### PR TITLE
Fix distributed explicit-state initialization in dynamic backend

### DIFF
--- a/python/runtime/cudaq/dynamics/pyDynamics.cpp
+++ b/python/runtime/cudaq/dynamics/pyDynamics.cpp
@@ -203,13 +203,23 @@ NB_MODULE(nvqir_dynamics_bindings, m) {
   // Helper to initialize a data buffer state
   m.def("initializeState",
         [](cudaq::state &state, const std::vector<int64_t> &modeExtents,
-           bool asDensityMat, int64_t batchSize) {
+           bool requireDensityMatrix, int64_t batchSize) {
           auto &castSimState = *asCudmState(state);
-          if (!castSimState.is_initialized())
+          if (!castSimState.is_initialized()) {
+            if (requireDensityMatrix) {
+              std::size_t stateVectorSize = 1;
+              for (const auto extent : modeExtents)
+                stateVectorSize *= extent;
+              if (batchSize == 1 &&
+                  castSimState.get_element_count() == stateVectorSize)
+                return cudaq::state(new cudaq::CuDensityMatState(
+                    castSimState.to_density_matrix(modeExtents)));
+            }
             castSimState.initialize_cudm(
                 cudaq::dynamics::Context::getCurrentContext()->getHandle(),
                 modeExtents, batchSize);
-          if (asDensityMat && !castSimState.is_density_matrix()) {
+          }
+          if (requireDensityMatrix && !castSimState.is_density_matrix()) {
             return cudaq::state(
                 new cudaq::CuDensityMatState(castSimState.to_density_matrix()));
           }
@@ -241,14 +251,14 @@ NB_MODULE(nvqir_dynamics_bindings, m) {
         });
   m.def("createBatchedState",
         [](std::vector<cudaq::state> &states,
-           const std::vector<int64_t> &modeExtents, bool asDensityMat) {
+           const std::vector<int64_t> &modeExtents, bool requireDensityMatrix) {
           std::vector<cudaq::CuDensityMatState *> statePtrs;
           for (auto &state : states) {
             statePtrs.emplace_back(asCudmState(state));
           }
           auto batchedState = cudaq::CuDensityMatState::createBatchedState(
               cudaq::dynamics::Context::getCurrentContext()->getHandle(),
-              statePtrs, modeExtents, asDensityMat);
+              statePtrs, modeExtents, requireDensityMatrix);
           return cudaq::state(batchedState.release());
         });
 

--- a/python/tests/parallel/test_mpi_dynamics.py
+++ b/python/tests/parallel/test_mpi_dynamics.py
@@ -231,6 +231,40 @@ def testMpiDistributedUnevenQuditSlices():
 
 
 @skipIfUnsupported
+def testMpiDistributedQuditExplicitStateWithCollapse():
+    """Test distributed pure-to-mixed conversion from an explicit state."""
+    import cupy as cp
+
+    dimensions = {0: 16, 1: 2}
+    target_level = 9
+    state_data = cp.zeros(32, dtype=cp.complex128)
+    state_data[target_level + 16] = 1.0
+    initial_state = cudaq.State.from_data(state_data)
+
+    number_operator = boson.number(0)
+    decay_rate = 0.1
+    final_time = 0.1
+    result = cudaq.evolve(
+        0.0 * number_operator,
+        dimensions,
+        Schedule([0.0, final_time], ["time"]),
+        initial_state,
+        observables=[number_operator],
+        collapse_operators=[np.sqrt(decay_rate) * boson.annihilate(0)],
+        store_intermediate_results=cudaq.IntermediateResultSave.
+        EXPECTATION_VALUE,
+        integrator=RungeKuttaIntegrator())
+
+    expectations = result.expectation_values()
+    np.testing.assert_allclose(expectations[0][0].expectation(),
+                               target_level,
+                               atol=1e-12)
+    np.testing.assert_allclose(expectations[1][0].expectation(),
+                               target_level * np.exp(-decay_rate * final_time),
+                               rtol=1e-5)
+
+
+@skipIfUnsupported
 def testMpiDistributedRankLocalExplicitState():
     """Test initialization from an already packed rank-local state buffer."""
     import cupy as cp
@@ -262,6 +296,35 @@ def testMpiDistributedRankLocalExplicitState():
     np.testing.assert_allclose(np.array(result.final_state()),
                                cp.asnumpy(local_state_data),
                                atol=1e-12)
+
+
+@skipIfUnsupported
+def testMpiDistributedRankLocalExplicitStateWithCollapseRejected():
+    """Test that rank-local pure states cannot be promoted after partitioning."""
+    import cupy as cp
+    from cudaq.dynamics import nvqir_dynamics_bindings as bindings
+
+    _require_exactly_two_ranks()
+    dimensions = {0: 16, 1: 2}
+    local_state_data = cp.zeros(16, dtype=cp.complex128)
+    if cudaq.mpi.rank() == 1:
+        local_state_data[9] = 1.0
+    initial_state = bindings.initializeState(local_state_data.data.ptr,
+                                             local_state_data.size,
+                                             list(dimensions.values()), 1)
+
+    number_operator = boson.number(0)
+    with pytest.raises(RuntimeError,
+                       match="rank-local distributed state vector"):
+        cudaq.evolve(0.0 * number_operator,
+                     dimensions,
+                     Schedule([0.0], ["time"]),
+                     initial_state,
+                     observables=[number_operator],
+                     collapse_operators=[0.1 * boson.annihilate(0)],
+                     store_intermediate_results=cudaq.IntermediateResultSave.
+                     EXPECTATION_VALUE,
+                     integrator=RungeKuttaIntegrator())
 
 
 @skipIfUnsupported

--- a/python/tests/parallel/test_mpi_dynamics.py
+++ b/python/tests/parallel/test_mpi_dynamics.py
@@ -7,7 +7,7 @@
 # ============================================================================ #
 
 import cudaq, os, pytest
-from cudaq import spin, Schedule, RungeKuttaIntegrator
+from cudaq import boson, spin, Schedule, RungeKuttaIntegrator
 import numpy as np
 
 skipIfUnsupported = pytest.mark.skipif(
@@ -25,6 +25,11 @@ def setup_mpi():
     yield
     cudaq.reset_target()
     cudaq.mpi.finalize()
+
+
+def _require_exactly_two_ranks():
+    if cudaq.mpi.num_ranks() != 2:
+        pytest.skip("This test requires exactly 2 MPI ranks")
 
 
 @skipIfUnsupported
@@ -71,6 +76,192 @@ def testMpiRun():
 
     # Verify result exists
     assert evolution_result is not None
+
+
+@skipIfUnsupported
+def testMpiDistributedQuditExplicitState():
+    """Test distributed initialization from an explicit state with a split qudit mode."""
+    import cupy as cp
+
+    num_qubits = 10
+    qudit_mode = num_qubits
+    qudit_dimension = 16
+    target_level = 9
+    dimensions = {i: 2 for i in range(num_qubits)}
+    dimensions[qudit_mode] = qudit_dimension
+
+    state_data = cp.zeros((2**num_qubits) * qudit_dimension,
+                          dtype=cp.complex128)
+    state_data[target_level * (2**num_qubits)] = 1.0
+    initial_state = cudaq.State.from_data(state_data)
+
+    number_operator = boson.number(qudit_mode)
+    result = cudaq.evolve(0.0 * number_operator,
+                          dimensions,
+                          Schedule([0.0], ["time"]),
+                          initial_state,
+                          observables=[number_operator],
+                          collapse_operators=[],
+                          store_intermediate_results=cudaq.
+                          IntermediateResultSave.EXPECTATION_VALUE,
+                          integrator=RungeKuttaIntegrator())
+
+    expectation = result.expectation_values()[0][0].expectation()
+    np.testing.assert_allclose(expectation, target_level, atol=1e-12)
+
+
+@skipIfUnsupported
+def testMpiDistributedQuditExplicitDensityMatrix():
+    """Test distributed initialization from an explicit qudit density matrix."""
+    import cupy as cp
+
+    dimension = 16
+    target_level = 9
+    density_matrix = cp.zeros((dimension, dimension),
+                              dtype=cp.complex128,
+                              order="F")
+    density_matrix[target_level, target_level] = 1.0
+    initial_state = cudaq.State.from_data(density_matrix)
+
+    number_operator = boson.number(0)
+    result = cudaq.evolve(0.0 * number_operator, {0: dimension},
+                          Schedule([0.0], ["time"]),
+                          initial_state,
+                          observables=[number_operator],
+                          collapse_operators=[],
+                          store_intermediate_results=cudaq.
+                          IntermediateResultSave.EXPECTATION_VALUE,
+                          integrator=RungeKuttaIntegrator())
+
+    expectation = result.expectation_values()[0][0].expectation()
+    np.testing.assert_allclose(expectation, target_level, atol=1e-12)
+
+
+@skipIfUnsupported
+def testMpiDistributedNoncontiguousQuditSlice():
+    """Test gathering a slice produced by splitting the fastest-varying mode."""
+    import cupy as cp
+
+    num_ranks = cudaq.mpi.num_ranks()
+    qudit_dimension = 8 * num_ranks
+    dimensions = {0: qudit_dimension, 1: 2}
+    target_level = qudit_dimension // 2 + 1
+    state_data = cp.zeros(2 * qudit_dimension, dtype=cp.complex128)
+    state_data[target_level + qudit_dimension] = 1.0
+    initial_state = cudaq.State.from_data(state_data)
+
+    number_operator = boson.number(0)
+    result = cudaq.evolve(0.0 * number_operator,
+                          dimensions,
+                          Schedule([0.0], ["time"]),
+                          initial_state,
+                          observables=[number_operator],
+                          collapse_operators=[],
+                          store_intermediate_results=cudaq.
+                          IntermediateResultSave.EXPECTATION_VALUE,
+                          integrator=RungeKuttaIntegrator())
+
+    expectation = result.expectation_values()[0][0].expectation()
+    np.testing.assert_allclose(expectation, target_level, atol=1e-12)
+    local_state = np.array(result.final_state())
+    local_norm = float(np.vdot(local_state, local_state).real)
+    global_norm = sum(cudaq.mpi.all_gather(num_ranks, [local_norm]))
+    np.testing.assert_allclose(global_norm, 1.0, atol=1e-12)
+
+
+@skipIfUnsupported
+def testMpiDistributedNoncontiguousQuditDensityMatrixSlice():
+    """Test gathering a noncontiguous slice of an explicit density matrix."""
+    import cupy as cp
+
+    dimensions = {0: 16, 1: 2}
+    target_level = 9
+    basis_index = target_level + 16
+    density_matrix = cp.zeros((32, 32), dtype=cp.complex128, order="F")
+    density_matrix[basis_index, basis_index] = 1.0
+    initial_state = cudaq.State.from_data(density_matrix)
+
+    number_operator = boson.number(0)
+    result = cudaq.evolve(0.0 * number_operator,
+                          dimensions,
+                          Schedule([0.0], ["time"]),
+                          initial_state,
+                          observables=[number_operator],
+                          collapse_operators=[],
+                          store_intermediate_results=cudaq.
+                          IntermediateResultSave.EXPECTATION_VALUE,
+                          integrator=RungeKuttaIntegrator())
+
+    expectation = result.expectation_values()[0][0].expectation()
+    np.testing.assert_allclose(expectation, target_level, atol=1e-12)
+
+
+@skipIfUnsupported
+def testMpiDistributedUnevenQuditSlices():
+    """Test local tensor volumes smaller than the worst-case storage capacity."""
+    import cupy as cp
+
+    num_ranks = cudaq.mpi.num_ranks()
+    qudit_dimension = 2 * num_ranks - 1
+    dimensions = {0: qudit_dimension, 1: 2}
+    target_level = qudit_dimension - 1
+    state_data = cp.zeros(2 * qudit_dimension, dtype=cp.complex128)
+    state_data[target_level + qudit_dimension] = 1.0
+    initial_state = cudaq.State.from_data(state_data)
+
+    number_operator = boson.number(0)
+    final_time = 0.1
+    result = cudaq.evolve(number_operator,
+                          dimensions,
+                          Schedule([0.0, final_time], ["time"]),
+                          initial_state,
+                          observables=[number_operator],
+                          collapse_operators=[],
+                          store_intermediate_results=cudaq.
+                          IntermediateResultSave.EXPECTATION_VALUE,
+                          integrator=RungeKuttaIntegrator(order=4,
+                                                          max_step_size=0.01))
+
+    expectation = result.expectation_values()[-1][0].expectation()
+    np.testing.assert_allclose(expectation, target_level, rtol=1e-5)
+    local_state = np.array(result.final_state())
+    local_norm = float(np.vdot(local_state, local_state).real)
+    global_norm = sum(cudaq.mpi.all_gather(num_ranks, [local_norm]))
+    np.testing.assert_allclose(global_norm, 1.0, rtol=1e-5, atol=1e-10)
+
+
+@skipIfUnsupported
+def testMpiDistributedRankLocalExplicitState():
+    """Test initialization from an already packed rank-local state buffer."""
+    import cupy as cp
+    from cudaq.dynamics import nvqir_dynamics_bindings as bindings
+
+    _require_exactly_two_ranks()
+    dimensions = {0: 16, 1: 2}
+    target_level = 9
+    local_state_data = cp.zeros(16, dtype=cp.complex128)
+    if cudaq.mpi.rank() == 1:
+        local_state_data[9] = 1.0
+    initial_state = bindings.initializeState(local_state_data.data.ptr,
+                                             local_state_data.size,
+                                             list(dimensions.values()), 1)
+
+    number_operator = boson.number(0)
+    result = cudaq.evolve(0.0 * number_operator,
+                          dimensions,
+                          Schedule([0.0], ["time"]),
+                          initial_state,
+                          observables=[number_operator],
+                          collapse_operators=[],
+                          store_intermediate_results=cudaq.
+                          IntermediateResultSave.EXPECTATION_VALUE,
+                          integrator=RungeKuttaIntegrator())
+
+    expectation = result.expectation_values()[0][0].expectation()
+    np.testing.assert_allclose(expectation, target_level, atol=1e-12)
+    np.testing.assert_allclose(np.array(result.final_state()),
+                               cp.asnumpy(local_state_data),
+                               atol=1e-12)
 
 
 @skipIfUnsupported

--- a/runtime/nvqir/cudensitymat/CuDensityMatErrorHandling.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatErrorHandling.h
@@ -10,6 +10,7 @@
 #include "cudaq/runtime/logger/cudaq_fmt.h"
 #include <cublas_v2.h>
 #include <cudensitymat.h>
+#include <cutensor.h>
 #include <stdexcept>
 
 #define HANDLE_CUDM_ERROR(x)                                                   \
@@ -39,5 +40,15 @@
       std::printf("[cublas] error %d at %s:%d\n", cudaq_fmt::underlying(err_), \
                   __FILE__, __LINE__);                                         \
       throw std::runtime_error("cublas error");                                \
+    }                                                                          \
+  } while (0)
+
+#define HANDLE_CUTENSOR_ERROR(x)                                               \
+  do {                                                                         \
+    const auto err = (x);                                                      \
+    if (err != CUTENSOR_STATUS_SUCCESS) {                                      \
+      throw std::runtime_error(cudaq_fmt::format(                              \
+          "[cutensor] %{} ({}) in {} (line {})", cudaq_fmt::underlying(err),   \
+          cutensorGetErrorString(err), __FUNCTION__, __LINE__));               \
     }                                                                          \
   } while (0)

--- a/runtime/nvqir/cudensitymat/CuDensityMatErrorHandling.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatErrorHandling.h
@@ -10,7 +10,6 @@
 #include "cudaq/runtime/logger/cudaq_fmt.h"
 #include <cublas_v2.h>
 #include <cudensitymat.h>
-#include <cutensor.h>
 #include <stdexcept>
 
 #define HANDLE_CUDM_ERROR(x)                                                   \
@@ -40,15 +39,5 @@
       std::printf("[cublas] error %d at %s:%d\n", cudaq_fmt::underlying(err_), \
                   __FILE__, __LINE__);                                         \
       throw std::runtime_error("cublas error");                                \
-    }                                                                          \
-  } while (0)
-
-#define HANDLE_CUTENSOR_ERROR(x)                                               \
-  do {                                                                         \
-    const auto err = (x);                                                      \
-    if (err != CUTENSOR_STATUS_SUCCESS) {                                      \
-      throw std::runtime_error(cudaq_fmt::format(                              \
-          "[cutensor] %{} ({}) in {} (line {})", cudaq_fmt::underlying(err),   \
-          cutensorGetErrorString(err), __FUNCTION__, __LINE__));               \
     }                                                                          \
   } while (0)

--- a/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
@@ -295,14 +295,21 @@ evolve_result evolveSingle(
     dims.emplace_back(dim);
 
   auto *cudmState = asCudmState(const_cast<state &>(initialState));
-  if (!cudmState->is_initialized())
+  state initial_State = initialState;
+  std::size_t stateVectorSize = 1;
+  for (const auto extent : dims)
+    stateVectorSize *= extent;
+  if (!cudmState->is_initialized() && !collapseOperators.empty() &&
+      cudmState->get_element_count() == stateVectorSize) {
+    initial_State =
+        state(new CuDensityMatState(cudmState->to_density_matrix(dims)));
+    cudmState = asCudmState(initial_State);
+  } else if (!cudmState->is_initialized()) {
     cudmState->initialize_cudm(handle, dims, /*batchSize=*/1);
-
-  state initial_State = [&]() {
-    if (!collapseOperators.empty() && !cudmState->is_density_matrix())
-      return state(new CuDensityMatState(cudmState->to_density_matrix()));
-    return initialState;
-  }();
+  }
+  if (!collapseOperators.empty() && !cudmState->is_density_matrix())
+    initial_State =
+        state(new CuDensityMatState(cudmState->to_density_matrix()));
 
   SystemDynamics system(dims, hamiltonian, collapseOperators);
   cudaq::integrator_helper::init_system_dynamics(integrator, system, schedule);

--- a/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
@@ -17,6 +17,7 @@
 #include "common/FmtCore.h"
 #include "cudaq/algorithms/integrator.h"
 #include <iterator>
+#include <numeric>
 #include <random>
 #include <stdexcept>
 
@@ -203,6 +204,30 @@ static CuDensityMatState *asCudmState(cudaq::state &cudaqState) {
   return cudmState;
 }
 
+static state prepareInitialState(cudensitymatHandle_t handle,
+                                 const state &initialState,
+                                 const std::vector<int64_t> &dims,
+                                 bool requireDensityMatrix) {
+  auto *cudmState = asCudmState(const_cast<state &>(initialState));
+  if (!cudmState->is_initialized()) {
+    const auto stateVectorSize = std::accumulate(
+        dims.begin(), dims.end(), std::size_t{1}, std::multiplies<>());
+    if (requireDensityMatrix &&
+        cudmState->get_element_count() == stateVectorSize)
+      return state(new CuDensityMatState(cudmState->to_density_matrix(dims)));
+    cudmState->initialize_cudm(handle, dims, /*batchSize=*/1);
+  }
+  if (requireDensityMatrix && !cudmState->is_density_matrix())
+    return state(new CuDensityMatState(cudmState->to_density_matrix()));
+  return initialState;
+}
+
+static bool requiresDensityMatrix(const super_op &superOp) {
+  return std::any_of(
+      superOp.begin(), superOp.end(),
+      [](const auto &operatorPair) { return operatorPair.second.has_value(); });
+}
+
 static evolve_result
 evolveSingleImpl(const std::vector<int64_t> &dims, const schedule &schedule,
                  base_integrator &integrator,
@@ -294,26 +319,12 @@ evolve_result evolveSingle(
   for (const auto &[id, dim] : dimensions)
     dims.emplace_back(dim);
 
-  auto *cudmState = asCudmState(const_cast<state &>(initialState));
-  state initial_State = initialState;
-  std::size_t stateVectorSize = 1;
-  for (const auto extent : dims)
-    stateVectorSize *= extent;
-  if (!cudmState->is_initialized() && !collapseOperators.empty() &&
-      cudmState->get_element_count() == stateVectorSize) {
-    initial_State =
-        state(new CuDensityMatState(cudmState->to_density_matrix(dims)));
-    cudmState = asCudmState(initial_State);
-  } else if (!cudmState->is_initialized()) {
-    cudmState->initialize_cudm(handle, dims, /*batchSize=*/1);
-  }
-  if (!collapseOperators.empty() && !cudmState->is_density_matrix())
-    initial_State =
-        state(new CuDensityMatState(cudmState->to_density_matrix()));
+  auto preparedInitialState = prepareInitialState(handle, initialState, dims,
+                                                  !collapseOperators.empty());
 
   SystemDynamics system(dims, hamiltonian, collapseOperators);
   cudaq::integrator_helper::init_system_dynamics(integrator, system, schedule);
-  integrator.setState(initial_State, 0.0);
+  integrator.setState(preparedInitialState, 0.0);
   return evolveSingleImpl(dims, schedule, integrator, observables,
                           storeIntermediateResults);
 }
@@ -550,13 +561,12 @@ evolveSingle(const super_op &superOp, const cudaq::dimension_map &dimensionsMap,
   for (const auto &[id, dim] : dimensions)
     dims.emplace_back(dim);
 
-  auto *cudmState = asCudmState(const_cast<state &>(initialState));
-  if (!cudmState->is_initialized())
-    cudmState->initialize_cudm(handle, dims, /*batchSize=*/1);
+  auto preparedInitialState = prepareInitialState(
+      handle, initialState, dims, requiresDensityMatrix(superOp));
 
   cudaq::integrator_helper::init_system_dynamics(integrator, {superOp}, dims,
                                                  schedule);
-  integrator.setState(initialState, 0.0);
+  integrator.setState(preparedInitialState, 0.0);
 
   return evolveSingleImpl(dims, schedule, integrator, observables,
                           storeIntermediateResults);
@@ -572,13 +582,7 @@ evolveSingle(const super_op &superOp, const cudaq::dimension_map &dimensionsMap,
   LOG_API_TIME();
   cudensitymatHandle_t handle =
       dynamics::Context::getCurrentContext()->getHandle();
-  const bool has_right_apply = [&]() {
-    for (const auto &[leftOp, rightOp] : superOp) {
-      if (rightOp.has_value())
-        return true;
-    }
-    return false;
-  }();
+  const bool has_right_apply = requiresDensityMatrix(superOp);
   auto cudmState = CuDensityMatState::createInitialState(
       handle, initial_state, dimensionsMap, has_right_apply);
   return evolveSingle(superOp, dimensionsMap, schedule,
@@ -606,13 +610,7 @@ evolveBatched(const super_op &superOp,
   for (auto &initialState : initialStates) {
     states.emplace_back(asCudmState(const_cast<state &>(initialState)));
   }
-  const bool has_right_apply = [&]() {
-    for (const auto &[leftOp, rightOp] : superOp) {
-      if (rightOp.has_value())
-        return true;
-    }
-    return false;
-  }();
+  const bool has_right_apply = requiresDensityMatrix(superOp);
   auto batchedState = CuDensityMatState::createBatchedState(
       handle, states, dims, has_right_apply);
   cudaq::integrator_helper::init_system_dynamics(integrator, {superOp}, dims,
@@ -730,14 +728,9 @@ evolveBatched(const std::vector<sum_op<cudaq::matrix_handler>> &hamiltonians,
                         std::make_move_iterator(results.begin()),
                         std::make_move_iterator(results.end()));
     } else {
-      if (!states[0]->is_initialized())
-        states[0]->initialize_cudm(handle, dims, /*batchSize=*/1);
-      state canonicalize_initial_state = [&]() {
-        if (isMasterEquation && !states[0]->is_density_matrix())
-          return state(new CuDensityMatState(states[0]->to_density_matrix()));
-        return initial_states[i];
-      }();
-      integrator.setState(canonicalize_initial_state, 0.0);
+      auto preparedInitialState = prepareInitialState(handle, initial_states[i],
+                                                      dims, isMasterEquation);
+      integrator.setState(preparedInitialState, 0.0);
       auto result = evolveSingleImpl(dims, schedule, integrator, observables,
                                      store_intermediate_results);
       allResults.emplace_back(std::move(result));
@@ -798,15 +791,8 @@ evolveBatched(const std::vector<super_op> &superOps,
     params[param] = schedule.get_value_function()(param, 0.0);
   }
 
-  const bool has_right_apply = [&]() {
-    for (const auto &superOp : superOps) {
-      for (const auto &[leftOp, rightOp] : superOp) {
-        if (rightOp.has_value())
-          return true;
-      }
-    }
-    return false;
-  }();
+  const bool has_right_apply =
+      std::any_of(superOps.begin(), superOps.end(), requiresDensityMatrix);
   // Run batched evolution up to the batch size and concatenate the results.
   std::vector<evolve_result> allResults;
   allResults.reserve(superOps.size());
@@ -849,16 +835,9 @@ evolveBatched(const std::vector<super_op> &superOps,
                         std::make_move_iterator(results.begin()),
                         std::make_move_iterator(results.end()));
     } else {
-      if (!states[0]->is_initialized())
-        states[0]->initialize_cudm(handle, dims, /*batchSize=*/1);
-
-      state canonicalize_initial_state = [&]() {
-        if (has_right_apply && !states[0]->is_density_matrix())
-          return state(new CuDensityMatState(states[0]->to_density_matrix()));
-        return initial_states[i];
-      }();
-
-      integrator.setState(canonicalize_initial_state, 0.0);
+      auto preparedInitialState =
+          prepareInitialState(handle, initial_states[i], dims, has_right_apply);
+      integrator.setState(preparedInitialState, 0.0);
       auto result = evolveSingleImpl(dims, schedule, integrator, observables,
                                      store_intermediate_results);
       allResults.emplace_back(std::move(result));

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -964,27 +964,11 @@ void CuDensityMatState::distributeBatchedStateData(
       /*stateComponentLocalId=*/0, &stateComponentGlobalId, &numModes,
       stateComponentModeExtents.data(), stateComponentModeOffsets.data()));
 
-  // Calculate the batch index using the batch mode location.
-  // The batchModeLocation tells us which mode corresponds to the batch
-  // dimension. If batchModeLocation is valid (>= 0), use the offset directly
-  // from that mode. Otherwise, fall back to computing from the linear index.
-  int batchIdx = 0;
-  if (batchModeLocation >= 0 && batchModeLocation < numModes) {
-    // The batch mode offset directly gives us the starting batch index
-    batchIdx = static_cast<int>(stateComponentModeOffsets[batchModeLocation]);
-  } else {
-    // Fallback: compute from linear index (original logic)
-    int64_t startIdx = 0;
-    int64_t accumulatedIdx = 1;
-    for (int32_t i = 0; i < numModes; ++i) {
-      accumulatedIdx *= stateComponentModeExtents[i];
-      startIdx += (stateComponentModeOffsets[i] * accumulatedIdx);
-    }
-    batchIdx = startIdx / singleStateDimension;
-    if (batchIdx * singleStateDimension != startIdx)
-      throw std::runtime_error(
-          "Batched state cannot be evenly distributed across available GPUs");
-  }
+  if (batchModeLocation < 0 || batchModeLocation >= numModes)
+    throw std::runtime_error(
+        "Invalid distributed batched state layout: batch mode is absent");
+  const int batchIdx =
+      static_cast<int>(stateComponentModeOffsets[batchModeLocation]);
 
   const int64_t stateVolume = batchedState.dimension;
   const int numStatesPerGpu = stateVolume / singleStateDimension;

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -696,6 +696,11 @@ CuDensityMatState cudaq::CuDensityMatState::to_density_matrix() const {
                              "matrix is not supported.");
 
   const std::size_t vectorSize = calculate_state_vector_size(hilbertSpaceDims);
+  if (dimension != vectorSize)
+    throw std::runtime_error(
+        "Conversion of a rank-local distributed state vector to a density "
+        "matrix is not supported; provide the complete global state vector or "
+        "an explicit distributed density matrix.");
   const std::size_t expectedDensityMatrixSize = vectorSize * vectorSize;
   const std::size_t dmSizeBytes =
       expectedDensityMatrixSize * sizeof(std::complex<double>);
@@ -712,6 +717,42 @@ CuDensityMatState cudaq::CuDensityMatState::to_density_matrix() const {
       1, reinterpret_cast<const cuDoubleComplex *>(devicePtr), 1,
       reinterpret_cast<cuDoubleComplex *>(dmState.devicePtr), vectorSize));
   dmState.initialize_cudm(cudmHandle, hilbertSpaceDims, batchSize);
+  assert(dmState.is_initialized());
+  assert(dmState.is_density_matrix());
+  return dmState;
+}
+
+CuDensityMatState cudaq::CuDensityMatState::to_density_matrix(
+    const std::vector<int64_t> &dims) const {
+  if (is_initialized())
+    throw std::runtime_error("State is already initialized.");
+  if (batchSize > 1)
+    throw std::runtime_error("Conversion of a batched state to a density "
+                             "matrix is not supported.");
+
+  const std::size_t vectorSize = calculate_state_vector_size(dims);
+  if (dimension != vectorSize)
+    throw std::runtime_error(
+        "Conversion to a density matrix requires a complete global state "
+        "vector.");
+  const std::size_t expectedDensityMatrixSize =
+      checked_multiply(vectorSize, vectorSize, "density matrix size");
+  const std::size_t dmSizeBytes =
+      checked_multiply(expectedDensityMatrixSize, sizeof(std::complex<double>),
+                       "density matrix storage");
+
+  CuDensityMatState dmState;
+  dmState.devicePtr = cudaq::dynamics::DeviceAllocator::allocate(dmSizeBytes);
+  dmState.isDensityMatrix = true;
+  HANDLE_CUDA_ERROR(cudaMemset(dmState.devicePtr, 0, dmSizeBytes));
+  dmState.dimension = expectedDensityMatrixSize;
+  cuDoubleComplex scalar{1.0, 0.0};
+  HANDLE_CUBLAS_ERROR(cublasZgerc(
+      dynamics::Context::getCurrentContext()->getCublasHandle(), vectorSize,
+      vectorSize, &scalar, reinterpret_cast<const cuDoubleComplex *>(devicePtr),
+      1, reinterpret_cast<const cuDoubleComplex *>(devicePtr), 1,
+      reinterpret_cast<cuDoubleComplex *>(dmState.devicePtr), vectorSize));
+  dmState.initialize_cudm(cudmHandle, dims, /*batchSize=*/1);
   assert(dmState.is_initialized());
   assert(dmState.is_density_matrix());
   return dmState;

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -13,6 +13,8 @@
 #include "common/FmtCore.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
+#include <limits>
+#include <numeric>
 namespace cudaq {
 
 std::size_t CuDensityMatState::getNumQubits() const {
@@ -249,17 +251,208 @@ void CuDensityMatState::destroyState() {
   }
 }
 
-static size_t
+namespace {
+
+size_t
 calculate_state_vector_size(const std::vector<int64_t> &hilbertSpaceDims) {
   return std::accumulate(hilbertSpaceDims.begin(), hilbertSpaceDims.end(),
                          std::size_t{1}, std::multiplies<>());
 }
 
-static size_t
+size_t
 calculate_density_matrix_size(const std::vector<int64_t> &hilbertSpaceDims) {
   size_t vectorSize = calculate_state_vector_size(hilbertSpaceDims);
   return vectorSize * vectorSize;
 }
+
+std::vector<int64_t>
+get_global_component_extents(const std::vector<int64_t> &hilbertSpaceDims,
+                             bool isDensityMatrix, int64_t batchSize) {
+  std::vector<int64_t> globalExtents = hilbertSpaceDims;
+  if (isDensityMatrix)
+    globalExtents.insert(globalExtents.end(), hilbertSpaceDims.begin(),
+                         hilbertSpaceDims.end());
+  if (batchSize > 1)
+    globalExtents.emplace_back(batchSize);
+  return globalExtents;
+}
+
+std::size_t checked_multiply(std::size_t lhs, std::size_t rhs,
+                             const char *description) {
+  if (rhs != 0 && lhs > std::numeric_limits<std::size_t>::max() / rhs)
+    throw std::overflow_error(
+        fmt::format("Overflow while computing {}", description));
+  return lhs * rhs;
+}
+
+struct GlobalSliceLayout {
+  std::size_t startIdx;
+  std::size_t localVolume;
+  std::vector<int64_t> globalStrides;
+  bool isContiguous;
+};
+
+GlobalSliceLayout
+get_global_slice_layout(const std::vector<int64_t> &globalExtents,
+                        const std::vector<int64_t> &localExtents,
+                        const std::vector<int64_t> &offsets,
+                        std::size_t storageVolume, std::size_t globalVolume) {
+  if (globalExtents.size() != localExtents.size() ||
+      globalExtents.size() != offsets.size())
+    throw std::runtime_error(
+        "Invalid distributed state layout: mode count mismatch");
+
+  std::size_t localVolume = 1;
+  std::size_t stride = 1;
+  std::size_t startIdx = 0;
+  std::vector<int64_t> globalStrides(globalExtents.size());
+  bool foundPartialMode = false;
+  bool isContiguous = true;
+
+  for (std::size_t i = 0; i < globalExtents.size(); ++i) {
+    const auto globalExtent = globalExtents[i];
+    const auto localExtent = localExtents[i];
+    const auto offset = offsets[i];
+    if (globalExtent <= 0 || localExtent <= 0 || offset < 0 ||
+        localExtent > globalExtent || offset > globalExtent - localExtent)
+      throw std::runtime_error(fmt::format(
+          "Invalid distributed state layout for mode {}: global extent {}, "
+          "local extent {}, offset {}",
+          i, globalExtent, localExtent, offset));
+
+    const auto localExtentSize = static_cast<std::size_t>(localExtent);
+    const auto offsetSize = static_cast<std::size_t>(offset);
+    localVolume =
+        checked_multiply(localVolume, localExtentSize, "local state volume");
+
+    const auto offsetContribution =
+        checked_multiply(offsetSize, stride, "distributed state offset");
+    if (startIdx > std::numeric_limits<std::size_t>::max() - offsetContribution)
+      throw std::overflow_error(
+          "Overflow while computing distributed state offset");
+    startIdx += offsetContribution;
+    globalStrides[i] = static_cast<int64_t>(stride);
+
+    const bool isFullMode = offset == 0 && localExtent == globalExtent;
+    if (!foundPartialMode && !isFullMode)
+      foundPartialMode = true;
+    else if (foundPartialMode && localExtent != 1)
+      isContiguous = false;
+
+    stride = checked_multiply(stride, static_cast<std::size_t>(globalExtent),
+                              "global state stride");
+  }
+
+  if (localVolume > storageVolume)
+    throw std::runtime_error(fmt::format(
+        "Invalid distributed state layout: local volume {} exceeds component "
+        "storage volume {}",
+        localVolume, storageVolume));
+  if (stride != globalVolume)
+    throw std::runtime_error(fmt::format(
+        "Invalid distributed state layout: global volume {} does not match "
+        "input state volume {}",
+        stride, globalVolume));
+  std::size_t lastIdx = startIdx;
+  for (std::size_t i = 0; i < localExtents.size(); ++i) {
+    const auto contribution =
+        checked_multiply(static_cast<std::size_t>(localExtents[i] - 1),
+                         static_cast<std::size_t>(globalStrides[i]),
+                         "distributed state slice bound");
+    if (lastIdx > std::numeric_limits<std::size_t>::max() - contribution)
+      throw std::overflow_error(
+          "Overflow while computing distributed state slice bound");
+    lastIdx += contribution;
+  }
+  if (lastIdx >= globalVolume)
+    throw std::runtime_error(
+        "Distributed state slice exceeds the global state buffer");
+  return GlobalSliceLayout{startIdx, localVolume, std::move(globalStrides),
+                           isContiguous};
+}
+
+struct CutensorGatherResources {
+  cutensorHandle_t handle{nullptr};
+  cutensorTensorDescriptor_t sourceDescriptor{nullptr};
+  cutensorTensorDescriptor_t destinationDescriptor{nullptr};
+  cutensorOperationDescriptor_t operationDescriptor{nullptr};
+  cutensorPlanPreference_t planPreference{nullptr};
+  cutensorPlan_t plan{nullptr};
+
+  ~CutensorGatherResources() {
+    if (plan)
+      cutensorDestroyPlan(plan);
+    if (planPreference)
+      cutensorDestroyPlanPreference(planPreference);
+    if (operationDescriptor)
+      cutensorDestroyOperationDescriptor(operationDescriptor);
+    if (destinationDescriptor)
+      cutensorDestroyTensorDescriptor(destinationDescriptor);
+    if (sourceDescriptor)
+      cutensorDestroyTensorDescriptor(sourceDescriptor);
+    if (handle)
+      cutensorDestroy(handle);
+  }
+};
+
+uint32_t get_pointer_alignment(const void *ptr) {
+  constexpr uint32_t maxAlignment = 256;
+  const auto address = reinterpret_cast<std::uintptr_t>(ptr);
+  uint32_t alignment = 1;
+  while (alignment < maxAlignment && (address & alignment) == 0)
+    alignment <<= 1;
+  return alignment;
+}
+
+void gather_global_slice(void *devicePtr,
+                         const std::vector<int64_t> &localExtents,
+                         const GlobalSliceLayout &layout) {
+  const auto copySize = checked_multiply(
+      layout.localVolume, sizeof(std::complex<double>), "local copy size");
+  void *temporaryPtr = cudaq::dynamics::DeviceAllocator::allocate(copySize);
+  try {
+    CutensorGatherResources resources;
+    HANDLE_CUTENSOR_ERROR(cutensorCreate(&resources.handle));
+    const auto numModes = static_cast<uint32_t>(localExtents.size());
+    const auto *sourcePtr =
+        static_cast<const std::complex<double> *>(devicePtr) + layout.startIdx;
+    HANDLE_CUTENSOR_ERROR(cutensorCreateTensorDescriptor(
+        resources.handle, &resources.sourceDescriptor, numModes,
+        localExtents.data(), layout.globalStrides.data(), CUDA_C_64F,
+        get_pointer_alignment(sourcePtr)));
+    HANDLE_CUTENSOR_ERROR(cutensorCreateTensorDescriptor(
+        resources.handle, &resources.destinationDescriptor, numModes,
+        localExtents.data(), /*stride=*/nullptr, CUDA_C_64F,
+        get_pointer_alignment(temporaryPtr)));
+
+    std::vector<int32_t> modes(numModes);
+    std::iota(modes.begin(), modes.end(), 0);
+    HANDLE_CUTENSOR_ERROR(cutensorCreatePermutation(
+        resources.handle, &resources.operationDescriptor,
+        resources.sourceDescriptor, modes.data(), CUTENSOR_OP_IDENTITY,
+        resources.destinationDescriptor, modes.data(),
+        CUTENSOR_COMPUTE_DESC_64F));
+    HANDLE_CUTENSOR_ERROR(cutensorCreatePlanPreference(
+        resources.handle, &resources.planPreference, CUTENSOR_ALGO_DEFAULT,
+        CUTENSOR_JIT_MODE_NONE));
+    HANDLE_CUTENSOR_ERROR(cutensorCreatePlan(
+        resources.handle, &resources.plan, resources.operationDescriptor,
+        resources.planPreference, /*workspaceSizeLimit=*/0));
+
+    const cuDoubleComplex alpha{1.0, 0.0};
+    HANDLE_CUTENSOR_ERROR(cutensorPermute(resources.handle, resources.plan,
+                                          &alpha, sourcePtr, temporaryPtr,
+                                          /*stream=*/nullptr));
+    HANDLE_CUDA_ERROR(
+        cudaMemcpy(devicePtr, temporaryPtr, copySize, cudaMemcpyDefault));
+  } catch (...) {
+    cudaq::dynamics::DeviceAllocator::free(temporaryPtr);
+    throw;
+  }
+  cudaq::dynamics::DeviceAllocator::free(temporaryPtr);
+}
+
+} // namespace
 
 CuDensityMatState::CuDensityMatState(std::size_t size, void *ptr, bool borrowed)
     : devicePtr(ptr), dimension(size), borrowedData(borrowed),
@@ -595,20 +788,43 @@ void CuDensityMatState::initialize_cudm(cudensitymatHandle_t handleToSet,
         &stateComponentGlobalId, &numModes, stateComponentModeExtents.data(),
         stateComponentModeOffsets.data()));
 
-    dimension = stateVolume;
-    int64_t startIdx = 0;
-    int64_t accumulatedIdx = 1;
-    for (int32_t i = 0; i < numModes; ++i) {
-      accumulatedIdx *= stateComponentModeExtents[i];
-      startIdx += (stateComponentModeOffsets[i] * accumulatedIdx);
-    }
-    if (startIdx > 0) {
+    const auto globalExtents = get_global_component_extents(
+        hilbertSpaceDims, isDensityMatrix, batchSize);
+    const auto layout = get_global_slice_layout(
+        globalExtents, stateComponentModeExtents, stateComponentModeOffsets,
+        stateVolume, dimension);
+    if (!layout.isContiguous) {
+      gather_global_slice(devicePtr, stateComponentModeExtents, layout);
+    } else if (layout.startIdx > 0) {
       std::complex<double> *startPtr =
-          static_cast<std::complex<double> *>(devicePtr) + startIdx;
-      HANDLE_CUDA_ERROR(cudaMemcpy(devicePtr, startPtr,
-                                   stateVolume * sizeof(std::complex<double>),
-                                   cudaMemcpyDefault));
+          static_cast<std::complex<double> *>(devicePtr) + layout.startIdx;
+      const auto copySize = layout.localVolume * sizeof(std::complex<double>);
+      if (layout.startIdx < layout.localVolume) {
+        void *temporaryPtr =
+            cudaq::dynamics::DeviceAllocator::allocate(copySize);
+        try {
+          HANDLE_CUDA_ERROR(
+              cudaMemcpy(temporaryPtr, startPtr, copySize, cudaMemcpyDefault));
+          HANDLE_CUDA_ERROR(
+              cudaMemcpy(devicePtr, temporaryPtr, copySize, cudaMemcpyDefault));
+        } catch (...) {
+          cudaq::dynamics::DeviceAllocator::free(temporaryPtr);
+          throw;
+        }
+        cudaq::dynamics::DeviceAllocator::free(temporaryPtr);
+      } else {
+        HANDLE_CUDA_ERROR(
+            cudaMemcpy(devicePtr, startPtr, copySize, cudaMemcpyDefault));
+      }
     }
+    if (layout.localVolume < stateVolume) {
+      auto *paddingPtr =
+          static_cast<std::complex<double> *>(devicePtr) + layout.localVolume;
+      const auto paddingSize =
+          (stateVolume - layout.localVolume) * sizeof(std::complex<double>);
+      HANDLE_CUDA_ERROR(cudaMemset(paddingPtr, 0, paddingSize));
+    }
+    dimension = stateVolume;
   }
   // Attach initialized GPU storage to the input quantum state
   HANDLE_CUDM_ERROR(cudensitymatStateAttachComponentStorage(

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -13,8 +13,20 @@
 #include "common/FmtCore.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
+#include <cutensor.h>
 #include <limits>
 #include <numeric>
+
+#define HANDLE_CUTENSOR_ERROR(x)                                               \
+  do {                                                                         \
+    const auto err = (x);                                                      \
+    if (err != CUTENSOR_STATUS_SUCCESS) {                                      \
+      throw std::runtime_error(cudaq_fmt::format(                              \
+          "[cutensor] %{} ({}) in {} (line {})", cudaq_fmt::underlying(err),   \
+          cutensorGetErrorString(err), __FUNCTION__, __LINE__));               \
+    }                                                                          \
+  } while (0)
+
 namespace cudaq {
 
 std::size_t CuDensityMatState::getNumQubits() const {

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.h
@@ -147,6 +147,15 @@ public:
   /// @return A new CuDensityMatState representing the density matrix.
   CuDensityMatState to_density_matrix() const;
 
+  /// @brief Convert an uninitialized global state vector to a density matrix.
+  /// @return A new initialized CuDensityMatState representing the density
+  /// matrix.
+  CuDensityMatState
+  to_density_matrix(const std::vector<int64_t> &hilbertSpaceDims) const;
+
+  /// @brief Return the number of elements in the current storage buffer.
+  std::size_t get_element_count() const { return dimension; }
+
   /// @brief Get the underlying implementation (if any).
   /// @return The underlying state implementation.
   cudensitymatState_t get_impl() const;

--- a/unittests/nvqpp/mqpu/dynamics_mpi_batching_tester.cpp
+++ b/unittests/nvqpp/mqpu/dynamics_mpi_batching_tester.cpp
@@ -164,6 +164,110 @@ TEST(DynamicsBatchingMpi, checkDistributedExplicitStateWithCollapse) {
               targetLevel * std::exp(-decayRate * finalTime), 1e-5);
 }
 
+TEST(DynamicsBatchingMpi,
+     checkDistributedExplicitStateWithCollapseSingleStateBatchFallback) {
+  EXPECT_TRUE(cudaq::mpi::is_initialized());
+  EXPECT_GT(cudaq::mpi::num_ranks(), 1);
+
+  const cudaq::dimension_map dimensions{{0, 16}, {1, 2}};
+  constexpr int64_t targetLevel = 9;
+  std::vector<std::complex<double>> stateData(32, 0.0);
+  stateData[targetLevel + 16] = 1.0;
+  auto initialState = cudaq::state::from_data(stateData);
+  auto numberOperator = cudaq::boson_op::number(0);
+  auto hamiltonian = 0.0 * numberOperator;
+  constexpr double decayRate = 0.1;
+  auto collapseOperator = std::sqrt(decayRate) * cudaq::boson_op::annihilate(0);
+  constexpr double finalTime = 0.1;
+  cudaq::schedule schedule({0.0, finalTime}, {"time"});
+  cudaq::integrators::runge_kutta integrator;
+
+  auto results = cudaq::evolve(
+      std::vector{hamiltonian}, dimensions, schedule, std::vector{initialState},
+      integrator,
+      std::vector<std::vector<decltype(collapseOperator)>>{{collapseOperator}},
+      std::vector{numberOperator},
+      cudaq::IntermediateResultSave::ExpectationValue, /*batch_size=*/1);
+
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_TRUE(results[0].expectation_values.has_value());
+  ASSERT_EQ(results[0].expectation_values->size(), 2);
+  ASSERT_EQ(results[0].expectation_values->front().size(), 1);
+  EXPECT_NEAR(
+      static_cast<double>(results[0].expectation_values->front().front()),
+      targetLevel, 1e-12);
+  EXPECT_NEAR(
+      static_cast<double>(results[0].expectation_values->back().front()),
+      targetLevel * std::exp(-decayRate * finalTime), 1e-5);
+}
+
+TEST(DynamicsBatchingMpi,
+     checkDistributedExplicitStateSuperOpSingleStateBatchFallback) {
+  EXPECT_TRUE(cudaq::mpi::is_initialized());
+  EXPECT_GT(cudaq::mpi::num_ranks(), 1);
+
+  const cudaq::dimension_map dimensions{{0, 16}, {1, 2}};
+  constexpr int64_t targetLevel = 9;
+  std::vector<std::complex<double>> stateData(32, 0.0);
+  stateData[targetLevel + 16] = 1.0;
+  auto initialState = cudaq::state::from_data(stateData);
+  auto numberOperator = cudaq::boson_op::number(0);
+  cudaq::super_op superOperator;
+  superOperator += cudaq::super_op::left_multiply(
+      std::complex<double>(0.0, -1.0) * numberOperator);
+  superOperator += cudaq::super_op::right_multiply(
+      std::complex<double>(0.0, 1.0) * numberOperator);
+  cudaq::schedule schedule({0.0, 0.1}, {"time"});
+  cudaq::integrators::runge_kutta integrator;
+
+  auto results = cudaq::evolve(
+      std::vector{superOperator}, dimensions, schedule,
+      std::vector{initialState}, integrator, std::vector{numberOperator},
+      cudaq::IntermediateResultSave::ExpectationValue, /*batch_size=*/1);
+
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_TRUE(results[0].expectation_values.has_value());
+  ASSERT_EQ(results[0].expectation_values->size(), 2);
+  ASSERT_EQ(results[0].expectation_values->front().size(), 1);
+  EXPECT_NEAR(
+      static_cast<double>(results[0].expectation_values->front().front()),
+      targetLevel, 1e-12);
+  EXPECT_NEAR(
+      static_cast<double>(results[0].expectation_values->back().front()),
+      targetLevel, 1e-12);
+}
+
+TEST(DynamicsBatchingMpi, checkDistributedExplicitStateSuperOp) {
+  EXPECT_TRUE(cudaq::mpi::is_initialized());
+  EXPECT_GT(cudaq::mpi::num_ranks(), 1);
+
+  const cudaq::dimension_map dimensions{{0, 16}, {1, 2}};
+  constexpr int64_t targetLevel = 9;
+  std::vector<std::complex<double>> stateData(32, 0.0);
+  stateData[targetLevel + 16] = 1.0;
+  auto initialState = cudaq::state::from_data(stateData);
+  auto numberOperator = cudaq::boson_op::number(0);
+  cudaq::super_op superOperator;
+  superOperator += cudaq::super_op::left_multiply(
+      std::complex<double>(0.0, -1.0) * numberOperator);
+  superOperator += cudaq::super_op::right_multiply(
+      std::complex<double>(0.0, 1.0) * numberOperator);
+  cudaq::schedule schedule({0.0, 0.1}, {"time"});
+  cudaq::integrators::runge_kutta integrator;
+
+  auto result = cudaq::evolve(superOperator, dimensions, schedule, initialState,
+                              integrator, std::vector{numberOperator},
+                              cudaq::IntermediateResultSave::ExpectationValue);
+
+  ASSERT_TRUE(result.expectation_values.has_value());
+  ASSERT_EQ(result.expectation_values->size(), 2);
+  ASSERT_EQ(result.expectation_values->front().size(), 1);
+  EXPECT_NEAR(static_cast<double>(result.expectation_values->front().front()),
+              targetLevel, 1e-12);
+  EXPECT_NEAR(static_cast<double>(result.expectation_values->back().front()),
+              targetLevel, 1e-12);
+}
+
 TEST(DynamicsBatchingMpi, checkDifferentBatchSizes) {
   EXPECT_TRUE(cudaq::mpi::is_initialized());
   EXPECT_GT(cudaq::mpi::num_ranks(), 1);

--- a/unittests/nvqpp/mqpu/dynamics_mpi_batching_tester.cpp
+++ b/unittests/nvqpp/mqpu/dynamics_mpi_batching_tester.cpp
@@ -135,6 +135,35 @@ TEST(DynamicsBatchingMpi, checkSaveModes) {
   }
 }
 
+TEST(DynamicsBatchingMpi, checkDistributedExplicitStateWithCollapse) {
+  EXPECT_TRUE(cudaq::mpi::is_initialized());
+  EXPECT_GT(cudaq::mpi::num_ranks(), 1);
+
+  const cudaq::dimension_map dimensions{{0, 16}, {1, 2}};
+  constexpr int64_t targetLevel = 9;
+  std::vector<std::complex<double>> stateData(32, 0.0);
+  stateData[targetLevel + 16] = 1.0;
+  auto initialState = cudaq::state::from_data(stateData);
+  auto numberOperator = cudaq::boson_op::number(0);
+  constexpr double decayRate = 0.1;
+  constexpr double finalTime = 0.1;
+  cudaq::schedule schedule({0.0, finalTime}, {"time"});
+  cudaq::integrators::runge_kutta integrator;
+
+  auto result = cudaq::evolve(
+      0.0 * numberOperator, dimensions, schedule, initialState, integrator,
+      {std::sqrt(decayRate) * cudaq::boson_op::annihilate(0)}, {numberOperator},
+      cudaq::IntermediateResultSave::ExpectationValue);
+
+  ASSERT_TRUE(result.expectation_values.has_value());
+  ASSERT_EQ(result.expectation_values->size(), 2);
+  ASSERT_EQ(result.expectation_values->front().size(), 1);
+  EXPECT_NEAR(static_cast<double>(result.expectation_values->front().front()),
+              targetLevel, 1e-12);
+  EXPECT_NEAR(static_cast<double>(result.expectation_values->back().front()),
+              targetLevel * std::exp(-decayRate * finalTime), 1e-5);
+}
+
 TEST(DynamicsBatchingMpi, checkDifferentBatchSizes) {
   EXPECT_TRUE(cudaq::mpi::is_initialized());
   EXPECT_GT(cudaq::mpi::num_ranks(), 1);


### PR DESCRIPTION
## Background
### 1. 
for the fix introduced in  commit c3ffbc3192186da4c279e215f5d432af8d4c4e14, there is currently no test coverage for this part of the code logic (https://github.com/NVIDIA/cuda-quantum/blob/e2c9af33006f166353a65106b8aaec56288be1db/runtime/nvqir/cudensitymat/CuDensityMatState.cpp#L579):
```
if (stateVolume < dimension) {
  // Pack the rank-local slice from the global input buffer.
```
we don't have test coverage for:
* Distributed initialization from an explicit global state vector.
* Non-zero offsets on a split qudit mode.
* Explicit distributed density matrices.
* Non-contiguous local slices.
* Uneven slices where the logical local volume is smaller than the component storage capacity.
* Initialization from an already packed rank-local buffer.

But if you run a sample like this (with ten two-level modes followed by one 16-level qudit):
```
import cudaq
import cupy as cp
from cudaq import boson, Schedule

cudaq.mpi.initialize()
cudaq.set_target("dynamics")

dimensions = {i: 2 for i in range(10)}
dimensions[10] = 16

state_data = cp.zeros(16 * (2**10), dtype=cp.complex128)
state_data[0] = 1.0
initial_state = cudaq.State.from_data(state_data)

print(f"rank={cudaq.mpi.rank()} before evolve", flush=True)

cudaq.evolve(
    0.0 * boson.number(10),
    dimensions,
    Schedule([0.0], ["time"]),
    initial_state,
    observables=[],
    collapse_operators=[],
)

print(f"rank={cudaq.mpi.rank()} after evolve", flush=True)
```
run it with: 
```
mpirun -n 2 --allow-run-as-root \
  env PYTHONPATH=$PWD/build/python \
      LD_LIBRARY_PATH=$PWD/build/lib \
  python3 repro_distributed_qudit.py
```

Before this change, rank 1 fails during distributed state initialization:
```
RuntimeError: [cuda] %1 in initialize_cudm (line 608)
```

**root cause**:
The global tensor extents in the reproducer are:
```
[2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 16]
```
The global state contains 16384 elements. With two MPI ranks, cuDensityMat reports the following slice for rank 1:
```
local extents:
[2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 8]
mode offsets:
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8]
```
The previous implementation calculated the source offset using:
```
accumulatedIdx *= stateComponentModeExtents[i];
startIdx += stateComponentModeOffsets[i] * accumulatedIdx;
```
This calculation has two problems:

* It multiplies the extent before applying the offset of the current mode.
* It uses local extents to calculate strides in the global tensor.
For rank 1, it produces:
```
startIdx = 8 * (2^10 * 8) = 65536
```
The global input buffer only contains 16384 elements, so the subsequent device copy reads beyond the allocated buffer.

cuDensityMat stores dense state tensors using a generalized column-major (F-order) layout. The stride of mode i must therefore be calculated from the global extents preceding that mode:
```
globalStride[i] = product(globalExtents[0:i])
startIdx = sum(modeOffset[i] * globalStride[i])
```
For the split 16-level mode, the correct stride and offset are:
```
globalStride = 2^10 = 1024
startIdx = 8 * 1024 = 8192
```
in order to accommodate all the user scenarios mentioned above, **This change** (in  commit c3ffbc3192186da4c279e215f5d432af8d4c4e14):

* Reconstructs global component extents from the Hilbert-space dimensions, state representation, and batch size.
* Calculates slice offsets using global F-order strides.
* Validates mode counts, extents, offsets, storage bounds, and integer overflow.
* Uses cudaMemcpy for contiguous slices.
* Uses temporary storage when contiguous source and destination ranges overlap.
* Uses a cuTENSOR permutation to gather non-contiguous slices into dense local storage.

### 2.
for the fix introduced in d268dc4769ba27a854927aa5a905ee0fdc13f4f6, The missing coverage included:
```
- An explicit global pure state evolved with collapse operators.
- Pure-to-density conversion before distributed state initialization.
- The Python binding path through `initializeState()`.
- The C++ `evolveSingle()` path.
```
for example, the issue can be reproduced with an explicit two-mode pure state and a decay
operator:
```python
import cudaq
import cupy as cp
import numpy as np
from cudaq import boson, Schedule, RungeKuttaIntegrator
cudaq.mpi.initialize()
cudaq.set_target("dynamics")
dimensions = {0: 16, 1: 2}
target_level = 9
state_data = cp.zeros(32, dtype=cp.complex128)
state_data[target_level + 16] = 1.0
initial_state = cudaq.State.from_data(state_data)
number_operator = boson.number(0)
decay_rate = 0.1
final_time = 0.1
result = cudaq.evolve(
    0.0 * number_operator,
    dimensions,
    Schedule([0.0, final_time], ["time"]),
    initial_state,
    observables=[number_operator],
    collapse_operators=[
        np.sqrt(decay_rate) * boson.annihilate(0)
    ],
    store_intermediate_results=(
        cudaq.IntermediateResultSave.EXPECTATION_VALUE
    ),
    integrator=RungeKuttaIntegrator(),
)
for step in result.expectation_values():
    print(step[0].expectation())
```
Run it with:
```
mpirun -n 2 --allow-run-as-root \
  env PYTHONPATH=$PWD/build/python \
      LD_LIBRARY_PATH=$PWD/build/lib \
  python3 repro_distributed_pure_to_density.py
```
The initial expectation value should be `9.0`.
and the final expectation value should follow the expected decay:
```
9 * exp(-0.1 * 0.1) = 8.910448...
```

Before this change, the initial expectation value was incorrectly reported as approximately:
```
18.0
```
the **root cause** is:
Collapse operators require density-matrix evolution. The density matrix for a pure state vector is constructed from the outer product:
```
rho = |psi><psi|
```
Previously, the initialization order was:
```
global pure state vector
    -> initialize distributed cuDensityMat state
    -> compact global data into rank-local storage
    -> convert the rank-local storage to a density matrix
```
After distributed initialization, each rank only had its local slice packed at the beginning of the storage buffer. However, to_density_matrix() still used the global Hilbert-space dimension when calling cublasZgerc().

As a result, each rank treated its local slice as though it were the complete global state vector and constructed an invalid density matrix. Depending on the layout, the operation could also read stale data beyond the logical local volume.

The distributed slices cannot be converted independently:
```
|psi> = [psi_0, psi_1]
```
The global density matrix contains both local and cross-rank terms:
```
rho = [
  psi_0 psi_0*, psi_0 psi_1*,
  psi_1 psi_0*, psi_1 psi_1*
]
```
A rank holding only psi_0 or psi_1 cannot construct the complete density matrix without additional communication.

**Fix**
The conversion order is now:
```
global pure state vector
    -> construct the complete density matrix
    -> initialize the density matrix as a distributed cuDensityMat state
    -> pack the rank-local density-matrix slice
```
This commit:

* Adds a to_density_matrix(hilbertSpaceDims) overload for an uninitialized global state vector.
* Verifies that the input buffer contains the complete global vector.
* Constructs the complete density matrix before distributed initialization.
* Updates the Python initializeState() binding to use the pre-distribution conversion path.
* Updates the C++ evolveSingle() path to perform the same conversion.
* Rejects conversion when the state contains only a rank-local distributed vector.
* Improves the error message to explain that either the complete global state vector or an explicit distributed density matrix is required.

### 3.
for the last commit, removes an invalid local-extent-based fallback for deriving distributed batch offsets and requires cuDensityMat to report a valid batch mode.



