### PR TITLE
[CI] Add 30-minute timeout to the GPU wheel-validation job

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -497,6 +497,7 @@ jobs:
     needs: build_wheel
     if: inputs.platform == 'linux/amd64' && inputs.python_version == '3.11' && inputs.cuda_version == '12.6'
     runs-on: linux-amd64-gpu-a100-latest-1
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
The gpu_validation job runs the Python test suite against the nvidia GPU statevector simulator as a merge-queue gate. It had no timeout-minutes and inherited the 6-hour default, so a hang in the nvidia backend during the "Run Python tests on nvidia simulator" step ran the full 6 hours and cancelled the merge-queue run (e.g. run 30732253739), wedging the queue.

Cap the job at 30 minutes so such a hang fails fast instead of burning 6 hours. A normal run (image build, wheel install, test suite) is ~10-15 min.