### PR TITLE
Update the IB Stack in our docker containers for improved performance.

### DIFF
--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -53,7 +53,8 @@ RUN rm -f /etc/apt/sources.list.d/cuda.list
 # Install DOCA-OFED 3.1.0 userspace runtime dependencies.
 # Install only the RDMA/IB libraries needed by the HPC stack (UCX/OpenMPI), plus SHARP,
 # not the full doca-ofed-userspace metapackage (which also pulls in openmpi, hcoll, …).
-# Note: the sharp package Depends on DOCA's ucx package.
+# Note: the sharp package Depends on DOCA's ucx; our UCX build is preferred via
+# ld.so.conf.d / LD_LIBRARY_PATH.
 
 ARG TARGETARCH
 ARG DOCA_VERSION=3.1.0-091000-25.07
@@ -104,8 +105,14 @@ RUN echo "$GDRCOPY_INSTALL_PREFIX/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldco
 
 ARG UCX_INSTALL_PREFIX=/usr/local/ucx
 ENV UCX_INSTALL_PREFIX="$UCX_INSTALL_PREFIX"
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$UCX_INSTALL_PREFIX/lib"
+ENV LD_LIBRARY_PATH="$UCX_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+ENV PATH="$UCX_INSTALL_PREFIX/bin:$PATH"
 COPY --from=ompibuild "$UCX_INSTALL_PREFIX" "$UCX_INSTALL_PREFIX"
+
+# DOCA's sharp package pulls DOCA's ucx into /usr/lib; listing our prefix in
+# ld.so.conf.d makes the loader prefer this build (those entries precede the
+# default system directories).
+RUN echo "$UCX_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
 
 # Copy over MUNGE.
 

--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -130,10 +130,6 @@ RUN echo "$OPENMPI_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconf
 
 ENV OMPI_MCA_btl=^smcuda,vader,tcp,uct,openib
 ENV OMPI_MCA_pml=ucx
-ENV UCX_IB_PCI_RELAXED_ORDERING=on
-ENV UCX_MAX_RNDV_RAILS=1
-ENV UCX_MEMTYPE_CACHE=n
-ENV UCX_TLS=rc,cuda_copy,cuda_ipc,gdr_copy,sm
 
 # Install CUDA
 

--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -128,7 +128,6 @@ RUN echo "$OPENMPI_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconf
 
 # Set some configurations in the form of environment variables.
 
-ENV OMPI_MCA_btl=^smcuda,vader,tcp,uct,openib
 ENV OMPI_MCA_pml=ucx
 
 # Install CUDA

--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -50,17 +50,35 @@ RUN apt update && apt-get install -y --no-install-recommends ca-certificates wge
 # When cuda packages are installed below, the keyring will be reinstalled.
 RUN rm -f /etc/apt/sources.list.d/cuda.list
 
-# Install Mellanox OFED runtime and development dependencies.
+# Install DOCA-OFED 3.1.0 userspace runtime dependencies.
+# Install only the RDMA/IB libraries needed by the HPC stack (UCX/OpenMPI), plus SHARP,
+# not the full doca-ofed-userspace metapackage (which also pulls in openmpi, hcoll, …).
+# Note: the sharp package Depends on DOCA's ucx package.
 
-RUN apt-get update && apt-get install -y --no-install-recommends gnupg \
-    && wget -qO - "https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox" | apt-key add - \
-    && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d "https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list" \
-    && apt-get update -y && apt-get install -y --no-install-recommends \
-        ibverbs-providers ibverbs-utils \
-        libibmad5 libibumad3 libibverbs-dev libibverbs1 librdmacm1 \
-    && rm /etc/apt/trusted.gpg && rm /etc/apt/sources.list.d/mellanox_mlnx_ofed.list \
-    && apt-get remove -y gnupg \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+ARG TARGETARCH
+ARG DOCA_VERSION=3.1.0-091000-25.07
+ENV SHARP_INSTALL_PREFIX=/opt/mellanox/sharp
+RUN arch=$([ "$TARGETARCH" = "arm64" ] && echo arm64 || echo amd64) \
+    && doca_deb="doca-host_${DOCA_VERSION}-ubuntu2404_${arch}.deb" \
+    && wget -q -nc --no-check-certificate -P /var/tmp \
+        "https://www.mellanox.com/downloads/DOCA/DOCA_v3.1.0/host/${doca_deb}" \
+    && dpkg -i "/var/tmp/${doca_deb}" \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        libibverbs1 libibverbs-dev ibverbs-providers \
+        librdmacm1 librdmacm-dev \
+        libibumad3 libibumad-dev \
+        libibmad5 libibmad-dev \
+        libxpmem0 libxpmem-dev xpmem knem \
+        sharp \
+    && echo "$SHARP_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
+    && rm -f "/var/tmp/${doca_deb}" \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Optional runtime diagnostics (ibv_devinfo, rdma_*, ib_write_bw, ofed_info):
+# RUN apt-get update -y \
+#     && apt-get install -y --no-install-recommends \
+#         rdma-core ibverbs-utils rdmacm-utils perftest ofed-scripts \
+#     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy over SLURM PMI2.
 
