### PR TITLE
Add an owned single-flight compiled-module cache

### DIFF
--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -1710,15 +1710,15 @@ class PyKernel(object):
     def clearCache(self):
         if hasattr(self, 'qkeModule'):
             del self.qkeModule
-        if hasattr(self, '_compiled_module'):
-            del self._compiled_module
+        if hasattr(self, '_compiled_module_cache'):
+            del self._compiled_module_cache
 
-    def cachedCompiledModule(self):
-        """Return the kernel's CompiledModule cache slot, creating an empty
-        one on first access."""
-        if not hasattr(self, '_compiled_module'):
-            self._compiled_module = cudaq_runtime.CompiledModule()
-        return self._compiled_module
+    def compiledModuleCache(self):
+        """Return this builder kernel's shared compiled-module cache, creating
+        an empty one on first access."""
+        if not hasattr(self, '_compiled_module_cache'):
+            self._compiled_module_cache = cudaq_runtime.CompiledModuleCache()
+        return self._compiled_module_cache
 
     @trace.traced
     def compile(self):
@@ -1854,7 +1854,7 @@ class PyKernel(object):
             self.name,
             specialized,
             *processedArgs,
-            compiled=self.cachedCompiledModule())
+            cache=self.compiledModuleCache())
 
     def __getattr__(self, attr_name):
         # Search attributes in instance, class, base classes

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -623,12 +623,12 @@ class PyKernelDecorator(object):
 
         return processed_args, module
 
-    def cachedCompiledModule(self):
-        """Return the kernel's CompiledModule cache slot, creating an empty
+    def compiledModuleCache(self):
+        """Return this kernel's shared compiled-module cache, creating an empty
         one on first access."""
-        if not hasattr(self, '_compiled_module'):
-            self._compiled_module = cudaq_runtime.CompiledModule()
-        return self._compiled_module
+        if not hasattr(self, '_compiled_module_cache'):
+            self._compiled_module_cache = cudaq_runtime.CompiledModuleCache()
+        return self._compiled_module_cache
 
     def get_none_type(self):
         if self._cached_qkeModule:
@@ -677,7 +677,7 @@ class PyKernelDecorator(object):
             self.uniqName,
             module,
             *processed_args,
-            compiled=self.cachedCompiledModule())
+            cache=self.compiledModuleCache())
 
     def beta_reduction(self, isEntryPoint, *args):
         """
