### PR TITLE
Quake-based Quantum Machines server helper

### DIFF
--- a/docs/sphinx/targets/python/quantum_machines.py
+++ b/docs/sphinx/targets/python/quantum_machines.py
@@ -4,9 +4,13 @@ import math
 # The default executor is mock, use executor name to run on another backend (real or simulator).
 # Configure the address of the QOperator server in the `url` argument, and set the `api_key`.
 cudaq.set_target("quantum_machines",
-                 url="http://host.docker.internal:8080",
-                 api_key="1234567890",
-                 executor="mock")
+                 url="http://host.docker.internal:8000",
+                 #url="http://172.16.32.154:8000",
+                 #api_key="1234567890",
+                 #qubit_mapping_mode="backend",
+                 #qubit_mapping_mode="local_file",
+                 qubit_mapping_mode="local_get_latest",
+                 executor="sim")
 
 qubit_count = 5
 
@@ -16,13 +20,23 @@ qubit_count = 5
 def all_h():
     qvector = cudaq.qvector(qubit_count)
 
-    for i in range(qubit_count - 1):
-        h(qvector[i])
+    for i in range(8):
+        #h(qvector[i])
+        h(qvector[0])
+        h(qvector[1])
+        h(qvector[2])
+    # mz(qvector[0])
+    # mz(qvector[0])
 
-    s(qvector[0])
-    r1(math.pi / 2, qvector[1])
-    mz(qvector)
+    rz(math.pi / 2, qvector[0])
 
+# Define the Hamiltonian (Observable)
+#hamiltonian = 5.0 * cudaq.spin.z(0)
+
+# 2. Observe the observable (Expectation value)
+#result = cudaq.observe(all_h, hamiltonian)
+#print(f"Expectation Value: {result.expectation()}")
 
 # Submit synchronously
-cudaq.sample(all_h).dump()
+cudaq.sample(all_h, shots_count=4).dump()
+

--- a/docs/sphinx/targets/python/quantum_machines.py
+++ b/docs/sphinx/targets/python/quantum_machines.py
@@ -4,13 +4,9 @@ import math
 # The default executor is mock, use executor name to run on another backend (real or simulator).
 # Configure the address of the QOperator server in the `url` argument, and set the `api_key`.
 cudaq.set_target("quantum_machines",
-                 url="http://host.docker.internal:8000",
-                 #url="http://172.16.32.154:8000",
-                 #api_key="1234567890",
-                 #qubit_mapping_mode="backend",
-                 #qubit_mapping_mode="local_file",
-                 qubit_mapping_mode="local_get_latest",
-                 executor="sim")
+                 url="http://host.docker.internal:8080",
+                 api_key="1234567890",
+                 executor="mock")
 
 qubit_count = 5
 
@@ -20,23 +16,13 @@ qubit_count = 5
 def all_h():
     qvector = cudaq.qvector(qubit_count)
 
-    for i in range(8):
-        #h(qvector[i])
-        h(qvector[0])
-        h(qvector[1])
-        h(qvector[2])
-    # mz(qvector[0])
-    # mz(qvector[0])
+    for i in range(qubit_count - 1):
+        h(qvector[i])
 
-    rz(math.pi / 2, qvector[0])
+    s(qvector[0])
+    r1(math.pi / 2, qvector[1])
+    mz(qvector)
 
-# Define the Hamiltonian (Observable)
-#hamiltonian = 5.0 * cudaq.spin.z(0)
-
-# 2. Observe the observable (Expectation value)
-#result = cudaq.observe(all_h, hamiltonian)
-#print(f"Expectation Value: {result.expectation()}")
 
 # Submit synchronously
-cudaq.sample(all_h, shots_count=4).dump()
-
+cudaq.sample(all_h).dump()

--- a/python/tests/utils/mock_qpu/quantum_machines/__init__.py
+++ b/python/tests/utils/mock_qpu/quantum_machines/__init__.py
@@ -7,6 +7,7 @@
 # ============================================================================ #
 
 from fastapi import FastAPI, HTTPException, Header
+from fastapi.responses import PlainTextResponse
 from typing import Union
 import uuid
 from pydantic import BaseModel
