### PR TITLE
[core] The canonicalizer was performing a redundant quantum

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1580,7 +1580,6 @@ def R1Op : OneTargetParamOp<"r1", [Rotation]> {
      └───────┘
     ```
   }];
-  let hasCanonicalizer = 1;
 }
 
 def RxOp : OneTargetParamOp<"rx", [Rotation]> {
@@ -1599,7 +1598,6 @@ def RxOp : OneTargetParamOp<"rx", [Rotation]> {
      └───────┘
     ```
   }];
-  let hasCanonicalizer = 1;
 }
 
 def RyOp : OneTargetParamOp<"ry", [Rotation]> {
@@ -1618,7 +1616,6 @@ def RyOp : OneTargetParamOp<"ry", [Rotation]> {
      └───────┘
     ```
   }];
-  let hasCanonicalizer = 1;
 }
 
 def RzOp : OneTargetParamOp<"rz", [Rotation]> {
@@ -1637,7 +1634,6 @@ def RzOp : OneTargetParamOp<"rz", [Rotation]> {
      └───────┘
     ```
   }];
-  let hasCanonicalizer = 1;
 }
 
 def SOp : OneTargetOp<"s"> {

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -713,49 +713,6 @@ struct KillDeadWrapPattern : public OpRewritePattern<cudaq::quake::WrapOp> {
   }
 };
 
-template <typename OP>
-struct MergeRotationPattern : public OpRewritePattern<OP> {
-  using Base = OpRewritePattern<OP>;
-  using Base::Base;
-
-  LogicalResult matchAndRewrite(OP rotate,
-                                PatternRewriter &rewriter) const override {
-    auto wireTy = cudaq::quake::WireType::get(rewriter.getContext());
-    if (rotate.getTarget(0).getType() != wireTy ||
-        !rotate.getControls().empty() || rotate.getNegatedQubitControls())
-      return failure();
-    auto input = rotate.getTarget(0).template getDefiningOp<OP>();
-    if (!input || !input.getControls().empty() ||
-        input.getNegatedQubitControls())
-      return failure();
-
-    // At this point, we have
-    //   %input  = quake.rotate %angle1, %wire
-    //   %rotate = quake.rotate %angle2, %input
-    // Replace those ops with
-    //   %new    = quake.rotate (%angle1 + %angle2), %wire
-    auto loc = rotate.getLoc();
-    auto angle1 = input.getParameter(0);
-    auto angle2 = rotate.getParameter(0);
-    if (angle1.getType() != angle2.getType())
-      return failure();
-    auto adjAttr = rotate.getIsAdjAttr();
-    auto newAngle = [&]() -> Value {
-      if (input.isAdj() == rotate.isAdj())
-        return arith::AddFOp::create(rewriter, loc, angle1, angle2);
-      // One is adjoint, so it should be subtracted from the other.
-      if (input.isAdj())
-        return arith::SubFOp::create(rewriter, loc, angle2, angle1);
-      adjAttr = input.getIsAdjAttr();
-      return arith::SubFOp::create(rewriter, loc, angle1, angle2);
-    }();
-    rewriter.replaceOpWithNewOp<OP>(rotate, rotate.getResultTypes(), adjAttr,
-                                    ValueRange{newAngle}, ValueRange{},
-                                    ValueRange{input.getTarget(0)},
-                                    rotate.getNegatedQubitControlsAttr());
-    return success();
-  }
-};
 
 // Forward the argument to a relax_size to the users for all users that are
 // quake operations. All quake ops that take a sized veq argument are

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -713,7 +713,6 @@ struct KillDeadWrapPattern : public OpRewritePattern<cudaq::quake::WrapOp> {
   }
 };
 
-
 // Forward the argument to a relax_size to the users for all users that are
 // quake operations. All quake ops that take a sized veq argument are
 // polymorphic on all veq types. If the op is not a quake op, then maintain

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -1062,7 +1062,6 @@ void cudaq::quake::R1Op::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({1, 0, 0, std::exp(theta * 1i)});
 }
 
-
 void cudaq::quake::RxOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
   double theta;
@@ -1073,7 +1072,6 @@ void cudaq::quake::RxOp::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({std::cos(theta / 2.), -1i * std::sin(theta / 2.),
                  -1i * std::sin(theta / 2.), std::cos(theta / 2.)});
 }
