### PR TITLE
[Transformation] Harden `veq` control expansion for polarity and wire semantics

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/ExpandControlVeqs.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ExpandControlVeqs.cpp
@@ -33,6 +33,8 @@ public:
     // so we must track a new list of controls and reconstruct the operands
     // instead of replacing the controls in place.
     SmallVector<Value> newControls;
+    SmallVector<bool> newNegatedControls;
+    auto negatedControls = op.getNegatedQubitControls();
     bool update = false;
 
     // Search through the controls for veqs with known sizes
@@ -58,13 +60,22 @@ public:
           newControls.push_back(ext);
           update = true;
         }
+
+        if (negatedControls)
+          newNegatedControls.append(*size, (*negatedControls)[index]);
       } else {
         newControls.push_back(control);
+        if (negatedControls)
+          newNegatedControls.push_back((*negatedControls)[index]);
       }
     }
 
     if (!update)
       return failure();
+
+    DenseBoolArrayAttr negatedControlsAttr;
+    if (negatedControls)
+      negatedControlsAttr = rewriter.getDenseBoolArrayAttr(newNegatedControls);
 
     // Reconstruct the operation with the new controls
     auto segmentSizes = rewriter.getDenseI32ArrayAttr(
@@ -73,8 +84,8 @@ public:
          static_cast<int32_t>(op.getTargets().size())});
 
     auto newOp = rewriter.replaceOpWithNewOp<OP>(
-        op, op.getIsAdj(), op.getParameters(), newControls, op.getTargets(),
-        op.getNegatedQubitControlsAttr());
+        op, op.getResultTypes(), op.getIsAdjAttr(), op.getParameters(),
+        newControls, op.getTargets(), negatedControlsAttr);
 
     newOp->setAttr("operand_segment_sizes", segmentSizes);
 

