### PR TITLE
Fix density matrix layout across QPP and dynamics when states are created from complex_matrix

### DIFF
--- a/python/cudaq/dynamics/integrators/scipy_integrators.py
+++ b/python/cudaq/dynamics/integrators/scipy_integrators.py
@@ -52,7 +52,7 @@ class ScipyZvodeIntegrator(BaseIntegrator[cudaq_runtime.State]):
         state = bindings.initializeState(state, list(self.dimensions),
                                          self.is_density_state, self.batch_size)
         result = self.stepper.compute(state, t)
-        as_array = numpy.ravel(numpy.array(result))
+        as_array = numpy.ravel(numpy.array(result), order="F")
         return as_array
 
     def __post_init__(self):
@@ -117,7 +117,7 @@ class ScipyZvodeIntegrator(BaseIntegrator[cudaq_runtime.State]):
 
     def set_state(self, state: cudaq_runtime.State, t: float = 0.0):
         super().set_state(state, t)
-        as_array = numpy.ravel(numpy.array(self.state))
+        as_array = numpy.ravel(numpy.array(self.state), order="F")
         self.batch_size = bindings.getBatchSize(state)
         if self.dimensions is not None:
             self.is_density_state = (

--- a/python/cudaq/runtime/state.py
+++ b/python/cudaq/runtime/state.py
@@ -105,5 +105,8 @@ def to_cupy(state, dtype=None):
         sizeBytes = tensor.get_num_elements() * tensor.get_element_size()
         mem = cp.cuda.UnownedMemory(tensor.data(), sizeBytes, owner=state)
         memptr = cp.cuda.MemoryPointer(mem, offset=0)
-        arrays.append(cp.ndarray(tensor.extents, dtype=dtype, memptr=memptr))
+        order = ('F' if tensor.storage_order
+                 == cudaq_runtime.TensorStorageOrder.COLUMN_MAJOR else 'C')
+        arrays.append(
+            cp.ndarray(tensor.extents, dtype=dtype, memptr=memptr, order=order))
     return arrays

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -139,13 +139,34 @@ static bool isCContiguous(const std::vector<std::size_t> &shape,
   return true;
 }
 
+static bool isFContiguous(const std::vector<std::size_t> &shape,
+                          const std::vector<ssize_t> &strides,
+                          std::size_t itemsize) {
+  if (shape.size() != strides.size())
+    return false;
+
+  ssize_t expectedStride = static_cast<ssize_t>(itemsize);
+  for (std::size_t i = 0; i < shape.size(); ++i) {
+    if (shape[i] > 1 && strides[i] != expectedStride)
+      return false;
+    expectedStride *= static_cast<ssize_t>(shape[i]);
+  }
+
+  return true;
+}
+
 static bool shouldCanonicalizeCupyArray(const BufferInfo &info,
                                         const std::string &targetName) {
   if (info.shape.empty())
     return false;
 
-  // Only 2D arrays for the dynamics target or non-contiguous 1D arrays
-  // need canonicalization.
+  // TensorStateData expects contiguous column-major storage, so dynamics
+  // complex128 density matrices must be F-contiguous.
+  if (info.shape.size() == 2 && targetName == "dynamics" && info.format == "Zd")
+    return !isFContiguous(info.shape, info.strides, info.itemsize);
+
+  // Preserve the existing host fallback for non-contiguous 1D arrays and
+  // other dynamics density-matrix input types.
   bool needsCanon = (info.shape.size() == 1) ||
                     (info.shape.size() == 2 && targetName == "dynamics");
   return needsCanon && !isCContiguous(info.shape, info.strides, info.itemsize);
@@ -155,6 +176,17 @@ static nanobind::object
 canonicalizeCupyArrayToNumpy(nanobind::handle cupyArray) {
   return nanobind::module_::import_("cupy").attr("asnumpy")(
       nanobind::borrow<nanobind::object>(cupyArray));
+}
+
+static nanobind::object canonicalizeCupyArray(nanobind::handle cupyArray,
+                                              const BufferInfo &info,
+                                              const std::string &targetName) {
+  // Canonicalize the density matrix to column-major storage on the device.
+  if (info.shape.size() == 2 && targetName == "dynamics" && info.format == "Zd")
+    return nanobind::module_::import_("cupy").attr("asfortranarray")(
+        nanobind::borrow<nanobind::object>(cupyArray));
+
+  return canonicalizeCupyArrayToNumpy(cupyArray);
 }
 
 static std::vector<int> bitStringToIntVec(const std::string &bitString) {
@@ -318,7 +350,8 @@ static cudaq::state createStateFromPyBuffer(nanobind::object data,
         "`dtype=cudaq.complex()` for precision-agnostic code.");
 
   if (!isHostData && shouldCanonicalizeCupyArray(info, holder.getTarget().name))
-    return createStateFromPyBuffer(canonicalizeCupyArrayToNumpy(data), holder);
+    return createStateFromPyBuffer(
+        canonicalizeCupyArray(data, info, holder.getTarget().name), holder);
 
   if (!isHostData) {
     if (holder.getTarget().name == "dynamics") {

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -388,6 +388,14 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
       .value("UNIFORM", InitialState::UNIFORM)
       .export_values();
 
+  nanobind::enum_<SimulationState::Tensor::storage_order>(
+      mod, "TensorStorageOrder",
+      "Enumeration describing the storage order of tensor data.")
+      .value("UNSPECIFIED", SimulationState::Tensor::storage_order::unspecified)
+      .value("ROW_MAJOR", SimulationState::Tensor::storage_order::row_major)
+      .value("COLUMN_MAJOR",
+             SimulationState::Tensor::storage_order::column_major);
+
   nanobind::class_<SimulationState::Tensor>(
       mod, "Tensor",
       "The `Tensor` describes a pointer to simulation data as well as the rank "
@@ -397,6 +405,7 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
              return reinterpret_cast<intptr_t>(tensor.data);
            })
       .def_ro("extents", &SimulationState::Tensor::extents)
+      .def_ro("storage_order", &SimulationState::Tensor::order)
       .def("get_rank", &SimulationState::Tensor::get_rank)
       .def("get_element_size", &SimulationState::Tensor::element_size)
       .def("get_num_elements", &SimulationState::Tensor::get_num_elements);
@@ -436,6 +445,21 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
             auto precision = self.get_precision();
             std::vector<size_t> shape(stateVector.extents.begin(),
                                       stateVector.extents.end());
+            std::vector<int64_t> strides;
+            const int64_t *stridesPtr = nullptr;
+            if (stateVector.order !=
+                SimulationState::Tensor::storage_order::unspecified) {
+              strides.resize(shape.size(), 1);
+              if (stateVector.order ==
+                  SimulationState::Tensor::storage_order::column_major) {
+                for (std::size_t i = 1; i < shape.size(); ++i)
+                  strides[i] = strides[i - 1] * shape[i - 1];
+              } else {
+                for (std::size_t i = shape.size(); i > 1; --i)
+                  strides[i - 2] = strides[i - 1] * shape[i - 1];
+              }
+              stridesPtr = strides.data();
+            }
 
             if (self.is_on_gpu()) {
               auto numElements = stateVector.get_num_elements();
@@ -452,7 +476,8 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
 
                 return nanobind::cast(
                     nanobind::ndarray<nanobind::numpy, std::complex<float>>(
-                        hostData, shape.size(), shape.data(), owner));
+                        hostData, shape.size(), shape.data(), owner,
+                        stridesPtr));
               } else {
                 auto *hostData = new std::complex<double>[numElements];
                 self.to_host(hostData, numElements);
@@ -465,19 +490,20 @@ void cudaq::bindPyState(nanobind::module_ &mod, LinkedLibraryHolder &holder) {
 
                 return nanobind::cast(
                     nanobind::ndarray<nanobind::numpy, std::complex<double>>(
-                        hostData, shape.size(), shape.data(), owner));
+                        hostData, shape.size(), shape.data(), owner,
+                        stridesPtr));
               }
             } else {
               if (precision == SimulationState::precision::fp32) {
                 return nanobind::cast(
                     nanobind::ndarray<nanobind::numpy, std::complex<float>>(
                         stateVector.data, shape.size(), shape.data(),
-                        nanobind::handle()));
+                        nanobind::handle(), stridesPtr));
               } else {
                 return nanobind::cast(
                     nanobind::ndarray<nanobind::numpy, std::complex<double>>(
                         stateVector.data, shape.size(), shape.data(),
-                        nanobind::handle()));
+                        nanobind::handle(), stridesPtr));
               }
             }
           },

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -349,6 +349,11 @@ static cudaq::state createStateFromPyBuffer(nanobind::object data,
         "`dtype=numpy.complex128` if simulation is FP64, or "
         "`dtype=cudaq.complex()` for precision-agnostic code.");
 