@@ -757,9 +757,15 @@ def mk_decorator(builder):
     that handles both CUDA-Q kernel object classes more unified.
     """
     builder.compile()
-    return PyKernelDecorator(None,
-                             module=builder.qkeModule,
-                             kernelName=builder.uniqName)
+    decorator = PyKernelDecorator(None,
+                                  module=builder.qkeModule,
+                                  kernelName=builder.uniqName)
+    # The adapter is transient — one is made per wrapper call (`draw`,
+    # `get_state`, etc.). Share the builder's compiled-module cache so repeated
+    # wrapper calls reuse one compilation state instead of receiving a fresh,
+    # always-cold cache each time.
+    decorator._compiled_module_cache = builder.compiledModuleCache()
+    return decorator
 
 
 def kernel(function=None, **kwargs):

--- a/python/cudaq/runtime/draw.py
+++ b/python/cudaq/runtime/draw.py
@@ -21,7 +21,7 @@ def _detail_draw(format, decorator, *args):
     # Must handle arguments exactly like this is a `callsite` to the decorator.
     processedArgs, module = decorator.prepare_call(*args)
     return cudaq_runtime.draw_impl(format, decorator.uniqName, module,
-                                   decorator.cachedCompiledModule(),
+                                   decorator.compiledModuleCache(),
                                    *processedArgs)
 
 

--- a/python/cudaq/runtime/ptsbe.py
+++ b/python/cudaq/runtime/ptsbe.py
@@ -108,18 +108,18 @@ def sample(kernel,
         results = []
         for argSet in argSets:
             processedArgs, module = decorator.prepare_call(*argSet)
-            compiled = decorator.cachedCompiledModule()
+            cache = decorator.compiledModuleCache()
             result = cudaq_runtime.ptsbe.sample_impl(
-                decorator.uniqName, module, compiled, shots_count, noise_model,
+                decorator.uniqName, module, cache, shots_count, noise_model,
                 max_trajectories, sampling_strategy, shot_allocation,
                 return_execution_data, include_sequential_data, *processedArgs)
             results.append(result)
         return results
 
     processedArgs, module = decorator.prepare_call(*args)
-    compiled = decorator.cachedCompiledModule()
+    cache = decorator.compiledModuleCache()
     return cudaq_runtime.ptsbe.sample_impl(
-        decorator.uniqName, module, compiled, shots_count, noise_model,
+        decorator.uniqName, module, cache, shots_count, noise_model,
         max_trajectories, sampling_strategy, shot_allocation,
         return_execution_data, include_sequential_data, *processedArgs)
 

--- a/python/cudaq/runtime/run.py
+++ b/python/cudaq/runtime/run.py
@@ -63,7 +63,7 @@ def run(decorator, *args, shots_count=100, noise_model=None, qpu_id=0):
 
     processedArgs, module = decorator.prepare_call(*args)
     return cudaq_runtime.run_impl(decorator.uniqName + ".run", module,
-                                  decorator.cachedCompiledModule(), shots_count,
+                                  decorator.compiledModuleCache(), shots_count,
                                   noise_model, qpu_id, *processedArgs)
 
 

--- a/python/cudaq/runtime/state.py
+++ b/python/cudaq/runtime/state.py
@@ -47,7 +47,7 @@ def get_state(kernel, *args):
         decorator = mk_decorator(kernel)
     processedArgs, module = decorator.prepare_call(*args)
     return cudaq_runtime.get_state_impl(decorator.uniqName, module,
-                                        decorator.cachedCompiledModule(),
+                                        decorator.compiledModuleCache(),
                                         *processedArgs)
 
 

--- a/python/cudaq/runtime/unitary.py
+++ b/python/cudaq/runtime/unitary.py
@@ -40,5 +40,5 @@ def get_unitary(kernel, *args):
         decorator = mk_decorator(kernel)
     processedArgs, module = decorator.prepare_call(*args)
     return cudaq_runtime.get_unitary_impl(decorator.uniqName, module,
-                                          decorator.cachedCompiledModule(),
+                                          decorator.compiledModuleCache(),
                                           *processedArgs)

--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -94,6 +94,7 @@ declare_mlir_python_extension(CUDAQuantumPythonSources.Extension
     ../runtime/cudaq/algorithms/py_translate.cpp
     ../runtime/cudaq/algorithms/py_unitary.cpp
     ../runtime/cudaq/algorithms/py_utils.cpp
+    ../runtime/cudaq/platform/CompiledModuleCache.cpp
     ../runtime/cudaq/platform/ProgramFingerprint.cpp
     ../runtime/cudaq/platform/PythonSignalCheck.cpp
     ../runtime/cudaq/platform/py_alt_launch_kernel.cpp

--- a/python/runtime/cudaq/algorithms/py_draw.cpp
+++ b/python/runtime/cudaq/algorithms/py_draw.cpp
@@ -10,20 +10,20 @@
 #include "runtime/cudaq/platform/py_alt_launch_kernel.h"
 #include "cudaq/algorithms/draw.h"
 #include "cudaq/platform/nvqpp_interface.h"
+#include <nanobind/stl/shared_ptr.h>
 
 /// @brief Run `cudaq::contrib::draw`'s string overload on the provided kernel.
 /// \p kernel is a kernel decorator object and \p args are the arguments to
 /// launch \p kernel.
-static std::string pyDraw(const std::string &format,
-                          const std::string &shortName, MlirModule mod,
-                          cudaq::CompiledModule *compiled,
-                          nanobind::args runtimeArgs) {
+static std::string
+pyDraw(const std::string &format, const std::string &shortName, MlirModule mod,
+       std::shared_ptr<cudaq::detail::CompiledModuleCache> cache,
+       nanobind::args runtimeArgs) {
   if (format != "ascii" && format != "latex")
     throw std::runtime_error("format argument must be \"ascii\" or \"latex\".");
 
   auto f = [=]() {
-    return cudaq::marshal_and_launch_module(shortName, mod, runtimeArgs,
-                                            compiled);
+    return cudaq::marshal_and_launch_module(shortName, mod, runtimeArgs, cache);
   };
   if (format == "ascii")
     return cudaq::contrib::extractTrace(std::move(f));
@@ -35,9 +35,10 @@ void cudaq::bindPyDraw(nanobind::module_ &mod) {
   mod.def(
       "draw_impl",
       [](const std::string &format, const std::string &shortName,
-         MlirModule mod, cudaq::CompiledModule *compiled,
+         MlirModule mod,
+         std::shared_ptr<cudaq::detail::CompiledModuleCache> cache,
          nanobind::args runtimeArgs) {
-        return pyDraw(format, shortName, mod, compiled, runtimeArgs);
+        return pyDraw(format, shortName, mod, std::move(cache), runtimeArgs);
       },
       R"#(
 Return a string representing the drawing of the execution path, in the format

--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -20,6 +20,7 @@
 #include <nanobind/stl/complex.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
@@ -69,11 +70,10 @@ getFuncOpAndCheckResult(mlir::ModuleOp mod, const std::string &shortName) {
   return fn;
 }
 
-static detail::RunResultSpan
-pyRunTheKernel(const std::string &name, quantum_platform &platform,
-               mlir::ModuleOp mod, CompiledModule *compiled,
-               std::size_t shots_count, std::size_t qpu_id,
-               OpaqueArguments &opaques) {
+static detail::RunResultSpan pyRunTheKernel(
+    const std::string &name, quantum_platform &platform, mlir::ModuleOp mod,
+    std::shared_ptr<detail::CompiledModuleCache> cache, std::size_t shots_count,
+    std::size_t qpu_id, OpaqueArguments &opaques) {
   if (!name.ends_with(".run"))
     throw std::runtime_error("`cudaq.run` only supports runnable kernels.");
   // Set the `run` attribute on the module to indicate this is a run context
@@ -99,7 +99,7 @@ pyRunTheKernel(const std::string &name, quantum_platform &platform,
   cudaq::run_result runResult = detail::launchRun(
       [&]() mutable {
         [[maybe_unused]] auto result =
-            clean_launch_module(name, mod, opaques, compiled);
+            clean_launch_module(name, mod, opaques, cache);
       },
       platform, name, shots_count, qpu_id);
 
@@ -116,9 +116,9 @@ pyReadResults(detail::RunResultSpan results, mlir::ModuleOp mod,
 /// @brief Run `cudaq::run` on the provided kernel.
 static std::vector<nanobind::object>
 run_impl(const std::string &shortName, MlirModule module,
-         cudaq::CompiledModule *compiled, std::size_t shots_count,
-         std::optional<noise_model> noise_model, std::size_t qpu_id,
-         nanobind::args runtimeArgs) {
+         std::shared_ptr<detail::CompiledModuleCache> cache,
+         std::size_t shots_count, std::optional<noise_model> noise_model,
+         std::size_t qpu_id, nanobind::args runtimeArgs) {
   if (shots_count == 0)
     return {};
 
@@ -137,8 +137,8 @@ run_impl(const std::string &shortName, MlirModule module,
   detail::RunResultSpan span;
   {
     nanobind::gil_scoped_release release;
-    span = pyRunTheKernel(shortName, platform, mod, compiled, shots_count,
-                          qpu_id, opaques);
+    span = pyRunTheKernel(shortName, platform, mod, std::move(cache),
+                          shots_count, qpu_id, opaques);
   }
   auto results = pyReadResults(span, mod, shortName);
 

--- a/python/runtime/cudaq/algorithms/py_sample_ptsbe.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample_ptsbe.cpp
@@ -41,8 +41,8 @@ using namespace cudaq;
 // std::optional types for all nullable parameters instead.
 static ptsbe::sample_result
 pySamplePTSBE(const std::string &shortName, MlirModule module,
-              cudaq::CompiledModule *compiled, std::size_t shots_count,
-              noise_model noiseModel,
+              std::shared_ptr<detail::CompiledModuleCache> cache,
+              std::size_t shots_count, noise_model noiseModel,
               std::optional<std::size_t> max_trajectories,
               std::optional<std::shared_ptr<ptsbe::PTSSamplingStrategy>>
                   sampling_strategy,
@@ -78,7 +78,7 @@ pySamplePTSBE(const std::string &shortName, MlirModule module,
     result = ptsbe::detail::runSamplingPTSBE(
         [&]() mutable {
           [[maybe_unused]] auto res =
-              clean_launch_module(shortName, mod, opaques, compiled);
+              clean_launch_module(shortName, mod, opaques, cache);
         },
         platform, shortName, shots_count, ptsbe_options);
   } catch (const std::exception &e) {
@@ -402,7 +402,7 @@ void cudaq::bindSamplePTSBE(nanobind::module_ &mod) {
 
   // PTSBE sample implementation
   ptsbe.def("sample_impl", pySamplePTSBE, nanobind::arg("kernel_name"),
-            nanobind::arg("module"), nanobind::arg("compiled"),
+            nanobind::arg("module"), nanobind::arg("cache"),
             nanobind::arg("shots_count"), nanobind::arg("noise_model"),
             nanobind::arg("max_trajectories").none(),
             nanobind::arg("sampling_strategy").none(),

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include <limits>
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/shared_ptr.h>
 
 using namespace cudaq;
 
@@ -172,10 +173,10 @@ static std::vector<int> bitStringToIntVec(const std::string &bitString) {
 
 /// @brief Run `cudaq::get_state` on the provided kernel and spin operator.
 static state get_state_impl(const std::string &shortName, MlirModule mod,
-                            cudaq::CompiledModule *compiled,
+                            std::shared_ptr<detail::CompiledModuleCache> cache,
                             nanobind::args args) {
   auto closure = [=]() {
-    return marshal_and_launch_module(shortName, mod, args, compiled);
+    return marshal_and_launch_module(shortName, mod, args, cache);
   };
   return detail::extractState(std::move(closure));
 }
@@ -855,7 +856,8 @@ index pair.
   mod.def(
       "get_state_impl",
       [&](const std::string &shortName, MlirModule module,
-          cudaq::CompiledModule *compiled, nanobind::args args) {
+          std::shared_ptr<detail::CompiledModuleCache> cache,
+          nanobind::args args) {
         // Check for unsupported cases.
         if (holder.getTarget().name == "orca-photonics")
           throw std::runtime_error(
@@ -863,7 +865,7 @@ index pair.
 
         if (is_remote_platform() || is_emulated_platform())
           return pyGetStateQPU(shortName, module, args);
-        return get_state_impl(shortName, module, compiled, args);
+        return get_state_impl(shortName, module, std::move(cache), args);
       },
       "See the python documentation for get_state.");
 

--- a/python/runtime/cudaq/algorithms/py_unitary.cpp
+++ b/python/runtime/cudaq/algorithms/py_unitary.cpp
@@ -11,16 +11,17 @@
 #include "runtime/cudaq/platform/py_alt_launch_kernel.h"
 #include "cudaq/algorithms/unitary.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
+#include <nanobind/stl/shared_ptr.h>
 
 using namespace cudaq;
 
 /// Compute the unitary of this kernel module.
-static nanobind::object get_unitary_impl(const std::string &shortName,
-                                         MlirModule module,
-                                         cudaq::CompiledModule *compiled,
-                                         nanobind::args args) {
+static nanobind::object
+get_unitary_impl(const std::string &shortName, MlirModule module,
+                 std::shared_ptr<detail::CompiledModuleCache> cache,
+                 nanobind::args args) {
   auto f = [=]() {
-    return cudaq::marshal_and_launch_module(shortName, module, args, compiled);
+    return cudaq::marshal_and_launch_module(shortName, module, args, cache);
   };
 
   // Return as numpy array (dim, dim), complex128

--- a/python/runtime/cudaq/platform/CompiledModuleCache.cpp
+++ b/python/runtime/cudaq/platform/CompiledModuleCache.cpp
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "CompiledModuleCache.h"
+#include <algorithm>
+#include <exception>
+#include <stdexcept>
+
+namespace cudaq::detail {
+
+CompiledModuleCache::Result CompiledModuleCache::getOrCompile(
+    const Key &key, llvm::function_ref<SharedCompiledModule()> compile) {
+  std::shared_ptr<CompilingEntry> compilingEntry;
+  Role role;
+
+  // Without this lock scope, two callers could both observe "Missing" and
+  // become producers for the same compilation.
+  {
+    std::lock_guard<std::mutex> lock(cacheMutex);
+
+    auto readyIter =
+        std::find_if(readyEntries.begin(), readyEntries.end(),
+                     [&](const ReadyEntry &entry) { return entry.key == key; });
+    // A ready hit does not change insertion order (eviction is FIFO).
+    if (readyIter != readyEntries.end())
+      return {readyIter->module, Role::ReadyReader};
+
+    auto compilingIter =
+        std::find_if(compilingEntries.begin(), compilingEntries.end(),
+                     [&](const std::shared_ptr<CompilingEntry> &entry) {
+                       return entry->key == key;
+                     });
+    if (compilingIter != compilingEntries.end()) {
+      // Join the existing attempt rather than duplicating its compilation.
+      compilingEntry = *compilingIter;
+      role = Role::Follower;
+    } else {
+      // Publish the "Compiling" state before releasing mutex. Every later
+      // equivalent caller will therefore become a follower of this attempt.
+      compilingEntry = std::make_shared<CompilingEntry>(key);
+      compilingEntries.emplace_back(compilingEntry);
+      role = Role::Producer;
+    }
+  } // `cacheMutex` is released here
+
+  // Waiting while holding `cacheMutex` would deadlock.
+  if (role == Role::Follower)
+    return {compilingEntry->completion.get(), role};
+
+  SharedCompiledModule module;
+  // Written under the lock, destroyed after it: tearing down an evicted JIT
+  // artifact can be heavy and must not block callers on unrelated keys.
+  SharedCompiledModule evicted;
+  try {
+    // Only the producer invokes the callback. It runs without `cacheMutex`, so
+    // unrelated keys can compile concurrently.
+    module = compile();
+    // Reject rather than publish a null artifact: every joined caller would
+    // otherwise dereference it far from the failure. The catch path below
+    // makes this attempt retryable.
+    if (!module)
+      throw std::logic_error(
+          "CompiledModuleCache compile callback returned a null module");
+
+    // Replace "Compiling" with "Ready" under one lock. No caller can observe a
+    // "Missing" gap and incorrectly begin another compilation for this key.
+    std::lock_guard<std::mutex> lock(cacheMutex);
+    // Insert before evicting so an allocation failure preserves every existing
+    // "Ready" entry; the catch path then makes this attempt retryable.
+    // Publish the key snapshot that was claimed before compilation. The
+    // callback is user-supplied and must not be able to change the identity of
+    // this attempt by mutating the caller's original `key` object.
+    readyEntries.emplace_back(compilingEntry->key, module);
+    if (readyEntries.size() > maxReadyEntries) {
+      evicted = std::move(readyEntries.front().module);
+      readyEntries.erase(readyEntries.begin());
+    }
+    std::erase(compilingEntries, compilingEntry);
+  } catch (...) {
+    auto error = std::current_exception();
+    {
+      std::lock_guard<std::mutex> lock(cacheMutex);
+      // Removing the failed attempt makes a later call for this key eligible
+      // to become a new producer.
+      std::erase(compilingEntries, compilingEntry);
+    }
+    // Fulfill outside `cacheMutex` because making the future ready can wake all
+    // followers immediately.
+    compilingEntry->promise.set_exception(error);
+    std::rethrow_exception(error);
+  }
+
+  // "Ready" is already visible before followers wake. New callers can therefore
+  // reuse the module instead of joining a completed attempt.
+  compilingEntry->promise.set_value(module);
+  return {std::move(module), role};
+}
+
+} // namespace cudaq::detail

--- a/python/runtime/cudaq/platform/CompiledModuleCache.h
+++ b/python/runtime/cudaq/platform/CompiledModuleCache.h
@@ -1,0 +1,153 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "common/CompiledModule.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace cudaq::detail {
+
+/// Thread-safe, per-kernel cache of immutable compiled modules.
+///
+/// Calls for the same key share one compilation attempt. One caller produces
+/// the artifact while concurrent callers join that attempt; calls for different
+/// keys may compile concurrently. Successful artifacts remain usable through
+/// shared ownership even after their cache entry is evicted.
+///
+/// The cache retains up to four ready artifacts to bound the memory held by JIT
+/// engines. Eviction is first-in, first-out: a ready hit deliberately does not
+/// refresh insertion order, keeping the hot path read-only and publication
+/// order deterministic under concurrency. Outstanding compilation attempts are
+/// neither counted toward the ready-entry limit nor evicted.
+///
+/// Inherits `std::enable_shared_from_this` so the Python binding layer reuses
+/// the native `shared_ptr` control block when a cache crosses the language
+/// boundary. Without it, nanobind substitutes a Python-backed control block
+/// whose deletion logic must acquire the GIL — unsafe once asynchronous worker
+/// threads hold the last reference.
+class CompiledModuleCache
+    : public std::enable_shared_from_this<CompiledModuleCache> {
+public:
+  /// All compile-time inputs that determine whether an artifact can be reused.
+  struct Key {
+    /// Uniqued entry-point name of the kernel being compiled.
+    std::string kernelName;
+    /// Hash of the target configuration used for compilation.
+    std::size_t targetHash = 0;
+    /// Digest of the resolved program, including compile-time dependencies.
+    std::array<std::uint8_t, 32> programDigest = {};
+
+    bool operator==(const Key &) const = default;
+  };
+
+  /// Immutable compiled module shared by the cache and all callers using it.
+  using SharedCompiledModule = std::shared_ptr<const CompiledModule>;
+
+  /// Role this caller played while resolving a `getOrCompile()` request.
+  enum class Role {
+    /// This caller ran the compilation callback and published its result.
+    Producer,
+    /// This caller found and joined an existing compilation attempt.
+    Follower,
+    /// This caller found an artifact that had already been published.
+    ReadyReader
+  };
+
+  /// Compiled module returned by `getOrCompile()` and this caller's role.
+  struct Result {
+    /// Non-null compiled module owned independently of cache eviction.
+    SharedCompiledModule module;
+    Role role;
+  };
+
+  CompiledModuleCache() = default;
+  ~CompiledModuleCache() = default;
+
+  /// A cache has shared identity and must not be copied or relocated. Share it
+  /// with std::shared_ptr<CompiledModuleCache> instead.
+  CompiledModuleCache(const CompiledModuleCache &) = delete;
+  CompiledModuleCache &operator=(const CompiledModuleCache &) = delete;
+  CompiledModuleCache(CompiledModuleCache &&) = delete;
+  CompiledModuleCache &operator=(CompiledModuleCache &&) = delete;
+
+  /// Return the compiled artifact for \p key, invoking \p compile only when
+  /// this caller claims a missing entry.
+  ///
+  /// The check for an existing entry and installation of a new outstanding
+  /// attempt form one atomic cache operation. The cache mutex is not held while
+  /// invoking \p compile or waiting for another caller's attempt. This class
+  /// does not manage the Python GIL; Python launch paths must release it before
+  /// calling this function. The callback is invoked synchronously and is never
+  /// retained beyond this function call.
+  ///
+  /// On success, the produced artifact is published before this function
+  /// returns. If \p compile throws, concurrent callers joining the same attempt
+  /// observe that exception, the failed entry is removed, and a later call may
+  /// retry compilation.
+  ///
+  /// The callback must only create the compiled artifact; callers execute the
+  /// kernel after this function returns. It must return a non-null module —
+  /// a null result is rejected with an exception (observed by all joined
+  /// callers) rather than published. It must not call back into this cache
+  /// for the same key: the nested call would join the caller's own attempt
+  /// and deadlock waiting for it.
+  Result getOrCompile(const Key &key,
+                      llvm::function_ref<SharedCompiledModule()> compile);
+
+private:
+  /// A successfully published key/module pair. Ready entries are immutable
+  /// after insertion and are the only entries subject to FIFO eviction.
+  struct ReadyEntry {
+    Key key;
+    SharedCompiledModule module;
+  };
+
+  /// Completion state shared by every caller participating in one compilation
+  /// attempt. The producer completes the promise once; followers wait on the
+  /// shared future and observe either the same module or the same exception.
+  struct CompilingEntry {
+    /// `std::promise` permits `get_future()` only once, so create the copyable
+    /// `shared_future` before publishing this entry to any follower.
+    explicit CompilingEntry(Key compilationKey)
+        : key(std::move(compilationKey)),
+          completion(promise.get_future().share()) {}
+
+    /// Retained independently of the producer's stack frame so callers can
+    /// continue matching this attempt while compilation runs without the lock.
+    Key key;
+    /// Single-producer write end of the completion channel.
+    std::promise<SharedCompiledModule> promise;
+    /// Multi-follower read end of the completion channel.
+    std::shared_future<SharedCompiledModule> completion;
+  };
+
+  /// Bound only completed artifacts; compiling entries must remain discoverable
+  /// so a later equivalent caller cannot start duplicate work.
+  static constexpr std::size_t maxReadyEntries = 4;
+
+  /// One mutex protects both collections, making the Missing -> Compiling and
+  /// Compiling -> Ready transitions atomic.
+  std::mutex cacheMutex;
+  /// In insertion order so erasing the first element implements FIFO eviction.
+  std::vector<ReadyEntry> readyEntries;
+  /// `shared_ptr` keeps an attempt alive after the producer releases
+  /// `cacheMutex` and until it publishes either a module or an exception.
+  std::vector<std::shared_ptr<CompilingEntry>> compilingEntries;
+};
+
+} // namespace cudaq::detail

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "py_alt_launch_kernel.h"
+#include "CompiledModuleCache.h"
 #include "ProgramFingerprint.h"
 #include "common/AnalogHamiltonian.h"
 #include "common/ArgumentWrapper.h"
@@ -55,6 +56,7 @@
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/map.h>
 #include <nanobind/stl/pair.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
@@ -719,12 +721,14 @@ compileModuleImpl(const std::string &name, ModuleOp mod,
                                                  {rawArgs}, isEntryPoint);
 }
 
-// Launching the module \p mod will modify its content, such as by argument
-// synthesis into the entry-point kernel. Make a clone before we launch to
-// preserve (cache) the IR, and erase the clone after the kernel is done.
+// Resolve the launch through the kernel's compiled-module cache: form the
+// cache key (target hash + resolved-program digest), then reuse a published
+// artifact, join an in-progress compilation, or compile as the producer.
+// Compilation modifies the module, so it always operates on a clone and
+// leaves \p mod pristine for future calls.
 static cudaq::KernelThunkResultType
 pyLaunchModule(const std::string &name, ModuleOp mod,
-               cudaq::CompiledModule *cachedModule,
+               std::shared_ptr<cudaq::detail::CompiledModuleCache> cache,
                const std::vector<void *> &rawArgs) {
   auto target = getCompileTargetImpl();
   auto targetHash = std::hash<cudaq::CompileTarget>{}(*target);
@@ -733,13 +737,13 @@ pyLaunchModule(const std::string &name, ModuleOp mod,
   // runtime arguments would invalidate the cache. Currently, synthesis is
   // all-or-nothing, but if arg-by-arg synthesis is supported, then that will
   // need to be detected.
-  bool cacheable = cachedModule && !target->fullySpecialize && targetHash != 0;
+  bool cacheable = cache && !target->fullySpecialize && targetHash != 0;
 
   // Normally, we assume that the module IR is constant given the uniqued name.
   // However, kernels with compile-time dependencies — captured kernels or
   // direct callable arguments — resolve those dependencies at launch time, so
-  // the program presented to compilation can change between calls that reuse
-  // the same decorator slot.
+  // the program presented to compilation can change between calls that share
+  // the same cache.
   bool hasCompileTimeDependencies = [&]() {
     auto func = cudaq::getKernelFuncOp(mod, name);
     for (unsigned i = 0; i < func.getNumArguments(); ++i)
@@ -763,31 +767,52 @@ pyLaunchModule(const std::string &name, ModuleOp mod,
       cacheable = false;
   }
 
-  // Cache hit: same kernel, same target configuration, same resolved program.
-  if (cacheable && cachedModule->getName() == name &&
-      cachedModule->getMetadata().targetHash == targetHash &&
-      cachedModule->getMetadata().programDigest == programDigest) {
-    CUDAQ_INFO("Reusing cached module with name {} and hash ({}, {})", name,
-               targetHash, digestLogValue(programDigest));
-    return cudaq::streamlinedLaunchModule(*cachedModule, rawArgs);
+  // Targets that cannot form a stable key deliberately bypass the cache.
+  if (!cacheable) {
+    CUDAQ_INFO("Compiling module {}", name);
+    // Launch preparation modifies the module, so compile a disposable clone
+    // and leave `mod` pristine for later calls.
+    if (!resolvedModule)
+      resolvedModule = mod.clone();
+    auto compiled = compileModuleImpl(name, resolvedModule.get(), rawArgs, true,
+                                      std::move(target));
+    return cudaq::streamlinedLaunchModule(compiled, rawArgs);
   }
 
-  CUDAQ_INFO("Compiling module {}", name);
-  // Reuse the fingerprint's resolved clone when we have one. Otherwise clone
-  // here — launching modifies the module and `mod` must stay pristine for
-  // future calls.
-  if (!resolvedModule)
-    resolvedModule = mod.clone();
-  auto compiled = compileModuleImpl(name, resolvedModule.get(), rawArgs, true,
-                                    std::move(target));
-  auto res = cudaq::streamlinedLaunchModule(compiled, rawArgs);
-  if (cacheable) {
+  cudaq::detail::CompiledModuleCache::Key key{name, targetHash, programDigest};
+  auto result = cache->getOrCompile(
+      key, [&]() -> cudaq::detail::CompiledModuleCache::SharedCompiledModule {
+        // This callback runs for exactly one caller of this key. Followers
+        // wait for its result instead of repeating the compilation.
+        CUDAQ_INFO("Compiling module {}", name);
+
+        // Reuse the fingerprint's resolved clone when we have one. Otherwise
+        // clone here — compilation modifies the module and `mod` must remain
+        // pristine for future calls.
+        if (!resolvedModule)
+          resolvedModule = mod.clone();
+        return std::make_shared<cudaq::CompiledModule>(compileModuleImpl(
+            name, resolvedModule.get(), rawArgs, true, std::move(target)));
+      });
+
+  switch (result.role) {
+  case cudaq::detail::CompiledModuleCache::Role::Producer:
     CUDAQ_INFO("Caching module {} with hash ({}, {})", name, targetHash,
                digestLogValue(programDigest));
-    compiled.setCacheKey(targetHash, programDigest);
-    *cachedModule = std::move(compiled);
+    break;
+  case cudaq::detail::CompiledModuleCache::Role::Follower:
+    CUDAQ_INFO("Joined existing compilation for module {} with hash ({}, {})",
+               name, targetHash, digestLogValue(programDigest));
+    break;
+  case cudaq::detail::CompiledModuleCache::Role::ReadyReader:
+    CUDAQ_INFO("Reusing cached module with name {} and hash ({}, {})", name,
+               targetHash, digestLogValue(programDigest));
+    break;
   }
-  return res;
+
+  // Compilation is shared; execution is not. Every producer, follower, and
+  // ready reader launches the immutable artifact for its own runtime arguments.
+  return cudaq::streamlinedLaunchModule(*result.module, rawArgs);
 }
 
 static bool isCurrentTargetFullQIR() {
@@ -999,7 +1024,7 @@ appendResultToArgsVector(cudaq::OpaqueArguments &runtimeArgs, Type returnType,
 cudaq::KernelThunkResultType
 cudaq::clean_launch_module(const std::string &name, ModuleOp mod,
                            cudaq::OpaqueArguments &args,
-                           cudaq::CompiledModule *compiled) {
+                           std::shared_ptr<detail::CompiledModuleCache> cache) {
   // Release the GIL for MLIR compilation and JIT. PyEval_SaveThread requires
   // the GIL to be held, so guard with PyGILState_Check. Async paths invoke
   // this from worker threads that never held the GIL.
@@ -1010,7 +1035,7 @@ cudaq::clean_launch_module(const std::string &name, ModuleOp mod,
   Type retTy = cudaq::runtime::getReturnType(kernelFunc);
   // Append space for a result, as needed, to the vector of arguments.
   auto rawArgs = appendResultToArgsVector(args, retTy, mod, name);
-  return pyLaunchModule(name, mod, compiled, rawArgs);
+  return pyLaunchModule(name, mod, std::move(cache), rawArgs);
 }
 
 cudaq::OpaqueArguments cudaq::marshal_arguments_for_module_launch(
@@ -1032,10 +1057,9 @@ cudaq::OpaqueArguments cudaq::marshal_arguments_for_module_launch(
   return args;
 }
 
-nanobind::object
-cudaq::marshal_and_launch_module(const std::string &name, MlirModule module,
-                                 nanobind::args runtimeArgs,
-                                 cudaq::CompiledModule *compiled) {
+nanobind::object cudaq::marshal_and_launch_module(
+    const std::string &name, MlirModule module, nanobind::args runtimeArgs,
+    std::shared_ptr<detail::CompiledModuleCache> cache) {
   // Marker span identifying every nested pass / scoped trace as part of the
   // JIT-time pipeline. Paired with the cudaq.pipeline.aot span emitted around
   // aot-prep-pipeline in compile_to_mlir; tooling reads the trace ancestry to
@@ -1058,7 +1082,7 @@ cudaq::marshal_and_launch_module(const std::string &name, MlirModule module,
   auto args = marshal_arguments_for_module_launch(mod, runtimeArgs, kernelFunc);
 
   [[maybe_unused]] auto resultPtr =
-      clean_launch_module(name, mod, args, compiled);
+      clean_launch_module(name, mod, args, std::move(cache));
 
   if (!retTy)
     return nanobind::none();
@@ -1277,8 +1301,13 @@ void cudaq::bindAltLaunchKernel(nanobind::module_ &mod,
                                 std::function<std::string()> &&getTL) {
   getTransportLayer = std::move(getTL);
 
+  nanobind::class_<cudaq::detail::CompiledModuleCache>(mod,
+                                                       "CompiledModuleCache")
+      .def(nanobind::new_([]() {
+        return std::make_shared<cudaq::detail::CompiledModuleCache>();
+      }));
+
   nanobind::class_<cudaq::CompiledModule>(mod, "CompiledModule")
-      .def(nanobind::init<>())
       .def_prop_ro(
           "entry_point",
           [](const cudaq::CompiledModule &ck) {
@@ -1286,8 +1315,7 @@ void cudaq::bindAltLaunchKernel(nanobind::module_ &mod,
           },
           "The address of the JIT-compiled entry point.")
       .def_prop_ro("name", &cudaq::CompiledModule::getName,
-                   "The kernel name this module was compiled for. Empty for a "
-                   "default-constructed (uninstalled) module.")
+                   "The kernel name this module was compiled for.")
       .def_prop_ro("is_fully_specialized",
                    &cudaq::CompiledModule::isFullySpecialized,
                    "Whether all arguments have been specialized.");
@@ -1297,11 +1325,11 @@ void cudaq::bindAltLaunchKernel(nanobind::module_ &mod,
 
   mod.def("clean_launch_module", cudaq::clean_launch_module,
           nanobind::arg("kernel_name"), nanobind::arg("module"),
-          nanobind::arg("args"), nanobind::arg("compiled").none() = nullptr,
+          nanobind::arg("args"), nanobind::arg("cache").none() = nullptr,
           "Launch a kernel. Does not perform other mischief.");
   mod.def("marshal_and_launch_module", cudaq::marshal_and_launch_module,
           nanobind::arg("kernel_name"), nanobind::arg("module"),
-          nanobind::arg("args"), nanobind::arg("compiled").none() = nullptr,
+          nanobind::arg("args"), nanobind::arg("cache").none() = nullptr,
           "Launch a kernel. Marshaling of arguments and unmarshalling of "
           "results is performed.");
   mod.def("marshal_and_retain_module", marshal_and_retain_module,

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.h
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#include "CompiledModuleCache.h"
 #include "common/CompiledModule.h"
 #include "utils/OpaqueArguments.h"
 #include "utils/PyTypes.h"
 #include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/algorithms/run.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
+#include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/complex.h>
 #include <nanobind/stl/function.h>
@@ -49,17 +51,16 @@ void bindAltLaunchKernel(nanobind::module_ &mod,
 /// resolved at this `callsite` \e prior to launching this module. In particular
 /// this means \p module is ready for beta reduction of callables. The return
 /// type is obtained from the kernel's FuncOp. \p module must be modifiable.
-nanobind::object marshal_and_launch_module(const std::string &kernelName,
-                                           MlirModule module,
-                                           nanobind::args runtimeArgs,
-                                           CompiledModule *compiled = nullptr);
+nanobind::object marshal_and_launch_module(
+    const std::string &kernelName, MlirModule module,
+    nanobind::args runtimeArgs,
+    std::shared_ptr<detail::CompiledModuleCache> cache = nullptr);
 
 /// Pure C++ code that launches a kernel. Argument marshaling and result
 /// unmarshalling is \e not performed.
-KernelThunkResultType clean_launch_module(const std::string &kernelName,
-                                          mlir::ModuleOp mod,
-                                          OpaqueArguments &args,
-                                          CompiledModule *compiled = nullptr);
+KernelThunkResultType clean_launch_module(
+    const std::string &kernelName, mlir::ModuleOp mod, OpaqueArguments &args,
+    std::shared_ptr<detail::CompiledModuleCache> cache = nullptr);
 
 /// Marshal python arguments into an OpaqueArguments for kernel launch.
 /// Encodes arguments in the runtime ABI layout for direct local simulation,

--- a/python/tests/kernel/test_caching.py
+++ b/python/tests/kernel/test_caching.py
@@ -5,8 +5,7 @@
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
-"""Correctness tests for the automatic per-kernel JIT cache living behind
-`PyKernelDecorator._compiled_module` / `PyKernel._compiled_module`."""
+"""Ownership and behavioral tests for the automatic per-kernel JIT cache."""
 
 import numpy as np
 import pytest
@@ -14,13 +13,12 @@ import pytest
 import cudaq
 
 
-def assert_cached(kernel):
-    """A cacheable launch must leave the kernel's slot populated with a module
-    that was actually compiled (non-default name)."""
-    assert hasattr(kernel, '_compiled_module'), \
-        "no _compiled_module slot was installed after launch"
-    assert kernel._compiled_module.name != "", \
-        "_compiled_module slot was installed but never written"
+def assert_owns_compiled_module_cache(kernel):
+    """A launch installs one stable cache object on its kernel owner."""
+    assert hasattr(kernel, '_compiled_module_cache')
+    cache = kernel._compiled_module_cache
+    assert kernel.compiledModuleCache() is cache
+    assert kernel.compiledModuleCache() is cache
 
 
 # ---------------------------------------------------------------------------
@@ -39,11 +37,11 @@ def test_cache_mode_call():
 
     for _ in range(3):
         assert flip() is True
-    assert_cached(flip)
+    assert_owns_compiled_module_cache(flip)
 
 
 def test_cache_mode_sample():
-    """cudaq.sample drives the kernel via __call__, sharing the 'call' slot."""
+    """cudaq.sample drives the kernel through its per-kernel cache."""
 
     @cudaq.kernel
     def ones():
@@ -53,7 +51,7 @@ def test_cache_mode_sample():
 
     for _ in range(3):
         assert cudaq.sample(ones, shots_count=1).count("111") == 1
-    assert_cached(ones)
+    assert_owns_compiled_module_cache(ones)
 
 
 def test_cache_mode_draw():
@@ -70,7 +68,7 @@ def test_cache_mode_draw():
     # Repeated draws should be stable.
     assert cudaq.draw(bell) == drawn
     assert cudaq.draw(bell) == drawn
-    assert_cached(bell)
+    assert_owns_compiled_module_cache(bell)
 
 
 def test_cache_mode_get_state():
@@ -84,7 +82,7 @@ def test_cache_mode_get_state():
     s1 = np.array(cudaq.get_state(fixed))
     s2 = np.array(cudaq.get_state(fixed))
     np.testing.assert_allclose(s1, s2)
-    assert_cached(fixed)
+    assert_owns_compiled_module_cache(fixed)
 
 
 def test_cache_mode_get_unitary():
@@ -98,6 +96,7 @@ def test_cache_mode_get_unitary():
     u1 = cudaq.get_unitary(h_kernel)
     u2 = cudaq.get_unitary(h_kernel)
     np.testing.assert_allclose(u1, u2)
+    assert_owns_compiled_module_cache(h_kernel)
 
 
 def test_cache_mode_run():
@@ -114,16 +113,18 @@ def test_cache_mode_run():
                 total += 1
         return total
 
-    # Same arg → cache hit.
+    # Repeat one runtime argument.
     for _ in range(3):
         assert all(r == 3 for r in cudaq.run(count_ones, 3, shots_count=2))
-    # Different arg → cache turnover; result must still be correct.
+    # Runtime arguments are execution inputs, so changing them must preserve
+    # both compiled-code reuse and result correctness.
     assert all(r == 6 for r in cudaq.run(count_ones, 6, shots_count=2))
     assert all(r == 3 for r in cudaq.run(count_ones, 3, shots_count=2))
+    assert_owns_compiled_module_cache(count_ones)
 
 
 def test_cache_mode_builder():
-    """PyKernel (builder) uses its own _compiled_module slot."""
+    """PyKernel (builder) owns its compiled-module cache."""
 
     kernel = cudaq.make_kernel()
     qreg = kernel.qalloc(3)
@@ -132,6 +133,37 @@ def test_cache_mode_builder():
 
     for _ in range(3):
         assert cudaq.sample(kernel, shots_count=1).count("111") == 1
+    assert_owns_compiled_module_cache(kernel)
+
+
+def test_builder_wrapper_shares_builder_cache():
+    """Transient decorator adapters retain the builder's cache identity."""
+
+    kernel = cudaq.make_kernel()
+    qubit = kernel.qalloc()
+    kernel.x(qubit)
+
+    first = np.array(cudaq.get_state(kernel))
+    cache = kernel._compiled_module_cache
+    second = np.array(cudaq.get_state(kernel))
+
+    np.testing.assert_allclose(first, second)
+    assert kernel._compiled_module_cache is cache
+
+
+def test_builder_mutation_discards_compiled_module_cache():
+    """Extending a compiled builder cannot reuse code for its old body."""
+
+    kernel = cudaq.make_kernel()
+    qubit = kernel.qalloc()
+
+    assert cudaq.sample(kernel, shots_count=1).count("0") == 1
+    old_cache = kernel._compiled_module_cache
+
+    kernel.x(qubit)
+    assert not hasattr(kernel, '_compiled_module_cache')
+    assert cudaq.sample(kernel, shots_count=1).count("1") == 1
+    assert kernel._compiled_module_cache is not old_cache
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +172,7 @@ def test_cache_mode_builder():
 
 
 def test_independent_caches_per_kernel():