@@ -42,7 +43,7 @@ numQubitsRequired = 0
 
 server_exec_response = {
     "id": "12345678-1234-1234-1234-0123456789ab",
-    "samples": {
+    "results": {
         "000": 19,
         "001": 2,
         "010": 27,
@@ -54,6 +55,16 @@ server_exec_response = {
     },
     "status": "Done"
 }
+
+
+@app.get("/v1/config/qubits", response_class=PlainTextResponse)
+async def get_qubit_config():
+    return ("Number of nodes: 5\n"
+            "0 --> {1, 2, 3, 4}\n"
+            "1 --> {0, 2, 3, 4}\n"
+            "2 --> {0, 1, 3, 4}\n"
+            "3 --> {0, 1, 2, 4}\n"
+            "4 --> {0, 1, 2, 3}\n")
 
 
 @app.post("/v1/execute")

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -28,7 +28,7 @@ namespace cudaq {
 /// @brief The QuantumMachinesServerHelper class extends the ServerHelper class
 /// to handle interactions with the Quantum Machines server for submitting and
 /// retrieving quantum computation jobs.
-class QuantumMachinesServerHelper : public ServerHelper {
+class QuantumMachinesServerHelper : public ServerHelper, public QirServerHelper  {
   static constexpr const char *DEFAULT_URL = "https://api.quantum-machines.com";
   static constexpr const char *DEFAULT_VERSION = "v1.0.0";
   static constexpr const char *DEFAULT_EXECUTOR = "mock";
@@ -76,6 +76,29 @@ public:
                backendConfig);
   }
 
+  inline std::string kernelExecutionToString(const KernelExecution &ke) {
+    std::ostringstream ss;
+    ss << "KernelExecution {\n";
+    ss << "  name: " << ke.name << "\n";
+    ss << "  code:\n" << ke.code << "\n";
+
+    ss << "  jit: " << (ke.jit.has_value() ? "<present>" : "<none>") << "\n";
+    ss << "  resourceCounts: "
+      << (ke.resourceCounts.has_value() ? "<present>" : "<none>") << "\n";
+
+    ss << "  output_names: " << ke.output_names.get().dump(2) << "\n";
+    ss << "  user_data: " << ke.user_data.get().dump(2) << "\n";
+
+    ss << "  mapping_reorder_idx: [";
+    for (std::size_t i = 0; i < ke.mapping_reorder_idx.size(); ++i)
+      ss << ke.mapping_reorder_idx[i]
+        << (i + 1 < ke.mapping_reorder_idx.size() ? ", " : "");
+    ss << "]\n";
+
+    ss << "}";
+    return ss.str();
+  }
+
   /// @brief Creates a quantum computation job using the provided kernel
   /// executions and returns the corresponding payload.
   // A Server Job Payload consists of a job post URL path, the headers,
@@ -84,12 +107,22 @@ public:
   //    std::tuple<std::string, RestHeaders, std::vector<ServerMessage>>;
   ServerJobPayload
   createJob(std::vector<KernelExecution> &circuitCodes) override {
-    CUDAQ_INFO("In createJob. code: {}", circuitCodes[0].code);
+    CUDAQ_INFO("In createJob. code: {}", kernelExecutionToString(circuitCodes[0]));
+    auto toBool = [](const std::string &value) {
+        return value == "True" || value == "true" || value == "1";
+      };
+    bool disableQubitMapping = toBool(backendConfig["disable-qubit-mapping"]);
+    auto *executionContext = cudaq::getExecutionContext();
+    const std::string requestType =
+        executionContext ? executionContext->name : "unknown";
+    const bool isRunRequest = requestType == "run";
     ServerMessage job;
     job["content"] = circuitCodes[0].code;
-    job["source"] = "oq2";
+    job["source"] = "quake";
     job["shots"] = shots;
     job["executor"] = backendConfig["executor"];
+    job["disable-qubit-mapping"] = disableQubitMapping;
+    job["output_format"] = isRunRequest ? "qir-raw" : "histogram";
     RestHeaders headers = getHeaders();
     std::string path = backendConfig["url"] + "/v1/execute";
     return std::make_tuple(path, headers, std::vector<ServerMessage>{job});
@@ -157,11 +190,12 @@ public:
     return std::chrono::seconds(1);
   }
 
-  std::string extractOutputLog(ServerMessage &jobResponse,
-                                                       std::string &jobId) {
-    CUDAQ_INFO("extractOutputLog: {}, {}", jobId, jobResponse.dump());
+
+  std::string extractOutputLog(ServerMessage &postJobResponse,
+                               std::string &jobId) override {
+    CUDAQ_INFO("extractOutputLog: {}, {}", jobId, postJobResponse.dump());
     //TODO: implement
-    return "";
+    return "1";
   }
 
 };

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -63,6 +63,8 @@ public:
         getValueOrDefault(config, "version", DEFAULT_VERSION);
     backendConfig["executor"] =
         getValueOrDefault(config, "executor", DEFAULT_EXECUTOR);
+    backendConfig["qubit-mapping-mode"] =
+        getValueOrDefault(config, "qubit-mapping-mode", "local-get-latest");
     // Check for API key in config, then fall back to environment variable
     std::string apiKey = getValueOrDefault(config, "api_key", "");
     if (apiKey.empty()) {
@@ -108,10 +110,6 @@ public:
   ServerJobPayload
   createJob(std::vector<KernelExecution> &circuitCodes) override {
     CUDAQ_INFO("In createJob. code: {}", kernelExecutionToString(circuitCodes[0]));
-    auto toBool = [](const std::string &value) {
-        return value == "True" || value == "true" || value == "1";
-      };
-    bool disableQubitMapping = toBool(backendConfig["disable-qubit-mapping"]);
     auto *executionContext = cudaq::getExecutionContext();
     const std::string requestType =
         executionContext ? executionContext->name : "unknown";
@@ -121,7 +119,7 @@ public:
     job["source"] = "quake";
     job["shots"] = shots;
     job["executor"] = backendConfig["executor"];
-    job["disable-qubit-mapping"] = disableQubitMapping;
+    job["qubit_mapping_mode"] = backendConfig["qubit-mapping-mode"];
     job["output_format"] = isRunRequest ? "qir-raw" : "histogram";
     RestHeaders headers = getHeaders();
     std::string path = backendConfig["url"] + "/v1/execute";
@@ -197,6 +195,48 @@ public:
     //TODO: implement
     return "1";
   }
+
+  void updatePassPipeline(
+    const std::filesystem::path &platformPath, std::string &passPipeline) override {
+      CUDAQ_INFO("updatePassPipeline: platformPath: {}, passPipeline: {}", platformPath.string(), passPipeline);
+      std::string mappingMode = backendConfig["qubit-mapping-mode"];
+      if (mappingMode == "backend") {
+        // If mapping is done on the backend, we have to remove the SABRE mapping pass from the pipeline, and we don't need to provide a qpu config file for the mapping pass.
+        passPipeline = std::regex_replace(passPipeline, std::regex(",qubit-mapping{device=file(%QPU_ARCH%)"), "");
+        CUDAQ_INFO("After removing mapping pass, updated pass pipeline: {}", passPipeline);
+        return;
+      }
+      std::filesystem::path qpuConfigPath = platformPath / "mapping/quantum_machines" / "latest_qpu_config.txt";
+      std::string machineconfigFilePath = qpuConfigPath.string();
+      if (mappingMode == "local-get-latest") {
+        // If mapping is done locally with the latest qpu config from the backend, we need to get the latest qpu config file from the backend and provide that to the mapping pass.
+        // Get the latest qpu config file from the backend and set quantumArchitectureFilePath to its path
+        try {
+          // Create a RestClient and get the latest qpu config from backendConfig["url"]+"/v1/config/qubits" from the backend
+          // Store the response in a file in the platformPath / "mapping/quantum_machines" directory, and set quantumArchitectureFilePath to that file path
+          RestClient client;
+          client.setVerbose(true); 
+          auto headers = getHeaders();
+          auto response = client.getRawText(backendConfig["url"], "/v1/config/qubits", headers);
+          std::string qpuConfig = response;
+          CUDAQ_INFO("Updated configuration: {}", qpuConfig);
+          std::filesystem::create_directories(qpuConfigPath.parent_path());
+          std::ofstream outFile(qpuConfigPath);
+          outFile << qpuConfig;
+          outFile.close();
+
+        } catch (const std::exception &e) {
+          throw std::runtime_error("Failed to get latest qpu config from backend: " +
+                                    std::string(e.what()));
+          }
+      } 
+      else if (mappingMode != "local-file") {
+        throw std::runtime_error("qubit-mapping-mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
+      }
+      passPipeline =
+          std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), machineconfigFilePath);
+      CUDAQ_INFO("Updated pass pipeline: {}", passPipeline);
+    }
 
 };
 

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -193,52 +193,52 @@ public:
                                std::string &jobId) override {
     CUDAQ_INFO("extractOutputLog: {}, {}", jobId, postJobResponse.dump());
     //TODO: implement
-    return "1";
+    return postJobResponse["results"];
   }
 
   void updatePassPipeline(
-    const std::filesystem::path &platformPath, std::string &passPipeline) override {
-      CUDAQ_INFO("updatePassPipeline: platformPath: {}, passPipeline: {}", platformPath.string(), passPipeline);
-      std::string mappingMode = backendConfig["qubit_mapping_mode"];
-      if (mappingMode == "backend") {
-        // If mapping is done on the backend, we have to remove the SABRE mapping pass from the pipeline, and we don't need to provide a qpu config file for the mapping pass.
-        //passPipeline = std::regex_replace(passPipeline, std::regex(",qubit-mapping\\\\{device=file(%QPU_ARCH%)\\\\}"), "");
-        passPipeline = "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)";
-        CUDAQ_INFO("After removing mapping pass, updated pass pipeline: {}", passPipeline);
-        return;
-      }
-      std::filesystem::path qpuConfigPath = platformPath / "mapping/quantum_machines" / "latest_qpu_config.txt";
-      std::string machineconfigFilePath = qpuConfigPath.string();
-      if (mappingMode == "local_get_latest") {
-        // If mapping is done locally with the latest qpu config from the backend, we need to get the latest qpu config file from the backend and provide that to the mapping pass.
-        // Get the latest qpu config file from the backend and set quantumArchitectureFilePath to its path
-        try {
-          // Create a RestClient and get the latest qpu config from backendConfig["url"]+"/v1/config/qubits" from the backend
-          // Store the response in a file in the platformPath / "mapping/quantum_machines" directory, and set quantumArchitectureFilePath to that file path
-          RestClient client;
-          client.setVerbose(true); 
-          auto headers = getHeaders();
-          auto response = client.getRawText(backendConfig["url"], "/v1/config/qubits", headers);
-          std::string qpuConfig = response;
-          CUDAQ_INFO("Updated configuration: {}", qpuConfig);
-          std::filesystem::create_directories(qpuConfigPath.parent_path());
-          std::ofstream outFile(qpuConfigPath);
-          outFile << qpuConfig;
-          outFile.close();
-
-        } catch (const std::exception &e) {
-          throw std::runtime_error("Failed to get latest qpu config from backend: " +
-                                    std::string(e.what()));
-          }
-      } 
-      else if (mappingMode != "local_file") {
-        throw std::runtime_error("qubit_mapping_mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
-      }
-      passPipeline =
-          std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), machineconfigFilePath);
-      CUDAQ_INFO("Updated pass pipeline: {}", passPipeline);
+  const std::filesystem::path &platformPath, std::string &passPipeline) override {
+    CUDAQ_INFO("updatePassPipeline: platformPath: {}, passPipeline: {}", platformPath.string(), passPipeline);
+    std::string mappingMode = backendConfig["qubit_mapping_mode"];
+    if (mappingMode == "backend") {
+      // Adding a simple "tail": do not run any qubit mapping.
+      passPipeline += ",func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)";
+      CUDAQ_INFO("After removing mapping pass, updated pass pipeline: {}", passPipeline);
+      return;
     }
+    std::filesystem::path qpuConfigPath = platformPath / "mapping/quantum_machines" / "latest_qpu_config.txt";
+    std::string machineconfigFilePath = qpuConfigPath.string();
+    if (mappingMode == "local_get_latest") {
+      // If mapping is done locally with the latest qpu config from the backend, we need to get the latest qpu config file from the backend and provide that to the mapping pass.
+      // Get the latest qpu config file from the backend and set quantumArchitectureFilePath to its path
+      try {
+        // Create a RestClient and get the latest qpu config from backendConfig["url"]+"/v1/config/qubits" from the backend
+        // Store the response in a file in the platformPath / "mapping/quantum_machines" directory, and set quantumArchitectureFilePath to that file path
+        RestClient client;
+        client.setVerbose(true); 
+        auto headers = getHeaders();
+        auto response = client.getRawText(backendConfig["url"], "/v1/config/qubits", headers);
+        std::string qpuConfig = response;
+        CUDAQ_INFO("Updated configuration: {}", qpuConfig);
+        std::filesystem::create_directories(qpuConfigPath.parent_path());
+        std::ofstream outFile(qpuConfigPath);
+        outFile << qpuConfig;
+        outFile.close();
 
+      } catch (const std::exception &e) {
+        throw std::runtime_error("Failed to get latest qpu config from backend: " +
+                                  std::string(e.what()));
+        }
+    } 
+    else if (mappingMode != "local_file") {
+      throw std::runtime_error("qubit_mapping_mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
+    }
+    // Add the pipelines that ar responsible for qubit mapping, and adjust he file path
+    passPipeline += ",func.func(expand-control-veqs,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)";
+    passPipeline =
+        std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), machineconfigFilePath);
+    CUDAQ_INFO("Updated pass pipeline: {}", passPipeline);
+  }
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -63,8 +63,8 @@ public:
         getValueOrDefault(config, "version", DEFAULT_VERSION);
     backendConfig["executor"] =
         getValueOrDefault(config, "executor", DEFAULT_EXECUTOR);