+  if (!isHostData && holder.getTarget().name == "dynamics" &&
+      info.format != "Zd")
+    throw std::runtime_error(
+        "The dynamics target requires CuPy input with dtype complex128.");
+
   if (!isHostData && shouldCanonicalizeCupyArray(info, holder.getTarget().name))
     return createStateFromPyBuffer(
         canonicalizeCupyArray(data, info, holder.getTarget().name), holder);

--- a/python/tests/builder/test_state.py
+++ b/python/tests/builder/test_state.py
@@ -171,6 +171,28 @@ def test_state_density_matrix_simple():
     cudaq.reset_target()
 
 
+def test_state_from_complex_density_matrix_observable():
+    cudaq.set_target('density-matrix-cpu')
+    try:
+        rho = np.array([[0.5, 0.25j], [-0.25j, 0.5]], dtype=np.complex128)
+        initial_state = cudaq.State.from_data(rho)
+
+        assert np.isclose(initial_state[0, 1], rho[0, 1])
+        assert np.isclose(initial_state[1, 0], rho[1, 0])
+        np.testing.assert_allclose(np.array(initial_state), rho, atol=1e-12)
+
+        @cudaq.kernel
+        def prepare_from_state(state: cudaq.State):
+            qubits = cudaq.qvector(state)
+
+        result = cudaq.observe(prepare_from_state, cudaq.spin.y(0),
+                               initial_state)
+
+        assert np.isclose(result.expectation(), -0.5)
+    finally:
+        cudaq.reset_target()
+
+
 def test_state_density_matrix_self_overlap():
     cudaq.set_target('density-matrix-cpu')
 

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -347,7 +347,7 @@ def test_evolve_density_matrix_cupy_strided_layout_cudm():
     base = cp.array([[1.0 + 0.0j, 2.0 + 0.0j], [3.0 + 0.0j, 4.0 + 0.0j]],
                     dtype=cp.complex128)
     cases = [
-        ("c_order", base, cp.asnumpy(base)),  # Already C-contiguous, no copy
+        ("c_order", base, cp.asnumpy(base)),
         ("fortran_order", cp.asfortranarray(base), cp.asnumpy(base)),
         ("transpose_view", base.T, cp.asnumpy(base.T)),
     ]
