### PR TITLE
Don't forward to DefaultQPU::unifiedLaunchModule

### DIFF
--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -391,8 +391,6 @@ Platform
 .. doxygenclass:: cudaq::QPU
     :members:
 
-.. doxygenstruct:: cudaq::QPU::InKernelLaunchScope
-
 .. doxygenstruct:: cudaq::other_policies
 
 .. doxygenclass:: cudaq::DefaultQPU

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -300,7 +300,7 @@ public:
           "detector error model generation.");
 
     return cudaq::ExecutionManager::with_default_em(policy, [&] {
-      [[maybe_unused]] auto kernelResult = runJITEngine(module, args);
+      [[maybe_unused]] auto kernelResult = executeJitBinary(module, args);
     });
   }
 

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -300,7 +300,7 @@ public:
           "detector error model generation.");
 
     return cudaq::ExecutionManager::with_default_em(policy, [&] {
-      [[maybe_unused]] auto kernelResult = runJITCompiledModule(module, args);
+      [[maybe_unused]] auto kernelResult = runJITEngine(module, args);
     });
   }
 

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -7,6 +7,7 @@
  ******************************************************************************/
 #pragma once
 
+#include "common/KernelArgs.h"
 #include "common/NamedVariantStore.h"
 #include "common/Resources.h"
 #include "common/ThunkInterface.h"
@@ -320,5 +321,21 @@ public:
 };
 
 using AnyModule = std::variant<SourceModule, CompiledModule>;
+
+/// @brief Execute the compiled binary stored in @p module.
+///
+/// Dispatches to `executeFunctionPtrBinary` when an AOT function-pointer
+/// artifact is present, otherwise to `executeJitBinary`.
+[[nodiscard]] KernelThunkResultType
+executeCompiledModule(const CompiledModule &module, KernelArgs args);
+
+/// @brief Execute the JIT-compiled binary artifact stored in @p module.
+[[nodiscard]] KernelThunkResultType
+executeJitBinary(const CompiledModule &module, KernelArgs args);
+
+/// @brief Execute a pre-compiled AOT binary via a function-pointer artifact.
+[[nodiscard]] KernelThunkResultType
+executeFunctionPtrBinary(const FatQuakeModule::FunctionPtrArtifact &artifact,
+                         KernelArgs args);
 
 } // namespace cudaq

--- a/runtime/common/ExecutionContext.cpp
+++ b/runtime/common/ExecutionContext.cpp
@@ -9,6 +9,7 @@
 #include "ExecutionContext.h"
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <string>
 
 namespace {
@@ -45,4 +46,12 @@ void detail::setExecutionContext(ExecutionContext *ctx) {
 }
 
 void detail::resetExecutionContext() { currentExecutionContext = nullptr; }
+
+void rethrowDeferredKernelException() {
+  if (auto *ctx = getExecutionContext(); ctx && ctx->deferredKernelException) {
+    auto deferred = ctx->deferredKernelException;
+    ctx->deferredKernelException = nullptr;
+    std::rethrow_exception(deferred);
+  }
+}
 } // namespace cudaq

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -157,12 +157,11 @@ public:
   std::exception_ptr deferredKernelException;
 
   /// @brief True while a JIT/AOT-compiled kernel frame is executing on this
-  /// thread (set by the launcher around the kernel invocation; see
-  /// QPU::InKernelLaunchScope). The simulator only defers exceptions into
-  /// `deferredKernelException` while this is set. Outside the kernel frame
-  /// (for example, gate application during sample/observe finalization) there
-  /// is no JIT frame for an exception to unwind through, so it is thrown
-  /// directly, preserving the behavior callers see on all platforms.
+  /// thread. The simulator only defers exceptions into
+  /// `deferredKernelException` while this is set. Outside the kernel frame (for
+  /// example, gate application during sample/observe finalization) there is no
+  /// JIT frame for an exception to unwind through, so it is thrown directly,
+  /// preserving the behavior callers see on all platforms.
   bool inKernelLaunch = false;
 };
 