-    backendConfig["qubit-mapping-mode"] =
-        getValueOrDefault(config, "qubit-mapping-mode", "local-get-latest");
+    backendConfig["qubit_mapping_mode"] =
+        getValueOrDefault(config, "qubit_mapping_mode", "local_get_latest");
     // Check for API key in config, then fall back to environment variable
     std::string apiKey = getValueOrDefault(config, "api_key", "");
     if (apiKey.empty()) {
@@ -119,7 +119,7 @@ public:
     job["source"] = "quake";
     job["shots"] = shots;
     job["executor"] = backendConfig["executor"];
-    job["qubit_mapping_mode"] = backendConfig["qubit-mapping-mode"];
+    job["qubit_mapping_mode"] = backendConfig["qubit_mapping_mode"];
     job["output_format"] = isRunRequest ? "qir-raw" : "histogram";
     RestHeaders headers = getHeaders();
     std::string path = backendConfig["url"] + "/v1/execute";
@@ -167,7 +167,7 @@ public:
   cudaq::sample_result processResults(ServerMessage &getJobResponse,
                                       std::string &jobId) override {
     CUDAQ_INFO("Sample results: {}", getJobResponse.dump());
-    auto samplesJson = getJobResponse["samples"];
+    auto samplesJson = getJobResponse["results"];
     cudaq::CountsDictionary counts;
     for (auto &item : samplesJson.items()) {
       std::string bitstring = item.key();
@@ -199,16 +199,17 @@ public:
   void updatePassPipeline(
     const std::filesystem::path &platformPath, std::string &passPipeline) override {
       CUDAQ_INFO("updatePassPipeline: platformPath: {}, passPipeline: {}", platformPath.string(), passPipeline);
-      std::string mappingMode = backendConfig["qubit-mapping-mode"];
+      std::string mappingMode = backendConfig["qubit_mapping_mode"];
       if (mappingMode == "backend") {
         // If mapping is done on the backend, we have to remove the SABRE mapping pass from the pipeline, and we don't need to provide a qpu config file for the mapping pass.
-        passPipeline = std::regex_replace(passPipeline, std::regex(",qubit-mapping{device=file(%QPU_ARCH%)"), "");
+        //passPipeline = std::regex_replace(passPipeline, std::regex(",qubit-mapping\\\\{device=file(%QPU_ARCH%)\\\\}"), "");
+        passPipeline = "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)";
         CUDAQ_INFO("After removing mapping pass, updated pass pipeline: {}", passPipeline);
         return;
       }
       std::filesystem::path qpuConfigPath = platformPath / "mapping/quantum_machines" / "latest_qpu_config.txt";
       std::string machineconfigFilePath = qpuConfigPath.string();
-      if (mappingMode == "local-get-latest") {
+      if (mappingMode == "local_get_latest") {
         // If mapping is done locally with the latest qpu config from the backend, we need to get the latest qpu config file from the backend and provide that to the mapping pass.
         // Get the latest qpu config file from the backend and set quantumArchitectureFilePath to its path
         try {
@@ -230,8 +231,8 @@ public:
                                     std::string(e.what()));
           }
       } 
-      else if (mappingMode != "local-file") {
-        throw std::runtime_error("qubit-mapping-mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
+      else if (mappingMode != "local_file") {
+        throw std::runtime_error("qubit_mapping_mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
       }
       passPipeline =
           std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), machineconfigFilePath);

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include "common/ExtraPayloadProvider.h"
 #include "common/RestClient.h"
 #include "common/ServerHelper.h"
 #include "cudaq/Support/Version.h"
@@ -22,6 +23,11 @@
 #include <unordered_set>
 
 using json = nlohmann::json;
+
+namespace {
+constexpr const char *decoderConfigPayloadType = "gpu_decoder_config";
+constexpr const char *decoderConfigJobJsonPath = "/decoder_config";
+} // namespace
 
 namespace cudaq {
 
@@ -149,6 +155,26 @@ public:
     job["output_format"] = isRunRequest ? "qir-raw" : "histogram";
     if (backendConfig.find("simulator_duration") != backendConfig.end()) {
       job["simulator_duration"] = std::stoi(backendConfig["simulator_duration"]);
+    }
+    const auto providerConfig =
+        runtimeTarget.runtimeConfig.find("extra_payload_provider");
+    if (providerConfig != runtimeTarget.runtimeConfig.end()) {
+      cudaq::ExtraPayloadProvider *extraPayloadProvider = nullptr;
+      for (const auto &provider : cudaq::getExtraPayloadProviders()) {
+        if (provider->name() == providerConfig->second) {
+          extraPayloadProvider = provider.get();
+          break;
+        }
+      }
+      if (!extraPayloadProvider)
+        throw std::runtime_error("ExtraPayloadProvider with name " +
+                                 providerConfig->second + " not found.");
+      if (extraPayloadProvider->getPayloadType() != decoderConfigPayloadType)
+        throw std::runtime_error("Invalid extra payload provider type '" +
+                                 extraPayloadProvider->getPayloadType() +
+                                 "'. This is not supported on this target.");
+      job[json::json_pointer(decoderConfigJobJsonPath)] =
+          extraPayloadProvider->getExtraPayload(runtimeTarget);
     }
     RestHeaders headers = getHeaders();
     std::string path = backendConfig["url"] + "/v1/execute";

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -101,8 +101,11 @@ public:
     if (!postResponse.contains("id"))
       return "";
 
+    // Extract the job ID from the response
+    std::string id = postResponse.at("id");
+
     // Return the job ID from the response
-    return postResponse.at("id");
+    return id;
   }
 
   /// @brief Constructs the URL for retrieving a job based on the server's
@@ -153,6 +156,14 @@ public:
     CUDAQ_INFO("nextResultPollingInterval");
     return std::chrono::seconds(1);
   }
+
+  std::string extractOutputLog(ServerMessage &jobResponse,
+                                                       std::string &jobId) {
+    CUDAQ_INFO("extractOutputLog: {}, {}", jobId, jobResponse.dump());
+    //TODO: implement
+    return "";
+  }
+
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -8,10 +8,10 @@
 
 #include "common/RestClient.h"
 #include "common/ServerHelper.h"
-#include "nlohmann/json.hpp"
 #include "cudaq/Support/Version.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
+#include "nlohmann/json.hpp"
 #include <bitset>
 #include <fstream>
 #include <iostream>
@@ -66,8 +66,34 @@ public:
     backendConfig["qubit_mapping_mode"] =
         getValueOrDefault(config, "qubit_mapping_mode", "local_get_latest");
     // Check for API key in config, then fall back to environment variable
+    // Resolve the API key from either 'api_key' or 'api_key_file'.
     std::string apiKey = getValueOrDefault(config, "api_key", "");
-    if (apiKey.empty()) {
+    std::string apiKeyFile = getValueOrDefault(config, "api_key_file", "");
+
+    if (config.find("simulator_duration") != config.end()) {
+      backendConfig["simulator_duration"] = config.at("simulator_duration");
+    }
+
+    if (!apiKey.empty() && !apiKeyFile.empty()) {
+      CUDAQ_ERROR("Both 'api_key' and 'api_key_file' were provided. "
+                  "Please specify only one.");
+    } else if (!apiKeyFile.empty()) {
+      // Read the key from the file.
+      std::ifstream file(apiKeyFile);
+      if (!file.is_open()) {
+        CUDAQ_ERROR("Could not open api_key_file: " + apiKeyFile);
+      }
+      std::stringstream buffer;
+      buffer << file.rdbuf();
+      apiKey = buffer.str();
+      // Strip surrounding whitespace (e.g. a trailing newline).
+      cudaq::trim(apiKey);
+      // The file has been consumed into 'api_key'. Remove 'api_key_file' so a
+      // subsequent initialize() pass (the platform initializes more than once)
+      // does not see both keys and falsely trip the mutual-exclusivity guard.
+      backendConfig.erase("api_key_file");
+    } else if (apiKey.empty()) {
+      // Neither was provided: fall back to the environment variable.
       char *envApiKey = std::getenv("QUANTUM_MACHINES_API_KEY");
       if (envApiKey)
         apiKey = envApiKey;
@@ -121,6 +147,9 @@ public:
     job["executor"] = backendConfig["executor"];
     job["qubit_mapping_mode"] = backendConfig["qubit_mapping_mode"];
     job["output_format"] = isRunRequest ? "qir-raw" : "histogram";
+    if (backendConfig.find("simulator_duration") != backendConfig.end()) {
+      job["simulator_duration"] = std::stoi(backendConfig["simulator_duration"]);
+    }
     RestHeaders headers = getHeaders();
     std::string path = backendConfig["url"] + "/v1/execute";
     return std::make_tuple(path, headers, std::vector<ServerMessage>{job});
@@ -191,7 +220,6 @@ public:
   std::string extractOutputLog(ServerMessage &postJobResponse,
                                std::string &jobId) override {
     CUDAQ_INFO("extractOutputLog: {}, {}", jobId, postJobResponse.dump());
-    //TODO: implement
     return postJobResponse["results"];
   }
 
@@ -214,7 +242,7 @@ public:
         // Create a RestClient and get the latest qpu config from backendConfig["url"]+"/v1/config/qubits" from the backend
         // Store the response in a file in the platformPath / "mapping/quantum_machines" directory, and set quantumArchitectureFilePath to that file path
         RestClient client;
-        client.setVerbose(true); 
+        client.setVerbose(true);
         auto headers = getHeaders();
         auto response = client.getRawText(backendConfig["url"], "/v1/config/qubits", headers);
         std::string qpuConfig = response;
@@ -228,7 +256,7 @@ public:
         throw std::runtime_error("Failed to get latest qpu config from backend: " +
                                   std::string(e.what()));
         }
-    } 
+    }
     else if (mappingMode != "local_file") {
       throw std::runtime_error("qubit_mapping_mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
     }

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -188,7 +188,6 @@ public:
     return std::chrono::seconds(1);
   }
 
-
   std::string extractOutputLog(ServerMessage &postJobResponse,
                                std::string &jobId) override {
     CUDAQ_INFO("extractOutputLog: {}, {}", jobId, postJobResponse.dump());
@@ -202,8 +201,8 @@ public:
     std::string mappingMode = backendConfig["qubit_mapping_mode"];
     if (mappingMode == "backend") {
       // Adding a simple "tail": do not run any qubit mapping.
-      passPipeline += ",func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)";
-      CUDAQ_INFO("After removing mapping pass, updated pass pipeline: {}", passPipeline);
+      //passPipeline += ",func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)";
+      CUDAQ_INFO("Backend qubit mapping, full pass pipeline: {}", passPipeline);
       return;
     }
     std::filesystem::path qpuConfigPath = platformPath / "mapping/quantum_machines" / "latest_qpu_config.txt";
@@ -234,9 +233,14 @@ public:
       throw std::runtime_error("qubit_mapping_mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
     }
     // Add the pipelines that ar responsible for qubit mapping, and adjust he file path
-    passPipeline += ",func.func(expand-control-veqs,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)";
-    passPipeline =
-        std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), machineconfigFilePath);
+    //passPipeline += ",func.func(expand-control-veqs,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)";
+    const std::string needle = "qubit-mapping{device=bypass}";
+    auto pos = passPipeline.find(needle);
+    if (pos != std::string::npos) {
+      passPipeline.replace(pos, needle.size(),
+          "qubit-mapping{device=file(" + machineconfigFilePath + ") placement=greedy}");
+    }
+    //passPipeline = std::regex_replace(passPipeline, std::regex("qubit-mapping{device=bypass}"), "qubit-mapping{device=file("+machineconfigFilePath+") placement=greedy}");
     CUDAQ_INFO("Updated pass pipeline: {}", passPipeline);
   }
 };

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -9,10 +9,10 @@
 #include "common/ExtraPayloadProvider.h"
 #include "common/RestClient.h"
 #include "common/ServerHelper.h"
