### PR TITLE
[Realtime] Building CUDA sources with C++20

### DIFF
--- a/realtime/CMakeLists.txt
+++ b/realtime/CMakeLists.txt
@@ -114,14 +114,11 @@ if(CUDAQ_REALTIME_STANDALONE_BUILD)
       endif()
     endif()
     CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_TARGET_ARCHS})
-    # Keep realtime CUDA sources on C++17. nvcc's C++20 frontend can hit an
-    # internal compiler error in libstdc++ headers when compiling the standalone
-    # realtime tests, including test_host_dispatcher.cu, on the CI toolchain.
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -shared -std=c++17 ${CUDA_gencode_flags} --compiler-options ${_host_compiler_opts}")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -shared -std=c++20 ${CUDA_gencode_flags} --compiler-options ${_host_compiler_opts}")
 
     enable_language(CUDA)
     set(CUDA_FOUND TRUE)
-    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD 20)
     set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
     message(STATUS "Cuda language found.")
   endif()

--- a/realtime/examples/gpu_dispatch/CMakeLists.txt
+++ b/realtime/examples/gpu_dispatch/CMakeLists.txt
@@ -53,7 +53,7 @@ add_executable(dispatch_kernel dispatch_kernel.cu)
 
 set_target_properties(dispatch_kernel PROPERTIES
   CUDA_SEPARABLE_COMPILATION ON
-  CUDA_STANDARD 17
+  CUDA_STANDARD 20
 )
 set_target_properties(dispatch_kernel PROPERTIES CUDA_ARCHITECTURES "80;90")
 

--- a/realtime/unittests/CMakeLists.txt
+++ b/realtime/unittests/CMakeLists.txt
@@ -54,7 +54,7 @@ if(CMAKE_CUDA_COMPILER)
   
   set_target_properties(test_dispatch_kernel PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
-    CUDA_STANDARD 17
+    CUDA_STANDARD 20
   )
   
   target_include_directories(test_dispatch_kernel PRIVATE
@@ -85,7 +85,7 @@ if(CMAKE_CUDA_COMPILER)
   add_executable(test_host_dispatcher test_host_dispatcher.cu)
   set_target_properties(test_host_dispatcher PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
-    CUDA_STANDARD 17
+    CUDA_STANDARD 20
   )
   target_include_directories(test_host_dispatcher PRIVATE
     ${CUDAToolkit_INCLUDE_DIRS}

--- a/realtime/unittests/utils/CMakeLists.txt
+++ b/realtime/unittests/utils/CMakeLists.txt
@@ -171,7 +171,7 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND
 
   set_target_properties(rpc_increment_ft PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
-    CUDA_STANDARD 17)
+    CUDA_STANDARD 20)
 
   target_include_directories(rpc_increment_ft PRIVATE
     ${CUDAQ_REALTIME_INCLUDE_DIR}


### PR DESCRIPTION
Building CUDA sources with C++20

Realtime CUDA sources were pinned to C++17 on the assumption that nvcc's C++20 frontend hits an internal compiler error in libstdc++ headers. That is not the case on the current toolchain.

Verified on `CUDA 12.6.85` with host `gcc 12.4` and `gcc 13.3` (all realtime `.cu` files) compile clean at `-std=c++20`.

Fixes #4719 