### PR TITLE
Adding debugging capabilities to the CompileModuled

### DIFF
--- a/python/runtime/cudaq/platform/CompiledModuleCache.cpp
+++ b/python/runtime/cudaq/platform/CompiledModuleCache.cpp
@@ -116,6 +116,8 @@ CompiledModuleCache::CompiledModuleCache() {
   if (cudaq::CompiledModule::debugMode()) {
     std::cout << "CompiledModuleCache constructor with maxReadyEntries = "
               << maxReadyEntries << std::endl;
+    std::cout << "Size of CompiledModule: " << sizeof(CompiledModule)
+              << std::endl;
   }
 }
 

--- a/python/runtime/cudaq/platform/CompiledModuleCache.cpp
+++ b/python/runtime/cudaq/platform/CompiledModuleCache.cpp
@@ -9,6 +9,7 @@
 #include "CompiledModuleCache.h"
 #include <algorithm>
 #include <exception>
+#include <iostream>
 #include <stdexcept>
 
 namespace cudaq::detail {
@@ -78,6 +79,10 @@ CompiledModuleCache::Result CompiledModuleCache::getOrCompile(
     readyEntries.emplace_back(compilingEntry->key, module);
     if (readyEntries.size() > maxReadyEntries) {
       evicted = std::move(readyEntries.front().module);
+      if (cudaq::CompiledModule::debugMode()) {
+        std::cout << "Evicting compiled module for " << evicted->getName()
+                  << std::endl;
+      }
       readyEntries.erase(readyEntries.begin());
     }
     std::erase(compilingEntries, compilingEntry);
@@ -99,6 +104,19 @@ CompiledModuleCache::Result CompiledModuleCache::getOrCompile(
   // reuse the module instead of joining a completed attempt.
   compilingEntry->promise.set_value(module);
   return {std::move(module), role};
+}
+
+CompiledModuleCache::CompiledModuleCache() {
+  if (const auto *cacheSize = std::getenv("CUDAQ_COMPILED_MODULE_CACHE_SIZE")) {
+    try {
+      maxReadyEntries = std::stoi(cacheSize);
+    } catch (const std::exception &) {
+    }
+  }
+  if (cudaq::CompiledModule::debugMode()) {
+    std::cout << "CompiledModuleCache constructor with maxReadyEntries = "
+              << maxReadyEntries << std::endl;
+  }
 }
 
 } // namespace cudaq::detail

--- a/python/runtime/cudaq/platform/CompiledModuleCache.h
+++ b/python/runtime/cudaq/platform/CompiledModuleCache.h
@@ -75,7 +75,7 @@ public:
     Role role;
   };
 
-  CompiledModuleCache() = default;
+  CompiledModuleCache();
   ~CompiledModuleCache() = default;
 
   /// A cache has shared identity and must not be copied or relocated. Share it
@@ -138,7 +138,7 @@ private:
 
   /// Bound only completed artifacts; compiling entries must remain discoverable
   /// so a later equivalent caller cannot start duplicate work.
-  static constexpr std::size_t maxReadyEntries = 4;
+  std::size_t maxReadyEntries = 4;
 
   /// One mutex protects both collections, making the Missing -> Compiling and
   /// Compiling -> Ready transitions atomic.

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "CompiledModule.h"
+#include "Environment.h"
 #include <iostream>
 #include <string_view>
 
@@ -113,6 +114,6 @@ cudaq::CompiledModule::~CompiledModule() {
 
 bool cudaq::CompiledModule::debugMode() {
   static const bool enabled =
-      std::getenv("CUDAQ_DEBUG_COMPILED_MODULE") != nullptr;
+      cudaq::getEnvBool("CUDAQ_DEBUG_COMPILED_MODULE", false);
   return enabled;
 }

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "CompiledModule.h"
+#include <iostream>
 #include <string_view>
 
 cudaq::FatQuakeModule::FatQuakeModule(std::string kernelName)
@@ -101,4 +102,17 @@ const void *cudaq::SourceModule::getMlirOpaqueModulePtr() const {
   if (!mlirArt)
     return nullptr;
   return mlirArt->getOpaqueModulePtr();
+}
+
+cudaq::CompiledModule::~CompiledModule() {
+  if (debugMode()) {
+    // Disable this for now to avoid spamming the console
+    std::cout << "CompiledModule destructor for " << name << std::endl;
+  }
+}
+
+bool cudaq::CompiledModule::debugMode() {
+  static const bool enabled =
+      std::getenv("CUDAQ_DEBUG_COMPILED_MODULE") != nullptr;
+  return enabled;
 }

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -318,6 +318,13 @@ public:
   // `CompiledModuleHelper`.
   CompiledModule() : FatQuakeModule(std::string{}) {}
   explicit CompiledModule(SourceModule src) : FatQuakeModule(std::move(src)) {}
+
+  CompiledModule(const CompiledModule &) = default;
+  CompiledModule &operator=(const CompiledModule &) = default;
+
+  CompiledModule(CompiledModule &&) noexcept = default;
+  CompiledModule &operator=(CompiledModule &&) noexcept = default;
+
   ~CompiledModule();
 
   static bool debugMode();

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -318,6 +318,9 @@ public:
   // `CompiledModuleHelper`.
   CompiledModule() : FatQuakeModule(std::string{}) {}
   explicit CompiledModule(SourceModule src) : FatQuakeModule(std::move(src)) {}
+  ~CompiledModule();
+
+  static bool debugMode();
 };
 
 using AnyModule = std::variant<SourceModule, CompiledModule>;

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -41,6 +41,7 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include <cassert>
 #include <cxxabi.h>