+#include "nlohmann/json.hpp"
 #include "cudaq/Support/Version.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
-#include "nlohmann/json.hpp"
 #include <bitset>
 #include <fstream>
 #include <iostream>
@@ -34,7 +34,8 @@ namespace cudaq {
 /// @brief The QuantumMachinesServerHelper class extends the ServerHelper class
 /// to handle interactions with the Quantum Machines server for submitting and
 /// retrieving quantum computation jobs.
-class QuantumMachinesServerHelper : public ServerHelper, public QirServerHelper  {
+class QuantumMachinesServerHelper : public ServerHelper,
+                                    public QirServerHelper {
   static constexpr const char *DEFAULT_URL = "https://api.quantum-machines.com";
   static constexpr const char *DEFAULT_VERSION = "v1.0.0";
   static constexpr const char *DEFAULT_EXECUTOR = "mock";
@@ -118,7 +119,7 @@ public:
 
     ss << "  jit: " << (ke.jit.has_value() ? "<present>" : "<none>") << "\n";
     ss << "  resourceCounts: "
-      << (ke.resourceCounts.has_value() ? "<present>" : "<none>") << "\n";
+       << (ke.resourceCounts.has_value() ? "<present>" : "<none>") << "\n";
 
     ss << "  output_names: " << ke.output_names.get().dump(2) << "\n";
     ss << "  user_data: " << ke.user_data.get().dump(2) << "\n";
@@ -126,7 +127,7 @@ public:
     ss << "  mapping_reorder_idx: [";
     for (std::size_t i = 0; i < ke.mapping_reorder_idx.size(); ++i)
       ss << ke.mapping_reorder_idx[i]
-        << (i + 1 < ke.mapping_reorder_idx.size() ? ", " : "");
+         << (i + 1 < ke.mapping_reorder_idx.size() ? ", " : "");
     ss << "]\n";
 
     ss << "}";
@@ -141,7 +142,8 @@ public:
   //    std::tuple<std::string, RestHeaders, std::vector<ServerMessage>>;
   ServerJobPayload
   createJob(std::vector<KernelExecution> &circuitCodes) override {
-    CUDAQ_INFO("In createJob. code: {}", kernelExecutionToString(circuitCodes[0]));
+    CUDAQ_INFO("In createJob. code: {}",
+               kernelExecutionToString(circuitCodes[0]));
     auto *executionContext = cudaq::getExecutionContext();
     const std::string requestType =
         executionContext ? executionContext->name : "unknown";
@@ -154,7 +156,8 @@ public:
     job["qubit_mapping_mode"] = backendConfig["qubit_mapping_mode"];
     job["output_format"] = isRunRequest ? "qir-raw" : "histogram";
     if (backendConfig.find("simulator_duration") != backendConfig.end()) {
-      job["simulator_duration"] = std::stoi(backendConfig["simulator_duration"]);
+      job["simulator_duration"] =
+          std::stoi(backendConfig["simulator_duration"]);
     }
     const auto providerConfig =
         runtimeTarget.runtimeConfig.find("extra_payload_provider");
@@ -249,28 +252,30 @@ public:
     return postJobResponse["results"];
   }
 
-  void updatePassPipeline(
-  const std::filesystem::path &platformPath, std::string &passPipeline) override {
-    CUDAQ_INFO("updatePassPipeline: platformPath: {}, passPipeline: {}", platformPath.string(), passPipeline);
+  std::map<std::string, std::string>
+  getPipelineSubstitutions(const std::filesystem::path &platformPath) override {
     std::string mappingMode = backendConfig["qubit_mapping_mode"];
     if (mappingMode == "backend") {
-      // Adding a simple "tail": do not run any qubit mapping.
-      //passPipeline += ",func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)";
-      CUDAQ_INFO("Backend qubit mapping, full pass pipeline: {}", passPipeline);
-      return;
+      CUDAQ_INFO("Backend qubit mapping.");
+      return {};
     }
-    std::filesystem::path qpuConfigPath = platformPath / "mapping/quantum_machines" / "latest_qpu_config.txt";
+    std::filesystem::path qpuConfigPath =
+        platformPath / "mapping/quantum_machines" / "latest_qpu_config.txt";
     std::string machineconfigFilePath = qpuConfigPath.string();
     if (mappingMode == "local_get_latest") {
-      // If mapping is done locally with the latest qpu config from the backend, we need to get the latest qpu config file from the backend and provide that to the mapping pass.
-      // Get the latest qpu config file from the backend and set quantumArchitectureFilePath to its path
+      // If mapping is done locally with the latest qpu config from the backend,
+      // we need to get the latest qpu config file from the backend and provide
+      // that to the mapping pass. Get the latest qpu config file from the
+      // backend and set quantumArchitectureFilePath to its path
       try {
-        // Create a RestClient and get the latest qpu config from backendConfig["url"]+"/v1/config/qubits" from the backend
-        // Store the response in a file in the platformPath / "mapping/quantum_machines" directory, and set quantumArchitectureFilePath to that file path
+        // Create a RestClient and get the latest qpu config from
+        // backendConfig["url"]+"/v1/config/qubits" from the backend Store the
+        // response in a file in the platformPath / "mapping/quantum_machines"
+        // directory, and set quantumArchitectureFilePath to that file path
         RestClient client;
-        client.setVerbose(true);
         auto headers = getHeaders();
-        auto response = client.getRawText(backendConfig["url"], "/v1/config/qubits", headers);
+        auto response = client.getRawText(backendConfig["url"],
+                                          "/v1/config/qubits", headers);
         std::string qpuConfig = response;
         CUDAQ_INFO("Updated configuration: {}", qpuConfig);
         std::filesystem::create_directories(qpuConfigPath.parent_path());
@@ -279,23 +284,23 @@ public:
         outFile.close();
 
       } catch (const std::exception &e) {
-        throw std::runtime_error("Failed to get latest qpu config from backend: " +
-                                  std::string(e.what()));
-        }
+        throw std::runtime_error(
+            "Failed to get latest qpu config from backend: " +
+            std::string(e.what()));
+      }
+    } else if (mappingMode != "local_file") {
+      throw std::runtime_error(
+          "qubit_mapping_mode: " + mappingMode +
+          " is not supported. Supported modes are 'local-file', "
+          "'local-get-latest', and 'backend'.");
     }
-    else if (mappingMode != "local_file") {
-      throw std::runtime_error("qubit_mapping_mode: " + mappingMode + " is not supported. Supported modes are 'local-file', 'local-get-latest', and 'backend'.");
-    }
-    // Add the pipelines that ar responsible for qubit mapping, and adjust he file path
-    //passPipeline += ",func.func(expand-control-veqs,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)";
+    // Adjust the qubit-mapping pipeline to use the selected machine
+    // configuration file.
     const std::string needle = "qubit-mapping{device=bypass}";
-    auto pos = passPipeline.find(needle);
-    if (pos != std::string::npos) {
-      passPipeline.replace(pos, needle.size(),
-          "qubit-mapping{device=file(" + machineconfigFilePath + ") placement=greedy}");
-    }
-    //passPipeline = std::regex_replace(passPipeline, std::regex("qubit-mapping{device=bypass}"), "qubit-mapping{device=file("+machineconfigFilePath+") placement=greedy}");
-    CUDAQ_INFO("Updated pass pipeline: {}", passPipeline);
+    const std::string replacement = "qubit-mapping{device=file(" +
+                                    machineconfigFilePath +
+                                    ") placement=greedy}";
+    return {{needle, replacement}};
   }
 };
 

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements),qubit-mapping{device=file(%QPU_ARCH%)}"
   # Tell the rest-qpu that the required output format is quake.
   codegen-emission: nop
   # Library mode is only for simulators, physical backends must turn this off
@@ -38,9 +38,9 @@ target-arguments:
     help-string: "Specify the executor to run. Default is mock"
   - key: disable-qubit-mapping
     required: false
-    platform-arg: disable-qubit-mapping
+    platform-arg: qubit-mapping-mode
     type: string
-    help-string: "Disable qubit mapping (mapping will run on the backend). Default is false"
+    help-string: "'local-file': manually edited file located at <>, 'local-get-latest': use the local SABRE mapping algorithm, get the latest qpu config from the backend, 'backend': assign qubits in the backend, as part of the compilation process. Default is 'local-get-latest'."
   - key: api_key
     required: false
     type: string

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-high-level-pipeline: "expand-measurements"
+  jit-high-level-pipeline: "func.func(add-measurements),expand-measurements"
   jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "return-to-output-log,symbol-dce"
   #jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep"

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements),qubit-mapping{device=file(%QPU_ARCH%)}"
+  jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep"
   # Tell the rest-qpu that the required output format is quake.
   codegen-emission: nop
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -36,11 +36,11 @@ target-arguments:
     type: string
     platform-arg: executor
     help-string: "Specify the executor to run. Default is mock"