@@ -116,8 +134,7 @@ ENV MPI_HOME="$OPENMPI_INSTALL_PREFIX"
 ENV MPI_ROOT="$OPENMPI_INSTALL_PREFIX"
 ENV MPI_PATH="$OPENMPI_INSTALL_PREFIX"
 ENV PATH="$OPENMPI_INSTALL_PREFIX/bin:$PATH"
-ENV CPATH="$OPENMPI_INSTALL_PREFIX/include:/usr/local/ofed/5.0-0/include:$CPATH"
-ENV LIBRARY_PATH="/usr/local/ofed/5.0-0/lib:$LIBRARY_PATH"
+ENV CPATH="$OPENMPI_INSTALL_PREFIX/include:$CPATH"
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENMPI_INSTALL_PREFIX/lib"
 COPY --from=ompibuild "$OPENMPI_INSTALL_PREFIX" "$OPENMPI_INSTALL_PREFIX"
 

--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -162,6 +162,12 @@ RUN echo "$OPENMPI_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconf
 # Set some configurations in the form of environment variables.
 
 ENV OMPI_MCA_pml=ucx
+# Default shared-memory single-copy to CMA (avoids xpmem/knem device warnings
+# when those nodes are not mounted). Open MPI 4 uses btl_vader; Open MPI 5
+# uses the smsc framework (btl_sm is a 5.0.x alias for vader).
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=cma
+ENV OMPI_MCA_btl_sm_single_copy_mechanism=cma
+ENV OMPI_MCA_smsc=cma
 
 # Install CUDA
 

--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -51,7 +51,7 @@ RUN apt update && apt-get install -y --no-install-recommends ca-certificates wge
 RUN rm -f /etc/apt/sources.list.d/cuda.list
 
 # Install DOCA-OFED 3.1.0 userspace runtime dependencies.
-# Install only the RDMA/IB libraries needed by the HPC stack (UCX/OpenMPI), plus SHARP,
+# Install only the RDMA/IB libraries needed by UCX/UCC/OpenMPI, plus SHARP,
 # not the full doca-ofed-userspace metapackage (which also pulls in openmpi, hcoll, …).
 # Note: the sharp package Depends on DOCA's ucx; our UCX build is preferred via
 # ld.so.conf.d / LD_LIBRARY_PATH.
@@ -113,6 +113,15 @@ COPY --from=ompibuild "$UCX_INSTALL_PREFIX" "$UCX_INSTALL_PREFIX"
 # ld.so.conf.d makes the loader prefer this build (those entries precede the
 # default system directories).
 RUN echo "$UCX_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
+
+# Copy over UCC.
+
+ARG UCC_INSTALL_PREFIX=/usr/local/ucc
+ENV UCC_INSTALL_PREFIX="$UCC_INSTALL_PREFIX"
+ENV LD_LIBRARY_PATH="$UCC_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+ENV PATH="$UCC_INSTALL_PREFIX/bin:$PATH"
+COPY --from=ompibuild "$UCC_INSTALL_PREFIX" "$UCC_INSTALL_PREFIX"
+RUN echo "$UCC_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
 
 # Copy over MUNGE.
 

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -56,16 +56,34 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     && make -C contribs/pmi2 install \
     && rm -rf /var/tmp/slurm-21.08.8 /var/tmp/slurm-21.08.8.tar.bz2
 
-# 3 - Install Mellanox OFED version 5.3-1.0.0.1
+# 3 - Install DOCA-OFED 3.1.0 (userspace)
+# Install only the RDMA/IB libraries needed by the HPC stack (UCX/OpenMPI), plus SHARP,
+# not the full doca-ofed-userspace metapackage (which also pulls in openmpi, hcoll, …).
+# Note: the sharp package Depends on DOCA's ucx package.
 
-RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - \
-    && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list \
-    && apt-get update -y && apt-get install -y --no-install-recommends \
-        ibverbs-providers ibverbs-utils \
-        libibmad-dev libibmad5 libibumad-dev libibumad3 \
-        libibverbs-dev libibverbs1 \
-        librdmacm-dev librdmacm1 \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+ARG DOCA_VERSION=3.1.0-091000-25.07
+ENV SHARP_INSTALL_PREFIX=/opt/mellanox/sharp
+RUN arch=$([ "$TARGETARCH" = "arm64" ] && echo arm64 || echo amd64) \
+    && doca_deb="doca-host_${DOCA_VERSION}-ubuntu2404_${arch}.deb" \
+    && wget -q -nc --no-check-certificate -P /var/tmp \
+        "https://www.mellanox.com/downloads/DOCA/DOCA_v3.1.0/host/${doca_deb}" \
+    && dpkg -i "/var/tmp/${doca_deb}" \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        libibverbs1 libibverbs-dev ibverbs-providers \
+        librdmacm1 librdmacm-dev \
+        libibumad3 libibumad-dev \
+        libibmad5 libibmad-dev \
+        libxpmem0 libxpmem-dev xpmem knem \
+        sharp \
+    && echo "$SHARP_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
+    && rm -f "/var/tmp/${doca_deb}" \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Optional runtime diagnostics (ibv_devinfo, rdma_*, ib_write_bw, ofed_info):
+# RUN apt-get update -y \
+#     && apt-get install -y --no-install-recommends \
+#         rdma-core ibverbs-utils rdmacm-utils perftest ofed-scripts \
+#     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # 4 - Install GDRCOPY version 2.3.1
 

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -59,7 +59,8 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
 # 3 - Install DOCA-OFED 3.1.0 (userspace)
 # Install only the RDMA/IB libraries needed by the HPC stack (UCX/OpenMPI), plus SHARP,
 # not the full doca-ofed-userspace metapackage (which also pulls in openmpi, hcoll, …).
-# Note: the sharp package Depends on DOCA's ucx package.
+# Note: the sharp package Depends on DOCA's ucx; our UCX build below is preferred via
+# ld.so.conf.d / LD_LIBRARY_PATH.
 
 ARG DOCA_VERSION=3.1.0-091000-25.07
 ENV SHARP_INSTALL_PREFIX=/opt/mellanox/sharp
@@ -95,7 +96,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     && mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v${GDRCOPY_VERSION}.tar.gz \
     && tar -x -f /var/tmp/v${GDRCOPY_VERSION}.tar.gz -C /var/tmp -z && cd /var/tmp/gdrcopy-${GDRCOPY_VERSION} \
     && mkdir -p "$GDRCOPY_INSTALL_PREFIX/include" "$GDRCOPY_INSTALL_PREFIX/lib64" \
-    && make PREFIX="$GDRCOPY_INSTALL_PREFIX" lib lib_install \
+    && make prefix="$GDRCOPY_INSTALL_PREFIX" libdir="$GDRCOPY_INSTALL_PREFIX/lib64" lib lib_install \
     && echo "$GDRCOPY_INSTALL_PREFIX/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
     && rm -rf /var/tmp/gdrcopy-${GDRCOPY_VERSION} /var/tmp/v${GDRCOPY_VERSION}.tar.gz \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
@@ -103,13 +104,14 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 ENV CPATH="$GDRCOPY_INSTALL_PREFIX/include:$CPATH"
 ENV LIBRARY_PATH="$GDRCOPY_INSTALL_PREFIX/lib64:$LIBRARY_PATH"
 
-# 5 - Install UCX version v1.19.0
+# 5 - Install UCX version 1.21.0
 
+ENV UCX_VERSION=1.21.0
 ENV UCX_INSTALL_PREFIX=/usr/local/ucx
-RUN mkdir -p /var/tmp && cd /var/tmp \
-    && git clone https://github.com/openucx/ucx.git ucx && cd /var/tmp/ucx \
-    && git checkout v1.19.0 \
-    && ./autogen.sh \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp \
+        "https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz" \
+    && tar -x -f /var/tmp/ucx-${UCX_VERSION}.tar.gz -C /var/tmp -z \
+    && cd /var/tmp/ucx-${UCX_VERSION} \
     && export common_flags=$([ "$TARGETARCH" == "arm64" ] && echo "$COMMON_COMPILER_FLAGS_ARM" || echo "$COMMON_COMPILER_FLAGS") \
     &&  CC=gcc CFLAGS="$common_flags" \
         CXX=g++ CXXFLAGS="$common_flags" \