-
 
 void cudaq::quake::RyOp::getOperatorMatrix(Matrix &matrix) {
   // Get parameter
@@ -1088,7 +1086,6 @@ void cudaq::quake::RyOp::getOperatorMatrix(Matrix &matrix) {
                  -std::sin(theta / 2.), std::cos(theta / 2.)});
 }
 
-
 void cudaq::quake::RzOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
 
@@ -1102,7 +1099,6 @@ void cudaq::quake::RzOp::getOperatorMatrix(Matrix &matrix) {
 
   matrix.assign({std::exp(-1i * theta / 2.), 0, 0, std::exp(1i * theta / 2.)});
 }
-
 
 void cudaq::quake::SOp::getOperatorMatrix(Matrix &matrix) {
   using namespace llvm::numbers;

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -1062,10 +1062,6 @@ void cudaq::quake::R1Op::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({1, 0, 0, std::exp(theta * 1i)});
 }
 
-void cudaq::quake::R1Op::getCanonicalizationPatterns(
-    RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<MergeRotationPattern<cudaq::quake::R1Op>>(context);
-}
 
 void cudaq::quake::RxOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
@@ -1078,10 +1074,6 @@ void cudaq::quake::RxOp::getOperatorMatrix(Matrix &matrix) {
                  -1i * std::sin(theta / 2.), std::cos(theta / 2.)});
 }
 
-void cudaq::quake::RxOp::getCanonicalizationPatterns(
-    RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<MergeRotationPattern<cudaq::quake::RxOp>>(context);
-}
 
 void cudaq::quake::RyOp::getOperatorMatrix(Matrix &matrix) {
   // Get parameter
@@ -1096,10 +1088,6 @@ void cudaq::quake::RyOp::getOperatorMatrix(Matrix &matrix) {
                  -std::sin(theta / 2.), std::cos(theta / 2.)});
 }
 
-void cudaq::quake::RyOp::getCanonicalizationPatterns(
-    RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<MergeRotationPattern<cudaq::quake::RyOp>>(context);
-}
 
 void cudaq::quake::RzOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
@@ -1115,10 +1103,6 @@ void cudaq::quake::RzOp::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({std::exp(-1i * theta / 2.), 0, 0, std::exp(1i * theta / 2.)});
 }
 