-  - key: disable-qubit-mapping
+  - key: qubit_mapping_mode
     required: false
-    platform-arg: qubit-mapping-mode
+    platform-arg: qubit_mapping_mode
     type: string
-    help-string: "'local-file': manually edited file located at <>, 'local-get-latest': use the local SABRE mapping algorithm, get the latest qpu config from the backend, 'backend': assign qubits in the backend, as part of the compilation process. Default is 'local-get-latest'."
+    help-string: "'local_file': manually edited file located at <>, 'local_get_latest': use the local SABRE mapping algorithm, get the latest qpu config from the backend, 'backend': assign qubits in the backend, as part of the compilation process. Default is 'local_get_latest'."
   - key: api_key
     required: false
     type: string

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -36,6 +36,11 @@ target-arguments:
     type: string
     platform-arg: executor
     help-string: "Specify the executor to run. Default is mock"
+  - key: disable-qubit-mapping
+    required: false
+    platform-arg: disable-qubit-mapping
+    type: string
+    help-string: "Disable qubit mapping (mapping will run on the backend). Default is false"
   - key: api_key
     required: false
     type: string

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -21,7 +21,8 @@ config:
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "func.func(add-measurements),expand-measurements"
   jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
-  jit-low-level-pipeline: "return-to-output-log,symbol-dce"
+  jit-low-level-pipeline: "symbol-dce"
+  #jit-low-level-pipeline: "return-to-output-log,symbol-dce"
   #jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep"
   # Tell the rest-qpu that the required output format is quake.
   codegen-emission: nop

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -60,3 +60,8 @@ target-arguments:
     type: string
     platform-arg: simulator_duration
     help-string: "The duration of simulation. Relevant only if the executor is set to 'simulator'."