-    """Two kernels must not share a cache slot."""
+    """Two kernels must not share a compiled-module cache."""
 
     @cudaq.kernel
     def all_zero():
@@ -157,10 +189,13 @@ def test_independent_caches_per_kernel():
     assert cudaq.sample(all_one, shots_count=1).count("111") == 1
     assert cudaq.sample(all_zero, shots_count=1).count("000") == 1
     assert cudaq.sample(all_one, shots_count=1).count("111") == 1
+    assert_owns_compiled_module_cache(all_zero)
+    assert_owns_compiled_module_cache(all_one)
+    assert all_zero._compiled_module_cache is not all_one._compiled_module_cache
 
 
-def test_different_args_correct_after_cache_turnover():
-    """Different concrete args force a re-JIT; results must remain correct."""
+def test_different_runtime_args_remain_correct_with_cache_reuse():
+    """Different runtime arguments must not corrupt compiled-code reuse."""
 
     @cudaq.kernel
     def all_one(n: int):
@@ -179,7 +214,7 @@ def test_different_args_correct_after_cache_turnover():
 
 
 def test_synthesized_kernel_correctness():
-    """Two syntheses of the same parent kernel must not share cache state."""
+    """Two syntheses of the same parent kernel must remain independent."""
 
     @cudaq.kernel
     def all_one(n: int):
