### PR TITLE
[Python] Materialize broadcast arguments once

### DIFF
--- a/python/cudaq/runtime/utils.py
+++ b/python/cudaq/runtime/utils.py
@@ -115,6 +115,24 @@ def __isBroadcast(kernel, *args):
 
 def __createArgumentSet(*args):
     nArgSets = len(args[0])
+    if nArgSets == 0:
+        return []
+
+    # Materialize array-like arguments once.
+    materializedArgs = []
+    arrayRanks = []
+    for arg in args:
+        if hasattr(arg, "tolist"):
+            arrayRank = len(arg.shape)
+            arrayRanks.append(arrayRank)
+            # A later matrix argument may have more rows than the first
+            # argument that defines nArgSets. Do not materialize unused rows.
+            m = arg[:nArgSets] if arrayRank == 2 else arg
+            materializedArgs.append(m.tolist())
+        else:
+            arrayRanks.append(None)
+            materializedArgs.append(arg)
+
     argSet = []
     for j in range(nArgSets):
         currentArgs = [0 for i in range(len(args))]
@@ -123,12 +141,8 @@ def __createArgumentSet(*args):
             if isinstance(arg, list) or isinstance(arg, List):
                 currentArgs[i] = arg[j]
 
-            if hasattr(arg, "tolist"):
-                shape = arg.shape
-                if len(shape) == 2:
-                    currentArgs[i] = arg[j].tolist()
-                else:
-                    currentArgs[i] = arg.tolist()[j]
+            if arrayRanks[i] is not None:
+                currentArgs[i] = materializedArgs[i][j]
 
         argSet.append(tuple(currentArgs))
     return argSet

--- a/python/cudaq/runtime/utils.py
+++ b/python/cudaq/runtime/utils.py
@@ -126,7 +126,7 @@ def __createArgumentSet(*args):
             arrayRank = len(arg.shape)
             arrayRanks.append(arrayRank)
             # A later matrix argument may have more rows than the first
-            # argument that defines nArgSets. Do not materialize unused rows.
+            # argument that defines `nArgSets`. Do not materialize unused rows.
             m = arg[:nArgSets] if arrayRank == 2 else arg
             materializedArgs.append(m.tolist())
         else:


### PR DESCRIPTION
### Summary

Materialize array-like broadcast arguments once before constructing individual argument sets. This removes quadratic conversion work for 1-D arrays and row-by-row GPU-to-host transfers for 2-D tensors, while avoiding conversion of unused matrix rows.

### Testing

Existing kernel/builder `sample`, `observe`, and PTSBE broadcast tests pass.

### Performance

A local run of benchmark improved the `hybrid_quantum_neural_networks.ipynb` notebook's argument preparation step of size `[700, 2]` from 28.59 ms to 0.42 ms with identical results.