@@ -189,6 +188,11 @@ bool isLastBatch();
 
 /// @brief Get the ID of the current QPU.
 std::size_t getCurrentQpuId();
+
+/// @brief Re-throw an exception the kernel deferred during execution, if any.
+/// Call immediately after invoking a compiled kernel, from the C++ frame above
+/// the JIT/AOT boundary. No-op when nothing was deferred.
+void rethrowDeferredKernelException();
 
 namespace detail {
 /// Set the execution context for the current thread.

--- a/runtime/cudaq/CMakeLists.txt
+++ b/runtime/cudaq/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ctad-maybe-unsupported")
 add_library(${LIBRARY_NAME}
   SHARED
     cudaq.cpp
+    CompiledModuleExecution.cpp
     realtime.cpp
     target_control.cpp
     algorithms/draw.cpp

--- a/runtime/cudaq/CompiledModuleExecution.cpp
+++ b/runtime/cudaq/CompiledModuleExecution.cpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "common/CompiledModule.h"
+#include "common/ExecutionContext.h"
+#include "common/KernelArgs.h"
+#include "common/Timing.h"
+#include "nvqir/resourcecounter/ResourceCounterScope.h"
+#include "cudaq/runtime/logger/logger.h"
+#include <cstring>
+
+namespace {
+
+/// RAII marker for the window in which a JIT/AOT-compiled kernel frame is
+/// executing. While alive it sets `ExecutionContext::inKernelLaunch` on the
+/// active context, so the simulator defers (rather than throws) exceptions that
+/// would otherwise have to unwind through the kernel frame.
+struct InKernelLaunchScope {
+  InKernelLaunchScope() {
+    if (auto *ctx = cudaq::getExecutionContext())
+      ctx->inKernelLaunch = true;
+  }
+  ~InKernelLaunchScope() {
+    if (auto *ctx = cudaq::getExecutionContext())
+      ctx->inKernelLaunch = false;
+  }
+  InKernelLaunchScope(const InKernelLaunchScope &) = delete;
+  InKernelLaunchScope &operator=(const InKernelLaunchScope &) = delete;
+};
+
+} // namespace
+
+using namespace cudaq;
+
+KernelThunkResultType cudaq::executeCompiledModule(const CompiledModule &module,
+                                                   KernelArgs args) {
+  auto rawFn = module.getFunctionPtr();
+  if (rawFn)
+    return executeFunctionPtrBinary(*rawFn, args);
+  return executeJitBinary(module, args);
+}
+
+KernelThunkResultType cudaq::executeJitBinary(const CompiledModule &module,
+                                              KernelArgs args) {
+  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "executeJitBinary",
+                         module.getName());
+
+  // Propagate metadata from the compiled artifact to the execution context.
+  if (auto ctx = getExecutionContext()) {
+    ctx->hasConditionalsOnMeasureResults =
+        module.getMetadata().hasConditionalsOnMeasureResults;
+
+    if (ctx->name == "resource-count" && module.getResources()) {
+      nvqir::resource_counter::prepopulate(*module.getResources());
+    }
+  }
+
+  auto rawArgs = args.getTypeErased().value_or(std::span<void *const>{});
+  auto funcPtr = module.getJit()->getFn();
+  const auto &resultInfo = module.getResultInfo();
+  // Mark the kernel frame so the simulator defers (rather than throws)
+  // exceptions while the JIT'd kernel runs; rethrowDeferredKernelException()
+  // below surfaces any such error from this C++ frame.
+  InKernelLaunchScope kernelFrame;
+  if (!module.isFullySpecialized()) {
+    // Pack args at runtime via argsCreator, then call the thunk.
+    auto argsCreator = module.getArgsCreator();
+    void *buff = nullptr;
+    argsCreator(static_cast<const void *>(rawArgs.data()), &buff);
+    reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(funcPtr)(
+        buff, /*client_server=*/false);
+    // If the kernel has a result, copy it from the packed buffer into
+    // rawArgs.back() (where the caller expects to find it).
+    if (resultInfo.hasResult()) {
+      auto offset = module.getReturnOffset().value();
+      std::memcpy(rawArgs.back(), static_cast<char *>(buff) + offset,
+                  resultInfo.getBufferSize());
+    }
+    std::free(buff);
+    rethrowDeferredKernelException();
+    return {nullptr, 0};
+  }
+  if (resultInfo.hasResult()) {
+    // Fully specialized with result: rawArgs.back() is the pre-allocated
+    // result buffer; pass it directly to the thunk.
+    void *buff = const_cast<void *>(rawArgs.back());
+    auto result = reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(
+        funcPtr)(buff, /*client_server=*/false);
+    rethrowDeferredKernelException();
+    return result;
+  }
+  // Fully specialized, no result.
+  funcPtr();
+  rethrowDeferredKernelException();
+  return {nullptr, 0};
+}
+
+KernelThunkResultType cudaq::executeFunctionPtrBinary(
+    const FatQuakeModule::FunctionPtrArtifact &artifact, KernelArgs args) {
+  auto packed = args.getPacked();
+  void *argData = packed ? packed->data.data() : nullptr;
+  // Mark the kernel frame so the simulator defers (rather than throws)
+  // exceptions while the AOT kernel runs; rethrowDeferredKernelException()
+  // below surfaces any such error from this C++ frame.
+  InKernelLaunchScope kernelFrame;
+  auto result = artifact.getFn()(argData, /*isRemote=*/false);
+  rethrowDeferredKernelException();
+  return result;
+}

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -51,28 +51,14 @@ cudaq::DefaultQPU::unifiedLaunchModule(const cudaq::AnyModule &module,
                                        cudaq::KernelArgs args) {
   ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::unifiedLaunchModule");
 
-  std::optional<FatQuakeModule::FunctionPtrArtifact> rawFn;
   if (std::holds_alternative<SourceModule>(module)) {
-    rawFn = std::get<SourceModule>(module).getFunctionPtr();
+    auto rawFn = std::get<SourceModule>(module).getFunctionPtr();
     assert(rawFn && "SourceModule must have a valid AOT-compiled thunk");
-  } else {
-    auto &compiled = std::get<CompiledModule>(module);
-    rawFn = compiled.getFunctionPtr();
-    if (!rawFn)
-      return runJITCompiledModule(compiled, args);
+    return runRawFnPointer(*rawFn, args);
   }
 
-  auto packed = args.getPacked();
-  void *argData = packed ? packed->data.data() : nullptr;
-  // Mark the kernel frame so the simulator defers (rather than throws)
-  // exceptions while the JIT'd kernel runs; rethrowDeferredKernelException()
-  // below surfaces any such error from this C++ frame.
-  InKernelLaunchScope kernelFrame;
-  auto result = rawFn->getFn()(argData, /*isRemote=*/false);
-  // Surface any error the kernel deferred rather than threw (see
-  // QPU::rethrowDeferredKernelException).
-  rethrowDeferredKernelException();
-  return result;
+  auto &compiled = std::get<CompiledModule>(module);
+  return runCompiledModule(compiled, args);
 }
 
 cudaq::sample_result
@@ -81,8 +67,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::sample_policy &policy,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
   return cudaq::ExecutionManager::with_default_em(
-      policy,
-      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+      policy, [this, &module, &args]() {
+        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
+      });
 }
 
 cudaq::async_sample_result
