### PR TITLE
Add the ability to disable all quantum optimizations

### DIFF
--- a/cudaq/include/cudaq/Frontend/nvqpp/AttributeNames.h
+++ b/cudaq/include/cudaq/Frontend/nvqpp/AttributeNames.h
@@ -27,4 +27,9 @@ static constexpr const char deviceCallAttrName[] = "cudaq-devicecall";
 static constexpr const char generatorAnnotation[] =
     "user_custom_quantum_operation";
 
+/// Name of the annotation attribute that disables quantum optimizations on a
+/// kernel. Attach via `[[cudaq::disable_quantum_optimization]]`.
+static constexpr const char disableQuantumOptAnnotation[] =
+    "disable_quantum_optimization";
+
 } // namespace cudaq

--- a/cudaq/include/cudaq/Frontend/nvqpp/AttributeNames.h
+++ b/cudaq/include/cudaq/Frontend/nvqpp/AttributeNames.h
@@ -28,7 +28,7 @@ static constexpr const char generatorAnnotation[] =
     "user_custom_quantum_operation";
 
 /// Name of the annotation attribute that disables quantum optimizations on a
-/// kernel. Attach via `[[cudaq::disable_quantum_optimization]]`.
+/// kernel. Attach via `__disable_quantum_optimization__`.
 static constexpr const char disableQuantumOptAnnotation[] =
     "disable_quantum_optimization";
 

--- a/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -8,6 +8,7 @@
 
 #include "cudaq/Frontend/nvqpp/ASTBridge.h"
 #include "cudaq/Frontend/nvqpp/QisBuilder.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
 #include "clang/AST/ParentMapContext.h"