+#include <iostream>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
@@ -283,6 +284,13 @@ public:
     };
   }
 
+  ~Impl() {
+    if (cudaq::CompiledModule::debugMode()) {
+      if (jitEngine) {
+        std::cout << "Destructing ExecutionEngine" << std::endl;
+      }
+    }
+  }
   std::size_t getKey() const {
     return reinterpret_cast<std::size_t>(jitEngine.get());
   }

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -291,6 +291,12 @@ public:
       }
     }
   }
+
+  Impl(const Impl &) = delete;
+  Impl &operator=(const Impl &) = delete;
+  Impl(Impl &&) = default;
+  Impl &operator=(Impl &&) = default;
+
   std::size_t getKey() const {
     return reinterpret_cast<std::size_t>(jitEngine.get());
   }


### PR DESCRIPTION
This PR is adding two environment variables for debug and test purposes. 
`CUDAQ_COMPILED_MODULE_CACHE_SIZE` to control the number of entries in the cache.
`CUDAQ_DEBUG_COMPILED_MODULE` to activate the debug messages in some key places:

- the CompiledModuleCache constructor
- the CompiledModuleCache eviction code
- the CompiledModule destructor and
- the JITEngine destructor


Two tests are attached 
[test_sync.py](https://github.com/user-attachments/files/30565219/test_sync.py)
[test_async.py](https://github.com/user-attachments/files/30565241/test_async.py)

And can be run with:
```
CUDAQ_COMPILED_MODULE_CACHE_SIZE=1 CUDAQ_DEBUG_COMPILED_MODULE=1 python3 test_sync.py
```

As of 12f5dba7, this produces:
```
CompiledModuleCache constructor with maxReadyEntries = 1
CompiledModule destructor for kernel1..0x7861794adfa0.run
CompiledModule destructor for kernel1..0x7861794adfa0.run
CompiledModule destructor for kernel1..0x7861794adfa0.run
CompiledModule destructor for kernel1..0x7861794adfa0.run
CompiledModule destructor for kernel1..0x7861794adfa0.run
CompiledModuleCache constructor with maxReadyEntries = 1
CompiledModule destructor for kernel2..0x7861738e3200.run
CompiledModule destructor for kernel2..0x7861738e3200.run
CompiledModule destructor for kernel2..0x7861738e3200.run
CompiledModule destructor for kernel2..0x7861738e3200.run
CompiledModule destructor for kernel2..0x7861738e3200.run
CompiledModuleCache constructor with maxReadyEntries = 1
CompiledModule destructor for kernel3..0x78617aa86000.run
CompiledModule destructor for kernel3..0x78617aa86000.run
CompiledModule destructor for kernel3..0x78617aa86000.run
CompiledModule destructor for kernel3..0x78617aa86000.run
CompiledModule destructor for kernel3..0x78617aa86000.run
[True]
[True]
[True]
Before exiting
CompiledModule destructor for kernel1..0x7861794adfa0.run
Destructing ExecutionEngine
CompiledModule destructor for kernel2..0x7861738e3200.run
Destructing ExecutionEngine
CompiledModule destructor for kernel3..0x78617aa86000.run
Destructing ExecutionEngine
```

Meaning that 3 distinct caches are created each holding one entry. No eviction happens. `ExecutionEngine`s are deleted on exit.

The ultimate goal would be to support the eviction of a `CompiledModule` being run asynchronously. I believe this means that a `shared_ptr<CompiledModule>` instead of a raw pointer needs to be passed to the running thread. 