@@ -192,7 +227,7 @@ def test_synthesized_kernel_correctness():
 
     assert cudaq.sample(synth_3, shots_count=1).count("111") == 1
     assert cudaq.sample(synth_5, shots_count=1).count("11111") == 1
-    # Repeat in reverse order — independent slots must keep results intact.
+    # Repeat in reverse order — independent caches must keep results intact.
     assert cudaq.sample(synth_5, shots_count=1).count("11111") == 1
     assert cudaq.sample(synth_3, shots_count=1).count("111") == 1
     # Parent kernel still works with arbitrary args.
@@ -255,9 +290,8 @@ def test_observe_with_different_spin_operators():
     assert ez2 == pytest.approx(np.cos(theta), abs=1e-6)
 
 
-def test_synthesized_kernel_does_not_cache():
-    """Synthesized kernels bypass the cache (is_cachable arity check fails);
-    interleaved launches must remain independent."""
+def test_synthesized_kernels_remain_independent():
+    """Interleaved launches of synthesized kernels must remain independent."""
 
     @cudaq.kernel
     def all_one(n: int):
@@ -286,7 +320,7 @@ def test_kernel_with_unused_argument():
 
     assert k(5) is True
     assert k(7) is True
-    assert_cached(k)
+    assert_owns_compiled_module_cache(k)
 
 
 def test_captured_kernel_change_reflected_after_first_launch():
