### PR TITLE
Extract shared ObservableUserData helper from Fermioniq

### DIFF
--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -164,6 +164,11 @@ public:
         throw std::runtime_error(
             "Returning an observe_result requires a spin_op.");
 
+      // Server-side observe backends return a single expectation on the
+      // global register (e.g. Fermioniq / external custom QPU plugins).
+      if (data.has_expectation())
+        return observe_result(data.expectation(), *spinOp, data);
+
       auto checkRegName = spinOp->to_string();
       if (data.has_expectation(checkRegName))
         return observe_result(data.expectation(checkRegName), *spinOp, data);

--- a/runtime/common/ObservableUserData.h
+++ b/runtime/common/ObservableUserData.h
@@ -1,0 +1,46 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// Helpers for attaching a full spin_op to KernelExecution::user_data when a
+/// REST / custom QPU backend evaluates observables server-side (e.g. Fermioniq
+/// or an external plugin that registers its own QPU).
+
+#pragma once
+
+#include "common/KernelExecution.h"
+#include "nlohmann/json.hpp"
+#include "cudaq/runtime/logger/cudaq_fmt.h"
+#include "cudaq/spin_op.h"
+#include <cmath>
+
+namespace cudaq {
+
+/// @brief Attach a full spin observable to a KernelExecution as
+/// `user_data["observable"]` for server-side observe backends.
+///
+/// Format matches Fermioniq / external REST plugins:
+/// `[["Z0", "0.5+0.0j"], ["Z0 Z1", "0.3+0.0j"], ...]`
+inline void attachObservableUserData(KernelExecution &code,
+                                     const spin_op &spin) {
+  nlohmann::json user_data = nlohmann::json::object();
+  nlohmann::json obs = nlohmann::json::array();
+  for (const auto &term : spin) {
+    nlohmann::json terms = nlohmann::json::array();
+    terms.push_back(term.get_term_id());
+    auto coeff = term.evaluate_coefficient();
+    auto coeff_str = cudaq_fmt::format("{}{}{}j", coeff.real(),
+                                       coeff.imag() < 0.0 ? "-" : "+",
+                                       std::fabs(coeff.imag()));
+    terms.push_back(coeff_str);
+    obs.push_back(std::move(terms));
+  }
+  user_data["observable"] = std::move(obs);
+  code.user_data = cudaq_json(std::move(user_data));
+}
+
+} // namespace cudaq

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -7,30 +7,9 @@
  ******************************************************************************/
 
 #include "FermioniqQPU.h"
+#include "common/ObservableUserData.h"
 #include "cudaq_internal/compiler/Compiler.h"
-#include "nlohmann/json.hpp"
 #include "cudaq/algorithms/observe/policy.h"
-#include "cudaq/runtime/logger/cudaq_fmt.h"
-
-namespace {
-void attachFermioniqObservable(cudaq::KernelExecution &code,
-                               const cudaq::spin_op &spin) {
-  auto user_data = nlohmann::json::object();
-  auto obs = nlohmann::json::array();
-  for (const auto &term : spin) {
-    auto terms = nlohmann::json::array();
-    terms.push_back(term.get_term_id());
-    auto coeff = term.evaluate_coefficient();
-    auto coeff_str = cudaq_fmt::format("{}{}{}j", coeff.real(),
-                                       coeff.imag() < 0.0 ? "-" : "+",
-                                       std::fabs(coeff.imag()));
-    terms.push_back(coeff_str);
-    obs.push_back(terms);
-  }
-  user_data["observable"] = obs;
-  code.user_data = user_data;
-}
-} // namespace
 
 cudaq::FermioniqQPU::~FermioniqQPU() = default;
 
