### PR TITLE
[ci] Use sha-based cudaq version for nightly wheels

### DIFF
--- a/.github/actions/compute-cudaq-version/action.yml
+++ b/.github/actions/compute-cudaq-version/action.yml
@@ -1,0 +1,40 @@
+name: Compute CUDA-Q version
+description: |
+  Infer cudaq_version from the Git ref (tag, releases/*, or staging/*).
+  Unversioned refs use 0.0.0 with the short git SHA appended.
+inputs:
+  ref_name:
+    description: Git ref name to extract the version from.
+    required: false
+    default: ${{ github.ref_name }}
+  ref_type:
+    description: Git ref type (branch or tag).
+    required: false
+    default: ${{ github.ref_type }}
+outputs:
+  cudaq_version:
+    description: The inferred CUDA-Q version.
+    value: ${{ steps.compute.outputs.cudaq_version }}
+runs:
+  using: composite
+  steps:
+    - name: Compute version
+      id: compute
+      shell: bash
+      env:
+        REF_NAME: ${{ inputs.ref_name }}
+        REF_TYPE: ${{ inputs.ref_type }}
+      run: |
+        is_versioned=false
+        if [[ "$REF_TYPE" == "tag" ]] || [[ "$REF_NAME" == releases/* ]] || [[ "$REF_NAME" == staging/* ]]; then
+          is_versioned=true
+        fi
+
+        if $is_versioned; then
+          cudaq_version=$(echo "$REF_NAME" | egrep -o "([0-9]{1,}\.)+[0-9]{1,}" || true)
+        else
+          cudaq_version="0.0.0+${GITHUB_SHA:0:12}"
+        fi
+
+        echo "cudaq_version=$cudaq_version" >> "$GITHUB_OUTPUT"
+        echo "CUDA-Q version: $cudaq_version"

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -47,7 +47,7 @@ jobs:
 
     outputs:
       artifact_name: ${{ steps.prereqs.outputs.artifact_name }}
-      cudaq_version: ${{ steps.prereqs.outputs.cudaq_version }}
+      cudaq_version: ${{ steps.version.outputs.cudaq_version }}
 
     # Needed for making local images available to the docker/build-push-action.
     # See also https://stackoverflow.com/a/63927832.
@@ -83,6 +83,10 @@ jobs:
           key: ${{ inputs.devdeps_cache }}
           fail-on-cache-miss: true
 
+      - name: Compute CUDA-Q version
+        id: version
+        uses: ./.github/actions/compute-cudaq-version
+
       - name: Load prerequisites
         id: prereqs
         run: |
@@ -109,14 +113,7 @@ jobs:
           cache_id=`echo ${{ inputs.python_version }}-$devenv_tag | tr . -`
 
           mkdir -p "/tmp/wheels"
-          is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
-          if ${is_versioned}; then
-            cudaq_version=`echo ${{ github.ref_name }} | egrep -o "([0-9]{1,}\.)+[0-9]{1,}"`
-          else
-            cudaq_version=0.0.0
-          fi
-        
-          echo "cudaq_version=$cudaq_version" >> $GITHUB_OUTPUT
+
           echo "base_image=$base_image" >> $GITHUB_OUTPUT
           echo "docker_output=type=local,dest=/tmp/wheels" >> $GITHUB_OUTPUT
           # do not change this prefix without adjusting other workflows
@@ -168,7 +165,7 @@ jobs:
             ccache-data=/tmp/ccache-data
           build-args: |
             base_image=${{ steps.prereqs.outputs.base_image }}
-            release_version=${{ steps.prereqs.outputs.cudaq_version }}
+            release_version=${{ steps.version.outputs.cudaq_version }}
             python_version=${{ inputs.python_version }}
           outputs: ${{ steps.prereqs.outputs.docker_output }}
 
@@ -184,7 +181,7 @@ jobs:
             -f ./docker/release/cudaq.wheel.Dockerfile . \
             --build-context ccache-data=/tmp/ccache-data \
             --build-arg base_image=${{ steps.prereqs.outputs.base_image }} \
-            --build-arg release_version=${{ steps.prereqs.outputs.cudaq_version }} \
+            --build-arg release_version=${{ steps.version.outputs.cudaq_version }} \
             --build-arg python_version=${{ inputs.python_version }} \
             --target ccache-export \
             --output type=local,dest=/tmp/ccache-export \

--- a/pyproject.toml.cu12
+++ b/pyproject.toml.cu12
@@ -102,4 +102,3 @@ cmake.args = [
 ]
 
 [tool.setuptools_scm]
-write_to = "_version.py"

--- a/pyproject.toml.cu13
+++ b/pyproject.toml.cu13
@@ -112,4 +112,3 @@ if.platform-system = "darwin"
 install.strip = false
 
 [tool.setuptools_scm]
-write_to = "_version.py"


### PR DESCRIPTION
This PR does three things related to Python wheels versioning:
- when the wheel does not correspond to an actual release, set the wheel version to `0.0.0+<SHA>` instead of just `0.0.0`. This resolves cache issues when trying to install a 'new' 0.0.0 wheel.
- Moves the CI logic to infer the current CUDA-Q version into a dedicated file so that I can re-use it for some other CI scripts I am working on.
- Remove the generation of `_version.py`, which landed at the repo root (as opposed to the python project root), is git-ignored and is never used.