+  - key: extra-payload-provider
+    required: false
+    type: string
+    platform-arg: extra_payload_provider
+    help-string: "Specify the extra payload provider if any."

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -55,3 +55,8 @@ target-arguments:
     type: string
     platform-arg: api_key_file
     help-string: "Path to a file containing an API key to access the Qoperator server"
+  - key: simulator_duration
+    required: false
+    type: string
+    platform-arg: simulator_duration
+    help-string: "The duration of simulation. Relevant only if the executor is set to 'simulator'."

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -46,4 +46,8 @@ target-arguments:
     type: string
     platform-arg: api_key
     help-string: "An API key to access the Qoperator server"
-  
+  - key: api_key_file
+    required: false
+    type: string
+    platform-arg: api_key_file
+    help-string: "Path to a file containing an API key to access the Qoperator server"

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,7 +19,10 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep"
+  jit-high-level-pipeline: "expand-measurements"
+  jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
+  jit-low-level-pipeline: "return-to-output-log,symbol-dce"
+  #jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep"
   # Tell the rest-qpu that the required output format is quake.
   codegen-emission: nop
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,9 +19,11 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
-  # Tell the rest-qpu that we are generating OpenQASM 2.0.
-  codegen-emission: qasm2
+  jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  # Tell the rest-qpu that the required output format is quake.
+  codegen-emission: nop
+  # Library mode is only for simulators, physical backends must turn this off
+  library-mode: false
 
 target-arguments:
   - key: url

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -22,8 +22,6 @@ config:
   jit-high-level-pipeline: "func.func(add-measurements),expand-measurements"
   jit-mid-level-pipeline: "func.func(add-dealloc,expand-control-veqs,combine-quantum-alloc,canonicalize,cc-loop-normalize,cc-loop-unroll{unroll-only-wire-blocking-loops=true},canonicalize,cse,factor-quantum-alloc,dqe,cable-rough-in,canonicalize,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "symbol-dce"
-  #jit-low-level-pipeline: "return-to-output-log,symbol-dce"
-  #jit-mid-level-pipeline: "decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep"
   # Tell the rest-qpu that the required output format is quake.
   codegen-emission: nop
   # Library mode is only for simulators, physical backends must turn this off


### PR DESCRIPTION
Replacement for https://github.com/NVIDIA/cuda-quantum/pull/4962

- Cherry-pick QM commits on top of `main` (ref: the rebased fork's https://github.com/HanaGiatQM/cuda-quantum/commits/rebase-0.15.1/ branch).

- Refactor `updatePassPipeline` -> `getPipelineSubstitutions` as expected by `main`. 

- Fix the QM mock server (for CI purposes) 

- Minor code tidy up: e.g., code formatting.


**Note**: an equivalent implementation is available in https://github.com/NVIDIA/cuda-quantum/tree/qm-nvqlink (based on 0.15.1 branch - same set of commits, no `updatePassPipeline` -> `getPipelineSubstitutions` and CI/code format refactor).

Tested by: checking the quake IR submitting to the backend (same IR b/w this PR branch based on `main` and `qm-nvqlink` based on the release branch. 