@@ -90,7 +69,7 @@ cudaq::FermioniqQPU::launchKernel(const cudaq::observe_policy &policy,
   if (codes.size() != 1)
     throw std::runtime_error("Provider only allows 1 circuit at a time.");
 
-  attachFermioniqObservable(codes[0], policy.spin);
+  attachObservableUserData(codes[0], policy.spin);
   auto result =
       completeLaunchKernel(policy, module.getName(), std::move(codes));
   auto expectation = result.raw_data().expectation(GlobalRegisterName);
@@ -114,7 +93,7 @@ cudaq::FermioniqQPU::launchKernel(const cudaq::async_observe_policy &policy,
   if (codes.size() != 1)
     throw std::runtime_error("Provider only allows 1 circuit at a time.");
 
-  attachFermioniqObservable(codes[0], policy.inner.spin);
+  attachObservableUserData(codes[0], policy.inner.spin);
   return completeLaunchKernel(policy, module.getName(), std::move(codes));
 }
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -242,6 +242,19 @@ target_link_libraries(test_exec_ctx_thread
   gtest_main)
 cudaq_gtest_discover_tests(test_exec_ctx_thread DISCOVERY_TIMEOUT 120)
 
+# Server-side observe helpers (Fermioniq / external custom QPU wire format)
+add_executable(test_observable_user_data
+  main.cpp
+  common/ObservableUserDataTester.cpp)
+target_include_directories(test_observable_user_data PRIVATE .)
+target_link_libraries(test_observable_user_data
+  PRIVATE
+  cudaq
+  cudaq-common
+  cudaq-operator
+  gtest_main)
+cudaq_gtest_discover_tests(test_observable_user_data DISCOVERY_TIMEOUT 120)
+
 add_executable(test_quantum_platform main.cpp common/QuantumPlatformTester.cpp)
 target_include_directories(test_quantum_platform PRIVATE .)
 target_link_libraries(test_quantum_platform

--- a/unittests/common/ObservableUserDataTester.cpp
+++ b/unittests/common/ObservableUserDataTester.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// Unit tests for server-side observe helpers used by Fermioniq and external
+/// custom QPU plugins.
+
+#include "common/ObservableUserData.h"
+#include "common/SampleResult.h"
+#include "cudaq/operators.h"
+#include <gtest/gtest.h>
+#include <set>
+#include <string>
+
+TEST(ObservableUserDataTester, attachesFermioniqCompatibleObservable) {
+  cudaq::KernelExecution code;
+  auto spin =
+      0.5 * cudaq::spin::z(0) + 0.3 * cudaq::spin::z(0) * cudaq::spin::z(1);
+
+  cudaq::attachObservableUserData(code, spin);
+
+  ASSERT_TRUE(code.user_data->contains("observable"));
+  ASSERT_TRUE(code.user_data->at("observable").is_array());
+  ASSERT_EQ(code.user_data->at("observable").size(), 2u);
+
+  std::set<std::string> termIds;
+  for (const auto &entry : code.user_data->at("observable")) {
+    ASSERT_TRUE(entry.is_array());
+    ASSERT_EQ(entry.size(), 2u);
+    ASSERT_TRUE(entry[0].is_string());
+    ASSERT_TRUE(entry[1].is_string());
+    termIds.insert(entry[0].get<std::string>());
+    // Coefficient strings match Fermioniq: "re±imj"
+    const auto coeff = entry[1].get<std::string>();
+    EXPECT_NE(coeff.find('j'), std::string::npos);
+  }
+  EXPECT_TRUE(termIds.count("Z0"));
+  EXPECT_TRUE(termIds.count("Z0Z1"));
+}
+
+TEST(ObservableUserDataTester, serverSideExpectationUsesGlobalRegister) {
+  // processResults for server-side observe backends return
+  // ExecutionResult(double). async_observe_result::get() must accept
+  // has_expectation() on the global register without requiring
+  // spin_op->to_string() as the register name.
+  cudaq::sample_result data(cudaq::ExecutionResult(/*expVal=*/0.41));
+  EXPECT_TRUE(data.has_expectation());
+  EXPECT_DOUBLE_EQ(data.expectation(), 0.41);
+  EXPECT_TRUE(data.has_expectation(cudaq::GlobalRegisterName));
+}


### PR DESCRIPTION
## Summary
- Extract Fermioniq's server-side observe `user_data["observable"]` attachment into shared `ObservableUserData.h`
- Teach `Future` to accept global-register expectations used by server-side observe backends
- Add unit coverage for the shared helper

This is a focused subset of #4980 (no docs, no mock plugin, no platform-qpu auto-load).

## Test plan
- [ ] `test_observable_user_data` — Fermioniq-compatible observable attachment + global-register expectation
- [ ] Confirm Fermioniq still builds against the shared helper


Made with [Cursor](https://cursor.com)