--- a/cudaq/test/Transforms/expand_veqs.qke
+++ b/cudaq/test/Transforms/expand_veqs.qke
@@ -53,3 +53,51 @@ func.func @noreplace() {
 // CHECK:         %[[VAL_3:.*]] = quake.alloca !quake.ref
 // CHECK:         %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK:         quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
+
+func.func @negative_vector_control() {
+  %controls = quake.alloca !quake.veq<2>
+  %target = quake.alloca !quake.ref
+  quake.x [%controls neg [true]] %target : (!quake.veq<2>, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @negative_vector_control() {
+// CHECK:         %[[CONTROLS:.*]] = quake.alloca !quake.veq<2>
+// CHECK:         %[[TARGET:.*]] = quake.alloca !quake.ref
+// CHECK:         %[[CONTROL_0:.*]] = quake.extract_ref %[[CONTROLS]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK-NEXT:    %[[CONTROL_1:.*]] = quake.extract_ref %[[CONTROLS]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK-NEXT:    quake.x [%[[CONTROL_0]], %[[CONTROL_1]] neg [true, true]] %[[TARGET]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
+
+func.func @mixed_control_polarities() {
+  %left = quake.alloca !quake.ref
+  %vector = quake.alloca !quake.veq<2>
+  %right = quake.alloca !quake.ref
+  %target = quake.alloca !quake.ref
+  quake.x [%left, %vector, %right neg [true, false, true]] %target : (!quake.ref, !quake.veq<2>, !quake.ref, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @mixed_control_polarities() {
+// CHECK:         %[[LEFT:.*]] = quake.alloca !quake.ref
+// CHECK:         %[[VECTOR:.*]] = quake.alloca !quake.veq<2>
+// CHECK:         %[[RIGHT:.*]] = quake.alloca !quake.ref
+// CHECK:         %[[MIXED_TARGET:.*]] = quake.alloca !quake.ref
+// CHECK:         %[[VECTOR_CONTROL_0:.*]] = quake.extract_ref %[[VECTOR]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK-NEXT:    %[[VECTOR_CONTROL_1:.*]] = quake.extract_ref %[[VECTOR]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK-NEXT:    quake.x [%[[LEFT]], %[[VECTOR_CONTROL_0]], %[[VECTOR_CONTROL_1]], %[[RIGHT]] neg [true, false, false, true]] %[[MIXED_TARGET]] : (!quake.ref, !quake.ref, !quake.ref, !quake.ref, !quake.ref) -> ()
+
+func.func @preserve_wire_result() {
+  %controls = quake.alloca !quake.veq<2>
+  %target = quake.null_wire
+  %next = quake.x [%controls] %target : (!quake.veq<2>, !quake.wire) -> !quake.wire
+  quake.sink %next : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @preserve_wire_result() {
+// CHECK:         %[[WIRE_CONTROLS:.*]] = quake.alloca !quake.veq<2>
+// CHECK:         %[[WIRE_TARGET:.*]] = quake.null_wire
+// CHECK:         %[[WIRE_CONTROL_0:.*]] = quake.extract_ref %[[WIRE_CONTROLS]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK-NEXT:    %[[WIRE_CONTROL_1:.*]] = quake.extract_ref %[[WIRE_CONTROLS]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK-NEXT:    %[[NEXT:.*]] = quake.x [%[[WIRE_CONTROL_0]], %[[WIRE_CONTROL_1]]] %[[WIRE_TARGET]] : (!quake.ref, !quake.ref, !quake.wire) -> !quake.wire
+// CHECK-NEXT:    quake.sink %[[NEXT]] : !quake.wire

--- a/cudaq/test/Transforms/expand_veqs_relaxsize.qke
+++ b/cudaq/test/Transforms/expand_veqs_relaxsize.qke
@@ -45,3 +45,19 @@ func.func @relaxsize_3() {
 // CHECK:         %[[C1:.*]] = quake.extract_ref %[[SUB]][1] : (!quake.veq<3>) -> !quake.ref
 // CHECK:         %[[C2:.*]] = quake.extract_ref %[[SUB]][2] : (!quake.veq<3>) -> !quake.ref
 // CHECK:         quake.x [%[[C0]], %[[C1]], %[[C2]]] %[[TARGET]] : (!quake.ref, !quake.ref, !quake.ref, !quake.ref) -> ()
+
+func.func @relaxsize_negative_control() {
+  %q = quake.alloca !quake.veq<2>
+  %relaxed = quake.relax_size %q : (!quake.veq<2>) -> !quake.veq<?>
+  %target = quake.alloca !quake.ref
+  quake.x [%relaxed neg [true]] %target : (!quake.veq<?>, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @relaxsize_negative_control() {
+// CHECK:         %[[SIZED:.*]] = quake.alloca !quake.veq<2>
+// CHECK:         %[[RELAXED:.*]] = quake.relax_size %[[SIZED]] : (!quake.veq<2>) -> !quake.veq<?>
+// CHECK:         %[[NEG_TARGET:.*]] = quake.alloca !quake.ref
+// CHECK:         %[[NEG_C0:.*]] = quake.extract_ref %[[SIZED]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:         %[[NEG_C1:.*]] = quake.extract_ref %[[SIZED]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:         quake.x [%[[NEG_C0]], %[[NEG_C1]] neg [true, true]] %[[NEG_TARGET]] : (!quake.ref, !quake.ref, !quake.ref) -> ()


### PR DESCRIPTION
## Overview
In [`ExpandControlVeqs.cpp`](http://github.com/NVIDIA/cuda-quantum/blob/main/cudaq/lib/Optimizer/Transforms/ExpandControlVeqs.cpp), control qubits that are packaged in a `veq` are broken out into individual control references. However, if the `veq` is marked as a negative control, e.g.,
```mlir
quake.x [%controls neg [true]] %target : (!quake.veq<2>, !quake.ref) -> ()
```
the current `--expand-control-veqs` pass will output
```mlir
quake.x [%2, %3 neg [true]] %1 : (!quake.ref, !quake.ref, !quake.ref) -> ()
```

From the example, we see that the negative control boolean array does not expand the control polarities for all of the qubits that were extracted from the `veq` of control. 

The desired behavior would instead be
```mlir
quake.x [%2, %3 neg [true, true]] %1 : (!quake.ref, !quake.ref, !quake.ref) -> ()
```
where the salient change is the additional `bool` for the second of the two control qubits.

This PR addresses this by expanding the boolean control array if the `veq` is marked as having negative controls, and then using that information when building the new op with expanded controls and control polarities. Along with the above example as a test, we also verify that the case of mixed polarities, e.g., a mix of scalar and `veq` controls as input, and the case of wire-semantics gate with `veq` controls, e.g.,
```mlir
func.func @mixed_control_polarities() {
  %left = quake.alloca !quake.ref
  %vector = quake.alloca !quake.veq<2>
  %right = quake.alloca !quake.ref
  %target = quake.alloca !quake.ref
  quake.x [%left, %vector, %right neg [true, false, true]] %target : (!quake.ref, !quake.veq<2>, !quake.ref, !quake.ref) -> ()
  return
}
```