### PR TITLE
Clean up devcontainer GHCR images in nightly job

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -96,7 +96,7 @@ jobs:
 
     strategy:
       matrix:
-        image_name: [cuda-quantum, cuda-quantum-assets, cuda-quantum-dev, cuda-quantum-devdeps, open-mpi, cuda-quantum-macos-devdeps, cuda-quantum-macos-devdeps-ci, cuda-quantum-macos-ccache, cuda-quantum-linux-ccache]
+        image_name: [cuda-quantum, cuda-quantum-assets, cuda-quantum-dev, cuda-quantum-devcontainer, cuda-quantum-devdeps, open-mpi, cuda-quantum-macos-devdeps, cuda-quantum-macos-devdeps-ci, cuda-quantum-macos-ccache, cuda-quantum-linux-ccache]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
cuda-quantum-devcontainer was missing from the ghcr_images matrix in clean_up.yml, so its untagged versions were never pruned and piled up. Add it alongside the other images to get the same retention (delete untagged, keep newest 400).