### PR TITLE
[python] Add a quick and dirty mechanism to disable quantum optimizations

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Builder/RuntimeNames.h
+++ b/cudaq/include/cudaq/Optimizer/Builder/RuntimeNames.h
@@ -84,4 +84,6 @@ static constexpr const char cleanupArrays[] = "__nvqpp_cleanup_arrays";
 
 static constexpr const char pythonUniqueAttrName[] = "quake.python_uniqued";
 
+static constexpr const char disableQuantumOpts[] = "quake.noOptimization";
+
 } // namespace cudaq::runtime

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -6098,6 +6098,8 @@ def compile_to_mlir(uniqueId, astModule, signature: KernelSignature, defFrame,
     kernelModuleName = kwargs[
         'kernelModuleName'] if 'kernelModuleName' in kwargs else None
     cudaqAliases = kwargs.get('cudaqAliases', None)
+    disable_quantum_optimization = kwargs.get('disable_quantum_optimization',
+                                              False)
 
     # Build the AOT Quake Module for this kernel. Wrapped in a single span so
     # the tracer can separate Python-AST-to-MLIR construction from the AOT
@@ -6139,6 +6141,9 @@ def compile_to_mlir(uniqueId, astModule, signature: KernelSignature, defFrame,
     bridge.module.operation.attributes.__setitem__(
         cudaq__unique_attr_name, StringAttr.get(bridge.name,
                                                 context=bridge.ctx))
+    if disable_quantum_optimization:
+        bridge.module.operation.attributes.__setitem__(
+            'quake.noOptimization', UnitAttr.get(context=bridge.ctx))
     if verbose:
         print(bridge.module)
     # Clear the live operations cache. This avoids python crashing with

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -125,6 +125,7 @@ class PyKernelDecorator(object):
                  function,
                  verbose=False,
                  defer_compilation=True,
+                 disable_quantum_optimization=False,
                  module=None,
                  kernelName=None,
                  signature=None,
@@ -137,6 +138,7 @@ class PyKernelDecorator(object):
         self.kernelModuleName = None
         self.name = kernelName
         self.verbose = verbose
+        self.disable_quantum_optimization = disable_quantum_optimization
         # Caches the `qkeModule` property once compiled
         self._cached_qkeModule = None
         self.defFrame = _recover_defining_frame()
@@ -286,7 +288,8 @@ class PyKernelDecorator(object):
             location=self.location,
             kernelName=self.name,
             kernelModuleName=self.kernelModuleName,
-            cudaqAliases=getattr(self, 'cudaqAliases', None))
+            cudaqAliases=getattr(self, 'cudaqAliases', None),
+            disable_quantum_optimization=self.disable_quantum_optimization)
 
         # recursively compile any captured kernels if required
         for captured_arg in self.signature.captured_args:

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -18,6 +18,7 @@
 #include "cudaq_internal/compiler/JIT.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"
 #include "runtime/cudaq/platform/PythonSignalCheck.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
@@ -65,7 +66,11 @@ std::string cudaq::detail::lower_to_qir_llvm(const std::string &name,
     cudaq::opt::addAggressiveInlining(pm);
     cudaq::opt::createTargetFinalizePipeline(pm);
   }
-  cudaq::opt::addAOTPipelineConvertToQIR(pm, format);
+  bool disableQuantumOpt =
+      compiled_module->hasAttr(cudaq::runtime::disableQuantumOpts);
+  cudaq::opt::addAOTPipelineConvertToQIR(pm, format,
+                                         /*useValueSemantics=*/
+                                         !disableQuantumOpt);
   if (failed(cudaq_internal::compiler::runPassManager(pm, compiled_module)))
     throw std::runtime_error("Pass pipeline failed.");
   if (failed(cudaq::verifier::checkQIRLLVMIRDialect(compiled_module, format)))

--- a/runtime/internal/compiler/RuntimeMLIR.cpp
+++ b/runtime/internal/compiler/RuntimeMLIR.cpp
@@ -12,6 +12,7 @@
 #include "common/Timing.h"
 #include "cudaq_internal/compiler/TracePassInstrumentation.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/CodeGen/IQMJsonEmitter.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
 #include "cudaq/Optimizer/CodeGen/OptUtils.h"
@@ -450,13 +451,16 @@ qirProfileTranslationFunction(const std::string &qirProfile, Operation *op,
           return WalkResult::interrupt();
         }).wasInterrupted();
 
+  bool disableQuantumOpt = op->hasAttr(cudaq::runtime::disableQuantumOpts);
   std::string profileName;
   if (containsWireSet) {
     profileName = config.profile;
     cudaq::opt::addWiresetToProfileQIRPipeline(pm, profileName);
   } else {
     profileName = qirProfile;
-    cudaq::opt::addAOTPipelineConvertToQIR(pm, profileName);
+    cudaq::opt::addAOTPipelineConvertToQIR(pm, profileName,
+                                           /*useValueSemantics=*/
+                                           !disableQuantumOpt);
   }
 
   if (!additionalPasses.empty() &&


### PR DESCRIPTION
This lets the user have a course-grained control over python kernels getting optimized or not. This mechanism may change/impove and should not be relied upon.