### PR TITLE
Static-link CUDA runtime in cudaq-realtime UDP bridge provider

### DIFF
--- a/realtime/CMakeLists.txt
+++ b/realtime/CMakeLists.txt
@@ -171,16 +171,7 @@ if (CUDAQ_REALTIME_BUILD_EXAMPLES)
 endif()
 
 if (CUDAQ_REALTIME_BUILD_TESTS)
-  add_custom_target(CudaqRealtimeUnitTests)
   include(CTest)
-
-  add_custom_target(run_tests
-    COMMAND ${CMAKE_COMMAND} -E env 
-            PYTHONPATH="${CUDAQ_INSTALL_DIR}:${CMAKE_BINARY_DIR}/python"
-            ${CMAKE_CTEST_COMMAND} --output-on-failure
-    DEPENDS CudaqRealtimeUnitTests
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
   add_subdirectory(unittests)
 endif()
 

--- a/realtime/lib/daemon/bridge/udp/CMakeLists.txt
+++ b/realtime/lib/daemon/bridge/udp/CMakeLists.txt
@@ -27,7 +27,8 @@ target_link_libraries(cudaq-realtime-bridge-udp
     Threads::Threads
     # --pinned-rings allocates CUDA pinned+mapped ring memory for GPU
     # consumers; no GPU is touched unless the flag is used.
-    CUDA::cudart
+    # Static link, so only the build host need to toolkit, not the runtime host.
+    CUDA::cudart_static
 )
 
 set_target_properties(cudaq-realtime-bridge-udp PROPERTIES

--- a/realtime/unittests/CMakeLists.txt
+++ b/realtime/unittests/CMakeLists.txt
@@ -75,7 +75,6 @@ if(CMAKE_CUDA_COMPILER)
     ${CUDADEVRT_LIBRARY}
   )
   
-  add_dependencies(CudaqRealtimeUnitTests test_dispatch_kernel)
   cudaq_gtest_discover_tests(test_dispatch_kernel
     TEST_PREFIX "test_dispatch_kernel."
   )
@@ -100,7 +99,6 @@ if(CMAKE_CUDA_COMPILER)
     cudaq-realtime-host-dispatch
     ${CUDADEVRT_LIBRARY}
   )
-  add_dependencies(CudaqRealtimeUnitTests test_host_dispatcher)
   cudaq_gtest_discover_tests(test_host_dispatcher
     TEST_PREFIX "test_host_dispatcher."
   )
@@ -116,6 +114,10 @@ if (CUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS)
   add_subdirectory(utils)
   add_subdirectory(bridge_interface/hololink)
 endif()
+
+# UDP bridge provider tests: self-gated on the always-built udp provider
+# target, so they run in CI without any hololink/RDMA setup.
+add_subdirectory(bridge_interface/udp)
 
 # CPU RoCE transport (Phase 1 of cpu_transport umbrella).
 # Self-gates on TARGET cudaq-realtime-cpu-roce-transport so this is harmless when

--- a/realtime/unittests/bridge_interface/udp/CMakeLists.txt
+++ b/realtime/unittests/bridge_interface/udp/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# UDP bridge provider tests
+# ==============================================================================
+
+# Functional: load the built provider by absolute path and bring a plain
+# (non-pinned) udp bridge up through the v2 queries.  Links only the bridge
+# loader (cudaq-realtime), NOT the CUDA runtime, so a regressed dynamic cudart
+# dependency in the provider fails this test on a CUDA-runtime-less host.
+add_executable(test_udp_bridge_provider test_udp_bridge_provider.cpp)
+
+target_compile_definitions(test_udp_bridge_provider PRIVATE
+  UDP_BRIDGE_PROVIDER_PATH="$<TARGET_FILE:cudaq-realtime-bridge-udp>"
+)
+
+target_link_libraries(test_udp_bridge_provider PRIVATE
+  GTest::gtest_main
+  cudaq-realtime
+)
+
+cudaq_gtest_discover_tests(test_udp_bridge_provider DISCOVERY_TIMEOUT 120)