@@ -99,8 +86,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::observe_policy &policy,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
   return cudaq::ExecutionManager::with_default_em(
-      policy,
-      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+      policy, [this, &module, &args]() {
+        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
+      });
 }
 
 cudaq::run_result
@@ -109,8 +97,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::run_policy &policy,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
   return cudaq::ExecutionManager::with_default_em(
-      policy,
-      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+      policy, [this, &module, &args]() {
+        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
+      });
 }
 
 cudaq::async_run_policy::result_type
@@ -127,8 +116,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::msm_size_policy &policy,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
   return cudaq::ExecutionManager::with_default_em(
-      policy,
-      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+      policy, [this, &module, &args]() {
+        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
+      });
 }
 
 cudaq::msm_result
@@ -137,8 +127,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::msm_policy &policy,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
   return cudaq::ExecutionManager::with_default_em(
-      policy,
-      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+      policy, [this, &module, &args]() {
+        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
+      });
 }
 
 cudaq::async_observe_result
@@ -155,8 +146,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::dem_policy &policy,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
   return cudaq::ExecutionManager::with_default_em(
-      policy,
-      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+      policy, [this, &module, &args]() {
+        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
+      });
 }
 
 cudaq::ptsbe::sample_policy::result_type
@@ -165,8 +157,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::ptsbe::sample_policy &policy,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
   return cudaq::ExecutionManager::with_default_em(
-      policy,
-      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+      policy, [this, &module, &args]() {
+        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
+      });
 }
 
 std::unique_ptr<cudaq::CompileTarget>

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -54,11 +54,11 @@ cudaq::DefaultQPU::unifiedLaunchModule(const cudaq::AnyModule &module,
   if (std::holds_alternative<SourceModule>(module)) {
     auto rawFn = std::get<SourceModule>(module).getFunctionPtr();
     assert(rawFn && "SourceModule must have a valid AOT-compiled thunk");
-    return runRawFnPointer(*rawFn, args);
+    return executeFunctionPtrBinary(*rawFn, args);
   }
 
   auto &compiled = std::get<CompiledModule>(module);
-  return runCompiledModule(compiled, args);
+  return executeCompiledModule(compiled, args);
 }
 
 cudaq::sample_result
