### PR TITLE
Revert "Adding debugging capabilities to the CompileModuled (#5035)"

### DIFF
--- a/python/runtime/cudaq/platform/CompiledModuleCache.cpp
+++ b/python/runtime/cudaq/platform/CompiledModuleCache.cpp
@@ -9,7 +9,6 @@
 #include "CompiledModuleCache.h"
 #include <algorithm>
 #include <exception>
-#include <iostream>
 #include <stdexcept>
 
 namespace cudaq::detail {
@@ -79,10 +78,6 @@ CompiledModuleCache::Result CompiledModuleCache::getOrCompile(
     readyEntries.emplace_back(compilingEntry->key, module);
     if (readyEntries.size() > maxReadyEntries) {
       evicted = std::move(readyEntries.front().module);
-      if (cudaq::CompiledModule::debugMode()) {
-        std::cout << "Evicting compiled module for " << evicted->getName()
-                  << std::endl;
-      }
       readyEntries.erase(readyEntries.begin());
     }
     std::erase(compilingEntries, compilingEntry);
@@ -104,21 +99,6 @@ CompiledModuleCache::Result CompiledModuleCache::getOrCompile(
   // reuse the module instead of joining a completed attempt.
   compilingEntry->promise.set_value(module);
   return {std::move(module), role};
-}
-
-CompiledModuleCache::CompiledModuleCache() {
-  if (const auto *cacheSize = std::getenv("CUDAQ_COMPILED_MODULE_CACHE_SIZE")) {
-    try {
-      maxReadyEntries = std::stoi(cacheSize);
-    } catch (const std::exception &) {
-    }
-  }
-  if (cudaq::CompiledModule::debugMode()) {
-    std::cout << "CompiledModuleCache constructor with maxReadyEntries = "
-              << maxReadyEntries << std::endl;
-    std::cout << "Size of CompiledModule: " << sizeof(CompiledModule)
-              << std::endl;
-  }
 }
 
 } // namespace cudaq::detail

--- a/python/runtime/cudaq/platform/CompiledModuleCache.h
+++ b/python/runtime/cudaq/platform/CompiledModuleCache.h
@@ -75,7 +75,7 @@ public:
     Role role;
   };
 
-  CompiledModuleCache();
+  CompiledModuleCache() = default;
   ~CompiledModuleCache() = default;
 
   /// A cache has shared identity and must not be copied or relocated. Share it
@@ -138,7 +138,7 @@ private:
 
   /// Bound only completed artifacts; compiling entries must remain discoverable
   /// so a later equivalent caller cannot start duplicate work.
-  std::size_t maxReadyEntries = 4;
+  static constexpr std::size_t maxReadyEntries = 4;
 
   /// One mutex protects both collections, making the Missing -> Compiling and
   /// Compiling -> Ready transitions atomic.

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -7,8 +7,6 @@
  ******************************************************************************/
 
 #include "CompiledModule.h"
-#include "Environment.h"
-#include <iostream>
 #include <string_view>
 
 cudaq::FatQuakeModule::FatQuakeModule(std::string kernelName)
@@ -103,17 +101,4 @@ const void *cudaq::SourceModule::getMlirOpaqueModulePtr() const {
   if (!mlirArt)
     return nullptr;
   return mlirArt->getOpaqueModulePtr();
-}
-
-cudaq::CompiledModule::~CompiledModule() {
-  if (debugMode()) {
-    // Disable this for now to avoid spamming the console
-    std::cout << "CompiledModule destructor for " << name << std::endl;
-  }
-}
-
-bool cudaq::CompiledModule::debugMode() {
-  static const bool enabled =
-      cudaq::getEnvBool("CUDAQ_DEBUG_COMPILED_MODULE", false);
-  return enabled;
 }

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -318,16 +318,6 @@ public:
   // `CompiledModuleHelper`.
   CompiledModule() : FatQuakeModule(std::string{}) {}
   explicit CompiledModule(SourceModule src) : FatQuakeModule(std::move(src)) {}
-
-  CompiledModule(const CompiledModule &) = default;
-  CompiledModule &operator=(const CompiledModule &) = default;
-
-  CompiledModule(CompiledModule &&) noexcept = default;
-  CompiledModule &operator=(CompiledModule &&) noexcept = default;
-
-  ~CompiledModule();
-
-  static bool debugMode();
 };
 
 using AnyModule = std::variant<SourceModule, CompiledModule>;

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -42,7 +42,6 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include <cassert>
 #include <cxxabi.h>
-#include <iostream>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
@@ -288,19 +287,6 @@ public:
       funcPtr();
     };
   }
-
-  ~Impl() {
-    if (cudaq::CompiledModule::debugMode()) {
-      if (jitEngine) {
-        std::cout << "Destructing ExecutionEngine" << std::endl;
-      }
-    }
-  }
-
-  Impl(const Impl &) = delete;
-  Impl &operator=(const Impl &) = delete;
-  Impl(Impl &&) = default;
-  Impl &operator=(Impl &&) = default;
 
   std::size_t getKey() const {
     return reinterpret_cast<std::size_t>(jitEngine.get());


### PR DESCRIPTION
## Summary
- Reverts #5035 (`dee5b745`), removing the temporary `CUDAQ_COMPILED_MODULE_CACHE_SIZE` / `CUDAQ_DEBUG_COMPILED_MODULE` debugging hooks from `CompiledModule`, `CompiledModuleCache`, and `JITEngine`.

This was introduced as a hack to enable discussion around the deletion of the ExecutionEngine. It is not a productized solution and offers an attack surface. 