### PR TITLE
Adding qbraid examples to the doc

### DIFF
--- a/docs/sphinx/using/backends/cloud/qbraid.rst
+++ b/docs/sphinx/using/backends/cloud/qbraid.rst
@@ -104,6 +104,4 @@ Submitting
     ``--qbraid-machine`` with a qBraid simulator device ID (for example,
     ``qbraid:qbraid:sim:qir-sv``).
 
-To see a complete example for using qBraid's backends, take a look at our
-:doc:`Python examples <../../examples/examples>` and
-:doc:`C++ examples <../../examples/examples>`.
+To see a complete example, take a look at :ref:`qBraid examples <qbraid-examples>`.

--- a/docs/sphinx/using/examples/hardware_providers.rst
+++ b/docs/sphinx/using/examples/hardware_providers.rst
@@ -174,6 +174,24 @@ argument is supplied by QRMI at runtime.
       :language: cpp
 
 
+.. _qbraid-examples:
+
+qBraid
+==================================
+
+The following code illustrates how to run kernels on qBraid's backends.
+
+.. tab:: Python
+
+   .. literalinclude:: ../../targets/python/qbraid.py
+      :language: python
+
+.. tab:: C++
+
+   .. literalinclude:: ../../targets/cpp/qbraid.cpp
+      :language: cpp
+
+
 .. _quantinuum-examples:
 
 Quantinuum


### PR DESCRIPTION
Adding qbraid examples to the doc.

Fixes #5076 

@mmvandieren for viz.

Looks like this

<img width="1062" height="295" alt="image" src="https://github.com/user-attachments/assets/184b1a7b-1d61-4980-b20c-f36c8f437a66" />

Clicking on the above qbraid examples link take one to the page below

<img width="1081" height="968" alt="image" src="https://github.com/user-attachments/assets/8cc74033-f9c9-439a-8c90-a5c12b109009" />