@@ -66,10 +66,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::sample_policy &policy,
                                 const cudaq::CompiledModule &module,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
-  return cudaq::ExecutionManager::with_default_em(
-      policy, [this, &module, &args]() {
-        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
-      });
+  return cudaq::ExecutionManager::with_default_em(policy, [&module, &args]() {
+    [[maybe_unused]] auto res = executeCompiledModule(module, args);
+  });
 }
 
 cudaq::async_sample_result
@@ -85,10 +84,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::observe_policy &policy,
                                 const cudaq::CompiledModule &module,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
-  return cudaq::ExecutionManager::with_default_em(
-      policy, [this, &module, &args]() {
-        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
-      });
+  return cudaq::ExecutionManager::with_default_em(policy, [&module, &args]() {
+    [[maybe_unused]] auto res = executeCompiledModule(module, args);
+  });
 }
 
 cudaq::run_result
@@ -96,10 +94,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::run_policy &policy,
                                 const cudaq::CompiledModule &module,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
-  return cudaq::ExecutionManager::with_default_em(
-      policy, [this, &module, &args]() {
-        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
-      });
+  return cudaq::ExecutionManager::with_default_em(policy, [&module, &args]() {
+    [[maybe_unused]] auto res = executeCompiledModule(module, args);
+  });
 }
 
 cudaq::async_run_policy::result_type
@@ -115,10 +112,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::msm_size_policy &policy,
                                 const cudaq::CompiledModule &module,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
-  return cudaq::ExecutionManager::with_default_em(
-      policy, [this, &module, &args]() {
-        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
-      });
+  return cudaq::ExecutionManager::with_default_em(policy, [&module, &args]() {
+    [[maybe_unused]] auto res = executeCompiledModule(module, args);
+  });
 }
 
 cudaq::msm_result
@@ -126,10 +122,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::msm_policy &policy,
                                 const cudaq::CompiledModule &module,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
-  return cudaq::ExecutionManager::with_default_em(
-      policy, [this, &module, &args]() {
-        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
-      });
+  return cudaq::ExecutionManager::with_default_em(policy, [&module, &args]() {
+    [[maybe_unused]] auto res = executeCompiledModule(module, args);
+  });
 }
 
 cudaq::async_observe_result
