### PR TITLE
[Python] Pin conda MPI install to conda-forge with strict channel priority

### DIFF
--- a/python/README.md.in
+++ b/python/README.md.in
@@ -63,7 +63,7 @@ CUDA-Q with all its dependencies:
 cuda_version=${{ cuda_version_conda }} # set this variable to version ${{ cuda_version_requirement }}
 conda create -y -n cudaq-env python=3.11 pip
 conda install -y -n cudaq-env -c "nvidia/label/cuda-${cuda_version}" cuda
-conda install -y -n cudaq-env -c conda-forge mpi4py openmpi">=5.0.3" cxx-compiler
+conda install -y -n cudaq-env -c conda-forge --strict-channel-priority mpi4py openmpi">=5.0.3" cxx-compiler
 conda env config vars set -n cudaq-env LD_LIBRARY_PATH="$CONDA_PREFIX/envs/cudaq-env/lib:$LD_LIBRARY_PATH"
 conda env config vars set -n cudaq-env MPI_PATH=$CONDA_PREFIX/envs/cudaq-env
 conda activate cudaq-env


### PR DESCRIPTION
The conda install command in the wheel README resolved `openmpi` without strict channel priority and with Anaconda `defaults` (pkgs/main) enabled, so the solver could satisfy `openmpi >=5.0.3` from either channel. When it picked `pkgs/main::openmpi-5.0.10-h9de3fb3_0` (a monolithic build that ships no separate libpmix/prrte/ucx packages) instead of the intended `conda-forge::openmpi-5.0.10-h67ed482_1`, `mpirun` failed to bootstrap: rank 0 aborted during MPI initialization and exited status 1 before the test body ran, tearing down the job with no Python traceback.

This surfaced as intermittent "Run Python MPI tests" failures on the redhat/ubi9:9.6 wheel-validation job (the only matrix entry that runs the MPI test). Three unrelated PRs failed the identical step in the same merge-queue window (all pulling the pkgs/main build), while nightly runs pulling the conda-forge build passed. This README block is also the source the CI step extracts, so the fix corrects both the user instructions and CI.

Adding `--strict-channel-priority` forces openmpi and its runtime stack (libpmix, libevent, hwloc, ucx, ucc) from conda-forge, making the resolution deterministic.