### PR TITLE
[CI] Run the doc build on PRs to catch Sphinx warnings early

### DIFF
--- a/.github/required-checks.yml
+++ b/.github/required-checks.yml
@@ -56,5 +56,7 @@ push:
 - Build and test (arm64, llvm, openmpi) / Dev environment (Python)
 - Build and test (amd64, gcc12, openmpi) / Dev environment (Debug)
 - Build and test (amd64, gcc12, openmpi) / Dev environment (Python)
+# Doc gate for PR builds; the Docker image doc job is skipped here.
+- Documentation / Build and check docs
 workflow_dispatch: *full_matrix
 schedule: *full_matrix

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,120 @@
+on:
+  workflow_call:
+    inputs:
+      platform:
+        type: string
+        required: false
+        default: linux/amd64
+      devdeps_image:
+        required: false
+        type: string
+      devdeps_cache:
+        required: true
+        type: string
+      devdeps_archive:
+        required: true
+        type: string
+
+name: Build documentation
+
+jobs:
+  build_docs:
+    # Runs the merge-queue `-n -W` doc build at PR time.
+    name: Build and check docs
+    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu16') || 'linux-amd64-cpu16' }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Restore environment
+        id: restore_devdeps
+        if: inputs.devdeps_image == ''
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ inputs.devdeps_archive }}
+          key: ${{ inputs.devdeps_cache }}
+          fail-on-cache-miss: true
+
+      - name: Log in to GitHub CR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up ccache and ORAS
+        uses: ./.github/actions/ccache-setup
+
+      - name: Compute platform ID
+        id: platform_meta
+        run: |
+          platform_id=$(echo "${{ inputs.platform }}" | sed 's/linux\///g' | tr -d ' ')
+          echo "platform_id=$platform_id" >> $GITHUB_OUTPUT
+
+      # Reuse the Python job's cache; PR builds never write ccache back.
+      - name: Restore ccache from GHCR
+        uses: ./.github/actions/ccache-restore
+        with:
+          cache-key: ${{ steps.platform_meta.outputs.platform_id }}-devenv-python
+          registry-token: ${{ github.token }}
+
+      - name: Set up context for buildx
+        run: |
+          docker context create builder_context
+
+      - name: Set up buildx runner
+        uses: docker/setup-buildx-action@v4
+        with:
+          endpoint: builder_context
+          version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
+      - name: Set up dev environment
+        id: dev_env
+        run: |
+          if ${{ steps.restore_devdeps.outcome != 'skipped' }}; then
+            load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
+            base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
+            docker push $base_image
+            rm -rf "${{ inputs.devdeps_archive }}"
+          elif ${{ inputs.devdeps_image != '' }}; then
+            base_image=${{ inputs.devdeps_image }}
+          else
+            echo "::error file=build_docs.yml::Missing configuration for development dependencies. Either specify the image (i.e. provide devdeps_image) or cache (i.e. provide devdeps_cache and devdeps_archive) that should be used for the build."
+            exit 1
+          fi
+
+          docker buildx build --platform ${{ inputs.platform }} \
+            --load -t dev_env:local -f docker/build/cudaq.dev.Dockerfile . \
+            --build-context ccache-data=/tmp/ccache-data \
+            --build-arg base_image=$base_image
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+
+      - name: Build and check documentation
+        uses: ./.github/actions/run-in-docker
+        with:
+          image: dev_env:local
+          shell: bash
+          run: |
+            cd $CUDAQ_REPO_ROOT
+
+            # Sphinx exit code 12 == warnings treated as errors.
+            bash scripts/build_docs.sh
+            docs_status=$?
+            if [ ! $docs_status -eq 0 ]; then
+              echo "::error file=build_docs.yml::Documentation build failed with status $docs_status."
+              exit 1
+            fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,18 @@ jobs:
       devdeps_archive: ${{ fromJson(needs.config_devdeps.outputs.json).tar_archive[format('{0}-llvm', matrix.platform)] }}
       export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
 
+  # Doc gate for PR builds; complements docker_image (which covers other events).
+  documentation:
+    name: Documentation
+    needs: [metadata, config_devdeps]
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/build_docs.yml
+    with:
+      platform: linux/amd64
+      devdeps_image: ${{ fromJson(needs.config_devdeps.outputs.json).image_hash['amd64-gcc12'] }}
+      devdeps_cache: ${{ fromJson(needs.config_devdeps.outputs.json).cache_key['amd64-gcc12'] }}
+      devdeps_archive: ${{ fromJson(needs.config_devdeps.outputs.json).tar_archive['amd64-gcc12'] }}
+
   # Docker images are packaging, not correctness — only built on merge_group/dispatch.
   docker_image:
     name: Create Docker images
@@ -377,6 +389,7 @@ jobs:
       - config_source_build
       - build_and_test
       - gen_code_coverage
+      - documentation
       - docker_image
       - python_wheels
       - python_metapackages


### PR DESCRIPTION
The `-n -W` Sphinx doc build (warnings-as-errors) only ran in the merge queue, bundled in the push-skipped Docker image job. Doc regressions therefore accumulated on main and only surfaced in the queue, blocking every queued PR at once.

Add a `documentation` job that runs the same `scripts/build_docs.sh` build at PR time. It is the exact complement of `docker_image` (`event_name == 'push'`), so docs are checked on every event with no redundant build, and register it as a required check on push.