@@ -145,10 +140,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::dem_policy &policy,
                                 const cudaq::CompiledModule &module,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
-  return cudaq::ExecutionManager::with_default_em(
-      policy, [this, &module, &args]() {
-        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
-      });
+  return cudaq::ExecutionManager::with_default_em(policy, [&module, &args]() {
+    [[maybe_unused]] auto res = executeCompiledModule(module, args);
+  });
 }
 
 cudaq::ptsbe::sample_policy::result_type
@@ -156,10 +150,9 @@ cudaq::DefaultQPU::launchKernel(const cudaq::ptsbe::sample_policy &policy,
                                 const cudaq::CompiledModule &module,
                                 cudaq::KernelArgs args) {
   CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
-  return cudaq::ExecutionManager::with_default_em(
-      policy, [this, &module, &args]() {
-        [[maybe_unused]] auto res = this->runCompiledModule(module, args);
-      });
+  return cudaq::ExecutionManager::with_default_em(policy, [&module, &args]() {
+    [[maybe_unused]] auto res = executeCompiledModule(module, args);
+  });
 }
 
 std::unique_ptr<cudaq::CompileTarget>

--- a/runtime/cudaq/platform/default/DefaultQPU.h
+++ b/runtime/cudaq/platform/default/DefaultQPU.h
@@ -22,6 +22,9 @@ public:
   void enqueue(QuantumTask &task) override;
   void onRandomSeedSet(std::size_t seed) override;
 
+  // This is the legacy fallback for launch policies that do not support
+  // policy-based overloads yet. To be removed once all policies have been
+  // migrated.
   KernelThunkResultType unifiedLaunchModule(const cudaq::AnyModule &module,
                                             cudaq::KernelArgs args) override;
 

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -120,8 +120,15 @@ cudaq::QPU::InKernelLaunchScope::~InKernelLaunchScope() {
 }
 
 cudaq::KernelThunkResultType
-cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
-                                 KernelArgs args) {
+cudaq::QPU::runCompiledModule(const CompiledModule &compiled, KernelArgs args) {
+  auto rawFn = compiled.getFunctionPtr();
+  if (rawFn)
+    return runRawFnPointer(*rawFn, args);
+  return runJITEngine(compiled, args);
+}
+
+cudaq::KernelThunkResultType
+cudaq::QPU::runJITEngine(const CompiledModule &compiled, KernelArgs args) {
   ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::runJITCompiledModule",
                          compiled.getName());
 
@@ -173,6 +180,22 @@ cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
   funcPtr();
   rethrowDeferredKernelException();
   return {nullptr, 0};
+}
+
+cudaq::KernelThunkResultType
+cudaq::QPU::runRawFnPointer(const FatQuakeModule::FunctionPtrArtifact &rawFn,
+                            KernelArgs args) {
+  auto packed = args.getPacked();
+  void *argData = packed ? packed->data.data() : nullptr;
+  // Mark the kernel frame so the simulator defers (rather than throws)
+  // exceptions while the JIT'd kernel runs; rethrowDeferredKernelException()
+  // below surfaces any such error from this C++ frame.
+  InKernelLaunchScope kernelFrame;
+  auto result = rawFn.getFn()(argData, /*isRemote=*/false);
+  // Surface any error the kernel deferred rather than threw (see
+  // QPU::rethrowDeferredKernelException).
+  rethrowDeferredKernelException();
+  return result;
 }
 
 std::unique_ptr<cudaq::CompileTarget>

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -11,7 +11,6 @@
 #include "algorithms/policies.h"
 #include "algorithms/sample/policy.h"
 #include "common/CompiledModule.h"
-#include "common/ExecutionContext.h"
 #include "common/KernelArgs.h"
 #include "common/Timing.h"
 #include "cudaq/qis/execution_manager.h"
@@ -19,7 +18,6 @@
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <cstring>
-#include <exception>
 #include <stdexcept>
 
 using namespace cudaq_internal::compiler;