@@ -118,12 +120,23 @@ RUN mkdir -p /var/tmp && cd /var/tmp \
         LDFLAGS=-Wl,--as-needed \
         ./configure --prefix="$UCX_INSTALL_PREFIX" \
             --with-cuda="$CUDA_INSTALL_PREFIX" --with-gdrcopy="$GDRCOPY_INSTALL_PREFIX" \
-            --disable-assertions --disable-backtrace-detail --disable-debug \
+            --with-knem=/opt/knem-1.1.4.90mlnx3 --with-xpmem=/usr/include \
+            --with-devx --with-rdmacm --with-dm \
+            --without-java --enable-devel-headers --enable-shared \
+            --enable-optimizations --enable-cma --enable-mt \
+            --disable-assertions --disable-debug \
             --disable-params-check --disable-static \
             --disable-doxygen-doc --disable-logging \
-            --enable-mt \
+            --with-bfd=no \
     && make -j$(nproc) && make -j$(nproc) install \
-    && rm -rf /var/tmp/ucx
+    && rm -rf /var/tmp/ucx-${UCX_VERSION} /var/tmp/ucx-${UCX_VERSION}.tar.gz
+
+# DOCA's sharp package pulls DOCA's ucx into /usr/lib; listing our prefix in
+# ld.so.conf.d makes the loader prefer this build (those entries precede the
+# default system directories).
+RUN echo "$UCX_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
+ENV LD_LIBRARY_PATH="$UCX_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH" \
+    PATH="$UCX_INSTALL_PREFIX/bin:$PATH"
 
 # 6 - Install MUNGE version 0.5.14
 

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -224,9 +224,12 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
             --enable-mca-no-build=btl-uct --enable-mpi1-compatibility --enable-oshmem \
             --without-verbs \
             --with-cuda="$CUDA_INSTALL_PREFIX" \
+            --with-knem=/opt/knem-1.1.4.90mlnx3 \
+            --with-xpmem=/usr/include \
             --with-slurm --with-pmi="$PMI_INSTALL_PREFIX" \
             --with-pmix="$PMIX_INSTALL_PREFIX" \
             --with-ucx="$UCX_INSTALL_PREFIX" \
+            --with-ucc="$UCC_INSTALL_PREFIX" \
     && make -j$(nproc) && make -j$(nproc) install \
     && rm -rf /var/tmp/ompi \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     && rm -rf /var/tmp/slurm-21.08.8 /var/tmp/slurm-21.08.8.tar.bz2
 
 # 3 - Install DOCA-OFED 3.1.0 (userspace)
-# Install only the RDMA/IB libraries needed by the HPC stack (UCX/OpenMPI), plus SHARP,
+# Install only the RDMA/IB libraries needed to build UCX/UCC/OpenMPI, plus SHARP,
 # not the full doca-ofed-userspace metapackage (which also pulls in openmpi, hcoll, …).
 # Note: the sharp package Depends on DOCA's ucx; our UCX build below is preferred via
 # ld.so.conf.d / LD_LIBRARY_PATH.
@@ -138,7 +138,35 @@ RUN echo "$UCX_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
 ENV LD_LIBRARY_PATH="$UCX_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH" \
     PATH="$UCX_INSTALL_PREFIX/bin:$PATH"
 
-# 6 - Install MUNGE version 0.5.14
+# 6 - Install UCC version 1.8.0 (latest stable) with UCX + SHARP + CUDA
+
+ENV UCC_VERSION=1.8.0
+ENV UCC_INSTALL_PREFIX=/usr/local/ucc
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        autoconf automake libtool \
+    && mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp \
+        "https://github.com/openucx/ucc/archive/refs/tags/v${UCC_VERSION}.tar.gz" \
+    && tar -x -f /var/tmp/v${UCC_VERSION}.tar.gz -C /var/tmp -z \
+    && cd /var/tmp/ucc-${UCC_VERSION} \
+    && ./autogen.sh \
+    && export common_flags=$([ "$TARGETARCH" == "arm64" ] && echo "$COMMON_COMPILER_FLAGS_ARM" || echo "$COMMON_COMPILER_FLAGS") \
+    &&  CC=gcc CFLAGS="$common_flags" \
+        CXX=g++ CXXFLAGS="$common_flags" \
+        LDFLAGS=-Wl,--as-needed \
+        ./configure --prefix="$UCC_INSTALL_PREFIX" \
+            --with-ucx="$UCX_INSTALL_PREFIX" \
+            --with-cuda="$CUDA_INSTALL_PREFIX" \
+            --with-sharp="$SHARP_INSTALL_PREFIX" \
+            --enable-optimizations \
+    && make -j$(nproc) && make -j$(nproc) install \
+    && echo "$UCC_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
+    && rm -rf /var/tmp/ucc-${UCC_VERSION} /var/tmp/v${UCC_VERSION}.tar.gz \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV LD_LIBRARY_PATH="$UCC_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH" \
+    PATH="$UCC_INSTALL_PREFIX/bin:$PATH"
+
+# 7 - Install MUNGE version 0.5.14
 
 ENV MUNGE_INSTALL_PREFIX=/usr/local/munge
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/dun/munge/releases/download/munge-0.5.14/munge-0.5.14.tar.xz \
@@ -153,7 +181,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     && make -j$(nproc) && make -j$(nproc) install \
     && rm -rf /var/tmp/munge-0.5.14 /var/tmp/munge-0.5.14.tar.xz
 