@@ -368,9 +368,38 @@ def test_evolve_density_matrix_cupy_strided_layout_cudm():
         np.testing.assert_allclose(final_arr, expected, atol=1e-12)
 
 
+@pytest.mark.parametrize("layout",
+                         ["c_order", "fortran_order", "transpose_view"])
+def test_evolve_density_matrix_cupy_complex_input_observable_cudm(layout):
+    from cudaq.operators import spin
+
+    base = cp.array([[0.5, 0.25j], [-0.25j, 0.5]], dtype=cp.complex128)
+    if layout == "c_order":
+        rho = base
+    elif layout == "fortran_order":
+        rho = cp.asfortranarray(base)
+    else:
+        rho = cp.array(base.T, order="C").T
+
+    initial_state = cudaq.State.from_data(rho)
+    result = cudaq.evolve(
+        0.0 * spin.x(0),
+        {0: 2},
+        Schedule([0.0], ["time"]),
+        initial_state,
+        observables=[spin.y(0)],
+        collapse_operators=[],
+        store_intermediate_results=cudaq.IntermediateResultSave.
+        EXPECTATION_VALUE,
+    )
+
+    expectation_values = result.expectation_values()
+    assert expectation_values is not None
+    assert np.isclose(expectation_values[0][0].expectation(), -0.5)
+
+
 def test_evolve_density_matrix_cupy_contiguous_no_regression_cudm():
