### PR TITLE
Converting tests to be compatible with nvq++

### DIFF
--- a/runtime/cudaq/apply_noise.h
+++ b/runtime/cudaq/apply_noise.h
@@ -70,7 +70,8 @@ constexpr bool any_float = std::disjunction_v<
 template <typename T, typename... Q>
   requires(std::derived_from<T, cudaq::kraus_channel> && !any_float<Q...> &&
            TARGET_OK_FOR_APPLY_NOISE)
-void apply_noise(const std::vector<double> &params, Q &&...args) {
+__attribute__((noinline)) void apply_noise(const std::vector<double> &params,
+                                           Q &&...args) {
   auto &platform = get_platform();
   const auto *noiseModel = platform.get_noise();
 
@@ -121,7 +122,7 @@ constexpr bool any_vector_of_float = std::disjunction_v<std::is_same<
 template <typename T, typename... Args>
   requires(std::derived_from<T, cudaq::kraus_channel> &&
            !any_vector_of_float<Args...> && TARGET_OK_FOR_APPLY_NOISE)
-void apply_noise(Args &&...args) {
+__attribute__((noinline)) void apply_noise(Args &&...args) {
   constexpr auto ctor_arity = count_leading_floats<0, Args...>();
   constexpr auto qubit_arity = sizeof...(args) - ctor_arity;
 

--- a/runtime/cudaq/domains/chemistry/uccsd.h
+++ b/runtime/cudaq/domains/chemistry/uccsd.h
@@ -112,6 +112,11 @@ auto uccsd_num_parameters(std::size_t numElectrons, std::size_t numQubits) {
          doublesAlpha.size() + doublesBeta.size();
 }
 
+// The __qpu__ UCCSD helpers below use cudaq::excitations with structured
+// bindings. nvq++ cannot lower that type yet ("unhandled type, excitations"),
+// so keep these entry points for CUDAQ_LIBRARY_MODE only. nvq++ callers should
+// use the kernel_builder overloads instead.
+#ifdef CUDAQ_LIBRARY_MODE
 __qpu__ void singleExcitation(cudaq::qview<> qubits, std::size_t pOcc,
                               std::size_t qVirt, double theta) {
   // Y_p X_q
@@ -144,6 +149,7 @@ __qpu__ void singleExcitation(cudaq::qview<> qubits, std::size_t pOcc,
   rx(-M_PI_2, qubits[qVirt]);
   h(qubits[pOcc]);
 }
+#endif
 
 template <typename Kernel>
 void singleExcitation(Kernel &kernel, QuakeValue &qubits, std::size_t pOcc,
@@ -370,6 +376,7 @@ void doubleExcitation(Kernel &kernel, QuakeValue &qubits, std::size_t pOcc,
   kernel.rx(-M_PI_2, qubits[iOcc]);
 }
 
+#ifdef CUDAQ_LIBRARY_MODE
 __qpu__ void doubleExcitation(cudaq::qview<> qubits, std::size_t pOcc,
                               std::size_t qOcc, std::size_t rVirt,
                               std::size_t sVirt, double theta) {
@@ -594,6 +601,7 @@ __qpu__ void uccsd(cudaq::qview<> qubits, const std::vector<double> &thetas,
                      doublesBeta[i][2], doublesBeta[i][3],
                      thetas[thetaCounter++]);
 }
+#endif
 
 template <typename Kernel>
 void uccsd(Kernel &kernel, QuakeValue &qubits, QuakeValue &thetas,

--- a/runtime/cudaq/kernels/fermionic_swap.h
+++ b/runtime/cudaq/kernels/fermionic_swap.h
@@ -9,7 +9,7 @@
 #pragma once
 #include "cudaq/builder/kernel_builder.h"
 #include <cudaq.h>
-namespace cudaq {
+namespace cudaq_internal {
 /// @brief Apply global phase (e^(i * theta)).
 /// Note: since this is a global phase, the qubit operand can be selected
 /// arbitrarily from the qubit register to which the global phase is applied.
@@ -109,4 +109,4 @@ void fermionic_swap(KernelBuilder &kernel, double phi, cudaq::QuakeValue q0,
   fermionic_swap(kernel, kernel.constantVal(phi), q0, q1);
 }
 } // namespace builder
-} // namespace cudaq
+} // namespace cudaq_internal

--- a/runtime/cudaq/kernels/givens_rotation.h
+++ b/runtime/cudaq/kernels/givens_rotation.h
@@ -9,7 +9,7 @@
 #pragma once
 #include <cudaq.h>
 
-namespace cudaq {
+namespace cudaq_internal {
 /// @brief Implement Givens rotation at a specific angle
 ///
 /// This kernel is equivalent to matrix exp(-i theta (YX - XY) / 2)
@@ -54,4 +54,4 @@ void givens_rotation(KernelBuilder &kernel, double theta, cudaq::QuakeValue q0,
   givens_rotation(kernel, kernel.constantVal(theta), q0, q1);
 }
 } // namespace builder
-} // namespace cudaq
+} // namespace cudaq_internal

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -242,6 +242,7 @@ target_link_libraries(test_exec_ctx_thread
   gtest_main)
 cudaq_gtest_discover_tests(test_exec_ctx_thread DISCOVERY_TIMEOUT 120)
 
+add_subdirectory(qis)
 add_subdirectory(nvqpp)
 add_subdirectory(output_record)
 add_subdirectory(target_config)

--- a/unittests/nvqpp/CMakeLists.txt
+++ b/unittests/nvqpp/CMakeLists.txt
@@ -403,7 +403,7 @@ if (CUDA_FOUND AND TARGET nvqir-dynamics)
       if (MPI_CXX_FOUND)
         add_executable(test_dynamics_mpi_batching mqpu/dynamics_mpi_batching_tester.cpp)
         if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
-          target_link_options(test_dynamics_mpi_batching PRIVATE -Wl,--no-as-needed)
+          target_link_options(test_dynamics_mpi_batching PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
         endif()
         target_compile_definitions(test_dynamics_mpi_batching PRIVATE -DCUDAQ_ANALOG_TARGET)
         target_link_libraries(test_dynamics_mpi_batching

--- a/unittests/nvqpp/CMakeLists.txt
+++ b/unittests/nvqpp/CMakeLists.txt
@@ -470,6 +470,7 @@ if (CUDAQ_ENABLE_PYTHON)
     cudaq-operator
     cudaq-chemistry
     cudaq-pyscf
+    cudaq-builder
     gtest_main)
   cudaq_gtest_discover_tests(test_domains
     TEST_SUFFIX _Sampling PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python:${Python_SITELIB}" PROCESSORS ${CUDAQ_TEST_OMP_SLOTS} DISCOVERY_TIMEOUT 120)

--- a/unittests/nvqpp/backends/CMakeLists.txt
+++ b/unittests/nvqpp/backends/CMakeLists.txt
@@ -53,7 +53,7 @@ function(add_backend_unittest_executable target)
 
   add_executable(${target} ${ARG_SOURCES})
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
-    target_link_options(${target} PRIVATE -Wl,--no-as-needed)
+    target_link_options(${target} PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
   endif()
 
   if(ARG_BACKEND)

--- a/unittests/nvqpp/domains/ChemistryTester.cpp
+++ b/unittests/nvqpp/domains/ChemistryTester.cpp
@@ -10,8 +10,61 @@
 #include <random>
 
 #include "cudaq/algorithm.h"
-#include "cudaq/domains/chemistry.h"
+#include "cudaq/domains/chemistry/molecule.h"
+#include "cudaq/domains/chemistry/uccsd.h"
 #include "cudaq/optimizers.h"
+
+namespace chemistry_tester {
+// nvq++ does not support cudaq::cnot_coupling (see hwe.h), so inline the HWE
+// gate sequence here instead of calling cudaq::hwe from __qpu__ kernels.
+// noinline: nvq++ cannot inline one __qpu__ function into another.
+__attribute__((noinline)) __qpu__ void
+hwe_default(cudaq::qview<> qubits, std::size_t numLayers,
+            const std::vector<double> &parameters) {
+  std::size_t numQubits = qubits.size();
+  std::size_t thetaCounter = 0;
+  for (std::size_t i = 0; i < numQubits; i++) {
+    ry(parameters[thetaCounter], qubits[i]);
+    rz(parameters[thetaCounter + 1], qubits[i]);
+    thetaCounter += 2;
+  }
+
+  for (std::size_t layer = 0; layer < numLayers; layer++) {
+    for (std::size_t q = 0; q + 1 < numQubits; q++)
+      x<cudaq::ctrl>(qubits[q], qubits[q + 1]);
+
+    for (std::size_t q = 0; q < numQubits; q++) {
+      ry(parameters[thetaCounter], qubits[q]);
+      rz(parameters[thetaCounter + 1], qubits[q]);
+      thetaCounter += 2;
+    }
+  }
+}
+
+__attribute__((noinline)) __qpu__ void
+hwe_custom_chain(cudaq::qview<> qubits, std::size_t numLayers,
+                 const std::vector<double> &parameters) {
+  std::size_t numQubits = qubits.size();
+  std::size_t thetaCounter = 0;
+  for (std::size_t i = 0; i < numQubits; i++) {
+    ry(parameters[thetaCounter], qubits[i]);
+    rz(parameters[thetaCounter + 1], qubits[i]);
+    thetaCounter += 2;
+  }
+
+  for (std::size_t layer = 0; layer < numLayers; layer++) {
+    x<cudaq::ctrl>(qubits[0], qubits[1]);
+    x<cudaq::ctrl>(qubits[1], qubits[2]);
+    x<cudaq::ctrl>(qubits[2], qubits[3]);
+
+    for (std::size_t q = 0; q < numQubits; q++) {
+      ry(parameters[thetaCounter], qubits[q]);
+      rz(parameters[thetaCounter + 1], qubits[q]);
+      thetaCounter += 2;
+    }
+  }
+}
+} // namespace chemistry_tester
 
 CUDAQ_TEST(GenerateExcitationsTester, checkSimple) {
   {
@@ -109,21 +162,22 @@ CUDAQ_TEST(H2MoleculeTester, checkExpPauli) {
 }
 
 CUDAQ_TEST(H2MoleculeTester, checkUCCSD) {
+  // nvq++ cannot lower cudaq::uccsd's __qpu__ overload (cudaq::excitations is
+  // an unhandled type). Use the kernel_builder overload instead.
   {
     cudaq::molecular_geometry geometry{{"H", {0., 0., 0.}},
                                        {"H", {0., 0., .7474}}};
     auto molecule = cudaq::create_molecule(geometry, "sto-3g", 1, 0);
-    auto ansatz = [&](std::vector<double> thetas) __qpu__ {
-      cudaq::qvector q(2 * molecule.n_orbitals);
-      x(q[0]);
-      x(q[1]);
-      cudaq::uccsd(q, thetas, molecule.n_electrons);
-    };
+    auto numQubits = 2 * molecule.n_orbitals;
+    auto [ansatz, thetas] = cudaq::make_kernel<std::vector<double>>();
+    auto q = ansatz.qalloc(numQubits);
+    ansatz.x(q[0]);
+    ansatz.x(q[1]);
+    cudaq::uccsd(ansatz, q, thetas, molecule.n_electrons, numQubits);
 
     cudaq::optimizers::cobyla optimizer;
-    auto res = cudaq::vqe(ansatz, molecule.hamiltonian, optimizer,
-                          cudaq::uccsd_num_parameters(molecule.n_electrons,
-                                                      2 * molecule.n_orbitals));
+    auto nParams = cudaq::uccsd_num_parameters(molecule.n_electrons, numQubits);
+    auto res = cudaq::vqe(ansatz, molecule.hamiltonian, optimizer, nParams);
     EXPECT_NEAR(-1.137, std::get<0>(res), 1e-3);
 
     // Get the true ground state eigenvector
@@ -154,18 +208,16 @@ CUDAQ_TEST(H2MoleculeTester, checkUCCSD) {
 
     cudaq::molecular_geometry geometry(gen_random_h2_geometry());
     auto molecule = cudaq::create_molecule(geometry, "sto-3g", 1, 0);
-    auto ansatz = [&](const std::vector<double> &thetas) __qpu__ {
-      cudaq::qvector q(2 * molecule.n_orbitals);
-      for (std::size_t qId = 0; qId < molecule.n_orbitals; ++qId) {
-        x(q[qId]);
-      }
-      cudaq::uccsd(q, thetas, molecule.n_electrons);
-    };
+    auto numQubits = 2 * molecule.n_orbitals;
+    auto [ansatz, thetas] = cudaq::make_kernel<std::vector<double>>();
+    auto q = ansatz.qalloc(numQubits);
+    for (std::size_t qId = 0; qId < molecule.n_orbitals; ++qId)
+      ansatz.x(q[qId]);
+    cudaq::uccsd(ansatz, q, thetas, molecule.n_electrons, numQubits);
 
     cudaq::optimizers::cobyla optimizer;
-    auto res = cudaq::vqe(ansatz, molecule.hamiltonian, optimizer,
-                          cudaq::uccsd_num_parameters(molecule.n_electrons,
-                                                      2 * molecule.n_orbitals));
+    auto nParams = cudaq::uccsd_num_parameters(molecule.n_electrons, numQubits);
+    auto res = cudaq::vqe(ansatz, molecule.hamiltonian, optimizer, nParams);
 
     // Get the true ground state eigenvalue
     auto matrix = molecule.hamiltonian.to_matrix();
@@ -182,20 +234,23 @@ CUDAQ_TEST(H2MoleculeTester, checkHWE) {
   auto molecule = cudaq::create_molecule(geometry, "sto-3g", 1, 0);
 
   auto H = molecule.hamiltonian;
-  std::size_t numQubits = H.num_qubits();
-  std::size_t numLayers = 4;
-  auto numParams = cudaq::num_hwe_parameters(numQubits, numLayers);
+  // Host locals cannot be captured into __qpu__ lambdas; use macros for the
+  // sto-3g H2 sizes referenced inside kernels below.
+#define HWE_NUM_QUBITS 4
+#define HWE_NUM_LAYERS 4
+  EXPECT_EQ(HWE_NUM_QUBITS, H.num_qubits());
+  auto numParams = 2 * HWE_NUM_QUBITS * (1 + HWE_NUM_LAYERS);
   EXPECT_EQ(40, numParams);
   cudaq::optimizers::cobyla optimizer;
   optimizer.max_eval = 1000;
 
   std::vector<double> optParams;
   {
-    auto ansatz = [&](std::vector<double> thetas) __qpu__ {
-      cudaq::qvector q(numQubits);
+    auto ansatz = [](std::vector<double> thetas) __qpu__ {
+      cudaq::qvector q(HWE_NUM_QUBITS);
       x(q[0]);
       x(q[1]);
-      cudaq::hwe(q, numLayers, thetas);
+      chemistry_tester::hwe_default(q, HWE_NUM_LAYERS, thetas);
     };
 
     std::vector<double> params =
@@ -213,14 +268,16 @@ CUDAQ_TEST(H2MoleculeTester, checkHWE) {
   }
 
   {
-    auto ansatz = [&](std::vector<double> thetas) __qpu__ {
-      cudaq::qvector q(numQubits);
+    auto ansatz = [](std::vector<double> thetas) __qpu__ {
+      cudaq::qvector q(HWE_NUM_QUBITS);
       x(q[0]);
       x(q[1]);
-      cudaq::hwe(q, numLayers, thetas, {{0, 1}, {1, 2}, {2, 3}});
+      chemistry_tester::hwe_custom_chain(q, HWE_NUM_LAYERS, thetas);
     };
 
     double res = cudaq::observe(ansatz, H, optParams);
     EXPECT_NEAR(-1.137, res, 1e-3);
   }
+#undef HWE_NUM_QUBITS
+#undef HWE_NUM_LAYERS
 }

--- a/unittests/nvqpp/integration/adjoint_tester.cpp
+++ b/unittests/nvqpp/integration/adjoint_tester.cpp
@@ -72,6 +72,7 @@ struct twoqbit_adjoint_test {
   }
 };
 
+#ifndef CUDAQ_BACKEND_STIM
 struct test_adjoint {
   void operator()(cudaq::qview<> q) __qpu__ {
     h(q[0]);
@@ -90,6 +91,7 @@ struct test_cudaq_adjoint {
     mz(q);
   }
 };
+#endif
 CUDAQ_TEST(AdjointTester, checkSimple) {
   auto counts = cudaq::sample(1000, single_adjoint_test{});
   counts.dump();
@@ -250,7 +252,10 @@ static bool essentially_equal(std::complex<double> a, std::complex<double> b,
 
 #undef EPSILON
 
-static __qpu__ void foo(cudaq::qubit &q) { rz<cudaq::adj>(M_PI_2, q); }
+#ifndef CUDAQ_BACKEND_STIM
+static __attribute__((noinline)) __qpu__ void foo(cudaq::qubit &q) {
+  rz<cudaq::adj>(M_PI_2, q);
+}
 
 static __qpu__ void bar() {
   cudaq::qubit q;
@@ -258,7 +263,6 @@ static __qpu__ void bar() {
   cudaq::adjoint(foo, q);
 }
 
-#ifndef CUDAQ_BACKEND_STIM
 CUDAQ_TEST(AdjointTester, checkEvenAdjointNesting) {
   auto result = cudaq::get_state(bar);
   std::array<std::complex<double>, 2> expected = {1., 0};
@@ -267,9 +271,12 @@ CUDAQ_TEST(AdjointTester, checkEvenAdjointNesting) {
 }
 #endif
 
+#ifndef CUDAQ_BACKEND_STIM
 static __qpu__ void zaz(cudaq::qubit &q) { rz<cudaq::adj>(M_PI_2, q); }
 
-static __qpu__ void foo_2(cudaq::qubit &q) { cudaq::adjoint(zaz, q); }
+static __attribute__((noinline)) __qpu__ void foo_2(cudaq::qubit &q) {
+  cudaq::adjoint(zaz, q);
+}
 
 static __qpu__ void bar_2() {
   cudaq::qubit q;
@@ -277,7 +284,6 @@ static __qpu__ void bar_2() {
   cudaq::adjoint(foo_2, q);
 }
 
-#ifndef CUDAQ_BACKEND_STIM
 CUDAQ_TEST(AdjointTester, checkOddAdjointNesting) {
   auto result = cudaq::get_state(bar_2);
   std::array<std::complex<double>, 2> expected = {1., 0};

--- a/unittests/nvqpp/integration/bug67_vqe_then_sample.cpp
+++ b/unittests/nvqpp/integration/bug67_vqe_then_sample.cpp
@@ -15,20 +15,22 @@
 #if !defined(CUDAQ_BACKEND_DM) && !defined(CUDAQ_BACKEND_TENSORNET) &&         \
     !defined(CUDAQ_BACKEND_STIM)
 
+#define N_QBITS 4
+#define N_LAYERS 2
+constexpr int n_params = 2 * N_LAYERS;
+
 CUDAQ_TEST(VqeThenSample, checkBug67) {
 
   struct ansatz {
-    const int n_qubits;
-    const int n_layers;
     void operator()(std::vector<double> theta) __qpu__ {
-      cudaq::qvector q(n_qubits);
+      cudaq::qvector q(N_QBITS);
 
       // Prepare the initial state by superposition
       h(q);
 
       int N = q.size();
       // Loop over all the layers
-      for (int i = 0; i < n_layers; ++i) {
+      for (int i = 0; i < N_LAYERS; ++i) {
 
         for (std::size_t j = 0; j < q.size(); ++j) {
 
@@ -39,34 +41,29 @@ CUDAQ_TEST(VqeThenSample, checkBug67) {
 
         for (std::size_t j = 0; j < q.size(); ++j) {
           // Apply the mixer Hamiltonian (rx rotations)
-          rx(2.0 * theta[i + n_layers], q[j]); // this is gamma
+          rx(2.0 * theta[i + N_LAYERS], q[j]); // this is gamma
         }
       }
     }
   };
-
   cudaq::spin_op Hp = 0.5 * cudaq::spin_op::z(0) * cudaq::spin_op::z(1) +
                       0.5 * cudaq::spin_op::z(1) * cudaq::spin_op::z(2) +
                       0.5 * cudaq::spin_op::z(0) * cudaq::spin_op::z(3) +
                       0.5 * cudaq::spin_op::z(2) * cudaq::spin_op::z(3);
 
-  int n_qubits = 4;
-  int n_layers = 2;
-  int n_params = 2 * n_layers;
-
   cudaq::optimizers::lbfgs optimizer;
   optimizer.initial_parameters = std::vector<double>{-.75, 1.15, -1.15, -.75};
   optimizer.max_line_search_trials = 10;
   optimizer.max_eval = 10;
-  cudaq::gradients::central_difference gradient(ansatz{n_qubits, n_layers});
+  cudaq::gradients::central_difference gradient(ansatz{});
 
   auto [opt_val, opt_params] =
-      cudaq::vqe(ansatz{n_qubits, n_layers}, gradient, Hp, optimizer, n_params);
+      cudaq::vqe(ansatz{}, gradient, Hp, optimizer, n_params);
   printf("theta = (%lf, %lf, %lf, %lf) \n", opt_params[0], opt_params[1],
          opt_params[2], opt_params[3]);
 
   // Print out the final measurement after optimization
-  auto counts = cudaq::sample(ansatz{n_qubits, n_layers}, opt_params);
+  auto counts = cudaq::sample(ansatz{}, opt_params);
   counts.dump();
   EXPECT_EQ(counts.size(), 2);
   for (auto &[k, v] : counts) {

--- a/unittests/nvqpp/integration/bug77_vqe_with_shots.cpp
+++ b/unittests/nvqpp/integration/bug77_vqe_with_shots.cpp
@@ -16,9 +16,8 @@
 CUDAQ_TEST(VqeWithShots, checkBug77) {
 
   struct ansatz {
-    const int n_qubits;
-    const int n_layers;
-    void operator()(std::vector<double> theta) __qpu__ {
+    void operator()(std::vector<double> theta, int n_qubits,
+                    int n_layers) __qpu__ {
 
       cudaq::qvector q(n_qubits);
 
@@ -63,7 +62,7 @@ CUDAQ_TEST(VqeWithShots, checkBug77) {
 
   // Call the optimizer
   auto [opt_val, opt_params] =
-      cudaq::vqe(ansatz{n_qubits, n_layers}, Hp, optimizer, n_params);
+      cudaq::vqe(ansatz{}, Hp, optimizer, n_params, n_qubits, n_layers);
 
   // Print the optimized value and the parameters
   printf("Optimal value = %lf\n", opt_val);

--- a/unittests/nvqpp/integration/ccnot_tester.cpp
+++ b/unittests/nvqpp/integration/ccnot_tester.cpp
@@ -9,6 +9,24 @@
 #include "CUDAQTestUtils.h"
 #include <cudaq/algorithm.h>
 
+#ifndef CUDAQ_BACKEND_STIM
+namespace ccnot_tester {
+// Local lambdas passed to cudaq::control / cudaq::adjoint are lifted to
+// separate functions; apply-op-specialization then fails on those calls
+// because inlining runs later in the nvq++ pipeline. Use named noinline
+// __qpu__ helpers instead (same pattern as adjoint_tester / grover_test).
+// See https://github.com/NVIDIA/cuda-quantum/issues/3762.
+__attribute__((noinline)) __qpu__ void apply_x(cudaq::qubit &q) { x(q); }
+
+__attribute__((noinline)) __qpu__ void test_inner_adjoint(cudaq::qubit &q) {
+  cudaq::adjoint(apply_x, q);
+}
+
+__attribute__((noinline)) __qpu__ void ctrl_x(cudaq::qubit &ctrl,
+                                              cudaq::qubit &target) {
+  cudaq::control(apply_x, ctrl, target);
+}
+
 // Demonstrate we can perform multi-controlled operations
 struct ccnot_test {
   void operator()() __qpu__ {
@@ -16,11 +34,6 @@ struct ccnot_test {
 
     x(q);
     x(q[1]);
-
-    auto apply_x = [](cudaq::qubit &q) { x(q); };
-    auto test_inner_adjoint = [&](cudaq::qubit &q) {
-      cudaq::adjoint(apply_x, q);
-    };
 
     auto controls = q.front(2);
     cudaq::control(test_inner_adjoint, controls, q[2]);
@@ -31,8 +44,6 @@ struct ccnot_test {
 
 struct nested_ctrl {
   void operator()() __qpu__ {
-    auto apply_x = [](cudaq::qubit &r) { x(r); };
-
     cudaq::qvector q(3);
     // Create 101
     x(q);
@@ -44,17 +55,15 @@ struct nested_ctrl {
     // 2. Queue Ctrl (q[1]) X (q[2])
     // 3. Queue Ctrl (q[0], q[1]) X(q[2]);
     // 4. Apply
-    cudaq::control(
-        [&](cudaq::qubit &r) {
-          cudaq::control([&](cudaq::qubit &r) { apply_x(r); }, q[1], r);
-        },
-        q[0], q[2]);
+    cudaq::control(ctrl_x, q[0], q[1], q[2]);
 
     mz(q);
   }
 };
+} // namespace ccnot_tester
 
-#ifndef CUDAQ_BACKEND_STIM
+using namespace ccnot_tester;
+
 CUDAQ_TEST(CCNOTTester, checkSimple) {
   auto ccnot = []() {
     cudaq::qvector q(3);

--- a/unittests/nvqpp/integration/draw_tester.cpp
+++ b/unittests/nvqpp/integration/draw_tester.cpp
@@ -18,7 +18,7 @@ CUDAQ_TEST(DrawTester, checkEmpty) {
   EXPECT_EQ(expected_str, produced_str);
 }
 
-namespace {
+namespace draw_tester {
 __qpu__ void bar(cudaq::qvector<> &q) {
   double pi_d = M_PI;
   float pi_f = M_PI;
@@ -55,7 +55,9 @@ auto kernel = []() __qpu__ {
   cudaq::control(zaz, q[1], q[0]);
   cudaq::adjoint(bar, q);
 };
-} // namespace
+} // namespace draw_tester
+
+using namespace draw_tester;
 
 CUDAQ_TEST(DrawTester, checkOps) {
   // clang-format off

--- a/unittests/nvqpp/integration/gate_library_tester.cpp
+++ b/unittests/nvqpp/integration/gate_library_tester.cpp
@@ -30,12 +30,12 @@ CUDAQ_TEST(GateLibraryTester, checkGivensRotation) {
     auto test_01 = [](double theta) __qpu__ {
       cudaq::qarray<2> q;
       x(q[0]);
-      cudaq::givens_rotation(theta, q[0], q[1]);
+      cudaq_internal::givens_rotation(theta, q[0], q[1]);
     };
     auto test_10 = [](double theta) __qpu__ {
       cudaq::qarray<2> q;
       x(q[1]);
-      cudaq::givens_rotation(theta, q[0], q[1]);
+      cudaq_internal::givens_rotation(theta, q[0], q[1]);
     };
     // Matrix
     //    [[1, 0, 0, 0],
@@ -71,7 +71,7 @@ CUDAQ_TEST(GateLibraryTester, checkGivensRotationKernelBuilder) {
       // Allocate some qubits
       auto q = test_01.qalloc(2);
       test_01.x(q[0]);
-      cudaq::builder::givens_rotation(test_01, theta, q[0], q[1]);
+      cudaq_internal::builder::givens_rotation(test_01, theta, q[0], q[1]);
       auto ss_01 = cudaq::get_state(test_01, angle);
       EXPECT_NEAR(std::abs(ss_01[1] + s), 0.0, tol);
       EXPECT_NEAR(std::abs(ss_01[2] - c), 0.0, tol);
@@ -81,7 +81,7 @@ CUDAQ_TEST(GateLibraryTester, checkGivensRotationKernelBuilder) {
       // Allocate some qubits
       auto q = test_10.qalloc(2);
       test_10.x(q[1]);
-      cudaq::builder::givens_rotation(test_10, theta, q[0], q[1]);
+      cudaq_internal::builder::givens_rotation(test_10, theta, q[0], q[1]);
       auto ss_10 = cudaq::get_state(test_10, angle);
       EXPECT_NEAR(std::abs(ss_10[1] - c), 0.0, tol);
       EXPECT_NEAR(std::abs(ss_10[2] - s), 0.0, tol);
@@ -97,13 +97,15 @@ CUDAQ_TEST(GateLibraryTester, checkControlledGivensRotation) {
       x(q[2]);
       x(q[0]);
       x(q[1]);
-      cudaq::control(cudaq::givens_rotation, {q[0], q[1]}, theta, q[2], q[3]);
+      cudaq::control(cudaq_internal::givens_rotation, {q[0], q[1]}, theta, q[2],
+                     q[3]);
     };
 
     auto test_01_off = [](double theta) __qpu__ {
       cudaq::qarray<4> q;
       x(q[2]);
-      cudaq::control(cudaq::givens_rotation, {q[0], q[1]}, theta, q[2], q[3]);
+      cudaq::control(cudaq_internal::givens_rotation, {q[0], q[1]}, theta, q[2],
+                     q[3]);
       x(q[2]);
     };
 
@@ -122,22 +124,22 @@ CUDAQ_TEST(GateLibraryTester, checkFermionicSwap) {
   for (const auto &angle : cudaq::linspace(-M_PI, M_PI, NUM_ANGLES)) {
     auto test_00 = [](double theta) __qpu__ {
       cudaq::qarray<2> q;
-      cudaq::fermionic_swap(theta, q[0], q[1]);
+      cudaq_internal::fermionic_swap(theta, q[0], q[1]);
     };
     auto test_01 = [](double theta) __qpu__ {
       cudaq::qarray<2> q;
       x(q[0]);
-      cudaq::fermionic_swap(theta, q[0], q[1]);
+      cudaq_internal::fermionic_swap(theta, q[0], q[1]);
     };
     auto test_10 = [](double theta) __qpu__ {
       cudaq::qarray<2> q;
       x(q[1]);
-      cudaq::fermionic_swap(theta, q[0], q[1]);
+      cudaq_internal::fermionic_swap(theta, q[0], q[1]);
     };
     auto test_11 = [](double theta) __qpu__ {
       cudaq::qarray<2> q;
       x(q);
-      cudaq::fermionic_swap(theta, q[0], q[1]);
+      cudaq_internal::fermionic_swap(theta, q[0], q[1]);
     };
 
     // FermionicSWAP truth table
@@ -185,7 +187,7 @@ CUDAQ_TEST(GateLibraryTester, checkFermionicSwapKernelBuilder) {
       auto [test_00, theta] = cudaq::make_kernel<double>();
       // Allocate some qubits
       auto q = test_00.qalloc(2);
-      cudaq::builder::fermionic_swap(test_00, theta, q[0], q[1]);
+      cudaq_internal::builder::fermionic_swap(test_00, theta, q[0], q[1]);
       auto ss_00 = cudaq::get_state(test_00, angle);
       EXPECT_NEAR(std::norm(ss_00[0] - 1.0), 0.0, 1e-6);
     }
@@ -194,7 +196,7 @@ CUDAQ_TEST(GateLibraryTester, checkFermionicSwapKernelBuilder) {
       // Allocate some qubits
       auto q = test_01.qalloc(2);
       test_01.x(q[0]);
-      cudaq::builder::fermionic_swap(test_01, theta, q[0], q[1]);
+      cudaq_internal::builder::fermionic_swap(test_01, theta, q[0], q[1]);
       auto ss_01 = cudaq::get_state(test_01, angle);
       EXPECT_NEAR(std::norm(ss_01[1] - (-I * std::exp(I * angle / 2.0) * s)),
                   0.0, 1e-6);
@@ -206,7 +208,7 @@ CUDAQ_TEST(GateLibraryTester, checkFermionicSwapKernelBuilder) {
       // Allocate some qubits
       auto q = test_10.qalloc(2);
       test_10.x(q[1]);
-      cudaq::builder::fermionic_swap(test_10, theta, q[0], q[1]);
+      cudaq_internal::builder::fermionic_swap(test_10, theta, q[0], q[1]);
       auto ss_10 = cudaq::get_state(test_10, angle);
       EXPECT_NEAR(std::norm(ss_10[1] - (std::exp(I * angle / 2.0) * c)), 0.0,
                   1e-6);
@@ -218,7 +220,7 @@ CUDAQ_TEST(GateLibraryTester, checkFermionicSwapKernelBuilder) {
       // Allocate some qubits
       auto q = test_11.qalloc(2);
       test_11.x(q);
-      cudaq::builder::fermionic_swap(test_11, theta, q[0], q[1]);
+      cudaq_internal::builder::fermionic_swap(test_11, theta, q[0], q[1]);
       auto ss_11 = cudaq::get_state(test_11, angle);
       EXPECT_NEAR(std::norm(ss_11[3] - std::exp(I * angle)), 0.0, 1e-6);
     }

--- a/unittests/nvqpp/integration/ghz_nisq_tester.cpp
+++ b/unittests/nvqpp/integration/ghz_nisq_tester.cpp
@@ -20,7 +20,7 @@ struct ghz {
   auto operator()(int N) __qpu__ {
     cudaq::qvector q(N);
     h(q[0]);
-    for (auto i : range(N - 1)) {
+    for (auto i : cudaq::range(N - 1)) {
       x<cudaq::ctrl>(q[i], q[i + 1]);
     }
     mz(q);

--- a/unittests/nvqpp/integration/gradient_tester.cpp
+++ b/unittests/nvqpp/integration/gradient_tester.cpp
@@ -17,6 +17,8 @@
 // Note: CUDA-Q API level tests (e.g., `cudaq::observe`) should cover all
 // backend-specific functionalities required to interface gradient modules.
 #if !defined CUDAQ_BACKEND_DM && !defined CUDAQ_BACKEND_TENSORNET
+
+namespace gradient_tester {
 struct deuteron_n3_ansatz {
   void operator()(double x0, double x1) __qpu__ {
     cudaq::qvector q(3);
@@ -30,6 +32,9 @@ struct deuteron_n3_ansatz {
     x<cudaq::ctrl>(q[1], q[0]);
   }
 };
+} // namespace gradient_tester
+
+using namespace gradient_tester;
 
 CUDAQ_TEST(GradientTester, checkSimple) {
 

--- a/unittests/nvqpp/integration/grover_test.cpp
+++ b/unittests/nvqpp/integration/grover_test.cpp
@@ -11,8 +11,10 @@
 
 #include <numeric>
 
+#ifndef CUDAQ_BACKEND_STIM
+
 struct reflect_about_uniform {
-  void operator()(cudaq::qview<> q) __qpu__ {
+  __attribute__((noinline)) void operator()(cudaq::qview<> q) __qpu__ {
     auto ctrl_qubits = q.front(q.size() - 1);
     auto &last_qubit = q.back();
 
@@ -42,14 +44,13 @@ struct run_grover {
 };
 
 struct oracle {
-  void operator()(cudaq::qvector<> &q) __qpu__ {
+  __attribute__((noinline)) void operator()(cudaq::qvector<> &q) __qpu__ {
     cz(q[0], q[2]);
     cz(q[1], q[2]);
   }
 };
 
 // Multi-control gates not supported in stim.
-#ifndef CUDAQ_BACKEND_STIM
 
 CUDAQ_TEST(GroverTester, checkNISQ) {
   using namespace cudaq;

--- a/unittests/nvqpp/integration/kernels_tester.cpp
+++ b/unittests/nvqpp/integration/kernels_tester.cpp
@@ -449,47 +449,77 @@ template <typename NoiseType, int num_qubits>
 std::tuple<std::vector<std::string>, std::vector<double>,
            std::vector<std::size_t>>
 get_msm_test(double noise_probability) {
-  // This simple kernel just creates qubits and applies one noise operation,
-  // depending on the template parameters.
-  struct simple_test {
-    void operator()(double noise_probability) __qpu__ {
-      cudaq::qvector q(num_qubits);
-      if constexpr (std::is_same_v<NoiseType, cudaq::pauli1>) {
+  cudaq::noise_model noise;
+  cudaq::set_noise(noise);
+
+  // Helper that runs the two-stage MSM protocol for a given kernel and returns
+  // the transposed MSM, the probabilities, and the error ids.
+  auto run_msm = [&](auto kernel) {
+    // Stage 1 - get the MSM size by running with "msm_size". The
+    // result will be returned in ctx_msm_size.shots.
+    auto msm_dimensions =
+        cudaq::launch(cudaq::msm_size_policy{}, kernel, noise_probability);
+
+    // Stage 2 - get the MSM using the size calculated above
+    // (ctx_msm_size.msm_dimensions).
+    cudaq::msm_policy policy;
+    policy.dimensions = msm_dimensions;
+    auto msm = cudaq::launch(policy, kernel, noise_probability);
+
+    return std::tuple<std::vector<std::string>, std::vector<double>,
+                      std::vector<std::size_t>>{
+        transpose_msm(msm.samples.sequential_data()), msm.probabilities,
+        msm.probability_error_ids};
+  };
+
+  // These simple kernels just create qubits and apply one noise operation. The
+  // kernel is selected based on the template parameters here (on the host)
+  // rather than with `if constexpr` inside the kernel, which nvq++ does not
+  // support.
+  if constexpr (std::is_same_v<NoiseType, cudaq::pauli1>) {
+    struct simple_test {
+      void operator()(double noise_probability) __qpu__ {
+        cudaq::qvector q(num_qubits);
         double noise_prob_per_pauli = noise_probability / 3;
         cudaq::apply_noise<NoiseType>(noise_prob_per_pauli,
                                       noise_prob_per_pauli,
                                       noise_prob_per_pauli, q[0]);
-      } else if constexpr (std::is_same_v<NoiseType, cudaq::pauli2>) {
+        mz(q);
+      }
+    };
+    return run_msm(simple_test{});
+  } else if constexpr (std::is_same_v<NoiseType, cudaq::pauli2>) {
+    struct simple_test {
+      void operator()(double noise_probability) __qpu__ {
+        cudaq::qvector q(num_qubits);
         double tmp_prob = noise_probability / 15;
         cudaq::apply_noise<NoiseType>(tmp_prob, tmp_prob, tmp_prob, tmp_prob,
                                       tmp_prob, tmp_prob, tmp_prob, tmp_prob,
                                       tmp_prob, tmp_prob, tmp_prob, tmp_prob,
                                       tmp_prob, tmp_prob, tmp_prob, q[0], q[1]);
-      } else if constexpr (num_qubits > 1) {
-        cudaq::apply_noise<NoiseType>(noise_probability, q[0], q[1]);
-      } else {
-        cudaq::apply_noise<NoiseType>(noise_probability, q[0]);
+        mz(q);
       }
-      mz(q);
-    }
-  };
-
-  cudaq::noise_model noise;
-  cudaq::set_noise(noise);
-
-  // Stage 1 - get the MSM size by running with "msm_size". The
-  // result will be returned in ctx_msm_size.shots.
-  auto msm_dimensions =
-      cudaq::launch(cudaq::msm_size_policy{}, simple_test{}, noise_probability);
-
-  // Stage 2 - get the MSM using the size calculated above
-  // (ctx_msm_size.msm_dimensions).
-  cudaq::msm_policy policy;
-  policy.dimensions = msm_dimensions;
-  auto msm = cudaq::launch(policy, simple_test{}, noise_probability);
-
-  return {transpose_msm(msm.samples.sequential_data()), msm.probabilities,
-          msm.probability_error_ids};
+    };
+    return run_msm(simple_test{});
+  } else if constexpr (num_qubits > 1) {
+    struct simple_test {
+      void operator()(double noise_probability) __qpu__ {
+        cudaq::qvector q(num_qubits);
+        cudaq::apply_noise<NoiseType>(noise_probability, q[0], q[1]);
+        mz(q);
+      }
+    };
+    return run_msm(simple_test{});
+  } else {
+    struct simple_test {
+      void operator()(double noise_probability) __qpu__ {
+        cudaq::qvector q(num_qubits);
+        cudaq::apply_noise<NoiseType>(noise_probability, q[0]);
+        mz(q);
+      }
+    };
+    return run_msm(simple_test{});
+  }
 }
 
 CUDAQ_TEST(KernelsTester, msmTester_depol2) {

--- a/unittests/nvqpp/integration/noise_tester.cpp
+++ b/unittests/nvqpp/integration/noise_tester.cpp
@@ -97,12 +97,14 @@ struct hello_world : public ::cudaq::kraus_channel {
 };
 } // namespace test::hello
 
+#ifdef TEST2_SUPPORTED
 __qpu__ void test2(double p) {
   cudaq::qubit q;
   x(q);
+  // not yet implemented: C++ constructor (non-default)
   cudaq::apply_noise<test::hello::hello_world>({0.2}, q);
 }
-
+#endif
 __qpu__ void test3(double p) {
   cudaq::qubit q;
   x(q);
@@ -172,6 +174,8 @@ CUDAQ_TEST(NoiseTest, checkFineGrainArg) {
   }
 }
 
+// Hitting: not yet implemented: C++ constructor (non-default)
+#ifdef TEST2_SUPPORTED
 CUDAQ_TEST(NoiseTest, checkFineGrainVec) {
   {
     cudaq::noise_model noise;
@@ -197,6 +201,7 @@ CUDAQ_TEST(NoiseTest, checkFineGrainVec) {
     EXPECT_TRUE(counts.size() == 1);
   }
 }
+#endif
 
 CUDAQ_TEST(NoiseTest, checkSimple) {
   cudaq::set_random_seed(13);

--- a/unittests/nvqpp/integration/observe_result_tester.cpp
+++ b/unittests/nvqpp/integration/observe_result_tester.cpp
@@ -12,6 +12,8 @@
 // Rotational gates not supported in Stim.
 #ifndef CUDAQ_BACKEND_STIM
 
+namespace observe_result_tester {
+
 struct deuteron_n3_ansatz {
   void operator()(double x0, double x1) __qpu__ {
     cudaq::qvector q(3);
@@ -25,6 +27,9 @@ struct deuteron_n3_ansatz {
     x<cudaq::ctrl>(q[1], q[0]);
   }
 };
+} // namespace observe_result_tester
+
+using namespace observe_result_tester;
 
 CUDAQ_TEST(ObserveResult, checkSimple) {
 

--- a/unittests/nvqpp/integration/qpe_ftqc.cpp
+++ b/unittests/nvqpp/integration/qpe_ftqc.cpp
@@ -11,6 +11,9 @@
 
 #include <cmath>
 
+#ifndef CUDAQ_BACKEND_STIM
+
+namespace qpe_ftqc {
 struct iqft {
   void operator()(cudaq::qview<> &q) __qpu__ {
     int N = q.size();
@@ -59,15 +62,16 @@ struct qpe {
     // Apply inverse quantum fourier transform
     iqft{}(counting_qubits);
     // Measure and compute the phase...
-    return cudaq::to_integer(mz(counting_qubits)) / std::pow(2, n_c);
+    return cudaq::to_integer(cudaq::to_bools(mz(counting_qubits))) /
+           std::pow(2, n_c);
   }
 };
+} // namespace qpe_ftqc
 
 // Rotational gates not supported in Stim.
-#ifndef CUDAQ_BACKEND_STIM
 
 CUDAQ_TEST(QPEFTQCTester, checkSimple) {
-  double phase = qpe{}(3, 1);
+  double phase = qpe_ftqc::qpe{}(3, 1);
   EXPECT_NEAR(phase, .125, 1e-4);
   printf("Phase = %lf\n", phase);
 }

--- a/unittests/nvqpp/integration/qpe_nisq.cpp
+++ b/unittests/nvqpp/integration/qpe_nisq.cpp
@@ -15,6 +15,7 @@
 // Rotational gates not supported in Stim.
 #ifndef CUDAQ_BACKEND_STIM
 
+namespace qpe_nisq {
 struct iqft {
   void operator()(cudaq::qview<> &q) __qpu__ {
     int N = q.size();
@@ -76,14 +77,6 @@ struct qpe {
   }
 };
 
-CUDAQ_TEST(QPENisqTester, checkSimple) {
-  auto counts = cudaq::sample(
-      qpe{}, 3, 1, [](cudaq::qubit &q) __qpu__ { x(q); }, tgate{});
-  counts.dump();
-  EXPECT_EQ(1, counts.size());
-  EXPECT_TRUE(counts.begin()->first == "100");
-}
-
 struct xOp {
   void operator()(cudaq::qubit &q) __qpu__ { x(q); }
 };
@@ -121,6 +114,17 @@ struct qpeWithForwarding {
     return;
   }
 };
+
+} // namespace qpe_nisq
+
+using namespace qpe_nisq;
+CUDAQ_TEST(QPENisqTester, checkSimple) {
+  auto counts = cudaq::sample(
+      qpe{}, 3, 1, [](cudaq::qubit &q) __qpu__ { x(q); }, tgate{});
+  counts.dump();
+  EXPECT_EQ(1, counts.size());
+  EXPECT_TRUE(counts.begin()->first == "100");
+}
 
 CUDAQ_TEST(QPENisqTester, checkPerfectForwardingBug) {
   auto counts = cudaq::sample(qpeWithForwarding{}, 3, 1, xOp{}, tgate{});

--- a/unittests/nvqpp/integration/qubit_allocation.cpp
+++ b/unittests/nvqpp/integration/qubit_allocation.cpp
@@ -210,7 +210,7 @@ CUDAQ_TEST(AllocationTester, checkDensityOrderingBug) {
 #endif
 
 struct test_allocation_from_state {
-  void operator()(cudaq::state state) __qpu__ {
+  void operator()(cudaq::state *state) __qpu__ {
     cudaq::qvector q(state);
     mz(q);
   }
@@ -222,7 +222,7 @@ CUDAQ_TEST(AllocationTester, checkAllocationFromRetrievedState) {
     h(q[0]);
     cx(q[0], q[1]);
   });
-  auto counts = cudaq::sample(test_allocation_from_state{}, bellState);
+  auto counts = cudaq::sample(test_allocation_from_state{}, &bellState);
   counts.dump();
   EXPECT_EQ(2, counts.size());
   int c = 0;
@@ -251,11 +251,11 @@ CUDAQ_TEST(AllocationTester, checkChainingGetState) {
 
   // Second half of the circuit
   auto state2 = cudaq::get_state(
-      [](cudaq::state state) __qpu__ {
+      [](cudaq::state *state) __qpu__ {
         cudaq::qvector q(state);
         cx(q[0], q[1]);
       },
-      state1);
+      &state1);
 #ifdef CUDAQ_BACKEND_DM
   EXPECT_NEAR(std::abs(state2.amplitude({0, 0})), 0.5, 1e-6);
   EXPECT_NEAR(std::abs(state2.amplitude({1, 1})), 0.5, 1e-6);
@@ -312,12 +312,12 @@ CUDAQ_TEST(AllocationTester, checkStateFromMpsData) {
     auto state = cudaq::state::from_data(initData);
     state.dump();
     auto state2 = cudaq::get_state(
-        [](cudaq::state state) __qpu__ {
+        [](cudaq::state *state) __qpu__ {
           cudaq::qvector q(state);
           h(q[0]);
           cx(q[0], q[1]);
         },
-        state);
+        &state);
     state2.dump();
     EXPECT_NEAR(std::abs(state2.amplitude({0, 0})), M_SQRT1_2, 1e-6);
     EXPECT_NEAR(std::abs(state2.amplitude({1, 1})), M_SQRT1_2, 1e-6);
@@ -349,12 +349,12 @@ CUDAQ_TEST(AllocationTester, checkStateFromMpsData) {
     auto reconstructedState = cudaq::state::from_data(tensors);
     // Second half of the bell circuit
     auto state2 = cudaq::get_state(
-        [](cudaq::state state) __qpu__ {
+        [](cudaq::state *state) __qpu__ {
           cudaq::qvector q(state);
           for (std::size_t i = 0; i < q.size() - 1; ++i)
             cx(q[i], q[i + 1]);
         },
-        reconstructedState);
+        &reconstructedState);
     const std::vector<int> allZero(numQubits, 0);
     const std::vector<int> allOne(numQubits, 1);
     EXPECT_NEAR(std::abs(state2.amplitude(allZero)), M_SQRT1_2, 1e-6);

--- a/unittests/nvqpp/integration/tracer_tester.cpp
+++ b/unittests/nvqpp/integration/tracer_tester.cpp
@@ -54,46 +54,39 @@ CUDAQ_TEST(TracerTester, checkGHZ) {
 
 CUDAQ_TEST(TracerTester, checkLargeTrace) {
 
-  static std::unordered_map<std::string, std::function<void(cudaq::qubit &)>>
-      operations{{"h", [](cudaq::qubit &q) {
-        h(q); }},
-                 {"x", [](cudaq::qubit &q) {
-        x(q); }},
-                 {"y", [](cudaq::qubit &q) {
-        y(q); }},
-                 {"z", [](cudaq::qubit &q) {
-        z(q); }},
-                 {"s", [](cudaq::qubit &q) {
-        s(q); }},
-                 {"t", [](cudaq::qubit &q) {
-        t(q); }}};
+  auto largeTrace = [](int numQubits, int numLayers, std::vector<int> cnotPairs)
+                        __qpu__ {
+                          cudaq::qvector q(numQubits);
 
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_int_distribution<> distr(0, 5);
+                          for (int layer = 0; layer < numLayers; layer++) {
+                            // each layer should be composed of a set of random
+                            // single qubit gates on every qubit, followed by
+                            // a layer of random cnots
+                            for (int i = 0; i < numQubits; i++) {
+                              int choice = cnotPairs[layer * numQubits + i] % 6;
+                              if (choice == 0)
+                                h(q[i]);
+                              else if (choice == 1)
+                                x(q[i]);
+                              else if (choice == 2)
+                                y(q[i]);
+                              else if (choice == 3)
+                                z(q[i]);
+                              else if (choice == 4)
+                                s(q[i]);
+                              else
+                                t(q[i]);
+                            }
 
-  auto largeTrace = [&](int numQubits, int numLayers,
-                        std::vector<int> cnotPairs) __qpu__ {
-    cudaq::qvector q(numQubits);
-
-    for (int layer = 0; layer < numLayers; layer++) {
-      // each layer should be composed of a set of random
-      // single qubit gates on every qubit, followed by
-      // a layer of random cnots
-      for (int i = 0; i < numQubits; i++) {
-        auto iter = std::next(operations.begin(), distr(gen));
-        iter->second(q[i]);
-      }
-
-      for (int i = 0; i < numQubits; i += 2)
-        x<cudaq::ctrl>(q[i], q[i + 1]);
-    }
-  };
+                            for (int i = 0; i < numQubits; i += 2)
+                              x<cudaq::ctrl>(q[i], q[i + 1]);
+                          }
+                        };
 
   int numQubits = 1000;
   int numLayers = 1000;
 
-  std::vector<int> cnots(numQubits);
+  std::vector<int> cnots(numQubits * numLayers);
   std::iota(cnots.begin(), cnots.end(), 0);
   std::shuffle(cnots.begin(), cnots.end(),
                std::mt19937{std::random_device{}()});

--- a/unittests/nvqpp/mpi/tensornet_mpi_tester.cpp
+++ b/unittests/nvqpp/mpi/tensornet_mpi_tester.cpp
@@ -14,11 +14,12 @@ TEST(TensornetMPITester, checkInit) {
 }
 
 TEST(TensornetMPITester, checkSimple) {
-  constexpr std::size_t numQubits = 50;
+  // Host locals cannot be captured into __qpu__ lambdas.
+#define NUM_QUBITS 50
   auto kernel = []() __qpu__ {
-    cudaq::qvector q(numQubits);
+    cudaq::qvector q(NUM_QUBITS);
     h(q[0]);
-    for (int i = 0; i < numQubits - 1; i++)
+    for (int i = 0; i < NUM_QUBITS - 1; i++)
       x<cudaq::ctrl>(q[i], q[i + 1]);
     mz(q);
   };
@@ -30,9 +31,10 @@ TEST(TensornetMPITester, checkSimple) {
 
     for (auto &[bits, count] : counts) {
       printf("Observed: %s, %lu\n", bits.data(), count);
-      EXPECT_EQ(numQubits, bits.size());
+      EXPECT_EQ(NUM_QUBITS, bits.size());
     }
   }
+#undef NUM_QUBITS
 }
 
 int main(int argc, char **argv) {

--- a/unittests/nvqpp/ptsbe/PTSBESampleTester.cpp
+++ b/unittests/nvqpp/ptsbe/PTSBESampleTester.cpp
@@ -24,7 +24,7 @@
 
 using namespace cudaq::ptsbe;
 
-namespace {
+namespace ptsbe_sample_tester {
 
 auto bellKernel = []() __qpu__ {
   cudaq::qvector q(2);
@@ -73,7 +73,9 @@ auto inlineNoiseKernel = []() __qpu__ {
   mz(q);
 };
 
-} // namespace
+} // namespace ptsbe_sample_tester
+
+using namespace ptsbe_sample_tester;
 
 // ============================================================================
 // TRACE CAPTURE TESTS

--- a/unittests/nvqpp/qis/QubitQISTester.cpp
+++ b/unittests/nvqpp/qis/QubitQISTester.cpp
@@ -13,118 +13,11 @@
 #include <cudaq/operators.h>
 
 #ifndef CUDAQ_BACKEND_DM
-CUDAQ_TEST(QubitQISTester, checkAllocateDeallocateSubRegister) {
-
-  {
-    cudaq::qubit q, r;
-    EXPECT_EQ(q.id(), 0);
-    EXPECT_EQ(r.id(), 1);
-
-    h(q, r);
-    cudaq::qvector qq(3);
-    auto f = qq.front(2);
-    h(f, qq[2]);
-  }
-
-  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
-
-  {
-    cudaq::qvector q(10);
-    for (auto [i, q] : cudaq::enumerate(q)) {
-      EXPECT_EQ(i, q.id());
-    }
-
-    cudaq::qubit r, s;
-    EXPECT_EQ(r.id(), 10);
-    EXPECT_EQ(s.id(), 11);
-
-    // out of scope, qubits returned
-  }
-  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
-
-  {
-    cudaq::qvector q(15);
-    EXPECT_EQ(q[14].id(), 14);
-
-    EXPECT_EQ(q.front().id(), 0);
-    EXPECT_EQ(q.back().id(), 14);
-    auto f5 = q.front(5);
-    EXPECT_EQ(f5.size(), 5);
-    for (auto [i, qq] : cudaq::enumerate(f5)) {
-      EXPECT_EQ(i, qq.id());
-    }
-
-    auto b4 = q.back(4);
-    EXPECT_EQ(b4.size(), 4);
-    EXPECT_EQ(b4[0].id(), 11);
-    EXPECT_EQ(b4[1].id(), 12);
-    EXPECT_EQ(b4[2].id(), 13);
-    EXPECT_EQ(b4[3].id(), 14);
-    EXPECT_EQ(b4.front().id(), 11);
-    EXPECT_EQ(b4.back().id(), 14);
-
-    auto view_from_span = b4.front(2);
-    EXPECT_EQ(view_from_span[0].id(), 11);
-    EXPECT_EQ(view_from_span[1].id(), 12);
-
-    auto slice = q.slice(4, 7);
-    EXPECT_EQ(slice.size(), 7);
-    for (auto [i, qq] : cudaq::enumerate(slice)) {
-      EXPECT_EQ(i + 4, qq.id());
-    }
-
-    auto slice_from_span = b4.slice(1, 2);
-    EXPECT_EQ(slice_from_span.size(), 2);
-    EXPECT_EQ(slice_from_span[0].id(), 12);
-    EXPECT_EQ(slice_from_span[1].id(), 13);
-  }
-
-  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
-}
-
-CUDAQ_TEST(QubitQISTester, checkArray) {
-  {
-    cudaq::qarray<5> compileTimeQubits;
-    EXPECT_EQ(compileTimeQubits.size(), 5);
-    for (int i = 0; i < 5; i++)
-      EXPECT_EQ(compileTimeQubits[i].id(), i);
-  }
-
-  {
-    cudaq::qarray<15> q;
-    EXPECT_EQ(q[14].id(), 14);
-
-    EXPECT_EQ(q.front().id(), 0);
-    EXPECT_EQ(q.back().id(), 14);
-    auto f5 = q.front(5);
-    EXPECT_EQ(f5.size(), 5);
-    for (auto [i, qq] : cudaq::enumerate(f5)) {
-      EXPECT_EQ(i, qq.id());
-    }
-
-    auto b4 = q.back(4);
-    EXPECT_EQ(b4.size(), 4);
-    EXPECT_EQ(b4[0].id(), 11);
-    EXPECT_EQ(b4[1].id(), 12);
-    EXPECT_EQ(b4[2].id(), 13);
-    EXPECT_EQ(b4[3].id(), 14);
-    EXPECT_EQ(b4.front().id(), 11);
-    EXPECT_EQ(b4.back().id(), 14);
-
-    auto view_from_span = b4.front(2);
-    EXPECT_EQ(view_from_span[0].id(), 11);
-    EXPECT_EQ(view_from_span[1].id(), 12);
-
-    auto slice = q.slice(4, 7);
-    EXPECT_EQ(slice.size(), 7);
-    for (auto [i, qq] : cudaq::enumerate(slice)) {
-      EXPECT_EQ(i + 4, qq.id());
-    }
-  }
-}
+// Host-side quantum type tests (allocation, qarray, parameterized CustomU3)
+// live in unittests/qis/ . This file covers kernels compiled with nvq++.
 
 CUDAQ_TEST(QubitQISTester, checkCommonKernel) {
-  auto ghz = []() {
+  auto ghz = []() __qpu__ {
     const int N = 5;
     cudaq::qvector q(N);
     h(q[0]);
@@ -143,7 +36,7 @@ CUDAQ_TEST(QubitQISTester, checkCommonKernel) {
   EXPECT_EQ(counter, 1000);
 
 #ifndef CUDAQ_BACKEND_STIM
-  auto ansatz = [](double theta) {
+  auto ansatz = [](double theta) __qpu__ {
     cudaq::qvector q(2);
     x(q[0]);
     ry(theta, q[1]);
@@ -160,9 +53,60 @@ CUDAQ_TEST(QubitQISTester, checkCommonKernel) {
 }
 
 #ifndef CUDAQ_BACKEND_STIM
+namespace qubit_qis_tester {
+// Local lambdas passed to cudaq::control / cudaq::adjoint are lifted to
+// separate functions; apply-op-specialization then fails on those calls
+// because inlining runs later in the nvq++ pipeline. Use named noinline
+// __qpu__ helpers instead (same pattern as adjoint_tester / grover_test).
+// See https://github.com/NVIDIA/cuda-quantum/issues/3762.
+__attribute__((noinline)) __qpu__ void apply_x(cudaq::qubit &q) { x(q); }
+
+__attribute__((noinline)) __qpu__ void test_inner_adjoint(cudaq::qubit &q) {
+  cudaq::adjoint(apply_x, q);
+}
+
+__attribute__((noinline)) __qpu__ void ctrl_x(cudaq::qubit &ctrl,
+                                              cudaq::qubit &target) {
+  cudaq::control(apply_x, ctrl, target);
+}
+
+struct ccnot_test {
+  void operator()() __qpu__ {
+    cudaq::qvector q(3);
+
+    x(q);
+    x(q[1]);
+
+    auto controls = q.front(2);
+    cudaq::control(test_inner_adjoint, controls, q[2]);
+
+    mz(q);
+  }
+};
+
+struct nested_ctrl {
+  void operator()() __qpu__ {
+    cudaq::qvector q(3);
+    // Create 101
+    x(q);
+    x(q[1]);
+
+    // Fancy nested CCX
+    // Walking inner nest to outer
+    // 1. Queue X(q[2])
+    // 2. Queue Ctrl (q[1]) X (q[2])
+    // 3. Queue Ctrl (q[0], q[1]) X(q[2]);
+    // 4. Apply
+    cudaq::control(ctrl_x, q[0], q[1], q[2]);
+
+    mz(q);
+  }
+};
+} // namespace qubit_qis_tester
+
 CUDAQ_TEST(QubitQISTester, checkCtrlRegion) {
 
-  auto ccnot = []() {
+  auto ccnot = []() __qpu__ {
     cudaq::qvector q(3);
 
     x(q);
@@ -173,60 +117,16 @@ CUDAQ_TEST(QubitQISTester, checkCtrlRegion) {
     mz(q);
   };
 
-  struct ccnot_test {
-    void operator()() __qpu__ {
-      cudaq::qvector q(3);
-
-      x(q);
-      x(q[1]);
-
-      auto apply_x = [](cudaq::qubit &q) { x(q); };
-      auto test_inner_adjoint = [&](cudaq::qubit &q) {
-        cudaq::adjoint(apply_x, q);
-      };
-
-      auto controls = q.front(2);
-      cudaq::control(test_inner_adjoint, controls, q[2]);
-
-      mz(q);
-    }
-  };
-
-  struct nested_ctrl {
-    void operator()() __qpu__ {
-      auto apply_x = [](cudaq::qubit &r) { x(r); };
-
-      cudaq::qvector q(3);
-      // Create 101
-      x(q);
-      x(q[1]);
-
-      // Fancy nested CCX
-      // Walking inner nest to outer
-      // 1. Queue X(q[2])
-      // 2. Queue Ctrl (q[1]) X (q[2])
-      // 3. Queue Ctrl (q[0], q[1]) X(q[2]);
-      // 4. Apply
-      cudaq::control(
-          [&](cudaq::qubit &r) {
-            cudaq::control([&](cudaq::qubit &r) { apply_x(r); }, q[1], r);
-          },
-          q[0], q[2]);
-
-      mz(q);
-    }
-  };
-
   auto counts = cudaq::sample(ccnot);
   counts.dump();
   EXPECT_EQ(1, counts.size());
   EXPECT_TRUE(counts.begin()->first == "101");
 
-  auto counts2 = cudaq::sample(ccnot_test{});
+  auto counts2 = cudaq::sample(qubit_qis_tester::ccnot_test{});
   EXPECT_EQ(1, counts2.size());
   EXPECT_TRUE(counts2.begin()->first == "101");
 
-  auto counts3 = cudaq::sample(nested_ctrl{});
+  auto counts3 = cudaq::sample(qubit_qis_tester::nested_ctrl{});
   EXPECT_EQ(1, counts3.size());
   EXPECT_TRUE(counts3.begin()->first == "101");
 }
@@ -375,7 +275,7 @@ CUDAQ_TEST(QubitQISTester, checkMeasureResetFence) {
 
 #ifndef CUDAQ_BACKEND_STIM
 CUDAQ_TEST(QubitQISTester, checkU3Op) {
-  auto check_x = []() {
+  auto check_x = []() __qpu__ {
     cudaq::qubit q;
     // mimic Pauli-X gate
     u3(M_PI, M_PI, M_PI_2, q);
@@ -386,7 +286,7 @@ CUDAQ_TEST(QubitQISTester, checkU3Op) {
     EXPECT_TRUE(bits == "1");
   }
 
-  auto bell_pair = []() {
+  auto bell_pair = []() __qpu__ {
     cudaq::qvector qubits(2);
     // mimic Hadamard gate
     u3(M_PI_2, 0., M_PI, qubits[0]);
@@ -402,7 +302,7 @@ CUDAQ_TEST(QubitQISTester, checkU3Op) {
 
 #ifndef CUDAQ_BACKEND_STIM
 CUDAQ_TEST(QubitQISTester, checkU3Ctrl) {
-  auto another_bell_pair = []() {
+  auto another_bell_pair = []() __qpu__ {
     cudaq::qvector qubits(2);
     u3(M_PI_2, 0., M_PI, qubits[0]);
     u3<cudaq::ctrl>(M_PI, M_PI, M_PI_2, qubits[0], qubits[1]);
@@ -417,7 +317,7 @@ CUDAQ_TEST(QubitQISTester, checkU3Ctrl) {
 
 #ifndef CUDAQ_BACKEND_STIM
 CUDAQ_TEST(QubitQISTester, checkU3Adj) {
-  auto rotation_adjoint_test = []() {
+  auto rotation_adjoint_test = []() __qpu__ {
     cudaq::qubit q;
     // mimic Rx gate
     u3(1.1, -M_PI_2, M_PI_2, q);
@@ -436,8 +336,6 @@ CUDAQ_TEST(QubitQISTester, checkU3Adj) {
 }
 #endif
 
-using namespace std::complex_literals;
-
 #ifndef CUDAQ_BACKEND_STIM
 
 // Test someone can build a library of custom operations
@@ -447,19 +345,14 @@ CUDAQ_REGISTER_OPERATION(
 CUDAQ_REGISTER_OPERATION(CustomX, 1, 0, {0, 1, 1, 0});
 CUDAQ_REGISTER_OPERATION(CustomCNOT, 2, 0,
                          {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0});
-CUDAQ_REGISTER_OPERATION(
-    CustomU3, 1, 3,
-    {std::cos(parameters[0] / 2.),
-     -std::exp(1i * parameters[2]) * std::sin(parameters[0] / 2.),
-     std::exp(1i * parameters[1]) * std::sin(parameters[0] / 2.),
-     std::exp(1i * (parameters[2] + parameters[1])) *
-         std::cos(parameters[0] / 2.)})
+// Parameterized CustomU3 (std::exp on complex values) lives in
+// unittests/qis/ under CUDAQ_LIBRARY_MODE.
 CUDAQ_REGISTER_OPERATION(CustomSwap, 2, 0,
                          {1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1})
 
 CUDAQ_TEST(CustomUnitaryTester, checkBasic) {
   {
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qubit q, r;
       CustomHadamard(q);
       CustomCNOT(q, r);
@@ -476,7 +369,7 @@ CUDAQ_TEST(CustomUnitaryTester, checkBasic) {
   }
   {
     // Can be controlled
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qubit q, r;
       x(q);
       CustomX<cudaq::ctrl>(q, r);
@@ -493,7 +386,7 @@ CUDAQ_TEST(CustomUnitaryTester, checkBasic) {
   }
   {
     // Can be controlled with negation
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qubit q, r;
       CustomX<cudaq::ctrl>(!q, r);
     };
@@ -509,69 +402,10 @@ CUDAQ_TEST(CustomUnitaryTester, checkBasic) {
   }
 }
 
-/// NOTE: This is supported only in library mode
-CUDAQ_TEST(CustomUnitaryTester, checkParameterized) {
-  {
-    // parameterized op, custom u3
-    auto check_x = []() {
-      cudaq::qubit q;
-      // mimic Pauli-X gate
-      CustomU3(M_PI, M_PI, M_PI_2, q);
-    };
-    auto counts = cudaq::sample(check_x);
-    counts.dump();
-    for (auto &[bits, count] : counts) {
-      EXPECT_TRUE(bits == "1");
-    }
-
-    auto bell_pair = []() {
-      cudaq::qvector qubits(2);
-      // mimic Hadamard gate
-      CustomU3(M_PI_2, 0., M_PI, qubits[0]);
-      x<cudaq::ctrl>(qubits[0], qubits[1]);
-    };
-    counts = cudaq::sample(bell_pair);
-    counts.dump();
-    for (auto &[bits, count] : counts) {
-      EXPECT_TRUE(bits == "00" || bits == "11");
-    }
-
-    // Can control
-    auto another_bell_pair = []() {
-      cudaq::qvector qubits(2);
-      CustomU3(M_PI_2, 0., M_PI, qubits[0]);
-      CustomU3<cudaq::ctrl>(M_PI, M_PI, M_PI_2, qubits[0], qubits[1]);
-    };
-    counts = cudaq::sample(another_bell_pair);
-    counts.dump();
-    for (auto &[bits, count] : counts) {
-      EXPECT_TRUE(bits == "00" || bits == "11");
-    }
-
-    // can adjoint
-    auto rotation_adjoint_test = []() {
-      cudaq::qubit q;
-      // mimic Rx gate
-      CustomU3(1.1, -M_PI_2, M_PI_2, q);
-      // rx<adj>(angle) = u3<adj>(angle, pi/2, -pi/2)
-      CustomU3<cudaq::adj>(1.1, M_PI_2, -M_PI_2, q);
-      // mimic Ry gate
-      CustomU3(1.1, 0., 0., q);
-      CustomU3<cudaq::adj>(1.1, 0., 0., q);
-    };
-
-    counts = cudaq::sample(rotation_adjoint_test);
-    counts.dump();
-    for (auto &[bits, count] : counts) {
-      EXPECT_TRUE(bits == "0");
-    }
-  }
-}
-
 CUDAQ_TEST(CustomUnitaryTester, checkMultiQubitOps) {
   {
     // Test swap operation
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qubit q, r;
       x(q);             // q -> 1, r -> 0
       CustomSwap(q, r); // q -> 0 , r -> 1
@@ -591,7 +425,7 @@ CUDAQ_TEST(CustomUnitaryTester, checkMultiQubitOps) {
 #ifndef CUDAQ_BACKEND_TENSORNET
   {
     // Multi-qubit can be controlled, with one-control
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qvector q(3);
       x(q[0]);
       x(q[1]);
@@ -608,7 +442,7 @@ CUDAQ_TEST(CustomUnitaryTester, checkMultiQubitOps) {
   }
   {
     // Multi-qubit can be controlled, with multi-qubit control
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qvector q(4);
       x(q.front(3));
       CustomCNOT<cudaq::ctrl>(q[0], q[1], q[2], q[3]);
@@ -624,7 +458,7 @@ CUDAQ_TEST(CustomUnitaryTester, checkMultiQubitOps) {
   }
   {
     // Test controlled swap operation
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qubit q, r, c;
       x(q);
       CustomSwap<cudaq::ctrl>(c, q, r); // no swap
@@ -640,7 +474,7 @@ CUDAQ_TEST(CustomUnitaryTester, checkMultiQubitOps) {
   }
   {
     // Test multi-controlled swap operation
-    auto kernel = []() {
+    auto kernel = []() __qpu__ {
       cudaq::qvector q(4);
       x(q.front(3));
       CustomSwap<cudaq::ctrl>(q[0], q[1], q[2], q[3]); // swap q[3] and q[2]

--- a/unittests/ptsbe/CMakeLists.txt
+++ b/unittests/ptsbe/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(test_ptsbe ${CUDAQ_GTEST_MAIN}
   NoiseExtractorTester.cpp
   TrajectoryDeduplicationTester.cpp)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
-  target_link_options(test_ptsbe PRIVATE -Wl,--no-as-needed)
+  target_link_options(test_ptsbe PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
 endif()
 target_include_directories(test_ptsbe PRIVATE .)
 target_link_libraries(test_ptsbe

--- a/unittests/qis/CMakeLists.txt
+++ b/unittests/qis/CMakeLists.txt
@@ -1,0 +1,29 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Library-mode QIS tests (host quantum types / parameterized custom ops).
+# Compiled with the ambient g++ under CUDAQ_LIBRARY_MODE from the parent
+# unittests/CMakeLists.txt. Kernel coverage that needs nvq++ lives under
+# unittests/nvqpp/qis/.
+
+add_executable(test_qis ${CUDAQ_GTEST_MAIN} QubitQISTester.cpp)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+  target_link_options(test_qis PRIVATE -Wl,--no-as-needed)
+endif()
+target_compile_definitions(test_qis PRIVATE -DNVQIR_BACKEND_NAME=qpp)
+target_link_libraries(test_qis
+  PRIVATE
+  cudaq
+  cudaq-em-default
+  cudaq-platform-default
+  cudaq-mlir-runtime
+  nvqir
+  nvqir-qpp
+  gtest_main)
+cudaq_gtest_discover_tests(test_qis PROPERTIES PROCESSORS ${CUDAQ_TEST_OMP_SLOTS}
+                            DISCOVERY_TIMEOUT 120)

--- a/unittests/qis/CMakeLists.txt
+++ b/unittests/qis/CMakeLists.txt
@@ -12,6 +12,9 @@
 # unittests/nvqpp/qis/.
 
 add_executable(test_qis ${CUDAQ_GTEST_MAIN} QubitQISTester.cpp)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+  target_link_options(test_qis PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
+endif()
 target_compile_definitions(test_qis PRIVATE -DNVQIR_BACKEND_NAME=qpp)
 target_link_libraries(test_qis
   PRIVATE

--- a/unittests/qis/CMakeLists.txt
+++ b/unittests/qis/CMakeLists.txt
@@ -12,9 +12,6 @@
 # unittests/nvqpp/qis/.
 
 add_executable(test_qis ${CUDAQ_GTEST_MAIN} QubitQISTester.cpp)
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
-  target_link_options(test_qis PRIVATE -Wl,--no-as-needed)
-endif()
 target_compile_definitions(test_qis PRIVATE -DNVQIR_BACKEND_NAME=qpp)
 target_link_libraries(test_qis
   PRIVATE

--- a/unittests/qis/QubitQISTester.cpp
+++ b/unittests/qis/QubitQISTester.cpp
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "CUDAQTestUtils.h"
+
+// Host-side quantum types (qubit.id(), qvector outside __qpu__, parameterized
+// custom ops using std::exp on complex values) require the CUDAQ_LIBRARY_MODE
+// inline QIS path. These tests stay here under the parent unittests/ g++
+// build; the nvq++ kernel coverage lives in unittests/nvqpp/qis/.
+
+CUDAQ_TEST(QubitQISTester, checkAllocateDeallocateSubRegister) {
+
+  {
+    cudaq::qubit q, r;
+    EXPECT_EQ(q.id(), 0);
+    EXPECT_EQ(r.id(), 1);
+
+    h(q, r);
+    cudaq::qvector qq(3);
+    auto f = qq.front(2);
+    h(f, qq[2]);
+  }
+
+  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
+
+  {
+    cudaq::qvector q(10);
+    for (auto [i, q] : cudaq::enumerate(q)) {
+      EXPECT_EQ(i, q.id());
+    }
+
+    cudaq::qubit r, s;
+    EXPECT_EQ(r.id(), 10);
+    EXPECT_EQ(s.id(), 11);
+
+    // out of scope, qubits returned
+  }
+  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
+
+  {
+    cudaq::qvector q(15);
+    EXPECT_EQ(q[14].id(), 14);
+
+    EXPECT_EQ(q.front().id(), 0);
+    EXPECT_EQ(q.back().id(), 14);
+    auto f5 = q.front(5);
+    EXPECT_EQ(f5.size(), 5);
+    for (auto [i, qq] : cudaq::enumerate(f5)) {
+      EXPECT_EQ(i, qq.id());
+    }
+
+    auto b4 = q.back(4);
+    EXPECT_EQ(b4.size(), 4);
+    EXPECT_EQ(b4[0].id(), 11);
+    EXPECT_EQ(b4[1].id(), 12);
+    EXPECT_EQ(b4[2].id(), 13);
+    EXPECT_EQ(b4[3].id(), 14);
+    EXPECT_EQ(b4.front().id(), 11);
+    EXPECT_EQ(b4.back().id(), 14);
+
+    auto view_from_span = b4.front(2);
+    EXPECT_EQ(view_from_span[0].id(), 11);
+    EXPECT_EQ(view_from_span[1].id(), 12);
+
+    auto slice = q.slice(4, 7);
+    EXPECT_EQ(slice.size(), 7);
+    for (auto [i, qq] : cudaq::enumerate(slice)) {
+      EXPECT_EQ(i + 4, qq.id());
+    }
+
+    auto slice_from_span = b4.slice(1, 2);
+    EXPECT_EQ(slice_from_span.size(), 2);
+    EXPECT_EQ(slice_from_span[0].id(), 12);
+    EXPECT_EQ(slice_from_span[1].id(), 13);
+  }
+
+  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
+}
+
+CUDAQ_TEST(QubitQISTester, checkArray) {
+  {
+    cudaq::qarray<5> compileTimeQubits;
+    EXPECT_EQ(compileTimeQubits.size(), 5);
+    for (int i = 0; i < 5; i++)
+      EXPECT_EQ(compileTimeQubits[i].id(), i);
+  }
+
+  {
+    cudaq::qarray<15> q;
+    EXPECT_EQ(q[14].id(), 14);
+
+    EXPECT_EQ(q.front().id(), 0);
+    EXPECT_EQ(q.back().id(), 14);
+    auto f5 = q.front(5);
+    EXPECT_EQ(f5.size(), 5);
+    for (auto [i, qq] : cudaq::enumerate(f5)) {
+      EXPECT_EQ(i, qq.id());
+    }
+
+    auto b4 = q.back(4);
+    EXPECT_EQ(b4.size(), 4);
+    EXPECT_EQ(b4[0].id(), 11);
+    EXPECT_EQ(b4[1].id(), 12);
+    EXPECT_EQ(b4[2].id(), 13);
+    EXPECT_EQ(b4[3].id(), 14);
+    EXPECT_EQ(b4.front().id(), 11);
+    EXPECT_EQ(b4.back().id(), 14);
+
+    auto view_from_span = b4.front(2);
+    EXPECT_EQ(view_from_span[0].id(), 11);
+    EXPECT_EQ(view_from_span[1].id(), 12);
+
+    auto slice = q.slice(4, 7);
+    EXPECT_EQ(slice.size(), 7);
+    for (auto [i, qq] : cudaq::enumerate(slice)) {
+      EXPECT_EQ(i + 4, qq.id());
+    }
+  }
+}
+
+using namespace std::complex_literals;
+
+// Parameterized CustomU3 uses std::exp on complex values in the unitary
+// generator; nvq++ cannot lower that. Keep this registration and its tests
+// in library mode only.
+CUDAQ_REGISTER_OPERATION(
+    CustomU3, 1, 3,
+    {std::cos(parameters[0] / 2.),
+     -std::exp(1i * parameters[2]) * std::sin(parameters[0] / 2.),
+     std::exp(1i * parameters[1]) * std::sin(parameters[0] / 2.),
+     std::exp(1i * (parameters[2] + parameters[1])) *
+         std::cos(parameters[0] / 2.)})
+
+CUDAQ_TEST(CustomUnitaryTester, checkParameterized) {
+  {
+    // parameterized op, custom u3
+    auto check_x = []() {
+      cudaq::qubit q;
+      // mimic Pauli-X gate
+      CustomU3(M_PI, M_PI, M_PI_2, q);
+    };
+    auto counts = cudaq::sample(check_x);
+    counts.dump();
+    for (auto &[bits, count] : counts) {
+      EXPECT_TRUE(bits == "1");
+    }
+
+    auto bell_pair = []() {
+      cudaq::qvector qubits(2);
+      // mimic Hadamard gate
+      CustomU3(M_PI_2, 0., M_PI, qubits[0]);
+      x<cudaq::ctrl>(qubits[0], qubits[1]);
+    };
+    counts = cudaq::sample(bell_pair);
+    counts.dump();
+    for (auto &[bits, count] : counts) {
+      EXPECT_TRUE(bits == "00" || bits == "11");
+    }
+
+    // Can control
+    auto another_bell_pair = []() {
+      cudaq::qvector qubits(2);
+      CustomU3(M_PI_2, 0., M_PI, qubits[0]);
+      CustomU3<cudaq::ctrl>(M_PI, M_PI, M_PI_2, qubits[0], qubits[1]);
+    };
+    counts = cudaq::sample(another_bell_pair);
+    counts.dump();
+    for (auto &[bits, count] : counts) {
+      EXPECT_TRUE(bits == "00" || bits == "11");
+    }
+
+    // can adjoint
+    auto rotation_adjoint_test = []() {
+      cudaq::qubit q;
+      // mimic Rx gate
+      CustomU3(1.1, -M_PI_2, M_PI_2, q);
+      // rx<adj>(angle) = u3<adj>(angle, pi/2, -pi/2)
+      CustomU3<cudaq::adj>(1.1, M_PI_2, -M_PI_2, q);
+      // mimic Ry gate
+      CustomU3(1.1, 0., 0., q);
+      CustomU3<cudaq::adj>(1.1, 0., 0., q);
+    };
+
+    counts = cudaq::sample(rotation_adjoint_test);
+    counts.dump();
+    for (auto &[bits, count] : counts) {
+      EXPECT_TRUE(bits == "0");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR updates C++ kernel unit tests (and a few minimal runtime headers) so they can be compiled with **nvq++**, without yet switching the `unittests/nvqpp/` build to use nvq++ as the compiler. That build flip is a follow-up step in the library-mode → nvq++ migration.

nvq++ only supports a subset of C++ inside `__qpu__` kernels and links many test TUs into shared gtest binaries, which exposed several incompatibilities that library mode (g++ + inlined QIS) hid. This change set works around those constraints in the tests so the later CMake/driver migration can land cleanly.

### Test adaptations

- **Per-file namespaces** for kernel structs/helpers — avoid multiply-defined symbols when many `.cpp` files are linked into one executable under nvq++.
- **No cross-kernel inlining** — mark lifted helpers `__attribute__((noinline)) __qpu__`, and replace nested `cudaq::control` / `cudaq::adjoint` lambdas with named noinline kernels where needed.
- **Unsupported kernel C++** — move `if constexpr` / host-only template dispatch out of kernels (e.g. `kernels_tester`), prefer explicit `__qpu__` lambdas / named functors, and rewrite chemistry paths that hit unsupported constructs (e.g. UCCSD via `make_kernel` builder overload; local HWE helpers instead of unsupported library patterns).
- **Split library-mode-only QIS coverage** — move host quantum-type / library-mode-only cases from `unittests/nvqpp/qis/QubitQISTester.cpp` into a new `unittests/qis/` (`test_qis`) target; keep nvq++-relevant QIS tests under `unittests/nvqpp/qis/`.

### Minimal runtime header tweaks (test-driven)

- `apply_noise.h` — `noinline` on `apply_noise` overloads.
- `uccsd.h` — gate `__qpu__` UCCSD helpers behind `CUDAQ_LIBRARY_MODE` (nvq++ path uses builder overloads).
- `givens_rotation.h` / `fermionic_swap.h` — move helpers from `cudaq::` to `cudaq_internal::` so nvq++ does not treat them as unknown builtins in the `cudaq` namespace.

### Out of scope (follow-up)

- Switching `unittests/nvqpp/` to `CMAKE_CXX_COMPILER=nvq++` / `add_nvqpp_executable` (Phase 2).
- Backend `BACKEND_CONFIG` → nvq++ `--target` flag migration (Phase 2b).
- Fixing nvq++ frontend limitations themselves (tests work around them for now).