-# 7 - Install PMIX version 3.2.3
+# 8 - Install PMIX version 3.2.3
 
 ENV PMIX_INSTALL_PREFIX=/usr/local/pmix
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
@@ -176,7 +204,7 @@ ENV CPATH="$PMIX_INSTALL_PREFIX/include:$CPATH" \
     LD_LIBRARY_PATH="$PMIX_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH" \
     PATH="$PMIX_INSTALL_PREFIX/bin:$PATH"
 
-# 8 - Install OMPI version 4.1.4
+# 9 - Install OMPI version 4.1.4
 
 ENV OPENMPI_INSTALL_PREFIX=/usr/local/openmpi
 RUN apt-get update -y && apt-get install -y --no-install-recommends \

--- a/docker/build/package_sources.Dockerfile
+++ b/docker/build/package_sources.Dockerfile
@@ -57,11 +57,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && python3 -m pip install --upgrade unearth --break-system-packages \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install necessary repository for librdmac1
-RUN apt-get update && apt-get install -y --no-install-recommends gnupg wget \
-    && wget -qO - "https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox" | apt-key add - \
-    && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d "https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list" \
-    && echo 'deb-src http://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/$(ARCH) ./' >> /etc/apt/sources.list.d/mellanox_mlnx_ofed.list \
+# Install DOCA-Host repository (provides RDMA userspace packages formerly from MOFED)
+ARG TARGETARCH
+ARG DOCA_VERSION=3.1.0-091000-25.07
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && arch=$([ "$TARGETARCH" = "arm64" ] && echo arm64 || echo amd64) \
+    && doca_deb="doca-host_${DOCA_VERSION}-ubuntu2404_${arch}.deb" \
+    && wget -q -nc --no-check-certificate -P /var/tmp \
+        "https://www.mellanox.com/downloads/DOCA/DOCA_v3.1.0/host/${doca_deb}" \
+    && dpkg -i "/var/tmp/${doca_deb}" \
+    && rm -f "/var/tmp/${doca_deb}" \
     && apt-get update -y
 
 # Enable source repositories (Ubuntu 24.04 DEB822 format)

--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -105,6 +105,13 @@ RUN echo -e "$COPYRIGHT_NOTICE" > "$CUDA_QUANTUM_PATH/Copyright.txt" && \
     echo -e "$deprecation_notice" >> "$CUDA_QUANTUM_PATH/Copyright.txt"
 RUN echo 'cat "$CUDA_QUANTUM_PATH/Copyright.txt"' > /etc/profile.d/welcome.sh
 
+# Default shared-memory single-copy to CMA (avoids xpmem/knem device warnings
+# when those nodes are not mounted). Open MPI 4 uses btl_vader; Open MPI 5
+# uses the smsc framework (btl_sm is a 5.0.x alias for vader).
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=cma
+ENV OMPI_MCA_btl_sm_single_copy_mechanism=cma
+ENV OMPI_MCA_smsc=cma
+
 # See also https://github.com/microsoft/vscode-remote-release/issues/4781
 RUN env | egrep -v "^(HOME=|USER=|MAIL=|LC_ALL=|LS_COLORS=|LANG=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)" \
         >> /etc/environment


### PR DESCRIPTION
- Machine specific UCX and OpenMPI variables no longer set by default in the container.
- UCX version update and OS match (to 24.04)
- Addition of UCC for optimized collective support
- Tweaks to OpenMPI build to support optimized intranode and collective paths

The changes can improve out-of-box performance by 2X on some systems.