@@ -550,16 +551,17 @@ bool QuakeBridgeVisitor::isItaniumCXXABI() {
 namespace cudaq {
 bool ASTBridgeAction::ASTBridgeConsumer::isQuantum(
     const clang::FunctionDecl *decl) {
-  // Quantum kernels are Functions that are annotated with "quantum"
-  if (auto attr = decl->getAttr<clang::AnnotateAttr>())
-    return attr->getAnnotation().str() == cudaq::kernelAnnotation;
+  for (auto *attr : decl->specific_attrs<clang::AnnotateAttr>())
+    if (attr->getAnnotation().str() == cudaq::kernelAnnotation)
+      return true;
   return false;
 }
 
 bool ASTBridgeAction::ASTBridgeConsumer::isCustomOpGenerator(
     const clang::FunctionDecl *decl) {
-  if (auto attr = decl->getAttr<clang::AnnotateAttr>())
-    return attr->getAnnotation().str() == cudaq::generatorAnnotation;
+  for (auto *attr : decl->specific_attrs<clang::AnnotateAttr>())
+    if (attr->getAnnotation().str() == cudaq::generatorAnnotation)
+      return true;
   return false;
 }
 
@@ -730,6 +732,14 @@ void ASTBridgeAction::ASTBridgeConsumer::HandleTranslationUnit(
       auto unitAttr = UnitAttr::get(ctx);
       // Flag func as a quantum kernel.
       func->setAttr(kernelAttrName, unitAttr);
+      // If the kernel is annotated with disable_quantum_optimization, set the
+      // quake.noOptimization attribute on the module so that value semantics
+      // lowering and related quantum optimization passes are skipped.
+      for (auto *a : fdPair.second->specific_attrs<clang::AnnotateAttr>())
+        if (a->getAnnotation().str() == cudaq::disableQuantumOptAnnotation) {
+          (*module)->setAttr(cudaq::runtime::disableQuantumOpts, unitAttr);
+          break;
+        }
       bool hasDeviceOnlyTypes =
           hasAnyQuakeOrHandleTypes(func.getFunctionType());
       if (hasDeviceOnlyTypes)

--- a/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -738,6 +738,7 @@ void ASTBridgeAction::ASTBridgeConsumer::HandleTranslationUnit(
       for (auto *a : fdPair.second->specific_attrs<clang::AnnotateAttr>())
         if (a->getAnnotation().str() == cudaq::disableQuantumOptAnnotation) {
           (*module)->setAttr(cudaq::runtime::disableQuantumOpts, unitAttr);
+          func->setAttr(cudaq::runtime::disableQuantumOpts, unitAttr);
           break;
         }
       bool hasDeviceOnlyTypes =

--- a/cudaq/lib/Optimizer/Transforms/DeadQuantumElimination.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DeadQuantumElimination.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -87,6 +88,8 @@ public:
 
   void runOnOperation() override {
     auto *op = getOperation();
+    if (op->hasAttr(cudaq::runtime::disableQuantumOpts))
+      return;
     LLVM_DEBUG(llvm::dbgs() << "Before DQE:\n" << *op << '\n');
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);

--- a/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -633,6 +634,8 @@ class PhaseFoldingPass
 public:
   void runOnOperation() override {
     auto func = getOperation();
+    if (func->hasAttr(cudaq::runtime::disableQuantumOpts))
+      return;
     // Get the netlist represention for the qubits in the function,
     // this will walk the whole function once
     auto nl = Netlist(func);

--- a/cudaq/lib/Optimizer/Transforms/QuakeSimplify.cpp
+++ b/cudaq/lib/Optimizer/Transforms/QuakeSimplify.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
@@ -849,6 +850,8 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     auto *op = getOperation();
+    if (op->hasAttr(cudaq::runtime::disableQuantumOpts))
+      return;
     GreedyRewriteConfig config;
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Disabled);
     RewritePatternSet patterns(ctx);

--- a/cudaq/test/AST-Quake/no_optimization.cpp
+++ b/cudaq/test/AST-Quake/no_optimization.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | cudaq-opt --add-dealloc | \
+// RUN:   cudaq-translate --convert-to=qir:base | FileCheck %s
+
+#include <cudaq.h>
+
+struct Defeatism {
+   void operator()() __disable_quantum_optimization__ __qpu__ {
+    cudaq::qubit q0, q1;
+    h(q0);
+    h(q0);
+  }
+};
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__Defeatism()
+// CHECK:         %[[VAL_0:.*]] = tail call ptr @__quantum__rt__qubit_allocate_array(i64 2)
+// CHECK:         %[[VAL_1:.*]] = tail call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %[[VAL_0]], i64 0)
+// CHECK:         %[[VAL_2:.*]] = load ptr, ptr %[[VAL_1]], align 8
+// CHECK:         tail call void @__quantum__qis__h(ptr %[[VAL_2]])
+// CHECK:         tail call void @__quantum__qis__h(ptr %[[VAL_2]])
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(ptr %[[VAL_0]])

--- a/cudaq/test/AST-Quake/no_optimization.cpp
+++ b/cudaq/test/AST-Quake/no_optimization.cpp
@@ -21,9 +21,7 @@ struct Defeatism {
 
 // clang-format off
 // CHECK-LABEL: define void @__nvqpp__mlirgen__Defeatism()
-// CHECK:         %[[VAL_0:.*]] = tail call ptr @__quantum__rt__qubit_allocate_array(i64 2)
-// CHECK:         %[[VAL_1:.*]] = tail call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %[[VAL_0]], i64 0)
-// CHECK:         %[[VAL_2:.*]] = load ptr, ptr %[[VAL_1]], align 8
-// CHECK:         tail call void @__quantum__qis__h(ptr %[[VAL_2]])
-// CHECK:         tail call void @__quantum__qis__h(ptr %[[VAL_2]])
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(ptr %[[VAL_0]])
+// CHECK:         tail call void @__quantum__qis__h(ptr
+// CHECK:         tail call void @__quantum__qis__h(ptr
+// CHECK-NOT:     @__quantum__qis__h
+// CHECK:         ret void

--- a/cudaq/test/AST-Quake/no_optimization.cpp
+++ b/cudaq/test/AST-Quake/no_optimization.cpp
@@ -12,13 +12,14 @@
 #include <cudaq.h>
 
 struct Defeatism {
-   void operator()() __disable_quantum_optimization__ __qpu__ {
+  void operator()() __disable_quantum_optimization__ __qpu__ {
     cudaq::qubit q0, q1;
     h(q0);
     h(q0);
   }
 };
 
+// clang-format off
 // CHECK-LABEL: define void @__nvqpp__mlirgen__Defeatism()
 // CHECK:         %[[VAL_0:.*]] = tail call ptr @__quantum__rt__qubit_allocate_array(i64 2)
 // CHECK:         %[[VAL_1:.*]] = tail call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %[[VAL_0]], i64 0)

--- a/cudaq/test/AST-Quake/no_optimization.cpp
+++ b/cudaq/test/AST-Quake/no_optimization.cpp
@@ -21,7 +21,7 @@ struct Defeatism {
 
 // clang-format off
 // CHECK-LABEL: define void @__nvqpp__mlirgen__Defeatism()
-// CHECK:         tail call void @__quantum__qis__h(ptr
-// CHECK:         tail call void @__quantum__qis__h(ptr
+// CHECK:         tail call void @__quantum__qis__h
+// CHECK:         tail call void @__quantum__qis__h
 // CHECK-NOT:     @__quantum__qis__h
 // CHECK:         ret void

--- a/cudaq/test/AST-Quake/no_optimization.cpp
+++ b/cudaq/test/AST-Quake/no_optimization.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // RUN: cudaq-quake %s | cudaq-opt --add-dealloc | \
-// RUN:   cudaq-translate --convert-to=qir:base | FileCheck %s
+// RUN:   cudaq-translate --convert-to=qir-base | FileCheck %s
 
 #include <cudaq.h>
 

--- a/cudaq/tools/cudaq-translate/cudaq-translate.cpp
+++ b/cudaq/tools/cudaq-translate/cudaq-translate.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/CodeGen/IQMJsonEmitter.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
 #include "cudaq/Optimizer/CodeGen/OptUtils.h"
@@ -14,7 +15,6 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/InitAllDialects.h"
 #include "cudaq/Optimizer/InitAllPasses.h"
-#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/Support/Version.h"
 #include "cudaq/Todo.h"

--- a/cudaq/tools/cudaq-translate/cudaq-translate.cpp
+++ b/cudaq/tools/cudaq-translate/cudaq-translate.cpp
@@ -81,6 +81,12 @@ static llvm::cl::opt<bool> emitLLVM(
                    "translation will terminate with the selected dialect."),
     llvm::cl::init(true));
 
+static llvm::cl::opt<bool> disableQuantumOptimization(
+    "fdisable-quantum-optimization",
+    llvm::cl::desc("Disable value-semantics quantum optimization passes "
+                   "(quake-simplify, dqe) during QIR code generation."),
+    llvm::cl::init(false));
+
 using namespace mlir;
 
 static void checkErrorCode(const std::error_code &ec) {
@@ -178,6 +184,7 @@ int main(int argc, char **argv) {
       .Cases({"qir", "qir-full", "qir-adaptive", "qir-base"},
              [&]() {
                bool useValueSemantics =
+                   !disableQuantumOptimization &&
                    !modOp->hasAttr(cudaq::runtime::disableQuantumOpts);
                cudaq::opt::addAggressiveInlining(pm);
                cudaq::opt::createTargetFinalizePipeline(pm);

--- a/cudaq/tools/cudaq-translate/cudaq-translate.cpp
+++ b/cudaq/tools/cudaq-translate/cudaq-translate.cpp
@@ -14,6 +14,7 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/InitAllDialects.h"
 #include "cudaq/Optimizer/InitAllPasses.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/Support/Version.h"
 #include "cudaq/Todo.h"
@@ -176,9 +177,12 @@ int main(int argc, char **argv) {
   llvm::StringSwitch<std::function<void()>>(convertPair.first)
       .Cases({"qir", "qir-full", "qir-adaptive", "qir-base"},
              [&]() {
+               bool useValueSemantics =
+                   !modOp->hasAttr(cudaq::runtime::disableQuantumOpts);
                cudaq::opt::addAggressiveInlining(pm);
                cudaq::opt::createTargetFinalizePipeline(pm);
-               cudaq::opt::addAOTPipelineConvertToQIR(pm, convertValue);
+               cudaq::opt::addAOTPipelineConvertToQIR(pm, convertValue,
+                                                      useValueSemantics);
              })
       .Case("openqasm2",
             [&]() {

--- a/cudaq/tools/nvq++/nvq++.in
+++ b/cudaq/tools/nvq++/nvq++.in
@@ -191,6 +191,12 @@ function f_option_handling {
 	-fapply-specialization)
 		ENABLE_APPLY_SPECIALIZATION=true
 		;;
+	-fno-quantum-optimization)
+		ENABLE_QUANTUM_OPTIMIZATION=false
+		;;
+	-fquantum-optimization)
+		ENABLE_QUANTUM_OPTIMIZATION=true
+		;;
 	-fno-lambda-lifting)
 		ENABLE_LAMBDA_LIFTING=false
 		;;
@@ -566,6 +572,7 @@ ENABLE_AGGRESSIVE_INLINE=true
 ENABLE_LOWER_TO_CFG=true
 ENABLE_APPLY_SPECIALIZATION=true
 ENABLE_LAMBDA_LIFTING=true
+ENABLE_QUANTUM_OPTIMIZATION=true
 ENABLE_MLIR_LIB_LINKING=true
 DELETE_TEMPS=true
 TARGET_CONFIG=
@@ -938,6 +945,10 @@ if [ -n "${TARGET_CONFIG}" ]; then
 		fi
 	    PREPROCESSOR_DEFINES="${PREPROCESSOR_DEFINES} -D NVQPP_TARGET_BACKEND_CONFIG="\"${TARGET_CONFIG}\"""   
 	fi
+fi
+
+if ! ${ENABLE_QUANTUM_OPTIMIZATION}; then
+    CUDAQ_TRANSLATE_ARGS="${CUDAQ_TRANSLATE_ARGS} -fdisable-quantum-optimization"
 fi
 
 # Configure the NVQIR link line if this is in refactored mode

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -26,7 +26,7 @@
 #include <stdexcept>
 
 #define __qpu__ __attribute__((annotate("quantum")))
-#define __disable_quantum_optimization__                                        \
+#define __disable_quantum_optimization__                                       \
   __attribute__((annotate("disable_quantum_optimization")))
 
 // This file describes the API for a default qubit logical instruction

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -26,6 +26,8 @@
 #include <stdexcept>
 
 #define __qpu__ __attribute__((annotate("quantum")))
+#define __disable_quantum_optimization__                                        \
+  __attribute__((annotate("disable_quantum_optimization")))
 
 // This file describes the API for a default qubit logical instruction
 // set for CUDA-Q kernels.


### PR DESCRIPTION
Adding the C++ attribute `__disable_quantum_optimization__` on a kernel disables all quantum optimization. 