### PR TITLE
Deprecate set_noise / unset_noise global APIs

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -271,8 +271,24 @@ del _discover_external_backends
 set_random_seed = cudaq_runtime.set_random_seed
 mpi = cudaq_runtime.mpi
 num_available_gpus = cudaq_runtime.num_available_gpus
-set_noise = cudaq_runtime.set_noise
-unset_noise = cudaq_runtime.unset_noise
+
+
+def set_noise(model):
+    warnings.warn(
+        "set_noise is deprecated; please use launch arguments or launch options.",
+        DeprecationWarning,
+        stacklevel=2)
+    return cudaq_runtime.set_noise(model)
+
+
+def unset_noise():
+    warnings.warn(
+        "unset_noise is deprecated; please use launch arguments or launch options.",
+        DeprecationWarning,
+        stacklevel=2)
+    return cudaq_runtime.unset_noise()
+
+
 register_set_target_callback = cudaq_runtime.register_set_target_callback
 unregister_set_target_callback = cudaq_runtime.unregister_set_target_callback
 

--- a/python/runtime/common/py_NoiseModel.cpp
+++ b/python/runtime/common/py_NoiseModel.cpp
@@ -17,6 +17,13 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 namespace cudaq {
 
 /// @brief Extract the array data from a 2-d ndarray into our
@@ -46,8 +53,11 @@ void extractKrausData(nanobind::ndarray<std::complex<double>, nanobind::ndim<2>,
 /// @brief Bind the cudaq::noise_model, kraus_op, and kraus_channel.
 void bindNoiseModel(nanobind::module_ &mod) {
 
-  mod.def("set_noise", &set_noise, "Set the underlying noise model.");
+  mod.def("set_noise", &set_noise,
+          "Deprecated - please use launch arguments or launch options. "
+          "Set the underlying noise model.");
   mod.def("unset_noise", &unset_noise,
+          "Deprecated - please use launch arguments or launch options. "
           "Clear backend simulation from any existing noise models.");
   mod.def(
       "get_noise", []() { return cudaq::get_platform().get_noise(); },

--- a/python/tests/builder/test_noise_deprecation.py
+++ b/python/tests/builder/test_noise_deprecation.py
@@ -1,0 +1,77 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import warnings
+
+import pytest
+
+import cudaq
+
+
+def test_set_noise_emits_deprecation_warning():
+    cudaq.reset_target()
+    cudaq.set_target("density-matrix-cpu")
+    noise = cudaq.NoiseModel()
+    try:
+        with pytest.warns(
+                DeprecationWarning,
+                match=
+                "set_noise is deprecated; please use launch arguments or launch options."
+        ):
+            cudaq.set_noise(noise)
+    finally:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cudaq.unset_noise()
+        cudaq.reset_target()
+
+
+def test_unset_noise_emits_deprecation_warning():
+    cudaq.reset_target()
+    cudaq.set_target("density-matrix-cpu")
+    noise = cudaq.NoiseModel()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        cudaq.set_noise(noise)
+    try:
+        with pytest.warns(
+                DeprecationWarning,
+                match=
+                "unset_noise is deprecated; please use launch arguments or launch options."
+        ):
+            cudaq.unset_noise()
+    finally:
+        cudaq.reset_target()
+
+
+def test_sample_noise_model_kwarg_does_not_emit_set_noise_deprecation():
+    """Recommended launch path must not warn about the deprecated global API."""
+    cudaq.reset_target()
+    cudaq.set_target("density-matrix-cpu")
+    try:
+        kernel = cudaq.make_kernel()
+        q = kernel.qalloc()
+        kernel.x(q)
+        kernel.mz(q)
+
+        noise = cudaq.NoiseModel()
+        noise.add_all_qubit_channel("x", cudaq.BitFlipChannel(1.0))
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            result = cudaq.sample(kernel, shots_count=100, noise_model=noise)
+
+        deprecation = [
+            w for w in recorded
+            if issubclass(w.category, DeprecationWarning) and
+            "set_noise is deprecated" in str(w.message)
+        ]
+        assert not deprecation
+        assert result["0"] == 100
+    finally:
+        cudaq.reset_target()

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -173,9 +173,11 @@ inline std::string get_quake(std::string &&functionName) {
 
 /// @brief Set a custom noise model for simulation. The caller must also call
 /// `cudaq::unset_noise` before `model` gets deallocated or goes out of scope.
+[[deprecated("please use launch arguments or launch options.")]]
 void set_noise(const cudaq::noise_model &model);
 
 /// @brief Remove an existing noise model from simulation.
+[[deprecated("please use launch arguments or launch options.")]]
 void unset_noise();
 
 /// @brief Set a seed for any random number

--- a/targettests/execution/set_noise_deprecation.cpp
+++ b/targettests/execution/set_noise_deprecation.cpp
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: nvq++ %s -o %t 2>&1 | FileCheck %s
+// clang-format on
+
+#include <cudaq.h>
+
+int main() {
+  cudaq::noise_model noise;
+  cudaq::set_noise(noise);
+  cudaq::unset_noise();
+  return 0;
+}
+
+// clang-format off
+// CHECK: warning: 'set_noise' is deprecated: please use launch arguments or launch options.
+// CHECK: warning: 'unset_noise' is deprecated: please use launch arguments or launch options.
+// clang-format on

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set (CMAKE_CXX_FLAGS
-     "${CMAKE_CXX_FLAGS} -Wno-attributes -Wno-ctad-maybe-unsupported")
+     "${CMAKE_CXX_FLAGS} -Wno-attributes -Wno-ctad-maybe-unsupported -Wno-deprecated-declarations")
 # clear any flags for static linking, only keeping linker selection flags
 foreach(_flags_var IN ITEMS CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
   string(REGEX MATCHALL "-fuse-ld=[^ ]+|-B[^ ]+" _linker_selection "${${_flags_var}}")


### PR DESCRIPTION
## Summary
- Mark C++ `cudaq::set_noise` / `cudaq::unset_noise` as `[[deprecated]]`, steering users toward launch options / arguments (`sample_options.noise`, `noise_model=` kwargs, etc.).
- Emit matching Python `DeprecationWarning` from the public `cudaq.set_noise` / `cudaq.unset_noise` wrappers only; leave `cudaq_runtime.set_noise` unwarned so recommended `noise_model=` paths stay quiet.
- Add C++ lit and Python pytest coverage for the deprecation messages; silence in-tree unittest rebuild noise with `-Wno-deprecated-declarations` under `unittests/` (call sites there still use the globals during the deprecation window).

## Test plan
- [x] `llvm-lit` `targettests/execution/set_noise_deprecation.cpp` (FileChecks compiler warnings via `nvq++`)
- [x] `pytest python/tests/builder/test_noise_deprecation.py` (set/unset warn; `sample(..., noise_model=...)` does not)
- [x] Full incremental Release rebuild after `touch runtime/cudaq.h` with `CCACHE_DISABLE=1` — no deprecation flood from unittests