--- a/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
+++ b/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// @file test_udp_bridge_provider.cpp
+/// @brief Load-time contract test for the UDP bridge provider.
+///
+/// A plain (non --pinned-rings) UDP bridge must come up with NO CUDA runtime
+/// present: the udp wire is CUDA-free by design and CUDA is only touched when
+/// --pinned-rings is passed.  This test links only the bridge loader
+/// (cudaq-realtime), NOT the CUDA runtime, and loads the built provider by
+/// absolute path.  If the provider .so regresses to a dynamic dependency on
+/// libcudart, its dlopen fails here on a host without a CUDA runtime, and
+/// cudaq_bridge_create_from_library returns an error instead of CUDAQ_OK.
+
+#include "cudaq/realtime/daemon/bridge/bridge_interface.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifndef UDP_BRIDGE_PROVIDER_PATH
+#error "UDP_BRIDGE_PROVIDER_PATH must be defined (path to the built udp provider .so)"
+#endif
+
+TEST(UdpBridgeProvider, LoadsAndCreatesPlainBridgeWithoutCudaRuntime) {
+  std::vector<std::string> args = {"--port=0", "--num-slots=8",
+                                   "--slot-size=256"};
+  std::vector<char *> argv;
+  for (auto &a : args)
+    argv.push_back(a.data());
+
+  cudaq_realtime_bridge_handle_t bridge = nullptr;
+  const cudaq_status_t rc = cudaq_bridge_create_from_library(
+      &bridge, UDP_BRIDGE_PROVIDER_PATH, static_cast<int>(argv.size()),
+      argv.data());
+  ASSERT_EQ(rc, CUDAQ_OK)
+      << "Failed to load/create the udp bridge provider '"
+      << UDP_BRIDGE_PROVIDER_PATH
+      << "'. A dynamic dependency on the CUDA runtime (libcudart) makes the "
+         "plain (non-pinned) UDP path unloadable on hosts without a CUDA "
+         "runtime installed; link the CUDA runtime statically instead.";
+  ASSERT_NE(bridge, nullptr);
+
+  // Geometry and endpoint identity come from the provider's v2 queries.
+  uint32_t num_slots = 0;
+  uint32_t slot_size = 0;
+  EXPECT_EQ(cudaq_bridge_get_ring_geometry(bridge, &num_slots, &slot_size),
+            CUDAQ_OK);
+  EXPECT_EQ(num_slots, 8u);
+  EXPECT_EQ(slot_size, 256u);
+
+  char endpoint[256] = {0};
+  EXPECT_EQ(cudaq_bridge_get_endpoint_info(bridge, endpoint, sizeof(endpoint)),
+            CUDAQ_OK);
+  EXPECT_NE(std::strstr(endpoint, "transport=udp"), nullptr);
+
+  EXPECT_EQ(cudaq_bridge_destroy(bridge), CUDAQ_OK);
+}

--- a/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
+++ b/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
@@ -27,7 +27,8 @@
 #include <vector>
 
 #ifndef UDP_BRIDGE_PROVIDER_PATH
-#error "UDP_BRIDGE_PROVIDER_PATH must be defined (path to the built udp provider .so)"
+#error                                                                         \
+    "UDP_BRIDGE_PROVIDER_PATH must be defined (path to the built udp provider .so)"
 #endif
 
 TEST(UdpBridgeProvider, LoadsAndCreatesPlainBridgeWithoutCudaRuntime) {

--- a/realtime/unittests/cpu_transport/CMakeLists.txt
+++ b/realtime/unittests/cpu_transport/CMakeLists.txt
@@ -40,7 +40,6 @@ if (TARGET cudaq-realtime-udp-transport)
     Threads::Threads
   )
 
-  add_dependencies(CudaqRealtimeUnitTests test_udp_transceiver)
   gtest_discover_tests(test_udp_transceiver
     TEST_PREFIX "test_udp_transceiver."
   )


### PR DESCRIPTION
## Summary

The UDP bridge provider (`libcudaq-realtime-bridge-udp.so`) dynamically linked `CUDA::cudart`, giving it a `NEEDED` dependency on `libcudart.so.*`. Only the optional `--pinned-rings` path touches CUDA (pinned+mapped ring memory); the plain (non-pinned) UDP path uses no GPU. That dynamic dependency made the provider unloadable on hosts without a CUDA runtime installed (e.g. the `decoding_server` `dlopen`'ing it at runtime).

## Changes

- **Fix**: link the CUDA runtime statically (`CUDA::cudart_static`) in the UDP bridge provider, so only the build host needs the toolkit, not the runtime host.
- **Regression test**: `test_udp_bridge_provider` `dlopen`s the built provider by absolute path and brings up a plain UDP bridge, linking only `cudaq-realtime` (not the CUDA runtime), so a regressed dynamic `cudart` dependency fails the test on a CUDA-runtime-less host.
- **Cleanup**: To reduce maintenance, drop the undocumented `CudaqRealtimeUnitTests` / `run_tests` aggregate targets and the per-test `add_dependencies` boilerplate. Test executables are in the default `all` target, so the documented `ninja && ctest` flow already builds and runs them.