@@ -99,103 +97,6 @@ cudaq::QPU::launchKernel(const ptsbe::sample_policy &policy,
                          const CompiledModule &module, KernelArgs args) {
   throw std::runtime_error(
       "This QPU does not support launching the ptsbe::sample_policy.");
-}
-
-void cudaq::QPU::rethrowDeferredKernelException() {
-  if (auto *ctx = getExecutionContext(); ctx && ctx->deferredKernelException) {
-    auto deferred = ctx->deferredKernelException;
-    ctx->deferredKernelException = nullptr;
-    std::rethrow_exception(deferred);
-  }
-}
-
-cudaq::QPU::InKernelLaunchScope::InKernelLaunchScope() {
-  if (auto *ctx = getExecutionContext())
-    ctx->inKernelLaunch = true;
-}
-
-cudaq::QPU::InKernelLaunchScope::~InKernelLaunchScope() {
-  if (auto *ctx = getExecutionContext())
-    ctx->inKernelLaunch = false;
-}
-
-cudaq::KernelThunkResultType
-cudaq::QPU::runCompiledModule(const CompiledModule &compiled, KernelArgs args) {
-  auto rawFn = compiled.getFunctionPtr();
-  if (rawFn)
-    return runRawFnPointer(*rawFn, args);
-  return runJITEngine(compiled, args);
-}
-
-cudaq::KernelThunkResultType
-cudaq::QPU::runJITEngine(const CompiledModule &compiled, KernelArgs args) {
-  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::runJITCompiledModule",
-                         compiled.getName());
-
-  // Propagate metadata from the compiled artifact to the execution context.
-  if (auto ctx = getExecutionContext()) {
-    ctx->hasConditionalsOnMeasureResults =
-        compiled.getMetadata().hasConditionalsOnMeasureResults;
-
-    if (ctx->name == "resource-count" && compiled.getResources()) {
-      nvqir::resource_counter::prepopulate(*compiled.getResources());
-    }
-  }
-
-  auto rawArgs = args.getTypeErased().value_or(std::span<void *const>{});
-  auto funcPtr = compiled.getJit()->getFn();
-  const auto &resultInfo = compiled.getResultInfo();
-  // Mark the kernel frame so the simulator defers (rather than throws)
-  // exceptions while the JIT'd kernel runs; rethrowDeferredKernelException()
-  // below surfaces any such error from this C++ frame.
-  InKernelLaunchScope kernelFrame;
-  if (!compiled.isFullySpecialized()) {
-    // Pack args at runtime via argsCreator, then call the thunk.
-    auto argsCreator = compiled.getArgsCreator();
-    void *buff = nullptr;
-    argsCreator(static_cast<const void *>(rawArgs.data()), &buff);
-    reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(funcPtr)(
-        buff, /*client_server=*/false);
-    // If the kernel has a result, copy it from the packed buffer into
-    // rawArgs.back() (where the caller expects to find it).
-    if (resultInfo.hasResult()) {
-      auto offset = compiled.getReturnOffset().value();
-      std::memcpy(rawArgs.back(), static_cast<char *>(buff) + offset,
-                  resultInfo.getBufferSize());
-    }
-    std::free(buff);
-    rethrowDeferredKernelException();
-    return {nullptr, 0};
-  }
-  if (resultInfo.hasResult()) {
-    // Fully specialized with result: rawArgs.back() is the pre-allocated
-    // result buffer; pass it directly to the thunk.
-    void *buff = const_cast<void *>(rawArgs.back());
-    auto result = reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(
-        funcPtr)(buff, /*client_server=*/false);
-    rethrowDeferredKernelException();
-    return result;
-  }
-  // Fully specialized, no result.
-  funcPtr();
-  rethrowDeferredKernelException();
-  return {nullptr, 0};
-}
-
-cudaq::KernelThunkResultType
-cudaq::QPU::runRawFnPointer(const FatQuakeModule::FunctionPtrArtifact &rawFn,
-                            KernelArgs args) {
-  auto packed = args.getPacked();
-  void *argData = packed ? packed->data.data() : nullptr;
-  // Mark the kernel frame so the simulator defers (rather than throws)
-  // exceptions while the JIT'd kernel runs; rethrowDeferredKernelException()
-  // below surfaces any such error from this C++ frame.
-  InKernelLaunchScope kernelFrame;
-  auto result = rawFn.getFn()(argData, /*isRemote=*/false);
-  // Surface any error the kernel deferred rather than threw (see
-  // QPU::rethrowDeferredKernelException).
-  rethrowDeferredKernelException();
-  return result;
 }
 
 std::unique_ptr<cudaq::CompileTarget>

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -54,41 +54,6 @@ protected:
   /// @brief Noise model specified for QPU execution.
   const noise_model *noiseModel = nullptr;
 
