### PR TITLE
Use relative paths in clang.cfg

### DIFF
--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -314,19 +314,23 @@ if [ -n "$llvm_runtimes" ]; then
 
     # We can use a default config file to set specific clang configurations.
     # See https://clang.llvm.org/docs/UsersManual.html#configuration-files
+    # Use <CFGDIR> (directory containing this .cfg) so the install is relocatable
     clang_config_file="$LLVM_INSTALL_PREFIX/bin/clang++.cfg"
     if [ -f "$LLVM_INSTALL_PREFIX/bin/ld.lld" ]; then
       echo '-fuse-ld=lld' > "$clang_config_file"
+    else
+      : > "$clang_config_file"
     fi
-    echo '-L"'$LLVM_INSTALL_PREFIX/lib'"' >> "$clang_config_file"
-    echo '-Wl,-rpath,"'$LLVM_INSTALL_PREFIX/lib'"' >> "$clang_config_file"
+    echo '-L"<CFGDIR>/../lib"' >> "$clang_config_file"
+    echo '-Wl,-rpath,"<CFGDIR>/../lib"' >> "$clang_config_file"
     # On macOS, sysroot paths are NOT baked into the cfg because they become
     # stale after Xcode/SDK updates. nvq++ resolves them at runtime instead.
     if [ "$(uname)" != "Darwin" ]; then
       target_specific_libs=`ls -d "$LLVM_INSTALL_PREFIX/lib"/*linux*`
       for libdir in $target_specific_libs; do
-        echo '-L"'$libdir'"' >> "$clang_config_file"
-        echo '-Wl,-rpath,"'$libdir'"' >> "$clang_config_file"
+        libdir_name=$(basename "$libdir")
+        echo '-L"<CFGDIR>/../lib/'$libdir_name'"' >> "$clang_config_file"
+        echo '-Wl,-rpath,"<CFGDIR>/../lib/'$libdir_name'"' >> "$clang_config_file"
       done
     fi
     cp "$clang_config_file" "$LLVM_INSTALL_PREFIX/bin/clang.cfg"


### PR DESCRIPTION
This rewrites the paths stored in `clang.cfg` to be relative to the installation directory of the clang binary to make it robust to binary relocation.