@@ -313,7 +347,7 @@ def test_captured_kernel_change_reflected_after_first_launch():
 
     assert outer() is False
 
-    assert_cached(outer)
+    assert_owns_compiled_module_cache(outer)
 
 
 def test_remote_rest_target_disables_cache():

--- a/python/tests/kernel/test_caching.py
+++ b/python/tests/kernel/test_caching.py
@@ -16,9 +16,10 @@ import cudaq
 def assert_owns_compiled_module_cache(kernel):
     """A launch installs one stable cache object on its kernel owner."""
     assert hasattr(kernel, '_compiled_module_cache')
-    cache = kernel._compiled_module_cache
-    assert kernel.compiledModuleCache() is cache
-    assert kernel.compiledModuleCache() is cache
+    first_lookup = kernel.compiledModuleCache()
+    second_lookup = kernel.compiledModuleCache()
+    assert first_lookup is kernel._compiled_module_cache
+    assert second_lookup is first_lookup
 
 
 # ---------------------------------------------------------------------------
@@ -348,23 +349,3 @@ def test_captured_kernel_change_reflected_after_first_launch():
     assert outer() is False
 
     assert_owns_compiled_module_cache(outer)
-
-
-def test_remote_rest_target_disables_cache():
-    cudaq.set_target("quantinuum", emulate=True)
-    try:
-
-        @cudaq.kernel
-        def simple():
-            q = cudaq.qubit()
-            x(q)
-            mz(q)
-
-        cudaq.sample(simple, shots_count=10)
-
-        # Caching is disabled for this target: the slot must never be written
-        # with a compiled module.
-        assert (not hasattr(simple, '_compiled_module') or
-                simple._compiled_module.name == "")
-    finally:
-        cudaq.reset_target()