-  /// @brief Run the compiled module using either the raw function pointer or
-  /// the JIT engine stored in the compiled module.
-  [[nodiscard]] static KernelThunkResultType
-  runCompiledModule(const CompiledModule &compiled, KernelArgs args);
-
-  [[nodiscard]] static KernelThunkResultType
-  runJITEngine(const CompiledModule &compiled, KernelArgs args);
-
-  [[nodiscard]] static KernelThunkResultType
-  runRawFnPointer(const FatQuakeModule::FunctionPtrArtifact &rawFn,
-                  KernelArgs args);
-
-  /// @brief Re-throw an exception the kernel deferred during execution, if any.
-  /// Subclasses must call this immediately after invoking a kernel, from the
-  /// C++ frame above the JIT/AOT boundary. It exists because on some platforms
-  /// (macOS arm64) a C++ exception cannot unwind through a JIT-compiled kernel
-  /// frame; the simulator records the error on the execution context instead of
-  /// throwing across that boundary (see
-  /// ExecutionContext::deferredKernelException). No-op when nothing was
-  /// deferred.
-  static void rethrowDeferredKernelException();
-
-  /// @brief RAII marker for the window in which a JIT/AOT-compiled kernel frame
-  /// is executing. While alive it sets `ExecutionContext::inKernelLaunch` on
-  /// the active context, so the simulator defers (rather than throws)
-  /// exceptions that would otherwise have to unwind through the kernel frame.
-  /// Launchers wrap the raw kernel invocation in this scope and call
-  /// rethrowDeferredKernelException() immediately afterwards.
-  struct InKernelLaunchScope {
-    InKernelLaunchScope();
-    ~InKernelLaunchScope();
-    InKernelLaunchScope(const InKernelLaunchScope &) = delete;
-    InKernelLaunchScope &operator=(const InKernelLaunchScope &) = delete;
-  };
-
 public:
   /// The constructor, initializes the execution queue
   QPU() : execution_queue(std::make_unique<QuantumExecutionQueue>()) {}

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -54,8 +54,17 @@ protected:
   /// @brief Noise model specified for QPU execution.
   const noise_model *noiseModel = nullptr;
 
+  /// @brief Run the compiled module using either the raw function pointer or
+  /// the JIT engine stored in the compiled module.
   [[nodiscard]] static KernelThunkResultType
-  runJITCompiledModule(const CompiledModule &compiled, KernelArgs args);
+  runCompiledModule(const CompiledModule &compiled, KernelArgs args);
+
+  [[nodiscard]] static KernelThunkResultType
+  runJITEngine(const CompiledModule &compiled, KernelArgs args);
+
+  [[nodiscard]] static KernelThunkResultType
+  runRawFnPointer(const FatQuakeModule::FunctionPtrArtifact &rawFn,
+                  KernelArgs args);
 
   /// @brief Re-throw an exception the kernel deferred during execution, if any.
   /// Subclasses must call this immediately after invoking a kernel, from the


### PR DESCRIPTION
The `QPU::unifiedLaunchModule` methods are a legacy fallback that we use for policies that haven't been rewritten yet to use `QPU::launchKernel`.

We were using that method to implement all the `launchKernel` impls. It's better if we avoid relying on things that we want to remove.