-    """C-contiguous 2D CuPy array should go through the GPU path directly
-    without being copied back to host."""
+    """C-contiguous CuPy input should be canonicalized on the GPU."""
     rho = cp.array([[1.0 + 0.0j, 0.0j], [0.0j, 0.0j]], dtype=cp.complex128)
     assert rho.flags["C_CONTIGUOUS"]
     expected = cp.asnumpy(rho)

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -398,25 +398,13 @@ def test_evolve_density_matrix_cupy_complex_input_observable_cudm(layout):
     assert np.isclose(expectation_values[0][0].expectation(), -0.5)
 
 
-def test_evolve_density_matrix_cupy_contiguous_no_regression_cudm():
-    """C-contiguous CuPy input should be canonicalized on the GPU."""
-    rho = cp.array([[1.0 + 0.0j, 0.0j], [0.0j, 0.0j]], dtype=cp.complex128)
-    assert rho.flags["C_CONTIGUOUS"]
-    expected = cp.asnumpy(rho)
-
+def test_from_data_density_matrix_to_cupy_layout_cudm():
+    rho = cp.array([[0.5, 0.25j], [-0.25j, 0.5]], dtype=cp.complex128)
     state = cudaq.State.from_data(rho)
-    evolution_result = cudaq.evolve(
-        0.0 * boson.number(0),
-        {0: 2},
-        Schedule([0.0], ["t"]),
-        state,
-        observables=[],
-        collapse_operators=[],
-        store_intermediate_results=cudaq.IntermediateResultSave.NONE,
-    )
 