--- a/python/tests/mlir/compiled_module_cache.py
+++ b/python/tests/mlir/compiled_module_cache.py
@@ -13,10 +13,16 @@
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s dependencies 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=DEPENDENCIES %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s runtime_inputs 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=RUNTIME-INPUTS %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s callable_argument 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=CALLABLE-ARGUMENT %s
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s single_flight 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=SINGLE-FLIGHT %s
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s multi_entry 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=MULTI-ENTRY %s
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s fifo_eviction 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=FIFO-EVICTION %s
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s execution_failure 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=EXECUTION-FAILURE %s
 # clang-format on
 
+import concurrent.futures
 import math
 import sys
+import threading
 from typing import Callable
 
 import cudaq
@@ -243,6 +249,180 @@ def scenario_callable_argument():
 # CALLABLE-ARGUMENT-NEXT: Reusing cached module
 # CALLABLE-ARGUMENT-NOT: Compiling module
 
+
+def scenario_single_flight():
+    """Concurrent equivalent calls share one compilation."""
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qubit()
+        for _ in range(200):
+            x(q)
+
+    # Build portable Quake before starting the threads so this scenario
+    # isolates the runtime compiled-module cache.
+    kernel.compile()
+
+    thread_count = 4
+    barrier = threading.Barrier(thread_count)
+
+    def launch():
+        barrier.wait()
+        kernel()
+
+    with concurrent.futures.ThreadPoolExecutor(
+            max_workers=thread_count) as executor:
+        futures = [executor.submit(launch) for _ in range(thread_count)]
+        for future in futures:
+            future.result()
+
+
+# Exactly one caller produces the compiled artifact. Depending on scheduling,
+# the other callers either join that in-flight compilation or find it ready.
+# SINGLE-FLIGHT: Compiling module
+# SINGLE-FLIGHT-COUNT-3: {{Joined existing compilation|Reusing cached module}}
+# SINGLE-FLIGHT-NOT: Compiling module
+
+
+def scenario_multi_entry():
+    """Alternating compilation keys remain resident in one decorator cache."""
+
+    @cudaq.kernel
+    def apply_x(q: cudaq.qubit):
+        x(q)
+
+    @cudaq.kernel
+    def apply_identity(q: cudaq.qubit):
+        pass
+
+    helper = apply_x
+
+    @cudaq.kernel
+    def outer() -> bool:
+        q = cudaq.qubit()
+        helper(q)
+        return mz(q)
+
+    # A, B, A, B distinguishes a multi-entry cache from the former single
+    # slot: after compiling A and B, both later calls must be ready hits.
+    for helper, expected in ((apply_x, True), (apply_identity, False),
+                             (apply_x, True), (apply_identity, False)):
+        assert outer() is expected
+
+
+# Two distinct keys compile once each, then both remain resident.
+# MULTI-ENTRY: Compiling module
+# MULTI-ENTRY-NEXT: Caching module
+# MULTI-ENTRY-NEXT: Compiling module
+# MULTI-ENTRY-NEXT: Caching module
+# MULTI-ENTRY-NEXT: Reusing cached module
+# MULTI-ENTRY-NEXT: Reusing cached module
+# MULTI-ENTRY-NOT: Compiling module
+
+
+def scenario_fifo_eviction():
+    """Ready entries use bounded, non-refreshing FIFO eviction."""
+
+    @cudaq.kernel
+    def apply_x(q: cudaq.qubit):
+        x(q)
+
+    @cudaq.kernel
+    def apply_identity(q: cudaq.qubit):
+        pass
+
+    @cudaq.kernel
+    def apply_y(q: cudaq.qubit):
+        y(q)
+
+    @cudaq.kernel
+    def apply_z(q: cudaq.qubit):
+        z(q)
+
+    @cudaq.kernel
+    def apply_s(q: cudaq.qubit):
+        s(q)
+
+    helper = apply_x
+
+    @cudaq.kernel
+    def outer() -> bool:
+        q = cudaq.qubit()
+        helper(q)
+        return mz(q)
+
+    launches = (
+        # A, B, C, D fill the four ready-entry slots.
+        (apply_x, True),
+        (apply_identity, False),
+        (apply_y, True),
+        (apply_z, False),
+        # A is a hit, but FIFO deliberately does not refresh its position.
+        (apply_x, True),
+        # E therefore evicts A, and the final A must compile again.
+        (apply_s, False),
+        (apply_x, True),
+    )
+    for helper, expected in launches:
+        assert outer() is expected
+
+
+# A, B, C, D compile; hitting A does not refresh it; inserting E evicts A.
+# FIFO-EVICTION: Compiling module
+# FIFO-EVICTION-NEXT: Caching module
+# FIFO-EVICTION-NEXT: Compiling module
+# FIFO-EVICTION-NEXT: Caching module
+# FIFO-EVICTION-NEXT: Compiling module
+# FIFO-EVICTION-NEXT: Caching module
+# FIFO-EVICTION-NEXT: Compiling module
+# FIFO-EVICTION-NEXT: Caching module
+# FIFO-EVICTION-NEXT: Reusing cached module
+# FIFO-EVICTION-NEXT: Compiling module
+# FIFO-EVICTION-NEXT: Caching module
+# FIFO-EVICTION-NEXT: Compiling module
+# FIFO-EVICTION-NEXT: Caching module
+# FIFO-EVICTION-NOT: Compiling module
+
+
+def scenario_execution_failure():
+    """Execution errors do not invalidate successful compilation.
+
+    Compilation of `failing` succeeds; the adjoint synthesis error is raised
+    at execution time. The artifact therefore stays published: the second
+    call reuses it and fails with the same error. This also guards the
+    `getOrCompile` contract that the compile callback contains no execution —
+    if execution moved inside the callback, the failure would erase the
+    published entry and the second call would recompile.
+    """
+
+    @cudaq.kernel
+    def unadjointable(q: cudaq.qview):
+        while True:
+            if mz(q[1]):
+                x(q[1])
+                break
+
+    @cudaq.kernel
+    def failing():
+        q = cudaq.qvector(2)
+        h(q)
+        cudaq.adjoint(unadjointable, q)
+
+    for _ in range(2):
+        try:
+            cudaq.sample(failing, shots_count=1)
+        except RuntimeError as error:
+            assert "could not autogenerate the adjoint" in str(error).lower()
+        else:
+            raise AssertionError("unadjointable kernel unexpectedly executed")
+
+
+# One compile, published before the execution error; the second call reuses.
+# EXECUTION-FAILURE: Compiling module
+# EXECUTION-FAILURE-NEXT: Caching module
+# EXECUTION-FAILURE-NEXT: Reusing cached module
+# EXECUTION-FAILURE-NOT: Compiling module
+
 SCENARIOS = {
     "run": scenario_run,
     "sample": scenario_sample,
@@ -250,6 +430,10 @@ SCENARIOS = {
     "dependencies": scenario_dependencies,
     "runtime_inputs": scenario_runtime_inputs,
     "callable_argument": scenario_callable_argument,
+    "single_flight": scenario_single_flight,
+    "multi_entry": scenario_multi_entry,
+    "fifo_eviction": scenario_fifo_eviction,
+    "execution_failure": scenario_execution_failure,
 }
 
 if __name__ == "__main__":

--- a/python/tests/mlir/compiled_module_cache.py
+++ b/python/tests/mlir/compiled_module_cache.py
@@ -9,6 +9,8 @@
 # clang-format off
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s run 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=RUNLOOP %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s sample 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=SAMPLE %s
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s fully_specialized > %t.fully_specialized 2>&1 || (cat %t.fully_specialized && false)
+# RUN: grep 'py_alt_launch_kernel.cpp' %t.fully_specialized | FileCheck --check-prefix=FULLY-SPECIALIZED --implicit-check-not='Caching module' --implicit-check-not='Reusing cached module' --implicit-check-not='Joined existing compilation' %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s captured 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=CAPTURED %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s dependencies 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=DEPENDENCIES %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s runtime_inputs 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=RUNTIME-INPUTS %s
@@ -72,6 +74,29 @@ def scenario_sample():
 # SAMPLE-NOT: Compiling module
 # SAMPLE: Reusing cached module
 # SAMPLE-NOT: Compiling module
+
+
+def scenario_fully_specialized():
+    """Fully specialized remote targets bypass the compiled-module cache."""
+    cudaq.set_target("quantinuum", emulate=True)
+    try:
+
+        @cudaq.kernel
+        def all_ones(n: int):
+            qubits = cudaq.qvector(n)
+            for qubit in qubits:
+                x(qubit)
+            mz(qubits)
+
+        assert cudaq.sample(all_ones, 1, shots_count=10).count("1") == 10
+        assert cudaq.sample(all_ones, 3, shots_count=10).count("111") == 10
+    finally:
+        cudaq.reset_target()
+
+
+# Both launches compile independently and neither artifact enters the cache.
+# FULLY-SPECIALIZED-COUNT-2: Compiling module
+# FULLY-SPECIALIZED-NOT: Compiling module
 
 
 def scenario_captured():
@@ -420,6 +445,7 @@ def scenario_execution_failure():
 SCENARIOS = {
     "run": scenario_run,
     "sample": scenario_sample,
+    "fully_specialized": scenario_fully_specialized,
     "captured": scenario_captured,
     "dependencies": scenario_dependencies,
     "runtime_inputs": scenario_runtime_inputs,

--- a/python/tests/mlir/compiled_module_cache.py
+++ b/python/tests/mlir/compiled_module_cache.py
@@ -16,7 +16,8 @@
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s single_flight 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=SINGLE-FLIGHT %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s multi_entry 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=MULTI-ENTRY %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s fifo_eviction 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=FIFO-EVICTION %s
-# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s execution_failure 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=EXECUTION-FAILURE %s
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s execution_failure > %t.execution_failure 2>&1 || (cat %t.execution_failure && false)
+# RUN: grep 'py_alt_launch_kernel.cpp' %t.execution_failure | FileCheck --check-prefix=EXECUTION-FAILURE %s
 # clang-format on
 
 import concurrent.futures
@@ -387,34 +388,27 @@ def scenario_fifo_eviction():
 def scenario_execution_failure():
     """Execution errors do not invalidate successful compilation.
 
-    Compilation of `failing` succeeds; the adjoint synthesis error is raised
-    at execution time. The artifact therefore stays published: the second
-    call reuses it and fails with the same error. This also guards the
-    `getOrCompile` contract that the compile callback contains no execution —
-    if execution moved inside the callback, the failure would erase the
-    published entry and the second call would recompile.
+    The qubit count is a runtime input, so compilation of `failing` succeeds
+    before execution detects that the Pauli word and register sizes differ.
+    The artifact therefore stays published: the second call reuses it and
+    fails with the same error. This also guards the `getOrCompile` contract
+    that the compile callback contains no execution — if execution moved
+    inside the callback, the attempt would fail before publication and the
+    second call would compile again.
     """
 
     @cudaq.kernel
-    def unadjointable(q: cudaq.qview):
-        while True:
-            if mz(q[1]):
-                x(q[1])
-                break
-
-    @cudaq.kernel
-    def failing():
-        q = cudaq.qvector(2)
-        h(q)
-        cudaq.adjoint(unadjointable, q)
+    def failing(n: int):
+        q = cudaq.qvector(n)
+        exp_pauli(1.0, q, "XX")
 
     for _ in range(2):
         try:
-            cudaq.sample(failing, shots_count=1)
+            cudaq.sample(failing, 1, shots_count=1)
         except RuntimeError as error:
-            assert "could not autogenerate the adjoint" in str(error).lower()
+            assert "incorrect number of qubits" in str(error)
         else:
-            raise AssertionError("unadjointable kernel unexpectedly executed")
+            raise AssertionError("mismatched exp_pauli unexpectedly succeeded")
 
 
 # One compile, published before the execution error; the second call reuses.

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -102,9 +102,3 @@ const void *cudaq::SourceModule::getMlirOpaqueModulePtr() const {
     return nullptr;
   return mlirArt->getOpaqueModulePtr();
 }
-
-void cudaq::CompiledModule::setCacheKey(
-    std::size_t targetHash, const std::array<std::uint8_t, 32> &programDigest) {
-  metadata.targetHash = targetHash;
-  metadata.programDigest = programDigest;
-}

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -10,7 +10,6 @@
 #include "common/NamedVariantStore.h"
 #include "common/Resources.h"
 #include "common/ThunkInterface.h"
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -192,14 +191,6 @@ public:
     std::vector<std::size_t> reorderIdx;
     /// Whether the kernel has conditional feedback on measure results.
     bool hasConditionalsOnMeasureResults = false;
-    /// Hash of the CompileTarget used to compile this module.
-    std::size_t targetHash = 0;
-    /// SHA-256 digest of the resolved program presented to compilation: the
-    /// module IR with all callable closures merged in, plus every argument
-    /// substitution generated for compile-time-bound (callable) arguments.
-    /// Only set for kernels with such compile-time dependencies; stays
-    /// all-zeros otherwise.
-    std::array<std::uint8_t, 32> programDigest = {};
   };
 
   // --- Queries ---
@@ -326,10 +317,6 @@ public:
   // `CompiledModuleHelper`.
   CompiledModule() : FatQuakeModule(std::string{}) {}
   explicit CompiledModule(SourceModule src) : FatQuakeModule(std::move(src)) {}
-
-  /// Stamp the cache key (targetHash + programDigest) for the compiled module.
-  void setCacheKey(std::size_t targetHash,
-                   const std::array<std::uint8_t, 32> &programDigest);
 };
 
 using AnyModule = std::variant<SourceModule, CompiledModule>;