-void cudaq::quake::RzOp::getCanonicalizationPatterns(
-    RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<MergeRotationPattern<cudaq::quake::RzOp>>(context);
-}
 
 void cudaq::quake::SOp::getOperatorMatrix(Matrix &matrix) {
   using namespace llvm::numbers;

--- a/cudaq/test/Transforms/merge_rotation.qke
+++ b/cudaq/test/Transforms/merge_rotation.qke
@@ -7,6 +7,7 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt --add-dealloc --inline --factor-quantum-alloc --memtoreg --canonicalize %s | FileCheck %s
+// RUN: cudaq-opt --add-dealloc --inline --factor-quantum-alloc --memtoreg --quake-simplify --canonicalize %s | FileCheck --check-prefix=SIMPLE %s
 
 func.func @duplicate_rotation_check() {
   %0 = arith.constant 2 : i32
@@ -21,15 +22,14 @@ func.func @duplicate_rotation_check() {
 }
 
 // CHECK-LABEL:   func.func @duplicate_rotation_check() {
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1.180{{.*}} : f64
-// CHECK-DAG:       %[[VAL_1:.*]] = quake.null_wire
-// CHECK-DAG:       %[[VAL_2:.*]] = quake.null_wire
-// CHECK:           %[[VAL_4:.*]] = quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK-DAG:       quake.sink %[[VAL_6]] : !quake.wire
-// CHECK-DAG:       quake.sink %[[VAL_2]] : !quake.wire
-// CHECK:           return
-// CHECK:         }
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 5.900000e-01 : f64
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_0]]) %[[NULL_WIRE_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[RX_1:.*]] = quake.rx (%[[CONSTANT_0]]) %[[RX_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[RX_1]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           quake.sink %[[MZ_0]] : !quake.wire
+// CHECK:           quake.sink %[[NULL_WIRE_1]] : !quake.wire
 
 func.func @duplicate_rotation_check2() {
   %0 = arith.constant 2 : i32
@@ -46,15 +46,16 @@ func.func @duplicate_rotation_check2() {
 }
 
 // CHECK-LABEL:   func.func @duplicate_rotation_check2() {
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1.410{{.*}} : f64
-// CHECK-DAG:       %[[VAL_2:.*]] = quake.null_wire
-// CHECK-DAG:       %[[VAL_3:.*]] = quake.null_wire
-// CHECK:           %[[VAL_6:.*]] = quake.rx (%[[VAL_0]]) %[[VAL_2]] : (f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK-DAG:       quake.sink %[[VAL_8]] : !quake.wire
-// CHECK-DAG:       quake.sink %[[VAL_3]] : !quake.wire
-// CHECK:           return
-// CHECK:         }
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2.300000e-01 : f64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 5.900000e-01 : f64
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_1]]) %[[NULL_WIRE_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[RX_1:.*]] = quake.rx (%[[CONSTANT_1]]) %[[RX_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[RX_2:.*]] = quake.rx (%[[CONSTANT_0]]) %[[RX_1]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[RX_2]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           quake.sink %[[MZ_0]] : !quake.wire
+// CHECK:           quake.sink %[[NULL_WIRE_1]] : !quake.wire
 
 func.func @returns_angle(%arg0 : f64, %arg1 : f64) -> (f64) {
   %0 = arith.divf %arg0, %arg1 : f64
@@ -78,13 +79,44 @@ func.func @duplicate_rotation_check3() {
   return
 }
 
+
 // CHECK-LABEL:   func.func @duplicate_rotation_check3() {
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5.93782{{.*}} : f64
-// CHECK-DAG:       %[[VAL_3:.*]] = quake.null_wire
-// CHECK-DAG:       %[[VAL_4:.*]] = quake.null_wire
-// CHECK:           %[[VAL_7:.*]] = quake.rx (%[[VAL_0]]) %[[VAL_3]] : (f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK-DAG:       quake.sink %[[VAL_9]] : !quake.wire
-// CHECK-DAG:       quake.sink %[[VAL_4]] : !quake.wire
-// CHECK:           return
-// CHECK:         }
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2.7826086956521738 : f64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2.5652173913043477 : f64
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 5.900000e-01 : f64
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_2]]) %[[NULL_WIRE_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[RX_1:.*]] = quake.rx (%[[CONSTANT_0]]) %[[RX_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[RX_2:.*]] = quake.rx (%[[CONSTANT_1]]) %[[RX_1]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[RX_2]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           quake.sink %[[MZ_0]] : !quake.wire
+// CHECK:           quake.sink %[[NULL_WIRE_1]] : !quake.wire
+
+// SIMPLE-LABEL:   func.func @duplicate_rotation_check() {
+// SIMPLE:           %[[CONSTANT_0:.*]] = arith.constant 1.180000e+00 : f64
+// SIMPLE:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// SIMPLE:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// SIMPLE:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_0]]) %[[NULL_WIRE_0]] : (f64, !quake.wire) -> !quake.wire
+// SIMPLE:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[RX_0]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// SIMPLE:           quake.sink %[[MZ_0]] : !quake.wire
+// SIMPLE:           quake.sink %[[NULL_WIRE_1]] : !quake.wire
+
+// SIMPLE-LABEL:   func.func @duplicate_rotation_check2() {
+// SIMPLE:           %[[CONSTANT_0:.*]] = arith.constant 1.410000e+00 : f64
+// SIMPLE:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// SIMPLE:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// SIMPLE:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_0]]) %[[NULL_WIRE_0]] : (f64, !quake.wire) -> !quake.wire
+// SIMPLE:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[RX_0]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// SIMPLE:           quake.sink %[[MZ_0]] : !quake.wire
+// SIMPLE:           quake.sink %[[NULL_WIRE_1]] : !quake.wire
+
+// SIMPLE-LABEL:   func.func @duplicate_rotation_check3() {
+// SIMPLE:           %[[CONSTANT_0:.*]] = arith.constant 5.9378260869565214 : f64
+// SIMPLE:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// SIMPLE:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// SIMPLE:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_0]]) %[[NULL_WIRE_0]] : (f64, !quake.wire) -> !quake.wire
+// SIMPLE:           %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[RX_0]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// SIMPLE:           quake.sink %[[MZ_0]] : !quake.wire
+// SIMPLE:           quake.sink %[[NULL_WIRE_1]] : !quake.wire
+


### PR DESCRIPTION
optimization. This removes that optimization in favor of the one in the quantum simplify pass. (Two different algorithms are not needed and frowned upon.)

Update regression test.