-    final_arr = np.array(evolution_result.final_state())
-    np.testing.assert_allclose(final_arr, expected, atol=1e-12)
+    cupy_state = cudaq.to_cupy(state)[0]
+
+    cp.testing.assert_allclose(cupy_state, rho, atol=1e-12)
 
 
 @pytest.mark.parametrize("layout",
@@ -451,6 +439,12 @@ def test_from_data_cupy_2d_non_square_rejected():
     rho = cp.array([[1, 2, 3], [4, 5, 6]], dtype=cp.complex128)
     assert rho.flags["C_CONTIGUOUS"]
     with pytest.raises(RuntimeError, match="square matrix"):
+        cudaq.State.from_data(rho)
+
+
+def test_from_data_cupy_complex64_rejected_cudm():
+    rho = cp.eye(2, dtype=cp.complex64)
+    with pytest.raises(RuntimeError, match="complex128"):
         cudaq.State.from_data(rho)
 
 

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -269,6 +269,29 @@ def test_evolve_density_matrix_complex_input_observable_cudm(order):
     assert np.isclose(expectation_values[0][0].expectation(), -0.5)
 
 
+def test_evolve_density_matrix_numpy_readback_cudm():
+    from cudaq.operators import spin
+
+    initial_state = cudaq.State.from_data(
+        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.complex128))
+    result = cudaq.evolve(
+        spin.x(0),
+        {0: 2},
+        Schedule(np.linspace(0.0, np.pi / 4.0, 101), ["time"]),
+        initial_state,
+        observables=[],
+        collapse_operators=[],
+        store_intermediate_results=cudaq.IntermediateResultSave.NONE,
+    )
+
+    expected = np.array([[0.5, 0.5j], [-0.5j, 0.5]], dtype=np.complex128)
+    # The default integrator contributes about 1e-2 numerical error, while the
+    # transposed layout differs by O(1).
+    np.testing.assert_allclose(np.array(result.final_state()),
+                               expected,
+                               atol=1e-2)
+
+
 def test_evolve_density_matrix_numpy_layout_cudm():
     from cudaq.operators import spin
 

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -244,6 +244,31 @@ def test_precision_info():
     assert target.get_precision() == cudaq.SimulationPrecision.fp64
 
 
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_evolve_density_matrix_complex_input_observable_cudm(order):
+    from cudaq.operators import spin
+
+    rho = np.array([[0.5, 0.25j], [-0.25j, 0.5]],
+                   dtype=np.complex128,
+                   order=order)
+    initial_state = cudaq.State.from_data(rho)
+
+    result = cudaq.evolve(
+        0.0 * spin.x(0),
+        {0: 2},
+        Schedule([0.0], ["time"]),
+        initial_state,
+        observables=[spin.y(0)],
+        collapse_operators=[],
+        store_intermediate_results=cudaq.IntermediateResultSave.
+        EXPECTATION_VALUE,
+    )
+
+    expectation_values = result.expectation_values()
+    assert expectation_values is not None
+    assert np.isclose(expectation_values[0][0].expectation(), -0.5)
+
+
 def test_evolve_density_matrix_numpy_layout_cudm():
     from cudaq.operators import spin
 

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -108,9 +108,12 @@ public:
   /// vector of Tensors. Each tensor tracks its data pointer
   /// and the tensor extents.
   struct Tensor {
+    enum class storage_order { unspecified, row_major, column_major };
+
     void *data = nullptr;
     std::vector<std::size_t> extents;
     precision fp_precision;
+    storage_order order = storage_order::unspecified;
     std::size_t get_rank() const { return extents.size(); }
     std::size_t get_num_elements() const {
       std::size_t num = 1;

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -24,7 +24,7 @@ class SimulationState;
 enum class InitialState { ZERO, UNIFORM };
 
 /// @brief Encapsulates a list of tensors (data pointer and dimensions).
-// Note: tensor data is expected in column-major.
+/// @note Each tensor must be contiguous and stored in column-major order.
 using TensorStateData =
     std::vector<std::pair<const void *, std::vector<std::size_t>>>;
 /// @brief state_data is a variant type

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -182,7 +182,9 @@ CuDensityMatState::getTensor(std::size_t tensorIdx) const {
     const std::vector<std::size_t> extents =
         isDensityMatrix ? std::vector<std::size_t>{dim, dim}
                         : std::vector<std::size_t>{dim};
-    return Tensor{devicePtr, extents, precision::fp64};
+    const auto order = isDensityMatrix ? Tensor::storage_order::column_major
+                                       : Tensor::storage_order::unspecified;
+    return Tensor{devicePtr, extents, precision::fp64, order};
   } else {
     // For batched state, always returns the flat buffer.
     return Tensor{devicePtr, {dimension}, precision::fp64};

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -113,7 +113,7 @@ CuDensityMatState::createFromData(const state_data &data) {
           "[CuDensityMatState] Density matrix input must be square.");
     const std::size_t size = cMat.rows() * cMat.cols();
     void *dataPtr = const_cast<cudaq::complex_matrix &>(cMat).get_data(
-        cudaq::complex_matrix::order::row_major);
+        cudaq::complex_matrix::order::column_major);
     std::complex<double> *devicePtr = static_cast<std::complex<double> *>(
         cudaq::dynamics::DeviceAllocator::allocate(
             size * sizeof(std::complex<double>)));

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -33,16 +33,25 @@ struct QppDmState : public cudaq::SimulationState {
   std::size_t getNumQubits() const override { return std::log2(state.rows()); }
 
   std::complex<double> overlap(const cudaq::SimulationState &other) override {
-    if (other.getNumTensors() != 1 ||
-        (other.getTensor().extents != getTensor().extents))
+    if (other.getNumTensors() != 1)
       throw std::runtime_error("[qpp-dm-state] overlap error - other state "
                                "dimension not equal to this state dimension.");
+    const auto thisTensor = getTensor();
+    const auto otherTensor = other.getTensor();
+    if (otherTensor.extents != thisTensor.extents)
+      throw std::runtime_error("[qpp-dm-state] overlap error - other state "
+                               "dimension not equal to this state dimension.");
+    if (otherTensor.order != Tensor::storage_order::unspecified &&
+        otherTensor.order != thisTensor.order)
+      throw std::runtime_error(
+          "[qpp-dm-state] overlap error - storage order mismatch.");
+
     // Create rho and sigma matrices
     Eigen::MatrixXcd rho = Eigen::Map<Eigen::MatrixXcd>(
-        state.data(), getTensor().extents[0], getTensor().extents[1]);
+        state.data(), thisTensor.extents[0], thisTensor.extents[1]);
     Eigen::MatrixXcd sigma = Eigen::Map<Eigen::MatrixXcd>(
-        reinterpret_cast<std::complex<double> *>(other.getTensor().data),
-        other.getTensor().extents[0], other.getTensor().extents[1]);
+        reinterpret_cast<std::complex<double> *>(otherTensor.data),
+        otherTensor.extents[0], otherTensor.extents[1]);
 
     return (rho.adjoint() * sigma).trace();
   }
@@ -85,7 +94,7 @@ struct QppDmState : public cudaq::SimulationState {
             const_cast<std::complex<double> *>(state.data())),
         std::vector<std::size_t>{static_cast<std::size_t>(state.rows()),
                                  static_cast<std::size_t>(state.cols())},
-        getPrecision()};
+        getPrecision(), Tensor::storage_order::column_major};
   }
 
   // /// @brief Return all tensors that represent this state

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -41,10 +41,6 @@ struct QppDmState : public cudaq::SimulationState {
     if (otherTensor.extents != thisTensor.extents)
       throw std::runtime_error("[qpp-dm-state] overlap error - other state "
                                "dimension not equal to this state dimension.");
-    if (otherTensor.order != Tensor::storage_order::unspecified &&
-        otherTensor.order != thisTensor.order)
-      throw std::runtime_error(
-          "[qpp-dm-state] overlap error - storage order mismatch.");
 
     // Create rho and sigma matrices
     Eigen::MatrixXcd rho = Eigen::Map<Eigen::MatrixXcd>(

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -120,7 +120,7 @@ struct QppDmState : public cudaq::SimulationState {
 
       auto *dataPtr =
           reinterpret_cast<void *>(const_cast<complex_matrix &>(cMat).get_data(
-              complex_matrix::order::row_major));
+              complex_matrix::order::column_major));
 
       return std::make_unique<QppDmState>(Eigen::Map<qpp::cmat>(
           reinterpret_cast<std::complex<double> *>(dataPtr), cMat.rows(),

--- a/targettests/execution/qpp_dm_state_from_data.cpp
+++ b/targettests/execution/qpp_dm_state_from_data.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ %s --target density-matrix-cpu -o %t && %t | FileCheck %s
+
+#include <cudaq.h>
+
+#include <iomanip>
+#include <iostream>
+
+struct prepare_from_state {
+  void operator()(cudaq::state *initialState) __qpu__ {
+    cudaq::qvector qubits(initialState);
+  }
+};
+
+int main() {
+  cudaq::complex_matrix densityMatrix(2, 2);
+  densityMatrix[{0, 0}] = 0.5;
+  densityMatrix[{0, 1}] = std::complex<double>(0.0, 0.25);
+  densityMatrix[{1, 0}] = std::complex<double>(0.0, -0.25);
+  densityMatrix[{1, 1}] = 0.5;
+
+  auto initialState = cudaq::state::from_data(densityMatrix);
+  auto result =
+      cudaq::observe(prepare_from_state{}, cudaq::spin::y(0), &initialState);
+
+  std::cout << std::fixed << std::setprecision(1)
+            << "expectation = " << result.expectation() << '\n';
+
+  // CHECK: expectation = -0.5
+  return 0;
+}

--- a/unittests/dynamics/test_CuDensityMatState.cpp
+++ b/unittests/dynamics/test_CuDensityMatState.cpp
@@ -350,8 +350,8 @@ TEST_F(CuDensityMatStateTest, CreateFromDataDensityMatrixLayout) {
   cudaq::complex_matrix rhoRow(rhoRowMajor, {2, 2},
                                cudaq::complex_matrix::order::row_major);
 
-  using RowMajorMatrix = Eigen::Matrix<std::complex<double>, Eigen::Dynamic,
-                                       Eigen::Dynamic, Eigen::RowMajor>;
+  using ColumnMajorMatrix =
+      Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic>;
 
   CuDensityMatState prototype;
   auto stateRow = prototype.createFromData(cudaq::state_data(rhoRow));
@@ -360,7 +360,7 @@ TEST_F(CuDensityMatStateTest, CreateFromDataDensityMatrixLayout) {
   cudmRow->initialize_cudm(handle, {2}, /*batchSize=*/1);
   EXPECT_TRUE(cudmRow->is_density_matrix());
 
-  RowMajorMatrix hostRow(2, 2);
+  ColumnMajorMatrix hostRow(2, 2);
   cudmRow->toHost(hostRow.data(), 4);
   EXPECT_NEAR(hostRow(0, 0).real(), 1.0, 1e-12);
   EXPECT_NEAR(hostRow(0, 0).imag(), 0.0, 1e-12);
@@ -379,7 +379,7 @@ TEST_F(CuDensityMatStateTest, CreateFromDataDensityMatrixLayout) {
   cudmCol->initialize_cudm(handle, {2}, /*batchSize=*/1);
   EXPECT_TRUE(cudmCol->is_density_matrix());
 
-  RowMajorMatrix hostCol(2, 2);
+  ColumnMajorMatrix hostCol(2, 2);
   cudmCol->toHost(hostCol.data(), 4);
   EXPECT_NEAR(hostCol(0, 0).real(), 1.0, 1e-12);
   EXPECT_NEAR(hostCol(1, 0).real(), 0.0, 1e-12);
@@ -394,7 +394,7 @@ TEST_F(CuDensityMatStateTest, CreateFromDataDensityMatrixLayout) {
   auto *cudmOffRow = dynamic_cast<CuDensityMatState *>(stateOffRow.get());
   ASSERT_NE(cudmOffRow, nullptr);
   cudmOffRow->initialize_cudm(handle, {2}, /*batchSize=*/1);
-  RowMajorMatrix hostOffRow(2, 2);
+  ColumnMajorMatrix hostOffRow(2, 2);
   cudmOffRow->toHost(hostOffRow.data(), 4);
   EXPECT_NEAR(hostOffRow(0, 0).real(), 1.0, 1e-12);
   EXPECT_NEAR(hostOffRow(0, 1).real(), 2.0, 1e-12);
@@ -409,7 +409,7 @@ TEST_F(CuDensityMatStateTest, CreateFromDataDensityMatrixLayout) {
   auto *cudmOffCol = dynamic_cast<CuDensityMatState *>(stateOffCol.get());
   ASSERT_NE(cudmOffCol, nullptr);
   cudmOffCol->initialize_cudm(handle, {2}, /*batchSize=*/1);
-  RowMajorMatrix hostOffCol(2, 2);
+  ColumnMajorMatrix hostOffCol(2, 2);
   cudmOffCol->toHost(hostOffCol.data(), 4);
   EXPECT_NEAR(hostOffCol(0, 0).real(), 1.0, 1e-12);
   EXPECT_NEAR(hostOffCol(0, 1).real(), 2.0, 1e-12);

--- a/unittests/dynamics/test_EvolveApi.cpp
+++ b/unittests/dynamics/test_EvolveApi.cpp
@@ -44,6 +44,28 @@ TEST(EvolveAPITester, checkSimple) {
   }
 }
 
+TEST(EvolveAPITester, checkComplexDensityMatrixInputLayout) {
+  cudaq::complex_matrix densityMatrix(2, 2);
+  densityMatrix[{0, 0}] = 0.5;
+  densityMatrix[{0, 1}] = std::complex<double>(0.0, 0.25);
+  densityMatrix[{1, 0}] = std::complex<double>(0.0, -0.25);
+  densityMatrix[{1, 1}] = 0.5;
+
+  auto initialState = cudaq::state::from_data(densityMatrix);
+  cudaq::schedule schedule(std::vector<double>{0.0}, {"time"});
+  cudaq::integrators::runge_kutta integrator(4, 0.01);
+  auto result =
+      cudaq::evolve(0.0 * cudaq::spin_op::x(0), {{0, 2}}, schedule,
+                    initialState, integrator, {}, {cudaq::spin_op::y(0)},
+                    cudaq::IntermediateResultSave::ExpectationValue);
+
+  ASSERT_TRUE(result.expectation_values.has_value());
+  ASSERT_EQ(result.expectation_values->size(), 1);
+  ASSERT_EQ(result.expectation_values->front().size(), 1);
+  EXPECT_NEAR(static_cast<double>(result.expectation_values->front().front()),
+              -0.5, 1e-12);
+}
+
 TEST(EvolveAPITester, checkCavityModel) {
   constexpr int N = 10;
   constexpr int numSteps = 101;

--- a/unittests/dynamics/test_EvolveApi.cpp
+++ b/unittests/dynamics/test_EvolveApi.cpp
@@ -66,6 +66,25 @@ TEST(EvolveAPITester, checkComplexDensityMatrixInputLayout) {
               -0.5, 1e-12);
 }
 
+TEST(EvolveAPITester, checkDensityMatrixOutputStorageOrder) {
+  cudaq::complex_matrix densityMatrix(2, 2);
+  densityMatrix[{0, 0}] = 1.0;
+
+  auto initialState = cudaq::state::from_data(densityMatrix);
+  cudaq::schedule schedule(std::vector<double>{0.0}, {"time"});
+  cudaq::integrators::runge_kutta integrator(4, 0.01);
+  auto result =
+      cudaq::evolve(0.0 * cudaq::spin_op::x(0), {{0, 2}}, schedule,
+                    initialState, integrator, {}, {cudaq::spin_op::z(0)},
+                    cudaq::IntermediateResultSave::ExpectationValue);
+
+  ASSERT_TRUE(result.states.has_value());
+  ASSERT_EQ(result.states->size(), 1);
+  const auto tensor = result.states->front().get_tensor();
+  EXPECT_EQ(tensor.order,
+            cudaq::SimulationState::Tensor::storage_order::column_major);
+}
+
 TEST(EvolveAPITester, checkCavityModel) {
   constexpr int N = 10;
   constexpr int numSteps = 101;


### PR DESCRIPTION
This PR is trying to fix density matrix transposition in the QPP and dynamics backends when states are created from `complex_matrix` data or converted to NumPy.

## State creation from `complex_matrix` data.

1. The QPP density-matrix implementation stores its state as `qpp::cmat` (an alias of `Eigen::MatrixXcd`, which is column-major by default) and maps the input buffer with `Eigen::Map<qpp::cmat>`. Therefore, this specific input path expects contiguous column-major data.

2. cuDensityMat requires its dense state storage to use the generalized column-major layout.

we corrected the issue where the current implementation treated the input as row-major order in commit 96dca7ef2ad666461903a7bb14820221918919c9 (qpp) and c269cbae35d1521340164e35ed9d526d48f6a037 (dynamic). Before the fix, The following asymmetric density matrix has:
```text
ρ = [[ 0.5,  0.25i],
     [-0.25i, 0.5 ]]
⟨Y⟩ = +0.5
```
After this change, it is -0.5.

## State readback through `SimulationState::Tensor` and NumPy.
The output path had a related ambiguity: `SimulationState::Tensor` exposed the data pointer and extents but not its storage order. 

QPP and cuDensityMat returned their native column-major density-matrix buffers in getTensor (I understand that getTensor should not take the original column-major array and then convert it again into row-major order.), but State.to_numpy() created an ndarray without explicit strides. NumPy therefore interpreted the buffer using default C-order semantics and returned the transposed matrix.

Assuming `getTensor()` returns the native backend buffer without performing a layout conversion. Therefore, the consumer must know the buffer's storage order when constructing a multidimensional view.
We addressed this ambiguity in commits e5f7e9c5c7220fe8b126fbb50b7f8a229a496913 and a409200e571ba5b52eab67ebedff8b92722b434e by:
1. Adding storage-order metadata to `SimulationState::Tensor`. The default is `unspecified` to preserve compatibility with backends that do not report a layout.
2. Marking QPP and cuDensityMat density-matrix tensors as column-major.
3. Computing the NumPy strides from the tensor extents and reported storage order.
4. Flattening density matrices in Fortran order in the SciPy integrator.

Before the fix, evolving the state `|0><0|` under an X Hamiltonian produced the following NumPy readback:
```text
expected:
ρ = [[ 0.5,  0.5j],
     [-0.5j, 0.5 ]]
before fix:
ρ = [[0.5, -0.5j],
     [0.5j,  0.5 ]]
```
After this change, np.array(result.final_state()) returns the expected matrix.

This adds a new `storage_order` field to `SimulationState::Tensor`.
This changes the layout of the C++ struct and may affect ABI compatibility for components built against a different CUDA-Q version. The field defaults to `unspecified`, so existing aggregate initializers and backends preserve their previous behavior when rebuilt together.
The alternative would be to require every backend to convert the data returned by `getTensor()` into a canonical row-major layout. That would introduce copies for backends whose native storage is column-major and  maybe would conflict with the
current zero-copy purpose of `getTensor()`.