### PR DESCRIPTION
### Summary

Replaces the Python launch path's mutable one-module cache slot, passed as a `CompiledModule *`, with a shared, per-kernel `CompiledModuleCache`.

The new cache:

- gives each caller stable ownership of an immutable `shared_ptr<const CompiledModule>`;
- single-flights equivalent concurrent requests: at most one caller produces a missing key, callers that observe the attempt in progress join it, and later callers read the ready artifact;
- retains up to four ready artifacts, allowing several compilation keys to remain resident; and
- keeps compilation separate from execution, so every caller executes the shared artifact with its own runtime arguments.

### Motivation

[PR-4978 ](https://github.com/NVIDIA/cuda-quantum/pull/4978) made cache identity correct, but left three storage and concurrency problems in the one-slot container.

1. The slot could be read and overwritten concurrently: A cache hit read the stored `CompiledModule`, while a miss later assigned a newly compiled module into the same object. Both paths run with the Python GIL released. An unsynchronized read and write of that C++ object is a data race, and a caller has no stable ownership of the cache entry while another caller publishes a different key.

2. Equivalent concurrent misses could compile the same program more than once: Nothing claimed the missing key before starting the expensive compile/JIT path.

3. One slot cannot retain alternating compilation keys: For the launch sequence `A, B, A, B`, the resulting cache behavior is:

   | Container | Compilations | Ready hits |
   |---|---:|---:|
   | old one-module slot | 4 | 0 |
   | new four-entry ready cache | 2 | 2 |

### Design

#### Ownership

```text
BEFORE                                  AFTER
==================================      =====================================

PyKernelDecorator / PyKernel            PyKernelDecorator / PyKernel
        |                                       |
        v                                       v
mutable CompiledModule slot             shared_ptr<CompiledModuleCache>
        |                                       |
        | raw pointer passed to launch          +-- Ready entries (FIFO, max 4)
        |                                           Key
        | overwritten for another key               -> shared_ptr<const CM>
        |                                       |
        +-- caller does not own an entry         +-- Compiling entries
                                                    Key
                                                    -> shared promise/future

                                            caller receives its own shared_ptr
                                            |
                                            +-- eviction or cache reset cannot
                                                invalidate its artifact
```

`CompiledModuleCache::Key` contains `{kernelName, targetHash, programDigest}`. `kernelName` remains part of the key
because `cudaq.run` launches `<uniqName>.run`, a different entry point from `<uniqName>`.

The cache inherits `std::enable_shared_from_this` so nanobind can reuse the native `shared_ptr` control block when the object crosses the Python boundary. That avoids replacing it with a Python-backed control block whose deletion
logic may need the GIL when an asynchronous worker releases the final owner.

#### Single-flight protocol

`getOrCompile()` resolves one of three roles while holding `cacheMutex`, then releases the mutex before compiling or waiting:

```text
getOrCompile(key)
  |
  +-- lock cacheMutex
  |
  +-- key is Ready? -------- yes --> copy module -----> ReadyReader
  |
  +-- key is Compiling? ---- yes --> retain attempt --> Follower
  |
  +-- otherwise -----------------> install attempt ---> Producer
  |
  +-- unlock cacheMutex
          |
          +-- ReadyReader --> return module
          |
          +-- Follower ----> completion.get()  (no mutex)
          |
          +-- Producer ----> compile()     (no mutex)
                                  |
                         +--------+--------+
                         | success         | exception
                         v                 v
                    publish Ready     remove attempt
                    remove attempt    set_exception()
                    set_value()       rethrow
```

Installing `Compiling` before unlocking makes the `Missing -> Compiling` decision atomic for one key: while that state remains `Compiling`, another equivalent caller must become a follower rather than a second producer. Different keys can still compile concurrently. Neither compilation nor `shared_future::get()` runs under the cache mutex.

The cache does not manage the Python GIL. `clean_launch_module` already releases it before entering this path; a follower must not wait while holding either the GIL or `cacheMutex`.
