### PR TITLE
Fix passing a whole qvector to multi-qubit custom operations in C++ frontend

### DIFF
--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2212,7 +2212,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           StringAttr::get(builder.getContext(), genFuncName));
       ValueRange operands(args);
       assert(operands.size() >= 1 && "must be at least 1 operand");
-      if ((operands.size() == 1) &&
+      if ((targetCount == 1) && (operands.size() == 1) &&
           isa<cudaq::quake::VeqType>(operands[0].getType())) {
         auto target = operands[0];
         if (!negations.empty())
@@ -2235,6 +2235,21 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         auto [targets, ctrls] =
             maybeUnpackOperands(builder, loc, operands.drop_front(paramCount),
                                 isControl, targetCount);
+        bool allQubits = targets.size() == targetCount;
+        for (auto v : targets)
+          allQubits &= isa<cudaq::quake::RefType>(v.getType());
+        if (!allQubits) {
+          // Broadcasting over a qvector is only defined for single-qubit
+          // custom operations.
+          auto &de = mangler->getASTContext().getDiagnostics();
+          auto id = de.getCustomDiagID(
+              clang::DiagnosticsEngine::Error,
+              "custom operation requires %0 individual qubit target(s)");
+          de.Report(x->getBeginLoc(), id) << (unsigned)targetCount;
+          // Returning `false` here would cause the outer `TraverseStmt` to
+          // emit a second, generic "statement not supported" diagnostic.
+          return true;
+        }
         for (auto v : targets)
           if (std::find(negations.begin(), negations.end(), v) !=
               negations.end())

--- a/cudaq/test/AST-error/custom_op_invalid_argument.cpp
+++ b/cudaq/test/AST-error/custom_op_invalid_argument.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake -verify %s
+
+#include <cudaq.h>
+
+CUDAQ_REGISTER_OPERATION(custom_cnot, 2, 0,
+                         {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0})
+
+__qpu__ void too_many() {
+  cudaq::qubit a, b, c;
+  // expected-error@+1{{requires 2 individual qubit target(s)}}
+  custom_cnot(a, b, c);
+}
+
+__qpu__ void too_few() {
+  cudaq::qubit q;
+  // expected-error@+1{{requires 2 individual qubit target(s)}}
+  custom_cnot(q);
+}
+
+__qpu__ void whole_qvector() {
+  cudaq::qvector q(2);
+  // expected-error@+1{{requires 2 individual qubit target(s)}}
+  custom_cnot(q);
+}
+
+__qpu__ void qubit_then_qvector() {
+  cudaq::qvector q(2);
+  cudaq::qubit r;
+  // expected-error@+1{{requires 2 individual qubit target(s)}}
+  custom_cnot(r, q);
+}
+
+__qpu__ void ctrl_with_qvector_target() {
+  cudaq::qubit c;
+  cudaq::qvector q(2);
+  // expected-error@+1{{requires 2 individual qubit target(s)}}
+  custom_cnot<cudaq::ctrl>(c, q);
+}


### PR DESCRIPTION
Fixes [#4961.](https://github.com/NVIDIA/cuda-quantum/issues/4961)

Passing a `qvector` to a multi-qubit custom operation crashed nvq++ deep in the verifier
with `Invalid matrix size, required 2^N * 2^N for N-qubit operation`. The lowering treated
a lone `veq` argument as a broadcast target no matter what arity the operation had.

Per the review discussion, broadcasting only makes sense for single-qubit custom
operations, so the broadcast path is now gated on arity 1. Any other argument shape
(a `qvector` where individual qubits are required, or the wrong number of qubits) is
rejected at compile time with `custom operation requires N individual qubit argument(s)`.

Testing: a new AST-error test (`custom_op_invalid_argument.cpp`) covers too many and too
few qubits, a whole qvector (the reproducer from the issue), and a qubit followed by a
qvector. Existing custom-operation tests pass unchanged.