### PR TITLE
[python] Reuse compiled modules across asynchronous launches

### DIFF
--- a/python/cudaq/runtime/observe.py
+++ b/python/cudaq/runtime/observe.py
@@ -250,8 +250,10 @@ def observe_async(kernel, spin_operator, *args, qpu_id=0, shots_count=-1):
             " expected.")
     shortName = decorator.uniqName
     processedArgs, module = decorator.prepare_call(*args)
-    return cudaq_runtime.observe_async_impl(shortName, module, spin_operator,
-                                            qpu_id, shots_count, *processedArgs)
+    return cudaq_runtime.observe_async_impl(shortName, module,
+                                            decorator.compiledModuleCache(),
+                                            spin_operator, qpu_id, shots_count,
+                                            *processedArgs)
 
 
 def observe_parallel(kernel,
@@ -313,6 +315,8 @@ def observe_parallel(kernel,
             "unrecognized kernel - did you forget the @kernel attribute?")
     shortName = decorator.uniqName
     processedArgs, module = decorator.prepare_call(*args)
-    return cudaq_runtime.observe_parallel_impl(shortName, module, execution,
-                                               spin_operator, shots_count,
-                                               noise_model, *processedArgs)
+    return cudaq_runtime.observe_parallel_impl(shortName, module,
+                                               decorator.compiledModuleCache(),
+                                               execution, spin_operator,
+                                               shots_count, noise_model,
+                                               *processedArgs)

--- a/python/cudaq/runtime/ptsbe.py
+++ b/python/cudaq/runtime/ptsbe.py
@@ -167,8 +167,9 @@ def sample_async(kernel,
     processedArgs, module = decorator.prepare_call(*args)
 
     impl = cudaq_runtime.ptsbe.sample_async_impl(
-        decorator.uniqName, module, shots_count, noise_model, max_trajectories,
-        sampling_strategy, shot_allocation, return_execution_data,
-        include_sequential_data, *processedArgs)
+        decorator.uniqName, module, decorator.compiledModuleCache(),
+        shots_count, noise_model, max_trajectories, sampling_strategy,
+        shot_allocation, return_execution_data, include_sequential_data,
+        *processedArgs)
 
     return AsyncSampleResult(impl, module)

--- a/python/cudaq/runtime/run.py
+++ b/python/cudaq/runtime/run.py
@@ -31,9 +31,10 @@ class AsyncRunResult:
         cudaq_async_run_module_cache[self.counter] = mod
 
     def get(self):
-        result = self.impl.get()
-        self.getCalled = True
-        return result
+        try:
+            return self.impl.get()
+        finally:
+            self.getCalled = True
 
     def __del__(self):
         # FIXME: This potentially leaks memory intentionally. It is possible
@@ -118,8 +119,7 @@ Returns:
             raise ValueError("Noise model is not supported on hardware QPU.")
 
     processedArgs, module = decorator.prepare_call(*args)
-    async_results = cudaq_runtime.run_async_impl(decorator.uniqName + ".run",
-                                                 module, shots_count,
-                                                 noise_model, qpu_id,
-                                                 *processedArgs)
+    async_results = cudaq_runtime.run_async_impl(
+        decorator.uniqName + ".run", module, decorator.compiledModuleCache(),
+        shots_count, noise_model, qpu_id, *processedArgs)
     return AsyncRunResult(async_results, module)

--- a/python/cudaq/runtime/sample.py
+++ b/python/cudaq/runtime/sample.py
@@ -40,9 +40,10 @@ class AsyncSampleResult:
             self.counter = None
 
     def get(self):
-        result = self.impl.get()
-        self.getCalled = True
-        return result
+        try:
+            return self.impl.get()
+        finally:
+            self.getCalled = True
 
     def __del__(self):
         # FIXME : This potentially leaks memory intentionally. It is possible
@@ -268,8 +269,7 @@ def sample_async(decorator,
 
     _detail_check_explicit_measurements(explicit_measurements)
 
-    sample_results = cudaq_runtime.sample_async_impl(decorator.uniqName, module,
-                                                     shots_count, noise_model,
-                                                     explicit_measurements,
-                                                     qpu_id, *processedArgs)
+    sample_results = cudaq_runtime.sample_async_impl(
+        decorator.uniqName, module, decorator.compiledModuleCache(),
+        shots_count, noise_model, explicit_measurements, qpu_id, *processedArgs)
     return AsyncSampleResult(sample_results, module)

--- a/python/cudaq/runtime/state.py
+++ b/python/cudaq/runtime/state.py
@@ -76,6 +76,7 @@ def get_state_async(kernel, *args, qpu_id=0):
         decorator = mk_decorator(kernel)
     processedArgs, module = decorator.prepare_call(*args)
     return cudaq_runtime.get_state_async_impl(decorator.uniqName, module,
+                                              decorator.compiledModuleCache(),
                                               qpu_id, *processedArgs)
 
 

--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include <fmt/core.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
@@ -63,11 +64,11 @@ isValidObserveKernel_impl(const std::string &kernelName, MlirModule kernelMod) {
 }
 
 // The base `observe` launcher.
-static async_observe_result pyObserveAsync(const std::string &shortName,
-                                           mlir::ModuleOp mod,
-                                           const spin_op &spin_operator,
-                                           std::size_t qpu_id, int shots,
-                                           nanobind::args args) {
+static async_observe_result
+pyObserveAsync(const std::string &shortName, mlir::ModuleOp mod,
+               std::shared_ptr<detail::CompiledModuleCache> cache,
+               const spin_op &spin_operator, std::size_t qpu_id, int shots,
+               nanobind::args args) {
   auto &platform = get_platform();
   args = simplifiedValidateInputArguments(args);
   auto fnOp = getKernelFuncOp(mod, shortName);
@@ -81,18 +82,19 @@ static async_observe_result pyObserveAsync(const std::string &shortName,
         delete p;
       });
   return detail::runObservationAsync(
-      detail::make_copyable_function(
-          [opaques = std::move(opaques), shortName, clonedMod]() mutable {
-            if (cudaq::getEnvBool("CUDAQ_DUMP_JIT_IR", false))
-              clonedMod->dump();
-            [[maybe_unused]] auto result =
-                clean_launch_module(shortName, *clonedMod, opaques);
-          }),
+      detail::make_copyable_function([opaques = std::move(opaques), shortName,
+                                      clonedMod, cache]() mutable {
+        if (cudaq::getEnvBool("CUDAQ_DUMP_JIT_IR", false))
+          clonedMod->dump();
+        [[maybe_unused]] auto result =
+            clean_launch_module(shortName, *clonedMod, opaques, cache);
+      }),
       spin_operator, platform, shots, shortName, qpu_id);
 }
 
 static async_observe_result
 observe_async_impl(const std::string &shortName, MlirModule module,
+                   std::shared_ptr<detail::CompiledModuleCache> cache,
                    nanobind::object &spin_operator_obj, std::size_t qpu_id,
                    int shots, nanobind::args args) {
   // FIXME(OperatorCpp): Remove this when the operator class is implemented in
@@ -103,14 +105,15 @@ observe_async_impl(const std::string &shortName, MlirModule module,
     return nanobind::cast<spin_op>(obj);
   }(spin_operator_obj);
   auto mod = unwrap(module);
-  return pyObserveAsync(shortName, mod, spin_operator, qpu_id, shots, args);
+  return pyObserveAsync(shortName, mod, cache, spin_operator, qpu_id, shots,
+                        args);
 }
 
 /// @brief Run `cudaq::observe` on the provided kernel and spin operator.
-static observe_result
-pyObservePar(const PyParType &type, const std::string &shortName,
-             mlir::ModuleOp module, spin_op &spin_operator, int shots,
-             std::optional<noise_model> noise, nanobind::args args) {
+static observe_result pyObservePar(
+    const PyParType &type, const std::string &shortName, mlir::ModuleOp module,
+    std::shared_ptr<detail::CompiledModuleCache> cache, spin_op &spin_operator,
+    int shots, std::optional<noise_model> noise, nanobind::args args) {
   // Ensure the user input is correct.
   auto &platform = get_platform();
   if (!platform.supports_task_distribution())
@@ -134,7 +137,7 @@ pyObservePar(const PyParType &type, const std::string &shortName,
     return detail::distributeComputations(
         [&](std::size_t i, const spin_op &op) {
           nanobind::gil_scoped_acquire acquire;
-          return pyObserveAsync(shortName, module, op, i, shots, args);
+          return pyObserveAsync(shortName, module, cache, op, i, shots, args);
         },
         spin_operator, nQpus);
   }
@@ -159,7 +162,7 @@ pyObservePar(const PyParType &type, const std::string &shortName,
   auto localRankResult = detail::distributeComputations(
       [&](std::size_t i, const spin_op &op) {
         nanobind::gil_scoped_acquire acquire;
-        return pyObserveAsync(shortName, module, op, i, shots, args);
+        return pyObserveAsync(shortName, module, cache, op, i, shots, args);
       },
       localH, nQpus);
 
@@ -171,21 +174,21 @@ pyObservePar(const PyParType &type, const std::string &shortName,
 
 /// Observe can be a single observe call, a parallel observe call, or a observe
 /// broadcast. All these variants are handled here.
-static observe_result observe_parallel_impl(const std::string &shortName,
-                                            MlirModule module,
-                                            nanobind::object execution,
-                                            spin_op &spin_operator, int shots,
-                                            std::optional<noise_model> noise,
-                                            nanobind::args arguments) {
+static observe_result
+observe_parallel_impl(const std::string &shortName, MlirModule module,
+                      std::shared_ptr<detail::CompiledModuleCache> cache,
+                      nanobind::object execution, spin_op &spin_operator,
+                      int shots, std::optional<noise_model> noise,
+                      nanobind::args arguments) {
   std::string applicatorKey =
       std::string(nanobind::str(execution.attr("__name__")).c_str());
   auto mod = unwrap(module);
   if (applicatorKey == "thread")
-    return pyObservePar(PyParType::thread, shortName, mod, spin_operator, shots,
-                        noise, arguments);
+    return pyObservePar(PyParType::thread, shortName, mod, cache, spin_operator,
+                        shots, noise, arguments);
   if (applicatorKey == "mpi")
-    return pyObservePar(PyParType::mpi, shortName, mod, spin_operator, shots,
-                        noise, arguments);
+    return pyObservePar(PyParType::mpi, shortName, mod, cache, spin_operator,
+                        shots, noise, arguments);
   throw std::runtime_error("invalid parallel execution context");
 }
 
@@ -211,8 +214,8 @@ void cudaq::bindObserveAsync(nanobind::module_ &mod) {
 
   mod.def("observe_parallel_impl", observe_parallel_impl,
           nanobind::arg("shortName"), nanobind::arg("module"),
-          nanobind::arg("execution"), nanobind::arg("spin_operator"),
-          nanobind::arg("shots"), nanobind::arg("noise").none(),
-          nanobind::arg("arguments"),
+          nanobind::arg("cache"), nanobind::arg("execution"),
+          nanobind::arg("spin_operator"), nanobind::arg("shots"),
+          nanobind::arg("noise").none(), nanobind::arg("arguments"),
           "See the python documentation for observe_parallel.");
 }

--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -13,6 +13,7 @@
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/algorithms/run.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
+#include <exception>
 #include <future>
 #include <memory>
 #include <nanobind/nanobind.h>
@@ -151,12 +152,11 @@ run_impl(const std::string &shortName, MlirModule module,
 namespace {
 // Internal struct representing buffer to be filled asynchronously.
 // When the `ready` future is set, the content of the buffer is filled.
-// `results` and `error` are owned by the struct; the deferred future captures
-// non-owning raw pointers to them, which stay valid for the future's lifetime
-// because the future is destroyed before these members.
+// `results` is owned by the struct; the deferred future captures a non-owning
+// raw pointer to it, which stays valid for the future's lifetime because the
+// future is destroyed before this member.
 struct PyAsyncRunResult {
   std::unique_ptr<std::vector<nanobind::object>> results;
-  std::unique_ptr<std::string> error;
   std::future<void> ready;
 };
 } // namespace
@@ -164,6 +164,7 @@ struct PyAsyncRunResult {
 /// @brief Run `cudaq::run_async` on the provided kernel.
 static PyAsyncRunResult
 run_async_impl(const std::string &shortName, MlirModule module,
+               std::shared_ptr<detail::CompiledModuleCache> cache,
                std::size_t shots_count, std::optional<noise_model> noise_model,
                std::size_t qpu_id, nanobind::args runtimeArgs) {
   auto &platform = get_platform();
@@ -183,7 +184,6 @@ run_async_impl(const std::string &shortName, MlirModule module,
 
   PyAsyncRunResult result;
   result.results = std::make_unique<std::vector<nanobind::object>>();
-  result.error = std::make_unique<std::string>();
 
   if (shots_count == 0) {
     std::promise<void> promise;
@@ -195,9 +195,6 @@ run_async_impl(const std::string &shortName, MlirModule module,
   std::promise<detail::RunResultSpan> spanPromise;
   auto spanFuture = spanPromise.get_future();
 
-  std::promise<std::string> errorPromise;
-  auto errorFuture = errorPromise.get_future();
-
   auto fnOp = getFuncOpAndCheckResult(mod, shortName);
   auto opaques = marshal_arguments_for_module_launch(mod, runtimeArgs, fnOp);
   // Run the kernel and compute results span.
@@ -206,26 +203,30 @@ run_async_impl(const std::string &shortName, MlirModule module,
     // there is no need to re-acquire the GIL inside the thread.
     nanobind::gil_scoped_release gil_release{};
     QuantumTask wrapped = detail::make_copyable_function(
-        [sp = std::move(spanPromise), ep = std::move(errorPromise),
-         noise_model = std::move(noise_model), qpu_id, name = shortName,
-         opaques = std::move(opaques), shots_count,
-         mod = mod.clone()]() mutable {
+        [sp = std::move(spanPromise), noise_model = std::move(noise_model),
+         qpu_id, name = shortName, opaques = std::move(opaques), shots_count,
+         cache, mod = mod.clone()]() mutable {
           auto &platform = get_platform();
 
-          // Launch the kernel in the appropriate context.
-          if (noise_model.has_value())
-            platform.set_noise(&noise_model.value());
+          detail::RunResultSpan span{};
+          std::exception_ptr error;
           try {
-            auto span = pyRunTheKernel(name, platform, mod, nullptr,
-                                       shots_count, qpu_id, opaques);
-            sp.set_value(span);
-            ep.set_value("");
-          } catch (std::runtime_error &e) {
-            auto message = std::string(e.what());
-            sp.set_value({});
-            ep.set_value(message);
+            // Launch the kernel in the appropriate context.
+            if (noise_model.has_value())
+              platform.set_noise(&noise_model.value());
+            span = pyRunTheKernel(name, platform, mod, cache, shots_count,
+                                  qpu_id, opaques);
+          } catch (...) {
+            error = std::current_exception();
           }
-          platform.reset_noise();
+
+          if (noise_model.has_value())
+            detail::invoke_no_throw([&]() { platform.reset_noise(); });
+
+          if (error)
+            sp.set_exception(std::move(error));
+          else
+            sp.set_value(span);
         });
     platform.enqueueAsyncTask(qpu_id, wrapped);
   }
@@ -235,19 +236,14 @@ run_async_impl(const std::string &shortName, MlirModule module,
     // Release GIL to allow c++ threads, re-acquire for conversion of the
     // results to python objects.
     nanobind::gil_scoped_release gil_release{};
-    auto resultFuture = std::async(
-        std::launch::deferred,
-        [sf = std::move(spanFuture), ef = std::move(errorFuture),
-         errorPtr = result.error.get(), resultsPtr = result.results.get(), mod,
-         shortName]() mutable {
-          auto error = ef.get();
-          std::swap(*errorPtr, error);
-          if (error.empty()) {
-            auto span = sf.get();
-            nanobind::gil_scoped_acquire gil{};
-            auto results = pyReadResults(span, mod, shortName);
-            std::swap(*resultsPtr, results);
-          }
+    auto resultFuture =
+        std::async(std::launch::deferred, [sf = std::move(spanFuture),
+                                           resultsPtr = result.results.get(),
+                                           mod, shortName]() mutable {
+          auto span = sf.get();
+          nanobind::gil_scoped_acquire gil{};
+          auto results = pyReadResults(span, mod, shortName);
+          std::swap(*resultsPtr, results);
         });
     result.ready = std::move(resultFuture);
   }
@@ -288,15 +284,13 @@ void cudaq::bindPyRunAsync(nanobind::module_ &mod) {
               nanobind::gil_scoped_release release;
               self.ready.get();
             }
-            if (!self.error->empty())
-              throw std::runtime_error(*self.error);
             return std::move(*self.results);
           },
           "FIXME: documentation goes here");
 
   mod.def("run_async_impl", run_async_impl, nanobind::arg(), nanobind::arg(),
-          nanobind::arg(), nanobind::arg().none(), nanobind::arg(),
-          nanobind::arg(),
+          nanobind::arg(), nanobind::arg(), nanobind::arg().none(),
+          nanobind::arg(), nanobind::arg(),
           R"#(
 Run the provided `kernel` with the given kernel arguments over the specified
 number of circuit executions (`shots_count`) asynchronously on the specified

--- a/python/runtime/cudaq/algorithms/py_sample_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample_async.cpp
@@ -16,13 +16,15 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include <fmt/core.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
 using namespace cudaq;
 
 static async_sample_result sample_async_impl(
-    const std::string &shortName, MlirModule module, std::size_t shots_count,
+    const std::string &shortName, MlirModule module,
+    std::shared_ptr<detail::CompiledModuleCache> cache, std::size_t shots_count,
     std::optional<noise_model> noise_model, bool explicit_measurements,
     std::size_t qpu_id, nanobind::args runtimeArgs) {
   mlir::ModuleOp mod = unwrap(module);
@@ -57,11 +59,11 @@ static async_sample_result sample_async_impl(
       // (1) no Python data access is allowed in this lambda body.
       // (2) This lambda might be executed multiple times, e.g, when
       // the kernel contains measurement feedback.
-      detail::make_copyable_function(
-          [opaques = std::move(opaques), kernelName, clonedMod]() mutable {
-            [[maybe_unused]] auto result =
-                clean_launch_module(kernelName, *clonedMod, opaques);
-          }),
+      detail::make_copyable_function([opaques = std::move(opaques), kernelName,
+                                      clonedMod, cache]() mutable {
+        [[maybe_unused]] auto result =
+            clean_launch_module(kernelName, *clonedMod, opaques, cache);
+      }),
       platform, kernelName, shots_count, explicit_measurements, qpu_id,
       std::move(noise_model));
 }
@@ -111,7 +113,7 @@ programming pattern.
 
   mod.def("sample_async_impl", sample_async_impl, "FIXME: document",
           nanobind::arg("short_name"), nanobind::arg("module"),
-          nanobind::arg("shots_count"),
+          nanobind::arg("cache"), nanobind::arg("shots_count"),
           nanobind::arg("noise_model").none() = std::nullopt,
           nanobind::arg("explicit_measurements"), nanobind::arg("qpu_id"),
           nanobind::arg("runtime_args"));

--- a/python/runtime/cudaq/algorithms/py_sample_ptsbe.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample_ptsbe.cpp
@@ -113,6 +113,7 @@ struct AsyncPTSBESampleResultImpl {
 /// @brief Run PTSBE sampling asynchronously from Python.
 static AsyncPTSBESampleResultImpl
 pySampleAsyncPTSBE(const std::string &shortName, MlirModule module,
+                   std::shared_ptr<detail::CompiledModuleCache> cache,
                    std::size_t shots_count, noise_model &noiseModel,
                    std::optional<std::size_t> max_trajectories,
                    std::optional<std::shared_ptr<ptsbe::PTSSamplingStrategy>>
@@ -144,9 +145,10 @@ pySampleAsyncPTSBE(const std::string &shortName, MlirModule module,
   // Release GIL before launching async C++ work
   nanobind::gil_scoped_release release;
   return AsyncPTSBESampleResultImpl(ptsbe::detail::runSamplingAsyncPTSBE(
-      [opaques = std::move(opaques), kernelName, mod = mod.clone()]() mutable {
+      [opaques = std::move(opaques), kernelName, cache,
+       mod = mod.clone()]() mutable {
         [[maybe_unused]] auto result =
-            clean_launch_module(kernelName, mod, opaques);
+            clean_launch_module(kernelName, mod, opaques, cache);
       },
       platform, kernelName, shots_count, ptsbe_options, /*qpu_id=*/0,
       noiseModel));
@@ -432,8 +434,9 @@ Returns:
   // PTSBE async sample implementation
   ptsbe.def(
       "sample_async_impl", pySampleAsyncPTSBE, nanobind::arg("kernel_name"),
-      nanobind::arg("module"), nanobind::arg("shots_count"),
-      nanobind::arg("noise_model"), nanobind::arg("max_trajectories").none(),
+      nanobind::arg("module"), nanobind::arg("cache"),
+      nanobind::arg("shots_count"), nanobind::arg("noise_model"),
+      nanobind::arg("max_trajectories").none(),
       nanobind::arg("sampling_strategy").none(),
       nanobind::arg("shot_allocation").none(),
       nanobind::arg("return_execution_data"),

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -181,10 +181,10 @@ static state get_state_impl(const std::string &shortName, MlirModule mod,
   return detail::extractState(std::move(closure));
 }
 
-static std::future<state> get_state_async_impl(const std::string &shortName,
-                                               MlirModule module,
-                                               std::size_t qpu_id,
-                                               nanobind::args args) {
+static std::future<state>
+get_state_async_impl(const std::string &shortName, MlirModule module,
+                     std::shared_ptr<detail::CompiledModuleCache> cache,
+                     std::size_t qpu_id, nanobind::args args) {
   // Launch the asynchronous execution.
   auto mod = unwrap(module);
   std::string kernelName = shortName;
@@ -199,11 +199,11 @@ static std::future<state> get_state_async_impl(const std::string &shortName,
         delete p;
       });
   return detail::runGetStateAsync(
-      detail::make_copyable_function(
-          [opaques = std::move(opaques), kernelName, clonedMod]() mutable {
-            [[maybe_unused]] auto result =
-                clean_launch_module(kernelName, *clonedMod, opaques);
-          }),
+      detail::make_copyable_function([opaques = std::move(opaques), kernelName,
+                                      clonedMod, cache]() mutable {
+        [[maybe_unused]] auto result =
+            clean_launch_module(kernelName, *clonedMod, opaques, cache);
+      }),
       platform, qpu_id);
 }
 
@@ -885,15 +885,16 @@ for more information on this programming pattern.)#")
 
   mod.def(
       "get_state_async_impl",
-      [&](const std::string &shortName, MlirModule module, std::size_t qpu_id,
-          nanobind::args args) {
+      [&](const std::string &shortName, MlirModule module,
+          std::shared_ptr<detail::CompiledModuleCache> cache,
+          std::size_t qpu_id, nanobind::args args) {
         // Check for unsupported cases.
         if (holder.getTarget().name == "orca-photonics" ||
             is_remote_platform() || is_emulated_platform())
           throw std::runtime_error(
               "get_state_async is not supported in this context.");
 
-        return get_state_async_impl(shortName, module, qpu_id, args);
+        return get_state_async_impl(shortName, module, cache, qpu_id, args);
       },
       "See the python documentation for get_state_async.");
 

--- a/python/tests/mlir/compiled_module_cache.py
+++ b/python/tests/mlir/compiled_module_cache.py
@@ -20,9 +20,15 @@
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s fifo_eviction 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=FIFO-EVICTION %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s execution_failure > %t.execution_failure 2>&1 || (cat %t.execution_failure && false)
 # RUN: grep 'py_alt_launch_kernel.cpp' %t.execution_failure | FileCheck --check-prefix=EXECUTION-FAILURE %s
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s observe_async > %t.observe_async 2>&1 && (grep 'py_alt_launch_kernel.cpp' %t.observe_async | FileCheck --check-prefix=OBSERVE-ASYNC %s) || (cat %t.observe_async && false)
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s async_apis > %t.async_apis 2>&1 && (grep 'py_alt_launch_kernel.cpp' %t.async_apis | FileCheck --check-prefix=ASYNC-APIS %s) || (cat %t.async_apis && false)
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s async_dependencies > %t.async_dependencies 2>&1 && (grep 'py_alt_launch_kernel.cpp' %t.async_dependencies | FileCheck --check-prefix=ASYNC-DEPENDENCIES %s) || (cat %t.async_dependencies && false)
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s async_targets > %t.async_targets 2>&1 && (grep 'py_alt_launch_kernel.cpp' %t.async_targets | FileCheck --check-prefix=ASYNC-TARGETS %s) || (cat %t.async_targets && false)
+# RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s async_execution_failure > %t.async_execution_failure 2>&1 && (grep 'py_alt_launch_kernel.cpp' %t.async_execution_failure | FileCheck --check-prefix=ASYNC-EXECUTION-FAILURE %s) || (cat %t.async_execution_failure && false)
 # clang-format on
 
 import concurrent.futures
+import gc
 import math
 import sys
 import threading
@@ -156,12 +162,15 @@ def scenario_dependencies():
 
     @cudaq.kernel
     def leaf(q: cudaq.qubit):
-        pass
+        h(q)
 
     for _ in range(2):
-        assert cudaq.observe(outer, observable).expectation() == 1.0
+        expectation = cudaq.observe(outer, observable).expectation()
+        assert abs(expectation) < 1e-12, expectation
 
-    angle = 0.0
+    # Keep both captured-value variants non-degenerate. A zero rotation can be
+    # folded away and leave the allocated qubit dead under value semantics.
+    angle = math.pi / 3.0
 
     @cudaq.kernel
     def rotate(q: cudaq.qubit):
@@ -173,12 +182,13 @@ def scenario_dependencies():
         rotate(q)
 
     for _ in range(2):
-        assert cudaq.observe(rotate_outer, observable).expectation() == 1.0
+        expectation = cudaq.observe(rotate_outer, observable).expectation()
+        assert 0.4 < expectation < 0.6, expectation
 
-    angle = math.pi
+    angle = 2.0 * math.pi / 3.0
     for _ in range(2):
-        assert abs(cudaq.observe(rotate_outer, observable).expectation() +
-                   1.0) < 1e-12
+        expectation = cudaq.observe(rotate_outer, observable).expectation()
+        assert -0.6 < expectation < -0.4, expectation
 
 
 # A transitive helper rebind and a nested helper's captured-value change each
@@ -442,6 +452,195 @@ def scenario_execution_failure():
 # EXECUTION-FAILURE-NEXT: Reusing cached module
 # EXECUTION-FAILURE-NOT: Compiling module
 
+
+def scenario_observe_async():
+    """Outstanding equivalent observations reuse one compiled artifact."""
+
+    @cudaq.kernel
+    def flipped():
+        q = cudaq.qubit()
+        x(q)
+
+    observable = cudaq.spin.z(0)
+    futures = [cudaq.observe_async(flipped, observable) for _ in range(4)]
+    for future in futures:
+        assert future.get().expectation() == -1.0
+
+
+# One serial QPU queue: the first task compiles and publishes, then the three
+# remaining tasks find the artifact ready.
+# OBSERVE-ASYNC: Compiling module
+# OBSERVE-ASYNC-NEXT: Caching module
+# OBSERVE-ASYNC-NEXT: Reusing cached module
+# OBSERVE-ASYNC-NEXT: Reusing cached module
+# OBSERVE-ASYNC-NEXT: Reusing cached module
+# OBSERVE-ASYNC-NOT: Compiling module
+
+
+def scenario_async_apis():
+    """Every decorator-backed async API reuses its compiled artifact."""
+
+    @cudaq.kernel
+    def async_sample_ones():
+        q = cudaq.qubit()
+        x(q)
+
+    futures = [
+        cudaq.sample_async(async_sample_ones, shots_count=4) for _ in range(2)
+    ]
+    for future in futures:
+        assert future.get().count("1") == 4
+
+    @cudaq.kernel
+    def async_state_one():
+        q = cudaq.qubit()
+        x(q)
+
+    futures = [cudaq.get_state_async(async_state_one) for _ in range(2)]
+    for future in futures:
+        state = future.get()
+        assert abs(state[0]) < 1e-12
+        assert abs(state[1] - 1.0) < 1e-12
+
+    @cudaq.kernel
+    def async_run_true() -> bool:
+        return True
+
+    futures = [cudaq.run_async(async_run_true, shots_count=1) for _ in range(2)]
+    for future in futures:
+        assert future.get() == [True]
+
+    @cudaq.kernel
+    def async_ptsbe_ones():
+        q = cudaq.qubit()
+        x(q)
+
+    noise = cudaq.NoiseModel()
+    noise.add_all_qubit_channel("x", cudaq.BitFlipChannel(1.0))
+    futures = [
+        cudaq.ptsbe.sample_async(async_ptsbe_ones,
+                                 shots_count=4,
+                                 noise_model=noise) for _ in range(2)
+    ]
+    for future in futures:
+        assert future.get().count("0") == 4
+
+
+# Each API has its own decorator cache. On the serial CPU queue, the first
+# launch publishes and the second launch becomes a ready reader.
+# ASYNC-APIS: Compiling module {{.*}}async_sample_ones
+# ASYNC-APIS-NEXT: Caching module {{.*}}async_sample_ones
+# ASYNC-APIS-NEXT: Reusing cached module {{.*}}async_sample_ones
+# ASYNC-APIS: Compiling module {{.*}}async_state_one
+# ASYNC-APIS-NEXT: Caching module {{.*}}async_state_one
+# ASYNC-APIS-NEXT: Reusing cached module {{.*}}async_state_one
+# ASYNC-APIS: Compiling module {{.*}}async_run_true{{.*}}.run
+# ASYNC-APIS-NEXT: Caching module {{.*}}async_run_true{{.*}}.run
+# ASYNC-APIS-NEXT: Reusing cached module {{.*}}async_run_true{{.*}}.run
+# ASYNC-APIS: Compiling module {{.*}}async_ptsbe_ones
+# ASYNC-APIS-NEXT: Caching module {{.*}}async_ptsbe_ones
+# ASYNC-APIS-NEXT: Reusing cached module {{.*}}async_ptsbe_ones
+# ASYNC-APIS-NOT: Compiling module
+
+
+def scenario_async_dependencies():
+    """A changed captured dependency creates one new async artifact."""
+
+    @cudaq.kernel
+    def apply_x(q: cudaq.qubit):
+        x(q)
+
+    @cudaq.kernel
+    def apply_h(q: cudaq.qubit):
+        h(q)
+
+    helper = apply_x
+
+    @cudaq.kernel
+    def outer():
+        q = cudaq.qubit()
+        helper(q)
+
+    observable = cudaq.spin.z(0)
+    for dependency, expected in ((apply_x, -1.0), (apply_h, 0.0)):
+        helper = dependency
+        futures = [cudaq.observe_async(outer, observable) for _ in range(2)]
+        for future in futures:
+            assert abs(future.get().expectation() - expected) < 1e-12
+
+
+# The helper rebind changes the program digest once; each digest is then reused.
+# ASYNC-DEPENDENCIES: Compiling module
+# ASYNC-DEPENDENCIES-NEXT: Caching module
+# ASYNC-DEPENDENCIES-NEXT: Reusing cached module
+# ASYNC-DEPENDENCIES-NEXT: Compiling module
+# ASYNC-DEPENDENCIES-NEXT: Caching module
+# ASYNC-DEPENDENCIES-NEXT: Reusing cached module
+# ASYNC-DEPENDENCIES-NOT: Compiling module
+
+
+def scenario_async_targets():
+    """A fully specialized target takes the conservative async fallback."""
+
+    @cudaq.kernel
+    def flipped():
+        q = cudaq.qubit()
+        x(q)
+
+    observable = cudaq.spin.z(0)
+    assert cudaq.observe_async(flipped, observable).get().expectation() == -1.0
+
+    cudaq.set_target("quantinuum", emulate=True)
+    try:
+        assert cudaq.observe_async(flipped,
+                                   observable).get().expectation() == -1.0
+    finally:
+        cudaq.reset_target()
+
+    assert cudaq.observe_async(flipped, observable).get().expectation() == -1.0
+
+
+# The fully specialized target declines caching; returning to local simulator
+# reuses the original ready entry.
+# ASYNC-TARGETS: Compiling module
+# ASYNC-TARGETS-NEXT: Caching module
+# ASYNC-TARGETS-NEXT: Compiling module
+# ASYNC-TARGETS-NEXT: Reusing cached module
+# ASYNC-TARGETS-NOT: Compiling module
+
+
+def scenario_async_execution_failure():
+    """Execution errors leave the asynchronously published artifact ready."""
+    from cudaq.runtime.sample import cudaq_async_sample_module_cache
+
+    @cudaq.kernel
+    def failing(n: int):
+        q = cudaq.qvector(n)
+        exp_pauli(1.0, q, "XX")
+
+    retained_modules = len(cudaq_async_sample_module_cache)
+    futures = [cudaq.sample_async(failing, 1, shots_count=1) for _ in range(2)]
+    for future in futures:
+        try:
+            future.get()
+        except RuntimeError as error:
+            assert "incorrect number of qubits" in str(error)
+        else:
+            raise AssertionError("mismatched exp_pauli unexpectedly succeeded")
+
+    futures.clear()
+    del future
+    gc.collect()
+    assert len(cudaq_async_sample_module_cache) == retained_modules
+
+
+# Compilation publishes before execution fails; the second queued task reuses
+# the ready artifact and reports the same error through its future.
+# ASYNC-EXECUTION-FAILURE: Compiling module
+# ASYNC-EXECUTION-FAILURE-NEXT: Caching module
+# ASYNC-EXECUTION-FAILURE-NEXT: Reusing cached module
+# ASYNC-EXECUTION-FAILURE-NOT: Compiling module
+
 SCENARIOS = {
     "run": scenario_run,
     "sample": scenario_sample,
@@ -454,6 +653,11 @@ SCENARIOS = {
     "multi_entry": scenario_multi_entry,
     "fifo_eviction": scenario_fifo_eviction,
     "execution_failure": scenario_execution_failure,
+    "observe_async": scenario_observe_async,
+    "async_apis": scenario_async_apis,
+    "async_dependencies": scenario_async_dependencies,
+    "async_targets": scenario_async_targets,
+    "async_execution_failure": scenario_async_execution_failure
 }
 
 if __name__ == "__main__":

--- a/runtime/cudaq/algorithms/get_state.h
+++ b/runtime/cudaq/algorithms/get_state.h
@@ -19,6 +19,7 @@
 #include "cudaq/qis/qkernel.h"
 #include "cudaq/qis/state.h"
 #include <complex>
+#include <exception>
 #include <vector>
 
 namespace cudaq {
@@ -74,15 +75,19 @@ auto runGetStateAsync(KernelFunctor &&wrappedKernel,
   QuantumTask wrapped = detail::make_copyable_function(
       [p = std::move(promise), qpu_id, &platform,
        func = std::forward<KernelFunctor>(wrappedKernel)]() mutable {
-        ExecutionContext context("extract-state");
-        // Indicate that this is an async exec
-        context.asyncExec = true;
-        context.qpuId = qpu_id;
-        // Set the platform and the qpu id.
-        platform.with_execution_context(context,
-                                        std::forward<KernelFunctor>(func));
-        // Extract state data
-        p.set_value(state(context.simulationState.release()));
+        try {
+          ExecutionContext context("extract-state");
+          // Indicate that this is an async exec
+          context.asyncExec = true;
+          context.qpuId = qpu_id;
+          // Set the platform and the qpu id.
+          platform.with_execution_context(context,
+                                          std::forward<KernelFunctor>(func));
+          // Extract state data
+          p.set_value(state(context.simulationState.release()));
+        } catch (...) {
+          p.set_exception(std::current_exception());
+        }
       });
 
   platform.enqueueAsyncTask(qpu_id, wrapped);

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -17,6 +17,7 @@
 #include "cudaq/algorithms/policy_dispatch.h"
 #include "cudaq/platform/qpu.h"
 #include "cudaq/runtime/logger/logger.h"
+#include <exception>
 #include <string>
 
 using namespace cudaq_internal::compiler;
@@ -164,8 +165,11 @@ quantum_platform::enqueueAsyncTask(const std::size_t qpu_id,
   auto f = promise.get_future();
   QuantumTask wrapped = detail::make_copyable_function(
       [p = std::move(promise), t = task]() mutable {
-        auto counts = t();
-        p.set_value(counts);
+        try {
+          p.set_value(t());
+        } catch (...) {
+          p.set_exception(std::current_exception());
+        }
       });
 
   platformQPUs[qpu_id]->enqueue(wrapped);


### PR DESCRIPTION
### Summary

* Builds on the shared, per-kernel `CompiledModuleCache` merged in PR #4998.

* The synchronous Python launch paths already pass each kernel decorator's cache to the compiler. The asynchronous paths omitted it, causing every queued launch to compile a temporary artifact even when an equivalent artifact was already ready.

* This PR threads the same cache through all applicable decorator-backed asynchronous launch paths:

| Public path | Change |
|---|---|
| `cudaq.observe_async` and parallel observe | Pass the decorator cache into every queued QPU task |
| `cudaq.sample_async` | Capture the decorator cache in the sampling worker |
| `cudaq.get_state_async` | Capture the cache and propagate worker failures through the state future |
| `cudaq.run_async` | Use the cache in `pyRunTheKernel` and preserve noise cleanup on failure |
| `cudaq.ptsbe.sample_async` | Capture the cache in the PTSBE worker |
| Async result wrappers | Release retained Python modules after successful or failed `.get()` |

### Async exception transport

Previously, an exception escaping a queued task unwound out of the queue thread and terminated the process. That made compilation-failure propagation through an async future impossible.

This PR installs worker exceptions into the corresponding promise:

- the generic platform queue transports sample and observe failures;
- the state worker sets exceptions on its state promise; and
- `run_async` sets exceptions on its result-span promise and resets noise on
  every exit path.

Calling `.get()` now reports the original failure to Python. An execution failure after successful compilation does not remove or corrupt the ready cache entry.

### Performance

Release build at final commit, using one GPU with the `nvidia` target and `mqpu,fp32`. (Note these are from a local devbox, so absolute numbers are high)

| NVIDIA `mqpu,fp32` workload | #4998 baseline | This PR | Speedup |
|---|---:|---:|---:|
| Warm `observe_async` p50 (MAD), Transformer kernel | 81.499 ms (1.540) | 2.893 ms (0.154) | **28.2x** |
| Quantum Transformer 276-pair forward slice, median (MAD) | 22.860 s (0.298) | 0.638 s (0.006) | **35.8x** |
| Warm async trace: MLIR passes / JIT engines / module clones | 544 / 1 / 1 | 0 / 0 / 1 | Redundant compilation removed |

