### PR TITLE
Rename of the IR type stdvec

### DIFF
--- a/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/cudaq/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -67,7 +67,8 @@ inline mlir::Value loadHandleVectorIfPointer(mlir::OpBuilder &builder,
                                              mlir::Location loc,
                                              mlir::Value v) {
   if (auto ptrTy = mlir::dyn_cast<cudaq::cc::PointerType>(v.getType()))
-    if (auto sv = mlir::dyn_cast<cudaq::cc::StdvecType>(ptrTy.getElementType());
+    if (auto sv =
+            mlir::dyn_cast<cudaq::cc::SequenceType>(ptrTy.getElementType());
         sv && mlir::isa<cudaq::cc::MeasureHandleType>(sv.getElementType()))
       return cudaq::cc::LoadOp::create(builder, loc, v);
   return v;

--- a/cudaq/include/cudaq/Optimizer/Builder/Factory.h
+++ b/cudaq/include/cudaq/Optimizer/Builder/Factory.h
@@ -133,7 +133,7 @@ inline mlir::Type getStringType(mlir::MLIRContext *ctx, std::size_t length) {
 /// \p eleTy (`T`).
 inline mlir::LLVM::LLVMStructType stdVectorImplType(mlir::Type eleTy) {
   auto *ctx = eleTy.getContext();
-  // Map stdvec<complex<T>> to stdvec<struct<T,T>>
+  // Map sequence<complex<T>> to sequence<struct<T,T>>
   if (auto cTy = mlir::dyn_cast<mlir::ComplexType>(eleTy)) {
     llvm::SmallVector<mlir::Type> types = {cTy.getElementType(),
                                            cTy.getElementType()};
@@ -290,7 +290,7 @@ mlir::Type convertToHostSideType(mlir::Type ty, mlir::ModuleOp module);
 // Return `true` if the given type corresponds to a standard vector type
 // according to our convention.
 // The convention is a `ptr<struct<ptr<T>, ptr<T>, ptr<T>>>`.
-bool isStdVecArg(mlir::Type type);
+bool isSequenceArg(mlir::Type type);
 
 bool isX86_64(mlir::ModuleOp);
 bool isAArch64(mlir::ModuleOp);

--- a/cudaq/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/cudaq/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -44,16 +44,16 @@ static constexpr const char realtimeUnpackBits[] = "__nvqpp_RealtimeUnpackBits";
 
 // Convert a sequence of booleans (as bytes) into a std::vector<bool> (which is
 // typically specialized to be bit packed).
-static constexpr const char stdvecBoolCtorFromInitList[] =
+static constexpr const char sequenceBoolCtorFromInitList[] =
     "__nvqpp_initializer_list_to_vector_bool";
 
 // Convert a (likely packed) std::vector<bool> into a sequence of bytes, each
 // holding a boolean value.
-static constexpr const char stdvecBoolUnpackToInitList[] =
+static constexpr const char sequenceBoolUnpackToInitList[] =
     "__nvqpp_vector_bool_to_initializer_list";
 
 // Free any temporary buffers used to hold std::vector<bool> data.
-static constexpr const char stdvecBoolFreeTemporaryLists[] =
+static constexpr const char sequenceBoolFreeTemporaryLists[] =
     "__nvqpp_vector_bool_free_temporary_initlists";
 
 // The internal data of the cudaq::state object must be `2**n` in length. This

--- a/cudaq/include/cudaq/Optimizer/Builder/Marshal.h
+++ b/cudaq/include/cudaq/Optimizer/Builder/Marshal.h
@@ -71,9 +71,9 @@ cc::PointerType getPointerToPointerType(mlir::OpBuilder &builder);
 bool isDynamicSignature(mlir::FunctionType devFuncTy);
 
 std::pair<mlir::Value, bool>
-unpackAnyStdVectorBool(mlir::Location loc, mlir::OpBuilder &builder,
-                       mlir::ModuleOp module, mlir::Value arg, mlir::Type ty,
-                       mlir::Value heapTracker);
+unpackAnySequenceBool(mlir::Location loc, mlir::OpBuilder &builder,
+                      mlir::ModuleOp module, mlir::Value arg, mlir::Type ty,
+                      mlir::Value heapTracker);
 
 mlir::Value genSizeOfDynamicMessageBuffer(
     mlir::Location loc, mlir::OpBuilder &builder, mlir::ModuleOp module,
@@ -115,17 +115,17 @@ lookupHostEntryPointFunc(mlir::StringRef mangledEntryPointName,
 /// Generate code to initialize the std::vector<T>, \p sret, from an initializer
 /// list with data at \p data and length \p size. Use the library helper
 /// routine. This function takes two !llvm.ptr arguments.
-void genStdvecBoolFromInitList(mlir::Location loc, mlir::OpBuilder &builder,
-                               mlir::Value sret, mlir::Value data,
-                               mlir::Value size);
+void genSequenceBoolFromInitList(mlir::Location loc, mlir::OpBuilder &builder,
+                                 mlir::Value sret, mlir::Value data,
+                                 mlir::Value size);
 
 /// Generate a `std::vector<T>` (where `T != bool`) from an initializer list.
 /// This is done with the assumption that `std::vector` is implemented as a
 /// triple of pointers. The original content of the vector is freed and the new
 /// content, which is already on the stack, is moved into the `std::vector`.
-void genStdvecTFromInitList(mlir::Location loc, mlir::OpBuilder &builder,
-                            mlir::Value sret, mlir::Value data,
-                            mlir::Value tSize, mlir::Value vecSize);
+void genSequenceTFromInitList(mlir::Location loc, mlir::OpBuilder &builder,
+                              mlir::Value sret, mlir::Value data,
+                              mlir::Value tSize, mlir::Value vecSize);
 
 // Alloca a pointer to a pointer and initialize it to nullptr.
 mlir::Value createEmptyHeapTracker(mlir::Location loc,

--- a/cudaq/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/cudaq/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -137,9 +137,9 @@ static constexpr const char QISTrap[] = "__quantum__qis__trap";
 /// `Array` of `Qubit*` must be converted into a `cudaq::qvector`, which is
 /// presently a `std::vector<cudaq::qubit>` but with an extremely restricted
 /// interface.
-static constexpr const char QISConvertArrayToStdvec[] =
+static constexpr const char QISConvertArrayToSequence[] =
     "__quantum__qis__convert_array_to_stdvector";
-static constexpr const char QISFreeConvertedStdvec[] =
+static constexpr const char QISFreeConvertedSequence[] =
     "__quantum__qis__free_converted_stdvector";
 
 } // namespace cudaq::opt

--- a/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1225,7 +1225,7 @@ def cc_CreateStringLiteralOp : CCOp<"string_literal", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// Span/Stdvec operations.
+// Span/Sequence operations.
 //===----------------------------------------------------------------------===//
 
 def cc_ReifySpanOp : CCOp<"reify_span", [Pure]> {
@@ -1243,19 +1243,19 @@ def cc_ReifySpanOp : CCOp<"reify_span", [Pure]> {
       %1 = cc.const_array [ "XZ", "YI" ] : !cc.array<!cc.charspan x 2>
       %2 = cc.extract_value %1[1] : (!cc.array<!cc.charspan>) -> !cc.charspan
       %3 = cc.reify_span %1 : (!cc.array<!cc.charspan x 2>) ->
-                               !cc.stdvec<!cc.charspan>
+                               !cc.sequence<!cc.charspan>
     ```
 
     Expanding the reify_span op will generate the following code
     ```mlir
       %1 = cc.alloca !cc.array<!cc.charspan x 2>
       %2 = cc.string_literal "XZ" : !cc.ptr<!cc.array<i8 x 3>>
-      %4 = cc.stdvec_init %2 : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.charspan
+      %4 = cc.sequence_init %2 : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.charspan
       %5 = cc.cast %1 : (!cc.ptr<!cc.array<!cc.charspan x 2>>) ->
                          !cc.ptr<!cc.charspan>
       cc.store %4, %5 : !cc.ptr<!cc.charspan>
       %6 = cc.string_literal "YI" : !cc.ptr<!cc.array<i8 x 3>>
-      %8 = cc.stdvec_init %6 : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.charspan
+      %8 = cc.sequence_init %6 : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.charspan
       %9 = cc.compute_ptr %1[1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) ->
                                    !cc.ptr<!cc.charspan>
       cc.store %8, %9 : !cc.ptr<!cc.charspan>
@@ -1263,7 +1263,7 @@ def cc_ReifySpanOp : CCOp<"reify_span", [Pure]> {
   }];
 
   let arguments = (ins cc_ArrayType:$elements);
-  let results = (outs cc_StdVectorType:$spanType);
+  let results = (outs cc_SequenceType:$spanType);
   let assemblyFormat = [{
     $elements `:` functional-type(operands, results) attr-dict
   }];
@@ -1288,7 +1288,7 @@ def cc_ReifySpanOp : CCOp<"reify_span", [Pure]> {
     std::size_t vectorDimension() {
       std::size_t depth = 0;
       mlir::Type ty = getType();
-      while (auto vecTy = llvm::dyn_cast<cudaq::cc::StdvecType>(ty)) {
+      while (auto vecTy = llvm::dyn_cast<cudaq::cc::SequenceType>(ty)) {
         ty = vecTy.getElementType();
         ++depth;
       }
@@ -1297,10 +1297,10 @@ def cc_ReifySpanOp : CCOp<"reify_span", [Pure]> {
   }];
 }
 
-def cc_StdvecInitOp : CCOp<"stdvec_init", [Pure]> {
-  let summary = "Initialize a stdvec object from a pointer and length.";
+def cc_SequenceInitOp : CCOp<"sequence_init", [Pure]> {
+  let summary = "Initialize a sequence object from a pointer and length.";
   let description = [{
-    A StdvecInitOp can be used to create a "high-level" `std::vector` object in
+    A SequenceInitOp can be used to create a "high-level" `std::vector` object in
     cc. The construction is similar to the `std::vector` initializer list
     constructor. It takes two arguments: a pointer to a memory buffer and the
     length of the buffer in terms of the number of elements.
@@ -1313,13 +1313,13 @@ def cc_StdvecInitOp : CCOp<"stdvec_init", [Pure]> {
     ```mlir
       %buff = ... : !cc.ptr<f64>
       %len = ... : i64
-      %vec1 = cc.stdvec_init %buff, %len : (!cc.ptr<f64>, i64) ->
-                                            !cc.stdvec<f64>
+      %vec1 = cc.sequence_init %buff, %len : (!cc.ptr<f64>, i64) ->
+                                            !cc.sequence<f64>
       func.call @kernel(%vec1) ...
 
       %arr = ... : !cc.ptr<!cc.array<i64 x 12>>
-      %vec2 = cc.stdvec_init %arr : (!cc.ptr<!cc.array<i64 x 12>>) ->
-                                     !cc.stdvec<i64>  // span length is 12
+      %vec2 = cc.sequence_init %arr : (!cc.ptr<!cc.array<i64 x 12>>) ->
+                                     !cc.sequence<i64>  // span length is 12
     ```
   }];
 
@@ -1327,7 +1327,7 @@ def cc_StdvecInitOp : CCOp<"stdvec_init", [Pure]> {
     AnyPointerType:$buffer,
     Optional<AnyInteger>:$length
   );
-  let results = (outs SpanningType:$stdvec);
+  let results = (outs SpanningType:$sequence);
 
   let hasVerifier = 1;
   let hasCanonicalizer = 1;
@@ -1337,45 +1337,45 @@ def cc_StdvecInitOp : CCOp<"stdvec_init", [Pure]> {
   }];
 }
 
-def cc_StdvecDataOp : CCOp<"stdvec_data", [Pure]> {
-  let summary = "Retrieve the data pointer from a stdvec object.";
+def cc_SequenceDataOp : CCOp<"sequence_data", [Pure]> {
+  let summary = "Retrieve the data pointer from a sequence object.";
   let description = [{
-    A StdvecDataOp can be used to retrieve the data pointer from a stdvec
-    object. (See StdvecInitOp.) This operation is analogous to a call to
+    A SequenceDataOp can be used to retrieve the data pointer from a sequence
+    object. (See SequenceInitOp.) This operation is analogous to a call to
     `std::vector<T>::data()`.
 
     Note that this operation has value semantics. It does not touch memory as
     the data pointer is part of the aggregate value and nothing is dereferenced.
   }];
 
-  let arguments = (ins SpanningType:$stdvec);
+  let arguments = (ins SpanningType:$sequence);
   let results = (outs AnyPointerType:$data);
 
   let hasCanonicalizer = 1;
 
   let assemblyFormat = [{
-    $stdvec `:` functional-type(operands, results) attr-dict
+    $sequence `:` functional-type(operands, results) attr-dict
   }];
 }
 
-def cc_StdvecSizeOp : CCOp<"stdvec_size", [Pure]> {
-  let summary = "Retrieve the size from a stdvec object.";
+def cc_SequenceSizeOp : CCOp<"sequence_size", [Pure]> {
+  let summary = "Retrieve the size from a sequence object.";
   let description = [{
-    A StdvecSizeOp can be used to retrieve the size from a stdvec object.
+    A SequenceSizeOp can be used to retrieve the size from a sequence object.
     This is analogous to a call to `std::vector<T>::size()`.
 
     Note that this operation is pure and has value semantics. It does not
-    modify memory as the size is part of a stdvec's aggregate value and nothing
+    modify memory as the size is part of a sequence's aggregate value and nothing
     is dereferenced.
   }];
 
-  let arguments = (ins SpanningType:$stdvec);
+  let arguments = (ins SpanningType:$sequence);
   let results = (outs AnyInteger:$size);
 
   let hasCanonicalizer = 1;
 
   let assemblyFormat = [{
-    $stdvec `:` functional-type(operands, results) attr-dict
+    $sequence `:` functional-type(operands, results) attr-dict
   }];
 }
 
@@ -1890,7 +1890,7 @@ def cc_DeviceCallOp : CCOp<"device_call",
     OptionalAttr<DictArrayAttr>:$res_attrs,
     // Indices into `args` whose original C++ callee parameters were
     // non-const `std::vector<T>&`. The attribute preserves by-reference
-    // vector intent that is otherwise lost after lowering to `!cc.stdvec<T>`.
+    // vector intent that is otherwise lost after lowering to `!cc.sequence<T>`.
     OptionalAttr<DenseI64ArrayAttr>:$by_ref_vec_arg_indices
   );
   let results = (outs Variadic<AnyType>);

--- a/cudaq/include/cudaq/Optimizer/Dialect/CC/CCTypes.h
+++ b/cudaq/include/cudaq/Optimizer/Dialect/CC/CCTypes.h
@@ -35,7 +35,7 @@ public:
 namespace cudaq::cc {
 
 inline bool SpanLikeType::classof(mlir::Type type) {
-  return mlir::isa<StdvecType, CharspanType>(type);
+  return mlir::isa<SequenceType, CharspanType>(type);
 }
 
 /// Returns true if and only if \p ty has dynamic extent. This is a recursive

--- a/cudaq/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -146,7 +146,7 @@ def cc_ArrayType : CCType<"Array", "array"> {
     `!cc.array` should itself reside in memory. More precisely, loading an array
     into a register is not portable.
 
-    See also `!cc.stdvec` as another aggregate sequence of values.
+    See also `!cc.sequence` as another aggregate sequence of values.
   }];
 
   let parameters = (ins
@@ -221,10 +221,10 @@ def cc_IndirectCallableType : CCType<"IndirectCallable", "indirect_callable"> {
 }
 
 //===----------------------------------------------------------------------===//
-// StdVectorType - implemented as a span
+// SequenceType - implemented as a span
 //===----------------------------------------------------------------------===//
 
-def cc_StdVectorType : CCType<"Stdvec", "stdvec", [],
+def cc_SequenceType : CCType<"Sequence", "sequence", [],
     "cudaq::cc::SpanLikeType"> {
   let summary = "Abstract span-like sequence type in CC";
   let description = [{
@@ -238,7 +238,7 @@ def cc_StdVectorType : CCType<"Stdvec", "stdvec", [],
     ```
     will be lowered from the AST to CC as
     ```mlir
-    func.func @foo(%arg0 : !cc.stdvec<i32>) ...
+    func.func @foo(%arg0 : !cc.sequence<i32>) ...
     ```
     assuming `int` has a length of 32 bits for the target.
   }];
@@ -313,14 +313,14 @@ def AnyStateInitLike : TypeConstraint<cc_PointerType.predicate,
                          "state initializer types">;
 def AnyStateInitType : Type<AnyStateInitLike.predicate, "initial state type">;
 
-def IsStdvecTypePred : CPred<"::mlir::isa<::cudaq::cc::StdvecType>($_self)">;
+def IsSequenceTypePred : CPred<"::mlir::isa<::cudaq::cc::SequenceType>($_self)">;
 
-class StdvecOf<list<Type> allowedTypes> : Type<
-    And<[IsStdvecTypePred, Concat<"[](::mlir::Type elementType) { return ",
+class SequenceOf<list<Type> allowedTypes> : Type<
+    And<[IsSequenceTypePred, Concat<"[](::mlir::Type elementType) { return ",
       SubstLeaves<"$_self", "elementType", AnyTypeOf<allowedTypes>.predicate>,
-        "; }(::mlir::cast<::cudaq::cc::StdvecType>($_self).getElementType())">]>,
-    "stdvec of " # AnyTypeOf<allowedTypes>.summary # " values",
-    "::cudaq::cc::StdvecType">;
+        "; }(::mlir::cast<::cudaq::cc::SequenceType>($_self).getElementType())">]>,
+    "sequence of " # AnyTypeOf<allowedTypes>.summary # " values",
+    "::cudaq::cc::SequenceType">;
 
 def IsPointerTypePred : CPred<"::mlir::isa<::cudaq::cc::PointerType>($_self)">;
 

--- a/cudaq/include/cudaq/Optimizer/Dialect/QEC/QECOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/QEC/QECOps.td
@@ -22,12 +22,12 @@ def QEC_DetectorOp : QECOp<"detector"> {
     Declares a parity constraint over one or more measurement results. Under
     noise-free execution the XOR of the referenced measurements is
     deterministic. Operands may be individual `!cc.measure_handle` values or a
-    `!cc.stdvec<!cc.measure_handle>` collection. This is a side-effecting
+    `!cc.sequence<!cc.measure_handle>` collection. This is a side-effecting
     declaration that informs the backend.
   }];
   let arguments = (ins
     Variadic<AnyTypeOf<[cc_MeasureHandleType,
-                        StdvecOf<[cc_MeasureHandleType]>]>>:$measurements
+                        SequenceOf<[cc_MeasureHandleType]>]>>:$measurements
   );
   let assemblyFormat = [{
     $measurements `:` type($measurements) attr-dict
@@ -38,14 +38,14 @@ def QEC_DetectorsOp : QECOp<"pair_detectors"> {
   let summary =
     "Declare N detectors by pairing previous and current measurement vectors.";
   let description = [{
-    Given two `!cc.stdvec<!cc.measure_handle>` collections of measurement
+    Given two `!cc.sequence<!cc.measure_handle>` collections of measurement
     results, declares N detectors where detector `i` is the parity of `prev[i]`
-    and `curr[i]`. `!cc.stdvec` carries no static size, so size agreement
+    and `curr[i]`. `!cc.sequence` carries no static size, so size agreement
     between `prev` and `curr` is checked at runtime.
   }];
   let arguments = (ins
-    StdvecOf<[cc_MeasureHandleType]>:$prev,
-    StdvecOf<[cc_MeasureHandleType]>:$curr
+    SequenceOf<[cc_MeasureHandleType]>:$prev,
+    SequenceOf<[cc_MeasureHandleType]>:$curr
   );
   let assemblyFormat = [{
     $prev `,` $curr `:` type($prev) `,` type($curr) attr-dict
@@ -57,12 +57,12 @@ def QEC_ObservableOp : QECOp<"observable"> {
   let description = [{
     Declares a logical observable as a binary sum of measurement results.
     Operands may be individual `!cc.measure_handle` values or a
-    `!cc.stdvec<!cc.measure_handle>` collection. The optional observable index
+    `!cc.sequence<!cc.measure_handle>` collection. The optional observable index
     defaults to 0.
   }];
   let arguments = (ins
     Variadic<AnyTypeOf<[cc_MeasureHandleType,
-                        StdvecOf<[cc_MeasureHandleType]>]>>:$measurements,
+                        SequenceOf<[cc_MeasureHandleType]>]>>:$measurements,
     DefaultValuedOptionalAttr<I64Attr, "0">:$observableIndex
   );
   let assemblyFormat = [{

--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1137,14 +1137,14 @@ class Measurement<string mnemonic> : QuakeOp<mnemonic, [MeasurementInterface,
   // The classical result of a measurement is one of:
   //   - !quake.measure                   (the legacy SSA result),
   //   - !cc.measure_handle               (the cudaq::measure_handle alias),
-  //   - !cc.stdvec<!quake.measure>       (vector of legacy results),
-  //   - !cc.stdvec<!cc.measure_handle>   (vector of handles).
+  //   - !cc.sequence<!quake.measure>       (vector of legacy results),
+  //   - !cc.sequence<!cc.measure_handle>   (vector of handles).
   // The handle forms are emitted by the bridge for `cudaq::measure_handle`
   // callers (overloads of `mz`/`mx`/`my`) and are lowered to `i64` by
   // `--convert-to-qir-api`'s `TypeConverter`.
   let results = (outs
     AnyTypeOf<[MeasureType, cc_MeasureHandleType,
-               StdvecOf<[MeasureType, cc_MeasureHandleType]>]>:$measOut,
+               SequenceOf<[MeasureType, cc_MeasureHandleType]>]>:$measOut,
     Variadic<WireType>:$wires
   );
 
@@ -1222,8 +1222,8 @@ def quake_DiscriminateOp : QuakeOp<"discriminate",
     Multiple applications of discriminate on the same scalar measurement
     handle yield the same result, so the scalar form is treated as pure.
 
-    The vector form (`!cc.stdvec<!cc.measure_handle>` or
-    `!cc.stdvec<!quake.measure>`) operates on a `(data_ptr, size)`
+    The vector form (`!cc.sequence<!cc.measure_handle>` or
+    `!cc.sequence<!quake.measure>`) operates on a `(data_ptr, size)`
     descriptor that aliases mutable backing storage; storing a new handle
     into a slot through that storage changes the result of a subsequent
     discriminate of the same descriptor. The vector form therefore
@@ -1234,10 +1234,10 @@ def quake_DiscriminateOp : QuakeOp<"discriminate",
 
   let arguments = (ins
     AnyTypeOf<[MeasureType, cc_MeasureHandleType,
-               StdvecOf<[MeasureType, cc_MeasureHandleType]>]>:$measurement
+               SequenceOf<[MeasureType, cc_MeasureHandleType]>]>:$measurement
   );
   let results = (outs
-    AnyTypeOf<[AnySignlessInteger, StdvecOf<[AnySignlessInteger]>]>
+    AnyTypeOf<[AnySignlessInteger, SequenceOf<[AnySignlessInteger]>]>
   );
 
   let assemblyFormat = [{

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -308,7 +308,7 @@ def CombineMeasurements :
       %1 = ... : !quake.veq<4>
       %2 = quake.subveq %1, %c2, %c3 : (!quake.veq<4>, i32, i32) ->
             !quake.veq<2>
-      %measOut = quake.mz %2 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+      %measOut = quake.mz %2 : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
     }
     ```
     with:
@@ -316,7 +316,7 @@ def CombineMeasurements :
     func.func @kernel() attributes {"cudaq-entrypoint", ["output_names",
     "[[[0,[1,\22q0\22]],[1,[2,\22q1\22]]]]"]} {
       %1 = ... : !quake.veq<4>
-      %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+      %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
     }
     ```
   }];
@@ -745,13 +745,13 @@ def GetConcreteMatrix : Pass<"get-concrete-matrix", "mlir::ModuleOp"> {
     ```mlir
       module {
         func.func @__nvqpp__mlirgen__function_foo_generator_1.bar(%arg0:
-            !cc.stdvec<f64>) -> !cc.stdvec<complex<f64>> {
+            !cc.sequence<f64>) -> !cc.sequence<complex<f64>> {
           ...
           %0 = cc.address_of
               @__nvqpp__mlirgen__function_foo_generator_1.bar.rodata_0 :
               !cc.ptr<!cc.array<complex<f64> x 4>>
           ...
-          return %3 : !cc.stdvec<complex<f64>>
+          return %3 : !cc.sequence<complex<f64>>
         }
 
         func.func @__nvqpp__mlirgen__function_kernel_1._Z8kernel_1v() {
@@ -1616,7 +1616,7 @@ def RunSemanticsHackery : Pass<"run-semantics-hackery", "mlir::ModuleOp"> {
   let description = [{
     `cudaq::run` entry points log kernel results instead of returning them
     through the host ABI. After the `kernel-execution` pass creates the `.run`
-    wrapper, this pass finds wrappers that call kernels returning `!cc.stdvec`,
+    wrapper, this pass finds wrappers that call kernels returning `!cc.sequence`,
     clones those kernels, removes calls to `__nvqpp_vectorCopyCtor` from the
     clones, and redirects the wrappers to call the clones. It must run after
     `kernel-execution`, while both the generated wrapper and original kernel are

--- a/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -135,7 +135,7 @@ static bool isQubitType(Type ty) {
   if (cudaq::quake::isQuakeType(ty))
     return true;
   // FIXME: next if case is a bug.
-  if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))
+  if (auto vecTy = dyn_cast<cudaq::cc::SequenceType>(ty))
     return isQubitType(vecTy.getElementType());
   return false;
 }

--- a/cudaq/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -191,9 +191,9 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
                               "std::vector element type is not supported");
         return false;
       }
-      return pushType(cc::StdvecType::get(ctx, ty));
+      return pushType(cc::SequenceType::get(ctx, ty));
     }
-    // std::vector<bool>   =>   cc.stdvec<i1>
+    // std::vector<bool>   =>   cc.sequence<i1>
     if (name == "_Bit_reference" || name == "__bit_reference" ||
         name == "__bit_const_reference") {
       // Reference to a bit in a std::vector<bool>. Promote to a value.
@@ -738,8 +738,8 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
   }
 
   // Here we maybe have something like auto var = mz(qreg)
-  if (auto vecType = dyn_cast<cc::StdvecType>(type)) {
-    // Variable is of !cc.stdvec type.
+  if (auto vecType = dyn_cast<cc::SequenceType>(type)) {
+    // Variable is of !cc.sequence type.
     if (x->getInit()) {
       // At the very least, its a vector var = vec_init;
       auto initVec = popValue();
@@ -801,8 +801,8 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
         attachName(meas);
       }
 
-      // Did this come from a stdvec init op? If not drop out
-      auto stdVecInit = initVec.getDefiningOp<cc::StdvecInitOp>();
+      // Did this come from a sequence init op? If not drop out
+      auto stdVecInit = initVec.getDefiningOp<cc::SequenceInitOp>();
       if (!stdVecInit)
         return true;
 
@@ -905,7 +905,7 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     return pushValue(initValue);
   }
   auto qualTy = x->getType().getCanonicalType();
-  auto isStdvecBoolReference = [&](clang::QualType &qualTy) {
+  auto isSequenceBoolReference = [&](clang::QualType &qualTy) {
     if (auto *recTy = dyn_cast<clang::RecordType>(qualTy.getTypePtr())) {
       auto *recDecl = recTy->getDecl();
       if (isInNamespace(recDecl, "std")) {
@@ -916,7 +916,8 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     }
     return false;
   };
-  if (isStdvecBoolReference(qualTy) || qualTy.getTypePtr()->isReferenceType()) {
+  if (isSequenceBoolReference(qualTy) ||
+      qualTy.getTypePtr()->isReferenceType()) {
     // A similar case is when the C++ variable is a reference to a subobject.
     assert(isa<cc::PointerType>(type));
     Value cast = cc::CastOp::create(builder, loc, type, initValue);

--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -486,7 +486,7 @@ classDeclFromTemplateArgument(clang::FunctionDecl &func,
   return nullptr;
 }
 
-static bool isStdVectorType(clang::QualType type) {
+static bool isSequenceType(clang::QualType type) {
   const auto canonicalType = type.getCanonicalType();
   const auto *recordDecl = canonicalType.getTypePtr()->getAsCXXRecordDecl();
   return recordDecl && recordDecl->getName() == "vector" &&
@@ -519,7 +519,7 @@ buildByRefVecArgIndicesAttr(OpBuilder &builder, clang::CallExpr *call,
       continue;
 
     const clang::QualType pointeeType = refType->getPointeeType();
-    if (pointeeType.isConstQualified() || !isStdVectorType(pointeeType))
+    if (pointeeType.isConstQualified() || !isSequenceType(pointeeType))
       continue;
 
     indices.push_back(i);
@@ -1609,11 +1609,11 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       // fall through to the generic dispatch.
       Value thisTop = valueStack[valueStack.size() - 2];
       auto thisPtrTy = dyn_cast<cc::PointerType>(thisTop.getType());
-      auto lhsStdvecTy =
-          thisPtrTy ? dyn_cast<cc::StdvecType>(thisPtrTy.getElementType())
-                    : cc::StdvecType();
-      if (lhsStdvecTy &&
-          isa<cc::MeasureHandleType>(lhsStdvecTy.getElementType())) {
+      auto lhsSequenceTy =
+          thisPtrTy ? dyn_cast<cc::SequenceType>(thisPtrTy.getElementType())
+                    : cc::SequenceType();
+      if (lhsSequenceTy &&
+          isa<cc::MeasureHandleType>(lhsSequenceTy.getElementType())) {
         Value rhs = popValue();
         Value thisVal = popValue();
         [[maybe_unused]] auto calleeOp = popValue();
@@ -1626,18 +1626,18 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         Value rhsDescr = cc::LoadOp::create(builder, loc, rhs);
         auto i8PtrTy = cc::PointerType::get(builder.getI8Type());
         Value srcData =
-            cc::StdvecDataOp::create(builder, loc, i8PtrTy, rhsDescr);
-        Value size = cc::StdvecSizeOp::create(builder, loc,
-                                              builder.getI64Type(), rhsDescr);
+            cc::SequenceDataOp::create(builder, loc, i8PtrTy, rhsDescr);
+        Value size = cc::SequenceSizeOp::create(builder, loc,
+                                                builder.getI64Type(), rhsDescr);
         IRBuilder irb(builder);
         Value eltSize =
-            irb.getByteSizeOfType(loc, lhsStdvecTy.getElementType());
+            irb.getByteSizeOfType(loc, lhsSequenceTy.getElementType());
         Value heap = func::CallOp::create(builder, loc, i8PtrTy,
                                           "__nvqpp_vectorCopyCtor",
                                           ValueRange{srcData, size, eltSize})
                          .getResult(0);
-        Value newDescr = cc::StdvecInitOp::create(builder, loc, lhsStdvecTy,
-                                                  ValueRange{heap, size});
+        Value newDescr = cc::SequenceInitOp::create(builder, loc, lhsSequenceTy,
+                                                    ValueRange{heap, size});
         cc::StoreOp::create(builder, loc, newDescr, thisVal);
         return pushValue(thisVal);
       }
@@ -1654,7 +1654,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     if (isa<cc::PointerType>(svec.getType()))
       svec = cc::LoadOp::create(builder, loc, svec);
     auto ext =
-        cc::StdvecSizeOp::create(builder, loc, builder.getI64Type(), svec);
+        cc::SequenceSizeOp::create(builder, loc, builder.getI64Type(), svec);
     if (funcName == "size")
       if (auto memberCall = dyn_cast<clang::CXXMemberCallExpr>(x))
         if (memberCall->getImplicitObjectArgument()) {
@@ -1682,7 +1682,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto eleTy = cast<cc::SpanLikeType>(svec.getType()).getElementType();
           auto elePtrTy = cc::PointerType::get(eleTy);
           return pushValue(
-              cc::StdvecDataOp::create(builder, loc, elePtrTy, svec));
+              cc::SequenceDataOp::create(builder, loc, elePtrTy, svec));
         }
     if (funcName == "back" || funcName == "rbegin")
       if (auto memberCall = dyn_cast<clang::CXXMemberCallExpr>(x))
@@ -1695,8 +1695,9 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto elePtrTy = cc::PointerType::get(eleTy);
           auto *ctx = eleTy.getContext();
           auto i64Ty = mlir::IntegerType::get(ctx, 64);
-          auto vecPtr = cc::StdvecDataOp::create(builder, loc, eleArrTy, svec);
-          auto vecLen = cc::StdvecSizeOp::create(builder, loc, i64Ty, svec);
+          auto vecPtr =
+              cc::SequenceDataOp::create(builder, loc, eleArrTy, svec);
+          auto vecLen = cc::SequenceSizeOp::create(builder, loc, i64Ty, svec);
           Value vecLenMinusOne =
               arith::AddIOp::create(builder, loc, vecLen, negativeOneIndex);
           return pushValue(cc::ComputePtrOp::create(
@@ -1712,8 +1713,9 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto eleArrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
           auto *ctx = eleTy.getContext();
           auto i64Ty = mlir::IntegerType::get(ctx, 64);
-          auto vecPtr = cc::StdvecDataOp::create(builder, loc, eleArrTy, svec);
-          Value vecLen = cc::StdvecSizeOp::create(builder, loc, i64Ty, svec);
+          auto vecPtr =
+              cc::SequenceDataOp::create(builder, loc, eleArrTy, svec);
+          Value vecLen = cc::SequenceSizeOp::create(builder, loc, i64Ty, svec);
           return pushValue(cc::ComputePtrOp::create(
               builder, loc, elePtrTy, vecPtr, ValueRange{vecLen}));
         }
@@ -1727,7 +1729,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto eleTy = cast<cc::SpanLikeType>(svec.getType()).getElementType();
           auto elePtrTy = cc::PointerType::get(eleTy);
           auto eleArrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
-          auto vecPtr = cc::StdvecDataOp::create(builder, loc, eleArrTy, svec);
+          auto vecPtr =
+              cc::SequenceDataOp::create(builder, loc, eleArrTy, svec);
           return pushValue(cc::ComputePtrOp::create(
               builder, loc, elePtrTy, vecPtr, ValueRange{negativeOneIndex}));
         }
@@ -1740,7 +1743,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto eleTy = cast<cc::SpanLikeType>(svec.getType()).getElementType();
           auto eleArrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
           return pushValue(
-              cc::StdvecDataOp::create(builder, loc, eleArrTy, svec));
+              cc::SequenceDataOp::create(builder, loc, eleArrTy, svec));
         }
 
     TODO_loc(loc, "unhandled std::vector member function, " + funcName);
@@ -1979,8 +1982,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
               params.push_back(a);
               continue;
             }
-          if (auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(aTy))
-            if (stdvecTy.getElementType() == builder.getF64Type() &&
+          if (auto sequenceTy = dyn_cast<cudaq::cc::SequenceType>(aTy))
+            if (sequenceTy.getElementType() == builder.getF64Type() &&
                 iter.index() == 0) {
               params.push_back(a);
               inParams = false;
@@ -2023,16 +2026,16 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
 
     if (funcName == "mx" || funcName == "my" || funcName == "mz") {
       // Measurements emit `quake.{mz,mx,my}` producing `!cc.measure_handle`
-      // (scalar) or `!cc.stdvec<!cc.measure_handle>` (multi-qubit). The
+      // (scalar) or `!cc.sequence<!cc.measure_handle>` (multi-qubit). The
       // bridge does not inline `quake.discriminate` at the call site;
       // discrimination happens later, only when a downstream coercion site
       // demands it.
-      bool useStdvec =
+      bool useSequence =
           (args.size() > 1) ||
           (args.size() == 1 && isa<cudaq::quake::VeqType>(args[0].getType()));
       Type measTy = cc::MeasureHandleType::get(builder.getContext());
-      if (useStdvec)
-        measTy = cc::StdvecType::get(measTy);
+      if (useSequence)
+        measTy = cc::SequenceType::get(measTy);
       if (funcName == "mx")
         return pushValue(cudaq::quake::MxOp::create(builder, loc, measTy, args)
                              .getMeasOut());
@@ -2046,16 +2049,16 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     if (funcName == "to_bools") {
       // `cudaq::to_bools(std::vector<cudaq::measure_handle>)` is the bulk
       // counterpart to `measure_handle::operator bool()`. Lower to a
-      // vectorized `quake.discriminate` on the handle vector. The stdvec
+      // vectorized `quake.discriminate` on the handle vector. The sequence
       // shape is fixed by the C++ overload resolution (clang would reject
       // any other argument type before the bridge sees the call), so the
       // dyn_cast is a sanity check, not a user-facing path.
       Value handleArg = loadHandleVectorIfPointer(builder, loc, args[0]);
-      auto sv = dyn_cast<cc::StdvecType>(handleArg.getType());
+      auto sv = dyn_cast<cc::SequenceType>(handleArg.getType());
       assert(sv && isa<cc::MeasureHandleType>(sv.getElementType()) &&
-             "`cudaq::to_bools` always sees `!cc.stdvec<!cc.measure_handle>` "
+             "`cudaq::to_bools` always sees `!cc.sequence<!cc.measure_handle>` "
              "after C++ overload resolution");
-      auto resTy = cc::StdvecType::get(builder.getI1Type());
+      auto resTy = cc::SequenceType::get(builder.getI1Type());
       return pushValue(
           cudaq::quake::DiscriminateOp::create(builder, loc, resTy, handleArg));
     }
@@ -2528,13 +2531,14 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         reportClangError(x, mangler, "cannot load cudaqConvertToInteger");
         return false;
       }
-      // The intrinsic signature is `(!cc.stdvec<i1>) -> i64`. Normalize an
-      // `!cc.ptr<!cc.stdvec<measure_handle>>` lvalue to its value form first
-      // so the element-type check below sees the actual stdvec.
+      // The intrinsic signature is `(!cc.sequence<i1>) -> i64`. Normalize an
+      // `!cc.ptr<!cc.sequence<measure_handle>>` lvalue to its value form first
+      // so the element-type check below sees the actual sequence.
       args[0] = loadHandleVectorIfPointer(builder, loc, args[0]);
       // The bridge does not silently insert a discriminate.
-      if (auto stdvecTy = dyn_cast<cc::StdvecType>(args[0].getType());
-          stdvecTy && isa<cc::MeasureHandleType>(stdvecTy.getElementType())) {
+      if (auto sequenceTy = dyn_cast<cc::SequenceType>(args[0].getType());
+          sequenceTy &&
+          isa<cc::MeasureHandleType>(sequenceTy.getElementType())) {
         reportClangError(
             x, mangler,
             "`cudaq::to_integer` accepts `std::vector<bool>`; "
@@ -2562,7 +2566,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       if (eleTy == builder.getI1Type()) {
         eleTy = cc::ArrayType::get(builder.getI8Type());
         ptrTy = cc::PointerType::get(eleTy);
-        vecPtr = cc::StdvecDataOp::create(builder, loc, ptrTy, args[0]);
+        vecPtr = cc::SequenceDataOp::create(builder, loc, ptrTy, args[0]);
         auto bits = svecTy.getElementType().getIntOrFloatBitWidth();
         assert(bits > 0);
         auto scale =
@@ -2572,12 +2576,12 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       } else {
         ptrTy = cc::PointerType::get(eleTy);
         auto arrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
-        vecPtr = cc::StdvecDataOp::create(builder, loc, arrTy, args[0]);
+        vecPtr = cc::SequenceDataOp::create(builder, loc, arrTy, args[0]);
       }
       auto ptr = cc::ComputePtrOp::create(builder, loc, ptrTy, vecPtr,
                                           ArrayRef<Value>{offset});
       return pushValue(
-          cc::StdvecInitOp::create(builder, loc, svecTy, ptr, args[2]));
+          cc::SequenceInitOp::create(builder, loc, svecTy, ptr, args[2]));
     }
 
     if (funcName == "range") {
@@ -2591,9 +2595,9 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         auto upper = cc::CastOp::create(builder, loc, i64Ty, upVal,
                                         cc::CastOpMode::Unsigned);
         auto buffer = cc::AllocaOp::create(builder, loc, i64Ty, upper);
-        auto stdvecTy = cc::StdvecType::get(i64Ty);
+        auto sequenceTy = cc::SequenceType::get(i64Ty);
         auto call =
-            func::CallOp::create(builder, loc, stdvecTy, setCudaqRangeVector,
+            func::CallOp::create(builder, loc, sequenceTy, setCudaqRangeVector,
                                  ValueRange{buffer, upper});
         return pushValue(call.getResult(0));
       }
@@ -2612,8 +2616,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
                                ValueRange{start, stop, step});
       Value length = lengthCall.getResult(0);
       auto buffer = cc::AllocaOp::create(builder, loc, i64Ty, length);
-      auto stdvecTy = cc::StdvecType::get(i64Ty);
-      auto call = func::CallOp::create(builder, loc, stdvecTy,
+      auto sequenceTy = cc::SequenceType::get(i64Ty);
+      auto call = func::CallOp::create(builder, loc, sequenceTy,
                                        setCudaqRangeVectorTriple,
                                        ValueRange{buffer, start, stop, step});
       return pushValue(call.getResult(0));
@@ -2878,7 +2882,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       return false;
     }
     if (auto vecTy =
-            dyn_cast<cudaq::cc::StdvecType>(call.getResult(0).getType())) {
+            dyn_cast<cudaq::cc::SequenceType>(call.getResult(0).getType())) {
       auto irBuilder = cudaq::IRBuilder::atBlockEnd(module.getBody());
       if (failed(irBuilder.loadIntrinsic(module, "__nvqpp_vectorCopyToStack")))
         module.emitError("failed to load intrinsic");
@@ -2888,11 +2892,11 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           return builder.getI8Type();
         return et;
       }();
-      auto data = cudaq::cc::StdvecDataOp::create(
+      auto data = cudaq::cc::SequenceDataOp::create(
           builder, loc, cudaq::cc::PointerType::get(eleTy), call.getResult(0));
       auto i64Ty = builder.getI64Type();
-      auto len = cudaq::cc::StdvecSizeOp::create(builder, loc, i64Ty,
-                                                 call.getResult(0));
+      auto len = cudaq::cc::SequenceSizeOp::create(builder, loc, i64Ty,
+                                                   call.getResult(0));
       auto eleSize = cudaq::cc::SizeOfOp::create(builder, loc, i64Ty, eleTy);
       auto size = arith::MulIOp::create(builder, loc, len, eleSize);
       auto buffer = cudaq::cc::AllocaOp::create(builder, loc, eleTy, size);
@@ -2903,7 +2907,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
                            "__nvqpp_vectorCopyToStack",
                            ValueRange{cbuffer, cdata, size});
       Value newSpan =
-          cudaq::cc::StdvecInitOp::create(builder, loc, vecTy, buffer, len);
+          cudaq::cc::SequenceInitOp::create(builder, loc, vecTy, buffer, len);
       return pushValue(newSpan);
     }
     return pushValue(call.getResult(0));
@@ -3019,16 +3023,16 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
       auto svec = popValue();
       if (isa<cc::PointerType>(svec.getType()))
         svec = cc::LoadOp::create(builder, loc, svec);
-      if (!isa<cc::StdvecType>(svec.getType())) {
+      if (!isa<cc::SequenceType>(svec.getType())) {
         TODO_x(loc, x, mangler, "vector dereference");
         return false;
       }
-      auto eleTy = cast<cc::StdvecType>(svec.getType()).getElementType();
+      auto eleTy = cast<cc::SequenceType>(svec.getType()).getElementType();
       if (eleTy == builder.getI1Type())
         eleTy = builder.getI8Type();
       auto elePtrTy = cc::PointerType::get(eleTy);
       auto eleArrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
-      auto vecPtr = cc::StdvecDataOp::create(builder, loc, eleArrTy, svec);
+      auto vecPtr = cc::SequenceDataOp::create(builder, loc, eleArrTy, svec);
       auto eleAddr = cc::ComputePtrOp::create(builder, loc, elePtrTy, vecPtr,
                                               ValueRange{indexVar});
       return replaceTOSValue(eleAddr);
@@ -3040,11 +3044,11 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
       // likely going to pack the booleans as bits in words.
       auto indexVar = popValue();
       auto svec = popValue();
-      assert(isa<cc::StdvecType>(svec.getType()));
+      assert(isa<cc::SequenceType>(svec.getType()));
       auto i8Ty = builder.getI8Type();
       auto elePtrTy = cc::PointerType::get(i8Ty);
       auto eleArrTy = cc::PointerType::get(cc::ArrayType::get(i8Ty));
-      auto vecPtr = cc::StdvecDataOp::create(builder, loc, eleArrTy, svec);
+      auto vecPtr = cc::SequenceDataOp::create(builder, loc, eleArrTy, svec);
       auto eleAddr = cc::ComputePtrOp::create(builder, loc, elePtrTy, vecPtr,
                                               ValueRange{indexVar});
       auto i1PtrTy = cc::PointerType::get(builder.getI1Type());
@@ -3368,8 +3372,8 @@ static bool isInitializerListQualType(const clang::QualType &ty) {
 }
 
 static Type getEleTyFromVectorCtor(Type ctorTy) {
-  if (auto stdvecTy = dyn_cast<cc::StdvecType>(ctorTy))
-    return stdvecTy.getElementType();
+  if (auto sequenceTy = dyn_cast<cc::SequenceType>(ctorTy))
+    return sequenceTy.getElementType();
   return ctorTy;
 }
 
@@ -3431,20 +3435,22 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
         // cudaq::state ctor can be materialized when using local simulators and
         // converting raw data to state vectors. Use a runtime helper function
         // to perform the conversion.
-        Value stdvec = popValue();
+        Value sequence = popValue();
         auto stateTy = cudaq::cc::PointerType::get(
             cudaq::quake::StateType::get(builder.getContext()));
-        if (auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(stdvec.getType())) {
-          auto dataTy = cudaq::cc::PointerType::get(stdvecTy.getElementType());
+        if (auto sequenceTy =
+                dyn_cast<cudaq::cc::SequenceType>(sequence.getType())) {
+          auto dataTy =
+              cudaq::cc::PointerType::get(sequenceTy.getElementType());
           Value data =
-              cudaq::cc::StdvecDataOp::create(builder, loc, dataTy, stdvec);
+              cudaq::cc::SequenceDataOp::create(builder, loc, dataTy, sequence);
           auto i64Ty = builder.getI64Type();
           Value size =
-              cudaq::cc::StdvecSizeOp::create(builder, loc, i64Ty, stdvec);
+              cudaq::cc::SequenceSizeOp::create(builder, loc, i64Ty, sequence);
           return pushValue(cudaq::quake::CreateStateOp::create(
               builder, loc, stateTy, ValueRange{data, size}));
         }
-        if (auto alloc = stdvec.getDefiningOp<cudaq::cc::AllocaOp>()) {
+        if (auto alloc = sequence.getDefiningOp<cudaq::cc::AllocaOp>()) {
           Value size = alloc.getSeqSize();
           return pushValue(cudaq::quake::CreateStateOp::create(
               builder, loc, stateTy, ValueRange{alloc, size}));
@@ -3541,12 +3547,12 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
                   std::countr_zero(arraySize));
             }
           }
-        } else if (auto stdvecTy = dyn_cast<cc::StdvecType>(initialsTy)) {
-          Value vecLen = cc::StdvecSizeOp::create(
+        } else if (auto sequenceTy = dyn_cast<cc::SequenceType>(initialsTy)) {
+          Value vecLen = cc::SequenceSizeOp::create(
               builder, loc, builder.getI64Type(), initials);
           numQubits = math::CountTrailingZerosOp::create(builder, loc, vecLen);
-          auto ptrTy = cc::PointerType::get(stdvecTy.getElementType());
-          initials = cc::StdvecDataOp::create(builder, loc, ptrTy, initials);
+          auto ptrTy = cc::PointerType::get(sequenceTy.getElementType());
+          initials = cc::SequenceDataOp::create(builder, loc, ptrTy, initials);
         }
         if (!numQubits) {
           reportClangError(
@@ -3658,9 +3664,10 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           if (auto ptrTy = dyn_cast<cc::PointerType>(allocation.getType()))
             if (auto arrayTy = dyn_cast<cc::ArrayType>(ptrTy.getElementType()))
               if (auto definingOp = allocation.getDefiningOp<cc::AllocaOp>())
-                return pushValue(cc::StdvecInitOp::create(
-                    builder, loc, cc::StdvecType::get(arrayTy.getElementType()),
-                    allocation, definingOp.getSeqSize()));
+                return pushValue(cc::SequenceInitOp::create(
+                    builder, loc,
+                    cc::SequenceType::get(arrayTy.getElementType()), allocation,
+                    definingOp.getSeqSize()));
         }
 
         // Next check if its created from a size integer. Let's do a check on
@@ -3675,15 +3682,15 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
             auto arrSize = popValue();
             auto eleTy = getEleTyFromVectorCtor(ctorTy);
 
-            // Create stdvec init op without a buffer. Allocate the required
+            // Create sequence init op without a buffer. Allocate the required
             // memory chunk.
             Type ty =
                 (eleTy == builder.getI1Type()) ? builder.getI8Type() : eleTy;
             Value alloca = cc::AllocaOp::create(builder, loc, ty, arrSize);
 
-            // Create the stdvec_init op
-            return pushValue(cc::StdvecInitOp::create(
-                builder, loc, cc::StdvecType::get(eleTy), alloca, arrSize));
+            // Create the sequence_init op
+            return pushValue(cc::SequenceInitOp::create(
+                builder, loc, cc::SequenceType::get(eleTy), alloca, arrSize));
           }
         return false;
       };
@@ -3713,7 +3720,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
                          "kernel is not allowed (cannot resize the vector).");
 
       if (ctor->isMoveConstructor()) {
-        // Just use the !cc.stdvec<T> value at TOS.
+        // Just use the !cc.sequence<T> value at TOS.
         return true;
       }
     }
@@ -3852,8 +3859,8 @@ bool QuakeBridgeVisitor::VisitStringLiteral(clang::StringLiteral *x) {
 // This walk is lenient: it returns `false` (unbound) only when it can prove no
 // measurement reached the vector, and `true` (bound) for every shape it cannot
 // disprove. It proves "unbound" through exactly one shape: a local descriptor
-// slot initialized from a `cc.stdvec_init` whose backing array never receives a
-// bound element store.
+// slot initialized from a `cc.sequence_init` whose backing array never receives
+// a bound element store.
 //
 // Limitation: `anyStoreInto` is satisfied by the first bound element, so a
 // partially-bound vector (some elements measured, some not) reads as bound.
@@ -3884,7 +3891,7 @@ bool QuakeBridgeVisitor::isBoundHandleVector(
       return true;
     // Bound iff some element was stored from a bound handle; an empty backing
     // array is the only provable "unbound".
-    if (auto init = stored.getDefiningOp<cc::StdvecInitOp>()) {
+    if (auto init = stored.getDefiningOp<cc::SequenceInitOp>()) {
       auto arr = getOwningAlloca(init.getBuffer());
       if (!arr)
         return true;

--- a/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -137,7 +137,7 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
   if (!TraverseStmt(x->getRangeInit()))
     return false;
   // `std::vector<measure_handle>` locals are stack-allocated by
-  // `ConvertDecl.cpp` and arrive here as `!cc.ptr<!cc.stdvec<...>>`; the
+  // `ConvertDecl.cpp` and arrive here as `!cc.ptr<!cc.sequence<...>>`; the
   // `SpanLikeType` dispatch below needs the descriptor value, not the slot
   // pointer. Other handle-vec consumers in `ConvertExpr.cpp` call the same
   // helper. The `quake::VeqType` arm is unaffected.
@@ -146,8 +146,8 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
   auto *body = x->getBody();
   auto *loopVar = x->getLoopVariable();
   auto i64Ty = builder.getI64Type();
-  if (auto stdvecTy = dyn_cast<cc::SpanLikeType>(buffer.getType())) {
-    auto eleTy = stdvecTy.getElementType();
+  if (auto sequenceTy = dyn_cast<cc::SpanLikeType>(buffer.getType())) {
+    auto eleTy = sequenceTy.getElementType();
     const bool isBool = eleTy == builder.getI1Type();
     if (isBool)
       eleTy = builder.getI8Type();
@@ -192,8 +192,8 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
           return {i, {}, initial, stepBy};
         }
       }
-      Value i = cc::StdvecSizeOp::create(builder, loc, i64Ty, buffer);
-      Value p = cc::StdvecDataOp::create(builder, loc, dataArrPtrTy, buffer);
+      Value i = cc::SequenceSizeOp::create(builder, loc, i64Ty, buffer);
+      Value p = cc::SequenceDataOp::create(builder, loc, dataArrPtrTy, buffer);
       return {i, p, {}, {}};
     }();
 
@@ -367,7 +367,7 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
       // refresh that branch tests the stale pointer type and is skipped,
       // returning a descriptor that aliases a buffer freed when the callee
       // returns.
-      if (auto sv = dyn_cast<cc::StdvecType>(result.getType());
+      if (auto sv = dyn_cast<cc::SequenceType>(result.getType());
           sv && isa<cc::MeasureHandleType>(sv.getElementType()))
         resTy = result.getType();
       if (load.getType() == builder.getI8Type()) {
@@ -387,15 +387,15 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
       auto eleTy = vecTy.getElementType();
       auto createVectorInit = [&](Value eleSize) {
         auto ptrTy = cudaq::cc::PointerType::get(builder.getI8Type());
-        Value resBuff = cc::StdvecDataOp::create(builder, loc, ptrTy, result);
-        Value dynSize = cc::StdvecSizeOp::create(builder, loc,
-                                                 builder.getI64Type(), result);
+        Value resBuff = cc::SequenceDataOp::create(builder, loc, ptrTy, result);
+        Value dynSize = cc::SequenceSizeOp::create(
+            builder, loc, builder.getI64Type(), result);
         Value heapCopy =
             func::CallOp::create(builder, loc, ptrTy, "__nvqpp_vectorCopyCtor",
                                  ValueRange{resBuff, dynSize, eleSize})
                 .getResult(0);
-        return cc::StdvecInitOp::create(builder, loc, resTy,
-                                        ValueRange{heapCopy, dynSize});
+        return cc::SequenceInitOp::create(builder, loc, resTy,
+                                          ValueRange{heapCopy, dynSize});
       };
       IRBuilder irb(builder);
       Value tySize;

--- a/cudaq/lib/Optimizer/Builder/Factory.cpp
+++ b/cudaq/lib/Optimizer/Builder/Factory.cpp
@@ -416,7 +416,7 @@ Type factory::getSRetElementType(FunctionType funcTy) {
 }
 
 Type factory::convertToHostSideType(Type ty, ModuleOp mod) {
-  if (auto memrefTy = dyn_cast<cc::StdvecType>(ty))
+  if (auto memrefTy = dyn_cast<cc::SequenceType>(ty))
     return stlHostVectorType(
         convertToHostSideType(memrefTy.getElementType(), mod));
   if (isa<cc::IndirectCallableType>(ty))
@@ -721,7 +721,7 @@ FunctionType factory::toHostSideFuncType(FunctionType funcTy, bool addThisPtr,
   return FunctionType::get(ctx, inputTys, resultTy);
 }
 
-bool factory::isStdVecArg(Type type) {
+bool factory::isSequenceArg(Type type) {
   auto ptrTy = dyn_cast<cc::PointerType>(type);
   if (!ptrTy)
     return false;
@@ -739,7 +739,7 @@ bool factory::isStdVecArg(Type type) {
     if (!dyn_cast<cc::PointerType>(memberTys[i]))
       return false;
 
-  // This is a stdvec type to us.
+  // This is a sequence type to us.
   return true;
 }
 

--- a/cudaq/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/cudaq/lib/Optimizer/Builder/Intrinsics.cpp
@@ -101,7 +101,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     // Initialize a (preallocated) buffer (the first parameter) with i64 values
     // on the semi-open range `[0..n)` where `n` is the second parameter.
     {cudaq::setCudaqRangeVector, {}, R"#(
-  func.func private @__nvqpp_CudaqRangeInit(%arg0: !cc.ptr<!cc.array<i64 x ?>>, %arg1: i64) -> !cc.stdvec<i64> {
+  func.func private @__nvqpp_CudaqRangeInit(%arg0: !cc.ptr<!cc.array<i64 x ?>>, %arg1: i64) -> !cc.sequence<i64> {
     %0 = arith.constant 0 : i64
     %1 = cc.loop while ((%i = %0) -> i64) {
       %w1 = arith.cmpi ult, %i, %arg1 : i64
@@ -117,8 +117,8 @@ static constexpr IntrinsicCode intrinsicTable[] = {
         %s1 = arith.addi %i, %one : i64
         cc.continue %s1 : i64
     } {invariant}
-    %2 = cc.stdvec_init %arg0, %arg1 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.stdvec<i64>
-    return %2 : !cc.stdvec<i64>
+    %2 = cc.sequence_init %arg0, %arg1 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.sequence<i64>
+    return %2 : !cc.sequence<i64>
   }
 )#"},
 
@@ -133,7 +133,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     // three parameters are assumed to be signed values, which is required to
     // have a decrementing loop.
     {cudaq::setCudaqRangeVectorTriple, {cudaq::getCudaqSizeFromTriple}, R"#(
-  func.func private @__nvqpp_CudaqRangeInitTriple(%arg0: !cc.ptr<!cc.array<i64 x ?>>, %arg1: i64, %arg2: i64, %arg3: i64) -> !cc.stdvec<i64> {
+  func.func private @__nvqpp_CudaqRangeInitTriple(%arg0: !cc.ptr<!cc.array<i64 x ?>>, %arg1: i64, %arg2: i64, %arg3: i64) -> !cc.sequence<i64> {
     %c1_i64 = arith.constant 1 : i64
     %c0_i64 = arith.constant 0 : i64
     %0 = call @__nvqpp_CudaqSizeFromTriple(%arg1, %arg2, %arg3) : (i64, i64, i64) -> i64
@@ -151,8 +151,8 @@ static constexpr IntrinsicCode intrinsicTable[] = {
       %4 = arith.addi %arg5, %arg3 : i64
       cc.continue %3, %4 : i64, i64
     } {invariant}
-    %2 = cc.stdvec_init %arg0, %0 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.stdvec<i64>
-    return %2 : !cc.stdvec<i64>
+    %2 = cc.sequence_init %arg0, %0 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.sequence<i64>
+    return %2 : !cc.sequence<i64>
   }
 )#"},
 
@@ -468,9 +468,9 @@ static constexpr IntrinsicCode intrinsicTable[] = {
 )#"},
 
     {cudaq::cudaqConvertToInteger, {}, R"#(
-  func.func private @__nvqpp_cudaqConvertToInteger(%arg : !cc.stdvec<i1>) -> i64 {
-    %size = cc.stdvec_size %arg : (!cc.stdvec<i1>) -> i64
-    %data = cc.stdvec_data %arg : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
+  func.func private @__nvqpp_cudaqConvertToInteger(%arg : !cc.sequence<i1>) -> i64 {
+    %size = cc.sequence_size %arg : (!cc.sequence<i1>) -> i64
+    %data = cc.sequence_data %arg : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
     %zero = arith.constant 0 : i64
     %one = arith.constant 1 : i64
     %res:2 = cc.loop while ((%i = %zero, %v = %zero) -> (i64, i64)) {
@@ -570,7 +570,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
 )#"},
 
     // __nvqpp_initializer_list_to_vector_bool
-    {cudaq::stdvecBoolCtorFromInitList, {}, R"#(
+    {cudaq::sequenceBoolCtorFromInitList, {}, R"#(
   func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64) -> ())#"},
 
     // This helper function copies a buffer off the stack to the heap. This is
@@ -598,7 +598,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   })#"},
 
     // __nvqpp_vector_bool_free_temporary_lists
-    {cudaq::stdvecBoolFreeTemporaryLists, {}, R"#(
+    {cudaq::sequenceBoolFreeTemporaryLists, {}, R"#(
   func.func private @__nvqpp_vector_bool_free_temporary_initlists(!cc.ptr<i8>) -> ()
 )#"},
 
@@ -606,7 +606,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     // The array size is factory::stdVecBoolPaddingSize to match the host
     // std::vector<bool> layout. The {PADDING_SIZE} placeholder is replaced
     // at load time.
-    {cudaq::stdvecBoolUnpackToInitList, {}, R"#(
+    {cudaq::sequenceBoolUnpackToInitList, {}, R"#(
   func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x {PADDING_SIZE}>}>>, !cc.ptr<!cc.ptr<i8>>) -> ()
 )#"},
 
@@ -925,9 +925,9 @@ LogicalResult IRBuilder::loadIntrinsic(ModuleOp module, StringRef intrinName) {
       return failure();
   }
   // Now load the requested code.
-  // For stdvecBoolUnpackToInitList, replace the {PADDING_SIZE} placeholder
+  // For sequenceBoolUnpackToInitList, replace the {PADDING_SIZE} placeholder
   // with the actual padding size for the host's std::vector<bool>.
-  if (intrinName == cudaq::stdvecBoolUnpackToInitList) {
+  if (intrinName == cudaq::sequenceBoolUnpackToInitList) {
     std::string code = iter->code.str();
     const std::string placeholder = "{PADDING_SIZE}";
     auto pos = code.find(placeholder);

--- a/cudaq/lib/Optimizer/Builder/Marshal.cpp
+++ b/cudaq/lib/Optimizer/Builder/Marshal.cpp
@@ -28,8 +28,8 @@ Value genStringLength(Location loc, OpBuilder &builder, Value stringArg,
   if constexpr (FromQPU) {
     Type stringTy = stringArg.getType();
     assert(isa<cudaq::cc::CharspanType>(stringTy));
-    return cudaq::cc::StdvecSizeOp::create(builder, loc, builder.getI64Type(),
-                                           stringArg);
+    return cudaq::cc::SequenceSizeOp::create(builder, loc, builder.getI64Type(),
+                                             stringArg);
   } else /*constexpr */ {
     Type stringTy = stringArg.getType();
     assert(isa<cudaq::cc::PointerType>(stringTy) &&
@@ -70,9 +70,9 @@ template <bool FromQPU>
 Value genVectorSize(Location loc, OpBuilder &builder, Value vecArg) {
   if constexpr (FromQPU) {
     Type vecArgTy = vecArg.getType();
-    assert(isa<cudaq::cc::StdvecType>(vecArgTy));
-    return cudaq::cc::StdvecSizeOp::create(builder, loc, builder.getI64Type(),
-                                           vecArg);
+    assert(isa<cudaq::cc::SequenceType>(vecArgTy));
+    return cudaq::cc::SequenceSizeOp::create(builder, loc, builder.getI64Type(),
+                                             vecArg);
   } else /* constexpr */ {
     auto vecTy = cast<cudaq::cc::PointerType>(vecArg.getType());
     auto vecStructTy = cast<cudaq::cc::StructType>(vecTy.getElementType());
@@ -157,7 +157,7 @@ genByteSizeAndElementCount(Location loc, OpBuilder &builder, ModuleOp module,
                            Type eleTy, Value size, Value arg, Type t) {
   // If this is a vector<vector<...>>, convert the bytes of vector to bytes of
   // length (i64).
-  if (auto sty = dyn_cast<cudaq::cc::StdvecType>(eleTy)) {
+  if (auto sty = dyn_cast<cudaq::cc::SequenceType>(eleTy)) {
     auto eTy = cast<cudaq::cc::PointerType>(arg.getType()).getElementType();
     auto fTy = cast<cudaq::cc::StructType>(eTy).getMember(0);
     auto tTy = cast<cudaq::cc::PointerType>(fTy).getElementType();
@@ -199,21 +199,21 @@ genByteSizeAndElementCount(Location loc, OpBuilder &builder, ModuleOp module,
   return {};
 }
 
-static bool isStdVectorBool(Type ty) {
-  auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(ty);
-  return stdvecTy &&
-         (stdvecTy.getElementType() == IntegerType::get(ty.getContext(), 1));
+static bool isSequenceBool(Type ty) {
+  auto sequenceTy = dyn_cast<cudaq::cc::SequenceType>(ty);
+  return sequenceTy &&
+         (sequenceTy.getElementType() == IntegerType::get(ty.getContext(), 1));
 }
 
 /// Recursively check if \p ty contains a `std::vector<bool>`.
-static bool hasStdVectorBool(Type ty) {
-  if (isStdVectorBool(ty))
+static bool hasSequenceBool(Type ty) {
+  if (isSequenceBool(ty))
     return true;
-  if (auto sty = dyn_cast<cudaq::cc::StdvecType>(ty))
-    return hasStdVectorBool(sty.getElementType());
+  if (auto sty = dyn_cast<cudaq::cc::SequenceType>(ty))
+    return hasSequenceBool(sty.getElementType());
   if (auto sty = dyn_cast<cudaq::cc::StructType>(ty))
     for (auto mem : sty.getMembers())
-      if (hasStdVectorBool(mem))
+      if (hasSequenceBool(mem))
         return true;
   return false;
 }
@@ -223,11 +223,11 @@ static bool hasStdVectorBool(Type ty) {
 // of 40 bytes on libstdc++ (Linux) or 24 bytes on libc++ (macOS). The latter
 // is identical to `std::vector<char>` (which has a size of 24 bytes).
 static Type convertToTransientType(Type ty, ModuleOp mod) {
-  if (isStdVectorBool(ty)) {
+  if (isSequenceBool(ty)) {
     auto *ctx = ty.getContext();
     return cudaq::opt::factory::stlVectorType(IntegerType::get(ctx, 1));
   }
-  if (auto sty = dyn_cast<cudaq::cc::StdvecType>(ty))
+  if (auto sty = dyn_cast<cudaq::cc::SequenceType>(ty))
     return cudaq::opt::factory::stlVectorType(
         convertToTransientType(sty.getElementType(), mod));
   if (auto sty = dyn_cast<cudaq::cc::StructType>(ty)) {
@@ -245,28 +245,28 @@ static Type convertToTransientType(Type ty, ModuleOp mod) {
 // into a std::vector<char>. This conversion allows us to use all the same code
 // as every other std::vector<T> to marshal the argument.
 static std::pair<Value, bool>
-convertAllStdVectorBool(Location loc, OpBuilder &builder, ModuleOp module,
-                        Value arg, Type ty, Value heapTracker,
-                        std::optional<Value> preallocated = {}) {
+convertAllSequenceBool(Location loc, OpBuilder &builder, ModuleOp module,
+                       Value arg, Type ty, Value heapTracker,
+                       std::optional<Value> preallocated = {}) {
   // If we are here, `ty` must be a `std::vector<bool>` or recursively contain a
   // `std::vector<bool>`.
 
   // Handle `std::vector<bool>`.
-  if (isStdVectorBool(ty)) {
-    auto stdvecTy = cast<cudaq::cc::StdvecType>(ty);
-    Type stdvecHostTy =
-        cudaq::opt::factory::stlVectorType(stdvecTy.getElementType());
+  if (isSequenceBool(ty)) {
+    auto sequenceTy = cast<cudaq::cc::SequenceType>(ty);
+    Type sequenceHostTy =
+        cudaq::opt::factory::stlVectorType(sequenceTy.getElementType());
     Value tmp = preallocated.has_value()
                     ? *preallocated
-                    : cudaq::cc::AllocaOp::create(builder, loc, stdvecHostTy);
+                    : cudaq::cc::AllocaOp::create(builder, loc, sequenceHostTy);
     func::CallOp::create(builder, loc, TypeRange{},
-                         cudaq::stdvecBoolUnpackToInitList,
+                         cudaq::sequenceBoolUnpackToInitList,
                          ArrayRef<Value>{tmp, arg, heapTracker});
     return {tmp, true};
   }
 
   // Handle `std::vector<T>` where `T` != `bool`.
-  if (auto sty = dyn_cast<cudaq::cc::StdvecType>(ty)) {
+  if (auto sty = dyn_cast<cudaq::cc::SequenceType>(ty)) {
     // arg is a std::vector<T>.
     // It's type must be ptr<struct<ptr<T>, ptr<T>, ptr<T>>>.
     auto seleTy = sty.getElementType();
@@ -349,8 +349,8 @@ convertAllStdVectorBool(Location loc, OpBuilder &builder, ModuleOp module,
           auto currentVector = cudaq::cc::ComputePtrOp::create(
               builder, loc, cudaq::cc::PointerType::get(transientEleTy), buffer,
               ArrayRef<cudaq::cc::ComputePtrArg>{i});
-          convertAllStdVectorBool(loc, builder, module, inp, seleTy,
-                                  heapTracker, currentVector);
+          convertAllSequenceBool(loc, builder, module, inp, seleTy, heapTracker,
+                                 currentVector);
         });
     return {tmp, true};
   }
@@ -381,8 +381,8 @@ convertAllStdVectorBool(Location loc, OpBuilder &builder, ModuleOp module,
       Value toPtr = cudaq::cc::ComputePtrOp::create(
           builder, loc, cudaq::cc::PointerType::get(transientTy), buffer,
           ArrayRef<cudaq::cc::ComputePtrArg>{i});
-      convertAllStdVectorBool(loc, builder, module, fromPtr, memTy, heapTracker,
-                              toPtr);
+      convertAllSequenceBool(loc, builder, module, fromPtr, memTy, heapTracker,
+                             toPtr);
     }
     return {buffer, true};
   }
@@ -390,11 +390,11 @@ convertAllStdVectorBool(Location loc, OpBuilder &builder, ModuleOp module,
 }
 
 std::pair<Value, bool>
-cudaq::opt::marshal::unpackAnyStdVectorBool(Location loc, OpBuilder &builder,
-                                            ModuleOp module, Value arg, Type ty,
-                                            Value heapTracker) {
-  if (hasStdVectorBool(ty))
-    return convertAllStdVectorBool(loc, builder, module, arg, ty, heapTracker);
+cudaq::opt::marshal::unpackAnySequenceBool(Location loc, OpBuilder &builder,
+                                           ModuleOp module, Value arg, Type ty,
+                                           Value heapTracker) {
+  if (hasSequenceBool(ty))
+    return convertAllSequenceBool(loc, builder, module, arg, ty, heapTracker);
   return {arg, false};
 }
 
@@ -413,7 +413,7 @@ Value descendThroughDynamicType(Location loc, OpBuilder &builder,
             return genStringLength<FromQPU>(loc, builder, arg, module);
           })
           // A std::vector is dynamic and may be recursive dynamic as well.
-          .Case([&](cudaq::cc::StdvecType t) -> Value {
+          .Case([&](cudaq::cc::SequenceType t) -> Value {
             // Compute the byte span of the vector.
             Value size = genVectorSize<FromQPU>(loc, builder, arg);
             auto eleTy = t.getElementType();
@@ -526,7 +526,7 @@ Value populateStringAddendum(Location loc, OpBuilder &builder, Value host,
   auto ptrI8Ty = cudaq::cc::PointerType::get(builder.getI8Type());
   Value dataPtr;
   if constexpr (FromQPU) {
-    dataPtr = cudaq::cc::StdvecDataOp::create(builder, loc, ptrI8Ty, host);
+    dataPtr = cudaq::cc::SequenceDataOp::create(builder, loc, ptrI8Ty, host);
   } else /*constexpr*/ {
     auto fromPtr = cudaq::cc::CastOp::create(builder, loc, ptrI8Ty, host);
     StringRef helperName = module->getAttr(cudaq::runtime::sizeofStringAttrName)
@@ -557,10 +557,11 @@ Value populateVectorAddendum(Location loc, OpBuilder &builder, Value host,
   auto ptrPtrI8 = cudaq::opt::marshal::getPointerToPointerType(builder);
   Value dataPtr = [&]() -> Value {
     if constexpr (FromQPU) {
-      auto eleTy = cast<cudaq::cc::StdvecType>(host.getType()).getElementType();
+      auto eleTy =
+          cast<cudaq::cc::SequenceType>(host.getType()).getElementType();
       auto ptrTy = cudaq::cc::PointerType::get(eleTy);
       auto vecDataPtr =
-          cudaq::cc::StdvecDataOp::create(builder, loc, ptrTy, host);
+          cudaq::cc::SequenceDataOp::create(builder, loc, ptrTy, host);
       return cudaq::cc::CastOp::create(builder, loc, ptrI8Ty, vecDataPtr);
     } else /*constexpr*/ {
       auto fromPtrPtr = cudaq::cc::CastOp::create(builder, loc, ptrPtrI8, host);
@@ -585,7 +586,7 @@ Value populateDynamicAddendum(Location loc, OpBuilder &builder, ModuleOp module,
   if (isa<cudaq::cc::CharspanType>(devArgTy))
     return populateStringAddendum<FromQPU>(loc, builder, host, sizeSlot,
                                            addendum, module);
-  if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(devArgTy)) {
+  if (auto vecTy = dyn_cast<cudaq::cc::SequenceType>(devArgTy)) {
     auto eleTy = vecTy.getElementType();
     if (cudaq::cc::isDynamicType(eleTy)) {
       // Recursive case. Visit each dynamic element, copying it.
@@ -817,21 +818,21 @@ std::pair<bool, func::FuncOp> cudaq::opt::marshal::lookupHostEntryPointFunc(
   return {true, func::FuncOp{}};
 }
 
-void cudaq::opt::marshal::genStdvecBoolFromInitList(Location loc,
-                                                    OpBuilder &builder,
-                                                    Value sret, Value data,
-                                                    Value size) {
+void cudaq::opt::marshal::genSequenceBoolFromInitList(Location loc,
+                                                      OpBuilder &builder,
+                                                      Value sret, Value data,
+                                                      Value size) {
   auto ptrTy = cc::PointerType::get(builder.getContext());
   auto castData = cc::CastOp::create(builder, loc, ptrTy, data);
   auto castSret = cc::CastOp::create(builder, loc, ptrTy, sret);
-  func::CallOp::create(builder, loc, TypeRange{}, stdvecBoolCtorFromInitList,
+  func::CallOp::create(builder, loc, TypeRange{}, sequenceBoolCtorFromInitList,
                        ArrayRef<Value>{castSret, castData, size});
 }
 
-void cudaq::opt::marshal::genStdvecTFromInitList(Location loc,
-                                                 OpBuilder &builder, Value sret,
-                                                 Value data, Value tSize,
-                                                 Value vecSize) {
+void cudaq::opt::marshal::genSequenceTFromInitList(Location loc,
+                                                   OpBuilder &builder,
+                                                   Value sret, Value data,
+                                                   Value tSize, Value vecSize) {
   auto i8Ty = builder.getI8Type();
   auto stlVectorTy = cc::PointerType::get(opt::factory::stlVectorType(i8Ty));
   auto ptrTy = cc::PointerType::get(i8Ty);
@@ -883,7 +884,7 @@ void cudaq::opt::marshal::maybeFreeHeapAllocations(Location loc,
                      OpBuilder::InsertionGuard guard(builder);
                      builder.setInsertionPointToStart(&body);
                      func::CallOp::create(builder, loc, TypeRange{},
-                                          stdvecBoolFreeTemporaryLists,
+                                          sequenceBoolFreeTemporaryLists,
                                           ArrayRef<Value>{head});
                      cc::ContinueOp::create(builder, loc);
                    });
@@ -973,12 +974,12 @@ constructDynamicInputValue(Location loc, OpBuilder &builder, Type devTy,
   assert(cudaq::cc::isDynamicType(devTy) && "must be dynamic type");
   if constexpr (FromQPU) {
     if (auto charSpanTy = dyn_cast<cudaq::cc::CharspanType>(devTy)) {
-      // From host, so construct the stdvec span with it.
+      // From host, so construct the sequence span with it.
       auto eleTy = charSpanTy.getElementType();
       auto castTrailingData = cudaq::cc::CastOp::create(
           builder, loc, cudaq::cc::PointerType::get(eleTy), trailingData);
       Value vecLength = cudaq::cc::LoadOp::create(builder, loc, ptr);
-      auto result = cudaq::cc::StdvecInitOp::create(
+      auto result = cudaq::cc::SequenceInitOp::create(
           builder, loc, charSpanTy, castTrailingData, vecLength);
       auto nextTrailingData =
           incrementTrailingDataPointer(loc, builder, trailingData, vecLength);
@@ -1003,7 +1004,7 @@ constructDynamicInputValue(Location loc, OpBuilder &builder, Type devTy,
 
     if (cudaq::cc::isDynamicType(eleTy)) {
       // The vector is recursively dynamic.
-      // Create a new block in which to place the stdvec/struct data. The
+      // Create a new block in which to place the sequence/struct data. The
       // trailing data is in device-side format (pointer-free spans).
       Type toTy = [&]() {
         // From QPU, so we want to unpack the data into vectors (of vectors).
@@ -1052,12 +1053,12 @@ constructDynamicInputValue(Location loc, OpBuilder &builder, Type devTy,
             cudaq::cc::StoreOp::create(builder, loc, r.second, trailingDataVar);
           });
 
-      // Create the new outer stdvec span as the result.
-      Value stdvecResult = cudaq::cc::StdvecInitOp::create(
+      // Create the new outer sequence span as the result.
+      Value sequenceResult = cudaq::cc::SequenceInitOp::create(
           builder, loc, spanTy, newVecData, vecLength);
       nextTrailingData =
           cudaq::cc::LoadOp::create(builder, loc, trailingDataVar);
-      return {stdvecResult, nextTrailingData};
+      return {sequenceResult, nextTrailingData};
     }
 
     // This vector has constant data, so just use the data in-place.
@@ -1085,11 +1086,11 @@ constructDynamicInputValue(Location loc, OpBuilder &builder, Type devTy,
       result = cudaq::cc::InsertValueOp::create(builder, loc, vecTy, vecVar,
                                                 castEnd, 2);
     } else /*constexpr*/ {
-      // From host, so construct the stdvec span with it.
+      // From host, so construct the sequence span with it.
       auto castTrailingData = cudaq::cc::CastOp::create(
           builder, loc, cudaq::cc::PointerType::get(eleTy), trailingData);
-      result = cudaq::cc::StdvecInitOp::create(builder, loc, spanTy,
-                                               castTrailingData, vecLength);
+      result = cudaq::cc::SequenceInitOp::create(builder, loc, spanTy,
+                                                 castTrailingData, vecLength);
     }
     auto nextTrailingData =
         incrementTrailingDataPointer(loc, builder, trailingData, bytes);
@@ -1141,7 +1142,7 @@ processInputValueImpl(Location loc, OpBuilder &builder, Value trailingData,
     if constexpr (FromQPU) {
       auto dynamo = constructDynamicInputValue<FromQPU>(
           loc, builder, inTy, packedPtr, trailingData);
-      if (isa<cudaq::cc::StdvecType>(inTy)) {
+      if (isa<cudaq::cc::SequenceType>(inTy)) {
         Value retVal = dynamo.first;
         Value tmp = cudaq::cc::AllocaOp::create(builder, loc, retVal.getType());
         cudaq::cc::StoreOp::create(builder, loc, retVal, tmp);
@@ -1154,10 +1155,10 @@ processInputValueImpl(Location loc, OpBuilder &builder, Value trailingData,
         Value tmp = cudaq::cc::AllocaOp::create(builder, loc, arrTy);
         auto ptrTy = cudaq::cc::PointerType::get(builder.getI8Type());
         Value castTmp = cudaq::cc::CastOp::create(builder, loc, ptrTy, tmp);
-        Value len = cudaq::cc::StdvecSizeOp::create(
+        Value len = cudaq::cc::SequenceSizeOp::create(
             builder, loc, builder.getI64Type(), dynamo.first);
-        Value data =
-            cudaq::cc::StdvecDataOp::create(builder, loc, ptrTy, dynamo.first);
+        Value data = cudaq::cc::SequenceDataOp::create(builder, loc, ptrTy,
+                                                       dynamo.first);
         func::CallOp::create(builder, loc, TypeRange{},
                              cudaq::runtime::bindingInitializeString,
                              ArrayRef<Value>{castTmp, data, len});

--- a/cudaq/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -634,13 +634,13 @@ public:
   }
 };
 
-class StdvecDataOpPattern
-    : public ConvertOpToLLVMPattern<cudaq::cc::StdvecDataOp> {
+class SequenceDataOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::SequenceDataOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(cudaq::cc::StdvecDataOp data, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::cc::SequenceDataOp data, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operands = adaptor.getOperands();
     auto resTy = getTypeConverter()->convertType(data.getType());
@@ -648,7 +648,7 @@ public:
     auto zero = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{0});
     auto structTy = dyn_cast<LLVM::LLVMStructType>(operands[0].getType());
     if (!structTy)
-      return data.emitError("stdvec_data must have a struct as argument.");
+      return data.emitError("sequence_data must have a struct as argument.");
     auto extract = LLVM::ExtractValueOp::create(
         rewriter, data.getLoc(), structTy.getBody()[0], operands[0], zero);
     rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(data, resTy, extract);
@@ -656,13 +656,13 @@ public:
   }
 };
 
-class StdvecInitOpPattern
-    : public ConvertOpToLLVMPattern<cudaq::cc::StdvecInitOp> {
+class SequenceInitOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::SequenceInitOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(cudaq::cc::StdvecInitOp init, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::cc::SequenceInitOp init, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operands = adaptor.getOperands();
     auto resTy = getTypeConverter()->convertType(init.getType());
@@ -672,7 +672,7 @@ public:
     Value val = LLVM::UndefOp::create(rewriter, loc, resTy);
     auto structTy = dyn_cast<LLVM::LLVMStructType>(resTy);
     if (!structTy)
-      return init.emitError("stdvec_init must have a struct as argument.");
+      return init.emitError("sequence_init must have a struct as argument.");
     auto yolo = LLVM::BitcastOp::create(rewriter, loc, structTy.getBody()[0],
                                         operands[0]);
     val = LLVM::InsertValueOp::create(rewriter, loc, val, yolo, zero);
@@ -695,13 +695,13 @@ public:
   }
 };
 
-class StdvecSizeOpPattern
-    : public ConvertOpToLLVMPattern<cudaq::cc::StdvecSizeOp> {
+class SequenceSizeOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::SequenceSizeOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(cudaq::cc::StdvecSizeOp size, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::cc::SequenceSizeOp size, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operands = adaptor.getOperands();
     auto resTy = getTypeConverter()->convertType(size.getType());
@@ -836,14 +836,14 @@ class NoInlineCallPattern
 
 void cudaq::opt::populateCCToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                           RewritePatternSet &patterns) {
-  patterns
-      .insert<AddressOfOpPattern, AllocaOpPattern, CallableClosureOpPattern,
-              CallableFuncOpPattern, CallCallableOpPattern,
-              CallIndirectCallableOpPattern, CastOpPattern, ComputePtrOpPattern,
-              CreateStringLiteralOpPattern, ExtractValueOpPattern,
-              FuncToPtrOpPattern, GlobalOpPattern, InsertValueOpPattern,
-              InstantiateCallableOpPattern, LoadOpPattern, NoInlineCallPattern,
-              OffsetOfOpPattern, PoisonOpPattern, SizeOfOpPattern,
-              StdvecDataOpPattern, StdvecInitOpPattern, StdvecSizeOpPattern,
-              StoreOpPattern, UndefOpPattern, VarargCallPattern>(typeConverter);
+  patterns.insert<
+      AddressOfOpPattern, AllocaOpPattern, CallableClosureOpPattern,
+      CallableFuncOpPattern, CallCallableOpPattern,
+      CallIndirectCallableOpPattern, CastOpPattern, ComputePtrOpPattern,
+      CreateStringLiteralOpPattern, ExtractValueOpPattern, FuncToPtrOpPattern,
+      GlobalOpPattern, InsertValueOpPattern, InstantiateCallableOpPattern,
+      LoadOpPattern, NoInlineCallPattern, OffsetOfOpPattern, PoisonOpPattern,
+      SizeOfOpPattern, SequenceDataOpPattern, SequenceInitOpPattern,
+      SequenceSizeOpPattern, StoreOpPattern, UndefOpPattern, VarargCallPattern>(
+      typeConverter);
 }

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIR.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIR.cpp
@@ -82,7 +82,7 @@ public:
     SmallVector<Operation *> cleanUps;
     getOperation().walk([&](cudaq::cc::ConstantArrayOp carr) {
       // If there is a constant array, then we expect that it is involved in
-      // a stdvec initializer expression. So look for the pattern and expand
+      // a sequence initializer expression. So look for the pattern and expand
       // the store into a series of scalar stores.
       //
       //   %100 = cc.const_array [c1, c2, ... cN] : ...

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -160,7 +160,7 @@ struct QIRAPITypeConverter : public TypeConverter {
       return IntegerType::get(ty.getContext(), 64);
     });
     // Recursively convert handle / quake types nested in CC array and
-    // stdvec types so that container-shaped function signatures, allocations,
+    // sequence types so that container-shaped function signatures, allocations,
     // and pointers see consistent post-conversion element types.
     addConversion([&](cudaq::cc::ArrayType ty) -> Type {
       Type newEleTy = convertType(ty.getElementType());
@@ -170,11 +170,11 @@ struct QIRAPITypeConverter : public TypeConverter {
         return cudaq::cc::ArrayType::get(newEleTy);
       return cudaq::cc::ArrayType::get(ty.getContext(), newEleTy, ty.getSize());
     });
-    addConversion([&](cudaq::cc::StdvecType ty) -> Type {
+    addConversion([&](cudaq::cc::SequenceType ty) -> Type {
       Type newEleTy = convertType(ty.getElementType());
       if (newEleTy == ty.getElementType())
         return ty;
-      return cudaq::cc::StdvecType::get(ty.getContext(), newEleTy);
+      return cudaq::cc::SequenceType::get(ty.getContext(), newEleTy);
     });
   }
 
@@ -468,13 +468,13 @@ struct ApplyNoiseOpRewrite
       SmallVector<Value> args;
       const bool pushASpan =
           adaptor.getParameters().size() == 1 &&
-          isa<cudaq::cc::StdvecType>(getInitialType(noise, paramOffset));
+          isa<cudaq::cc::SequenceType>(getInitialType(noise, paramOffset));
       const bool usingDouble = [&]() {
         if (adaptor.getParameters().empty())
           return true;
         Type param0Ty = getInitialType(noise, paramOffset);
         if (pushASpan)
-          return cast<cudaq::cc::StdvecType>(param0Ty).getElementType() ==
+          return cast<cudaq::cc::SequenceType>(param0Ty).getElementType() ==
                  rewriter.getF64Type();
         return cast<cudaq::cc::PointerType>(param0Ty).getElementType() ==
                rewriter.getF64Type();
@@ -504,15 +504,15 @@ struct ApplyNoiseOpRewrite
       args.push_back(
           arith::ConstantIntOp::create(rewriter, loc, numTargets, 64));
       if (pushASpan) {
-        Value stdvec = adaptor.getParameters()[0];
-        auto stdvecTy =
-            cast<cudaq::cc::StdvecType>(getInitialType(noise, paramOffset));
+        Value sequence = adaptor.getParameters()[0];
+        auto sequenceTy =
+            cast<cudaq::cc::SequenceType>(getInitialType(noise, paramOffset));
         auto dataTy = cudaq::cc::PointerType::get(
-            cudaq::cc::ArrayType::get(stdvecTy.getElementType()));
+            cudaq::cc::ArrayType::get(sequenceTy.getElementType()));
         args.push_back(
-            cudaq::cc::StdvecDataOp::create(rewriter, loc, dataTy, stdvec));
-        args.push_back(cudaq::cc::StdvecSizeOp::create(
-            rewriter, loc, rewriter.getI64Type(), stdvec));
+            cudaq::cc::SequenceDataOp::create(rewriter, loc, dataTy, sequence));
+        args.push_back(cudaq::cc::SequenceSizeOp::create(
+            rewriter, loc, rewriter.getI64Type(), sequence));
       } else {
         args.append(adaptor.getParameters().begin(),
                     adaptor.getParameters().end());
@@ -547,22 +547,22 @@ struct ApplyNoiseOpRewrite
     // already the case, we just append the operands.
     SmallVector<Value> args;
     if (adaptor.getParameters().size() == 1 &&
-        isa<cudaq::cc::StdvecType>(getInitialType(noise, paramOffset))) {
+        isa<cudaq::cc::SequenceType>(getInitialType(noise, paramOffset))) {
       Value svp = adaptor.getParameters()[0];
       // Convert the device-side span back to a host-side vector so that C++
       // doesn't crash.
-      auto stdvecTy =
-          cast<cudaq::cc::StdvecType>(getInitialType(noise, paramOffset));
+      auto sequenceTy =
+          cast<cudaq::cc::SequenceType>(getInitialType(noise, paramOffset));
       auto *ctx = rewriter.getContext();
-      auto ptrTy = cudaq::cc::PointerType::get(stdvecTy.getElementType());
+      auto ptrTy = cudaq::cc::PointerType::get(sequenceTy.getElementType());
       auto ptrArrTy = cudaq::cc::PointerType::get(
-          cudaq::cc::ArrayType::get(stdvecTy.getElementType()));
+          cudaq::cc::ArrayType::get(sequenceTy.getElementType()));
       auto hostVecTy = cudaq::cc::ArrayType::get(ctx, ptrTy, 3);
       auto hostVec = cudaq::cc::AllocaOp::create(rewriter, loc, hostVecTy);
       Value startPtr =
-          cudaq::cc::StdvecDataOp::create(rewriter, loc, ptrArrTy, svp);
+          cudaq::cc::SequenceDataOp::create(rewriter, loc, ptrArrTy, svp);
       auto i64Ty = rewriter.getI64Type();
-      Value len = cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, svp);
+      Value len = cudaq::cc::SequenceSizeOp::create(rewriter, loc, i64Ty, svp);
       Value endPtr = cudaq::cc::ComputePtrOp::create(
           rewriter, loc, ptrTy, startPtr,
           ArrayRef<cudaq::cc::ComputePtrArg>{len});
@@ -611,7 +611,7 @@ struct ApplyNoiseOpRewrite
     for (auto [qb, oa] : llvm::zip(adaptor.getQubits(), origQubitTys)) {
       if (isa<cudaq::quake::VeqType>(oa)) {
         auto svec = func::CallOp::create(rewriter, loc, qirArrTy,
-                                         cudaq::opt::QISConvertArrayToStdvec,
+                                         cudaq::opt::QISConvertArrayToSequence,
                                          ValueRange{qb});
         qb = svec.getResult(0);
         converted.push_back(qb);
@@ -623,7 +623,7 @@ struct ApplyNoiseOpRewrite
                                               *noise.getNoiseFunc(), args);
     for (auto v : converted)
       func::CallOp::create(rewriter, loc, TypeRange{},
-                           cudaq::opt::QISFreeConvertedStdvec, ValueRange{v});
+                           cudaq::opt::QISFreeConvertedSequence, ValueRange{v});
     return success();
   }
 };
@@ -2153,14 +2153,14 @@ using UndefOpPattern = OpInterfacePattern<cudaq::cc::UndefOp>;
 using PoisonOpPattern = OpInterfacePattern<cudaq::cc::PoisonOp>;
 using CastOpPattern = OpInterfacePattern<cudaq::cc::CastOp>;
 using SelectOpPattern = OpInterfacePattern<arith::SelectOp>;
-// Pointer-arithmetic and `stdvec` accessors carry pointer/`stdvec` types whose
-// element types may need conversion (notably `!cc.measure_handle` -> `i64`).
-// Without explicit patterns the type converter inserts unrealized casts on
-// their results that the partial conversion cannot resolve.
+// Pointer-arithmetic and `sequence` accessors carry pointer/`sequence` types
+// whose element types may need conversion (notably `!cc.measure_handle` ->
+// `i64`). Without explicit patterns the type converter inserts unrealized casts
+// on their results that the partial conversion cannot resolve.
 using ComputePtrOpPattern = OpInterfacePattern<cudaq::cc::ComputePtrOp>;
-using StdvecDataOpPattern = OpInterfacePattern<cudaq::cc::StdvecDataOp>;
-using StdvecInitOpPattern = OpInterfacePattern<cudaq::cc::StdvecInitOp>;
-using StdvecSizeOpPattern = OpInterfacePattern<cudaq::cc::StdvecSizeOp>;
+using SequenceDataOpPattern = OpInterfacePattern<cudaq::cc::SequenceDataOp>;
+using SequenceInitOpPattern = OpInterfacePattern<cudaq::cc::SequenceInitOp>;
+using SequenceSizeOpPattern = OpInterfacePattern<cudaq::cc::SequenceSizeOp>;
 
 struct InstantiateCallablePattern
     : public OpConversionPattern<cudaq::cc::InstantiateCallableOp> {
@@ -2268,15 +2268,16 @@ struct CallableClosurePattern
 static void commonClassicalHandlingPatterns(RewritePatternSet &patterns,
                                             TypeConverter &typeConverter,
                                             MLIRContext *ctx) {
-  patterns.insert<
-      AllocaOpPattern, BranchOpPattern, CallableClosurePattern,
-      CallableFuncPattern, CallCallableOpPattern, CallIndirectCallableOpPattern,
-      CallIndirectOpPattern, CallOpPattern, CallNoInlineOpPattern,
-      CallVarargOpPattern, CastOpPattern, CondBranchOpPattern,
-      ComputePtrOpPattern, CreateLambdaPattern, FuncConstantPattern,
-      FuncSignaturePattern, FuncToPtrPattern, InstantiateCallablePattern,
-      LoadOpPattern, PoisonOpPattern, SelectOpPattern, StdvecDataOpPattern,
-      StdvecInitOpPattern, StdvecSizeOpPattern, StoreOpPattern, UndefOpPattern>(
+  patterns.insert<AllocaOpPattern, BranchOpPattern, CallableClosurePattern,
+                  CallableFuncPattern, CallCallableOpPattern,
+                  CallIndirectCallableOpPattern, CallIndirectOpPattern,
+                  CallOpPattern, CallNoInlineOpPattern, CallVarargOpPattern,
+                  CastOpPattern, CondBranchOpPattern, ComputePtrOpPattern,
+                  CreateLambdaPattern, FuncConstantPattern,
+                  FuncSignaturePattern, FuncToPtrPattern,
+                  InstantiateCallablePattern, LoadOpPattern, PoisonOpPattern,
+                  SelectOpPattern, SequenceDataOpPattern, SequenceInitOpPattern,
+                  SequenceSizeOpPattern, StoreOpPattern, UndefOpPattern>(
       typeConverter, ctx);
 }
 
@@ -2306,12 +2307,12 @@ static Type getQIRResultPtrType(const TypeConverter *converter,
 // Compute a `(Result**, i64 size)` pair for a variadic measurement-handle
 // operand list. Three shapes are handled:
 //
-//   1. Single `!cc.stdvec<i64>` operand — pass through `(data, size)`
+//   1. Single `!cc.sequence<i64>` operand — pass through `(data, size)`
 //      with no copy.
 //   2. All `i64` (scalar) operands — allocate a `Result*[N]` buffer and
 //      store each operand cast to `Result*`. Count is statically known.
-//   3. Mixed scalar + stdvec, or multiple vectors — allocate a dynamic-
-//      size `Result*[total]` buffer and copy each stdvec via a counted
+//   3. Mixed scalar + sequence, or multiple vectors — allocate a dynamic-
+//      size `Result*[total]` buffer and copy each sequence via a counted
 //      `cc.loop` while storing each scalar at the running offset.
 static std::pair<Value, Value>
 packMeasurementHandles(Location loc, ConversionPatternRewriter &rewriter,
@@ -2319,15 +2320,16 @@ packMeasurementHandles(Location loc, ConversionPatternRewriter &rewriter,
   auto i64Ty = rewriter.getI64Type();
   auto ptrToPtrTy = cudaq::cc::PointerType::get(resultPtrTy);
 
-  // Single-stdvec fast path: zero-copy pass-through.
+  // Single-sequence fast path: zero-copy pass-through.
   if (operands.size() == 1 &&
-      isa<cudaq::cc::StdvecType>(operands.front().getType())) {
+      isa<cudaq::cc::SequenceType>(operands.front().getType())) {
     Value vec = operands.front();
-    auto stdvecTy = cast<cudaq::cc::StdvecType>(vec.getType());
+    auto sequenceTy = cast<cudaq::cc::SequenceType>(vec.getType());
     auto dataPtrTy = cudaq::cc::PointerType::get(
-        cudaq::cc::ArrayType::get(stdvecTy.getElementType()));
-    Value data = cudaq::cc::StdvecDataOp::create(rewriter, loc, dataPtrTy, vec);
-    Value size = cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, vec);
+        cudaq::cc::ArrayType::get(sequenceTy.getElementType()));
+    Value data =
+        cudaq::cc::SequenceDataOp::create(rewriter, loc, dataPtrTy, vec);
+    Value size = cudaq::cc::SequenceSizeOp::create(rewriter, loc, i64Ty, vec);
     Value asPtrPtr = cudaq::cc::CastOp::create(rewriter, loc, ptrToPtrTy, data);
     return {asPtrPtr, size};
   }
@@ -2361,7 +2363,7 @@ packMeasurementHandles(Location loc, ConversionPatternRewriter &rewriter,
     Value contribution =
         isa<IntegerType>(v.getType())
             ? one
-            : cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, v)
+            : cudaq::cc::SequenceSizeOp::create(rewriter, loc, i64Ty, v)
                   .getResult();
     totalSize = arith::AddIOp::create(rewriter, loc, totalSize, contribution);
   }
@@ -2378,13 +2380,14 @@ packMeasurementHandles(Location loc, ConversionPatternRewriter &rewriter,
       cudaq::cc::StoreOp::create(rewriter, loc, resultPtr, dest);
       offset = arith::AddIOp::create(rewriter, loc, offset, one);
     } else {
-      auto stdvecTy = cast<cudaq::cc::StdvecType>(v.getType());
-      auto eltTy = stdvecTy.getElementType();
+      auto sequenceTy = cast<cudaq::cc::SequenceType>(v.getType());
+      auto eltTy = sequenceTy.getElementType();
       auto dataPtrTy =
           cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(eltTy));
       Value srcData =
-          cudaq::cc::StdvecDataOp::create(rewriter, loc, dataPtrTy, v);
-      Value srcSize = cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, v);
+          cudaq::cc::SequenceDataOp::create(rewriter, loc, dataPtrTy, v);
+      Value srcSize =
+          cudaq::cc::SequenceSizeOp::create(rewriter, loc, i64Ty, v);
       Value baseOffset = offset;
       cudaq::opt::factory::createInvariantLoop(
           rewriter, loc, srcSize,
@@ -2409,17 +2412,17 @@ packMeasurementHandles(Location loc, ConversionPatternRewriter &rewriter,
   return {bufAsPtrPtr, totalSize};
 }
 
-// Helper to extract `(Result**, size)` from a single stdvec operand.
-static std::pair<Value, Value> unpackStdvec(Location loc,
-                                            ConversionPatternRewriter &rewriter,
-                                            Type resultPtrTy, Value vec) {
+// Helper to extract `(Result**, size)` from a single sequence operand.
+static std::pair<Value, Value>
+unpackSequence(Location loc, ConversionPatternRewriter &rewriter,
+               Type resultPtrTy, Value vec) {
   auto i64Ty = rewriter.getI64Type();
   auto ptrToPtrTy = cudaq::cc::PointerType::get(resultPtrTy);
-  auto stdvecTy = cast<cudaq::cc::StdvecType>(vec.getType());
+  auto sequenceTy = cast<cudaq::cc::SequenceType>(vec.getType());
   auto dataPtrTy = cudaq::cc::PointerType::get(
-      cudaq::cc::ArrayType::get(stdvecTy.getElementType()));
-  Value data = cudaq::cc::StdvecDataOp::create(rewriter, loc, dataPtrTy, vec);
-  Value size = cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, vec);
+      cudaq::cc::ArrayType::get(sequenceTy.getElementType()));
+  Value data = cudaq::cc::SequenceDataOp::create(rewriter, loc, dataPtrTy, vec);
+  Value size = cudaq::cc::SequenceSizeOp::create(rewriter, loc, i64Ty, vec);
   Value asPtrPtr = cudaq::cc::CastOp::create(rewriter, loc, ptrToPtrTy, data);
   return {asPtrPtr, size};
 }
@@ -2474,9 +2477,9 @@ struct PairDetectorsOpConversion
     auto resultPtrTy =
         getQIRResultPtrType(getTypeConverter(), rewriter.getContext());
     auto [prevBuf, prevSize] =
-        unpackStdvec(loc, rewriter, resultPtrTy, adaptor.getPrev());
+        unpackSequence(loc, rewriter, resultPtrTy, adaptor.getPrev());
     auto [currBuf, currSize] =
-        unpackStdvec(loc, rewriter, resultPtrTy, adaptor.getCurr());
+        unpackSequence(loc, rewriter, resultPtrTy, adaptor.getCurr());
     rewriter.replaceOpWithNewOp<func::CallOp>(
         op, TypeRange{}, cudaq::opt::QIRPairDetectors,
         ValueRange{prevBuf, prevSize, currBuf, currSize});
@@ -2757,16 +2760,17 @@ struct QuakeToQIRAPIPass
         cudaq::cc::NoInlineCallOp, cudaq::cc::VarargCallOp,
         cudaq::cc::CallCallableOp, cudaq::cc::CallIndirectCallableOp,
         cudaq::cc::CastOp, cudaq::cc::ComputePtrOp, cudaq::cc::FuncToPtrOp,
-        cudaq::cc::StoreOp, cudaq::cc::LoadOp, cudaq::cc::StdvecDataOp,
-        cudaq::cc::StdvecInitOp, cudaq::cc::StdvecSizeOp>([&](Operation *op) {
-      for (auto opnd : op->getOperands())
-        if (needsTypeConversion(opnd.getType()))
-          return false;
-      for (auto res : op->getResults())
-        if (needsTypeConversion(res.getType()))
-          return false;
-      return true;
-    });
+        cudaq::cc::StoreOp, cudaq::cc::LoadOp, cudaq::cc::SequenceDataOp,
+        cudaq::cc::SequenceInitOp, cudaq::cc::SequenceSizeOp>(
+        [&](Operation *op) {
+          for (auto opnd : op->getOperands())
+            if (needsTypeConversion(opnd.getType()))
+              return false;
+          for (auto res : op->getResults())
+            if (needsTypeConversion(res.getType()))
+              return false;
+          return true;
+        });
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
     if (failed(applyPartialConversion(op, target, std::move(patterns))))
       signalPassFailure();
@@ -2776,7 +2780,7 @@ struct QuakeToQIRAPIPass
   // Returns true iff `ty` (or some type nested inside it) requires conversion
   // by `QIRAPITypeConverter`. The recursion descends through CC container
   // types that the converter rewrites (`cc.ptr`, `cc.callable`,
-  // `cc.indirect_callable`, function types, `cc.array`, `cc.stdvec`) and the
+  // `cc.indirect_callable`, function types, `cc.array`, `cc.sequence`) and the
   // leaf check covers Quake types and `!cc.measure_handle` (the IR alias of
   // `cudaq::measure_handle`, lowered to `i64`).
   static bool needsTypeConversion(Type ty) {
@@ -2788,7 +2792,7 @@ struct QuakeToQIRAPIPass
       return needsTypeConversion(cty.getSignature());
     if (auto aty = dyn_cast<cudaq::cc::ArrayType>(ty))
       return needsTypeConversion(aty.getElementType());
-    if (auto sty = dyn_cast<cudaq::cc::StdvecType>(ty))
+    if (auto sty = dyn_cast<cudaq::cc::SequenceType>(ty))
       return needsTypeConversion(sty.getElementType());
     if (auto fty = dyn_cast<FunctionType>(ty)) {
       for (auto t : fty.getInputs())

--- a/cudaq/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
@@ -128,10 +128,10 @@ public:
             genOutputLog(loc, rewriter, w, offset, allowDynamic);
           }
         })
-        .Case([&](cudaq::cc::StdvecType vecTy) {
-          // For this type, we expect a cc.stdvec_init operation as the input.
+        .Case([&](cudaq::cc::SequenceType vecTy) {
+          // For this type, we expect a cc.sequence_init operation as the input.
           // The data will be in a variable.
-          if (auto vecInit = val.getDefiningOp<cudaq::cc::StdvecInitOp>()) {
+          if (auto vecInit = val.getDefiningOp<cudaq::cc::SequenceInitOp>()) {
             auto maybeLen = [&]() -> std::optional<std::uint64_t> {
               if (Value len = vecInit.getLength())
                 return cudaq::opt::factory::maybeValueOfIntConstant(len);
@@ -193,10 +193,10 @@ public:
             return;
           auto eleTy = vecTy.getElementType();
           auto i8PtrTy = cudaq::cc::PointerType::get(rewriter.getI8Type());
-          Value size = cudaq::cc::StdvecSizeOp::create(
+          Value size = cudaq::cc::SequenceSizeOp::create(
               rewriter, loc, rewriter.getI64Type(), val);
           Value rawData =
-              cudaq::cc::StdvecDataOp::create(rewriter, loc, i8PtrTy, val);
+              cudaq::cc::SequenceDataOp::create(rewriter, loc, i8PtrTy, val);
           if (auto intTy = dyn_cast<IntegerType>(eleTy)) {
             if (eleTy == rewriter.getI1Type()) {
               func::CallOp::create(rewriter, loc, TypeRange{},
@@ -261,7 +261,7 @@ public:
       return {std::string("array<") + translateType(arrTy.getElementType()) +
               std::string(" x ") + std::to_string(size) + std::string(">")};
     }
-    if (auto arrTy = dyn_cast<cudaq::cc::StdvecType>(ty)) {
+    if (auto arrTy = dyn_cast<cudaq::cc::SequenceType>(ty)) {
       if (!vecSz)
         return {"error"};
       return {std::string("array<") + translateType(arrTy.getElementType()) +

--- a/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -713,7 +713,7 @@ LogicalResult cudaq::cc::ComputePtrOp::verify() {
       if (i != kDynamicIndex && !arrTy.isUnknownSize() &&
           (i < 0 || i > arrTy.getSize())) {
         // Note: allow indexing of last element + 1 so we can compute a
-        // pointer to `end()` of a stdvec buffer. Consider adding a flag
+        // pointer to `end()` of a sequence buffer. Consider adding a flag
         // to cc.compute_ptr explicitly for this or using casts.
         return emitOpError("array cannot index out of bounds elements");
       }
@@ -1342,16 +1342,16 @@ LogicalResult cudaq::cc::InsertValueOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// StdvecInitOp
+// SequenceInitOp
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct CollapseCastToStdvecInit
-    : public OpRewritePattern<cudaq::cc::StdvecInitOp> {
-  using Base = OpRewritePattern<cudaq::cc::StdvecInitOp>;
+struct CollapseCastToSequenceInit
+    : public OpRewritePattern<cudaq::cc::SequenceInitOp> {
+  using Base = OpRewritePattern<cudaq::cc::SequenceInitOp>;
   using Base::Base;
 
-  LogicalResult matchAndRewrite(cudaq::cc::StdvecInitOp init,
+  LogicalResult matchAndRewrite(cudaq::cc::SequenceInitOp init,
                                 PatternRewriter &rewriter) const override {
     if (auto buff = init.getBuffer().getDefiningOp<cudaq::cc::CastOp>()) {
       auto castVal = buff.getValue();
@@ -1363,7 +1363,7 @@ struct CollapseCastToStdvecInit
       if (auto arrTy = dyn_cast<cudaq::cc::ArrayType>(fromTy))
         if (!isa<cudaq::cc::ArrayType>(toTy)) {
           if (arrTy.isUnknownSize()) {
-            rewriter.replaceOpWithNewOp<cudaq::cc::StdvecInitOp>(
+            rewriter.replaceOpWithNewOp<cudaq::cc::SequenceInitOp>(
                 init, init.getType(), castVal, init.getLength());
             return success();
           }
@@ -1377,7 +1377,7 @@ struct CollapseCastToStdvecInit
             return arrSize + 1; // do not replace this one
           }();
           if (!initLen || arrSize == initSize) {
-            rewriter.replaceOpWithNewOp<cudaq::cc::StdvecInitOp>(
+            rewriter.replaceOpWithNewOp<cudaq::cc::SequenceInitOp>(
                 init, init.getType(), castVal);
             return success();
           }
@@ -1387,11 +1387,11 @@ struct CollapseCastToStdvecInit
   }
 };
 
-struct FoldStdvecInit : public OpRewritePattern<cudaq::cc::StdvecInitOp> {
-  using Base = OpRewritePattern<cudaq::cc::StdvecInitOp>;
+struct FoldSequenceInit : public OpRewritePattern<cudaq::cc::SequenceInitOp> {
+  using Base = OpRewritePattern<cudaq::cc::SequenceInitOp>;
   using Base::Base;
 
-  LogicalResult matchAndRewrite(cudaq::cc::StdvecInitOp init,
+  LogicalResult matchAndRewrite(cudaq::cc::SequenceInitOp init,
                                 PatternRewriter &rewriter) const override {
     if (auto arrTy =
             dyn_cast<cudaq::cc::ArrayType>(init.getBuffer().getType())) {
@@ -1400,7 +1400,7 @@ struct FoldStdvecInit : public OpRewritePattern<cudaq::cc::StdvecInitOp> {
       if (auto len = init.getLength())
         if (auto optInt = cudaq::opt::factory::getIntIfConstant(len))
           if (*optInt == arrTy.getSize()) {
-            rewriter.replaceOpWithNewOp<cudaq::cc::StdvecInitOp>(
+            rewriter.replaceOpWithNewOp<cudaq::cc::SequenceInitOp>(
                 init, init.getType(), init.getBuffer());
             return success();
           }
@@ -1410,12 +1410,12 @@ struct FoldStdvecInit : public OpRewritePattern<cudaq::cc::StdvecInitOp> {
 };
 } // namespace
 
-void cudaq::cc::StdvecInitOp::getCanonicalizationPatterns(
+void cudaq::cc::SequenceInitOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<CollapseCastToStdvecInit, FoldStdvecInit>(context);
+  patterns.add<CollapseCastToSequenceInit, FoldSequenceInit>(context);
 }
 
-LogicalResult cudaq::cc::StdvecInitOp::verify() {
+LogicalResult cudaq::cc::SequenceInitOp::verify() {
   Value buff = getBuffer();
   auto buffTy = cast<cc::PointerType>(buff.getType());
   auto buffEleTy = buffTy.getElementType();
@@ -1443,23 +1443,24 @@ LogicalResult cudaq::cc::StdvecInitOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// StdvecDataOp
+// SequenceDataOp
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct ForwardStdvecInitData
-    : public OpRewritePattern<cudaq::cc::StdvecDataOp> {
+struct ForwardSequenceInitData
+    : public OpRewritePattern<cudaq::cc::SequenceDataOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(cudaq::cc::StdvecDataOp data,
+  LogicalResult matchAndRewrite(cudaq::cc::SequenceDataOp data,
                                 PatternRewriter &rewriter) const override {
     // Bypass the std::vector wrappers for the creation of an abstract
     // subvector. This is possible because copies of std::vector data aren't
     // created but instead passed around like std::span objects. Specifically, a
-    // pointer to the data and a length. Thus the pointer wrapped by stdvec_init
-    // and unwrapped by stdvec_data is the same pointer value. This pattern will
-    // arise after inlining, for example.
-    if (auto ini = data.getStdvec().getDefiningOp<cudaq::cc::StdvecInitOp>()) {
+    // pointer to the data and a length. Thus the pointer wrapped by
+    // sequence_init and unwrapped by sequence_data is the same pointer value.
+    // This pattern will arise after inlining, for example.
+    if (auto ini =
+            data.getSequence().getDefiningOp<cudaq::cc::SequenceInitOp>()) {
       rewriter.replaceOpWithNewOp<cudaq::cc::CastOp>(data, data.getType(),
                                                      ini.getBuffer());
       return success();
@@ -1469,24 +1470,25 @@ struct ForwardStdvecInitData
 };
 } // namespace
 
-void cudaq::cc::StdvecDataOp::getCanonicalizationPatterns(
+void cudaq::cc::SequenceDataOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<ForwardStdvecInitData>(context);
+  patterns.add<ForwardSequenceInitData>(context);
 }
 
 //===----------------------------------------------------------------------===//
-// StdvecSizeOp
+// SequenceSizeOp
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct ForwardStdvecInitSize
-    : public OpRewritePattern<cudaq::cc::StdvecSizeOp> {
-  using Base = OpRewritePattern<cudaq::cc::StdvecSizeOp>;
+struct ForwardSequenceInitSize
+    : public OpRewritePattern<cudaq::cc::SequenceSizeOp> {
+  using Base = OpRewritePattern<cudaq::cc::SequenceSizeOp>;
   using Base::Base;
 
-  LogicalResult matchAndRewrite(cudaq::cc::StdvecSizeOp size,
+  LogicalResult matchAndRewrite(cudaq::cc::SequenceSizeOp size,
                                 PatternRewriter &rewriter) const override {
-    if (auto init = size.getStdvec().getDefiningOp<cudaq::cc::StdvecInitOp>()) {
+    if (auto init =
+            size.getSequence().getDefiningOp<cudaq::cc::SequenceInitOp>()) {
       auto ty = size.getType();
       if (Value len = init.getLength()) {
         rewriter.replaceOpWithNewOp<cudaq::cc::CastOp>(size, ty, len);
@@ -1505,9 +1507,9 @@ struct ForwardStdvecInitSize
 };
 } // namespace
 
-void cudaq::cc::StdvecSizeOp::getCanonicalizationPatterns(
+void cudaq::cc::SequenceSizeOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<ForwardStdvecInitSize>(context);
+  patterns.add<ForwardSequenceInitSize>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2682,8 +2684,8 @@ LogicalResult cudaq::cc::DeviceCallOp::verify() {
       return emitOpError("by_ref_vec_arg_indices contains duplicate "
                          "argument index ")
              << index;
-    if (!isa<StdvecType>(args[index].getType()))
-      return emitOpError("by_ref_vec_arg_indices references non-stdvec "
+    if (!isa<SequenceType>(args[index].getType()))
+      return emitOpError("by_ref_vec_arg_indices references non-sequence "
                          "argument index ")
              << index;
   }

--- a/cudaq/lib/Optimizer/Dialect/CC/CCTypes.cpp
+++ b/cudaq/lib/Optimizer/Dialect/CC/CCTypes.cpp
@@ -153,10 +153,10 @@ cc::ArrayType::verify(function_ref<InFlightDiagnostic()> emitError, Type eleTy,
 }
 
 LogicalResult
-cc::StdvecType::verify(function_ref<InFlightDiagnostic()> emitError,
-                       Type eleTy) {
+cc::SequenceType::verify(function_ref<InFlightDiagnostic()> emitError,
+                         Type eleTy) {
   if (cudaq::quake::isQuantumType(eleTy))
-    return emitError() << "cc.stdvec may not have a quake element type: "
+    return emitError() << "cc.sequence may not have a quake element type: "
                        << eleTy;
   return success();
 }
@@ -175,7 +175,7 @@ cc::StdvecType::verify(function_ref<InFlightDiagnostic()> emitError,
 namespace cudaq::cc {
 
 Type SpanLikeType::getElementType() const {
-  return llvm::TypeSwitch<Type, Type>(*this).Case<StdvecType, CharspanType>(
+  return llvm::TypeSwitch<Type, Type>(*this).Case<SequenceType, CharspanType>(
       [](auto type) { return type.getElementType(); });
 }
 
@@ -233,7 +233,7 @@ static bool containsMeasureHandleImpl(Type ty,
     return recurse(p.getElementType());
   if (auto a = dyn_cast<ArrayType>(ty))
     return recurse(a.getElementType());
-  if (auto v = dyn_cast<StdvecType>(ty))
+  if (auto v = dyn_cast<SequenceType>(ty))
     return recurse(v.getElementType());
   if (auto s = dyn_cast<StructType>(ty)) {
     for (auto m : s.getMembers())
@@ -255,7 +255,7 @@ bool containsMeasureHandle(Type ty) {
 
 void CCDialect::registerTypes() {
   addTypes<ArrayType, CallableType, CharspanType, IndirectCallableType,
-           MeasureHandleType, PointerType, StdvecType, StructType>();
+           MeasureHandleType, PointerType, SequenceType, StructType>();
 }
 
 } // namespace cudaq::cc

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -38,12 +38,12 @@ struct AdjustAdjointExpPauliPattern
 // Bind an exp_pauli operation to its constant pauli word.
 //
 //   %a = cc.string_literal "IZ" : !cc.ptr<!cc.array<i8 x 3>>
-//   %4 = cc.stdvec_init %a, %c3 : (!cc.ptr<!cc.array<i8 x 3>>, i64) ->
+//   %4 = cc.sequence_init %a, %c3 : (!cc.ptr<!cc.array<i8 x 3>>, i64) ->
 //           !cc.charspan
 //   quake.exp_pauli (%c) %q to %4 : (f64, !quake.ref, !cc.charspan) -> ()
 //   ─────────────────────────────────────────────────────────────────────
 //   %a = cc.string_literal "IZ" : !cc.ptr<!cc.array<i8 x 3>>
-//   %4 = cc.stdvec_init %a, %c3 : (!cc.ptr<!cc.array<i8 x 3>>, i64) ->
+//   %4 = cc.sequence_init %a, %c3 : (!cc.ptr<!cc.array<i8 x 3>>, i64) ->
 //           !cc.charspan  // DCE?
 //   quake.exp_pauli (%c) %q to "IZ" : (f64, !quake.ref) -> ()
 //
@@ -65,7 +65,7 @@ public:
     auto pauliWord = pauli.getPauli();
     if (!pauliWord)
       return failure();
-    auto vecInit = pauliWord.getDefiningOp<cudaq::cc::StdvecInitOp>();
+    auto vecInit = pauliWord.getDefiningOp<cudaq::cc::SequenceInitOp>();
     Value litVal = vecInit ? vecInit.getBuffer() : pauliWord;
     auto buffer = litVal.getDefiningOp<cudaq::cc::CreateStringLiteralOp>();
     if (!buffer)

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -440,11 +440,12 @@ LogicalResult cudaq::quake::ApplyNoiseOp::verify() {
       return emitOpError("cannot have a noise function and a key");
   }
 
-  // Parameters must be exactly one stdvec or 0 or more ptr<floating-point>.
+  // Parameters must be exactly one sequence or 0 or more ptr<floating-point>.
   auto params = getParameters();
   if (params.size() == 1) {
-    if (auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(params[0].getType())) {
-      if (stdvecTy.getElementType() != Float64Type::get(getContext()))
+    if (auto sequenceTy =
+            dyn_cast<cudaq::cc::SequenceType>(params[0].getType())) {
+      if (sequenceTy.getElementType() != Float64Type::get(getContext()))
         return emitOpError("must be std::vector<double>");
     } else if (auto ptrTy =
                    dyn_cast<cudaq::cc::PointerType>(params[0].getType())) {
@@ -863,17 +864,18 @@ LogicalResult verifyMeasurements(MEAS op, TypeRange targetsType,
                                  const Type bitsType) {
   if (failed(verifyWireResultsAreLinear(op)))
     return failure();
-  bool mustBeStdvec =
+  bool mustBeSequence =
       targetsType.size() > 1 ||
       (targetsType.size() == 1 && isa<cudaq::quake::VeqType>(targetsType[0]));
-  if (mustBeStdvec) {
-    auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(op.getMeasOut().getType());
-    if (!stdvecTy ||
+  if (mustBeSequence) {
+    auto sequenceTy =
+        dyn_cast<cudaq::cc::SequenceType>(op.getMeasOut().getType());
+    if (!sequenceTy ||
         !isa<cudaq::quake::MeasureType, cudaq::cc::MeasureHandleType>(
-            stdvecTy.getElementType()))
+            sequenceTy.getElementType()))
       return op.emitOpError(
-          "must return `!cc.stdvec<!quake.measure>` or "
-          "`!cc.stdvec<!cc.measure_handle>` when measuring a qvector, a "
+          "must return `!cc.sequence<!quake.measure>` or "
+          "`!cc.sequence<!cc.measure_handle>` when measuring a qvector, a "
           "series of qubits, or both");
   } else {
     if (!isa<cudaq::quake::MeasureType, cudaq::cc::MeasureHandleType>(
@@ -908,11 +910,11 @@ LogicalResult cudaq::quake::MzOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult cudaq::quake::DiscriminateOp::verify() {
-  if (isa<cudaq::cc::StdvecType>(getMeasurement().getType())) {
-    auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(getResult().getType());
-    if (!stdvecTy || !isa<IntegerType>(stdvecTy.getElementType()))
+  if (isa<cudaq::cc::SequenceType>(getMeasurement().getType())) {
+    auto sequenceTy = dyn_cast<cudaq::cc::SequenceType>(getResult().getType());
+    if (!sequenceTy || !isa<IntegerType>(sequenceTy.getElementType()))
       return emitOpError(
-          "must return a !cc.stdvec<integral> type, when discriminating a "
+          "must return a !cc.sequence<integral> type, when discriminating a "
           "qvector, a series of qubits, or both");
   } else {
     if (!isa<cudaq::quake::MeasureType, cudaq::cc::MeasureHandleType>(
@@ -927,14 +929,14 @@ LogicalResult cudaq::quake::DiscriminateOp::verify() {
 void cudaq::quake::DiscriminateOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  if (isa<cudaq::cc::StdvecType>(getMeasurement().getType()))
+  if (isa<cudaq::cc::SequenceType>(getMeasurement().getType()))
     effects.emplace_back(MemoryEffects::Read::get(),
                          SideEffects::DefaultResource::get());
 }
 
 mlir::Speculation::Speculatability
 cudaq::quake::DiscriminateOp::getSpeculatability() {
-  return isa<cudaq::cc::StdvecType>(getMeasurement().getType())
+  return isa<cudaq::cc::SequenceType>(getMeasurement().getType())
              ? Speculation::NotSpeculatable
              : Speculation::Speculatable;
 }

--- a/cudaq/lib/Optimizer/Transforms/AddMeasurements.cpp
+++ b/cudaq/lib/Optimizer/Transforms/AddMeasurements.cpp
@@ -74,7 +74,7 @@ LogicalResult addDeallocMeasurements(func::FuncOp funcOp,
   OpBuilder builder(ctx);
 
   auto measTy = cudaq::quake::MeasureType::get(builder.getContext());
-  auto stdvecTy = cudaq::cc::StdvecType::get(measTy);
+  auto sequenceTy = cudaq::cc::SequenceType::get(measTy);
   for (auto *op : deallocations) {
     if (auto dealloc = dyn_cast<cudaq::quake::DeallocOp>(op)) {
       auto loc = dealloc.getLoc();
@@ -82,7 +82,7 @@ LogicalResult addDeallocMeasurements(func::FuncOp funcOp,
       auto resTy = [&]() -> Type {
         if (isa<cudaq::quake::RefType>(dealloc.getReference().getType()))
           return measTy;
-        return stdvecTy;
+        return sequenceTy;
       }();
       cudaq::quake::MzOp::create(builder, loc, resTy, dealloc.getReference());
     } else {
@@ -140,8 +140,8 @@ addReturnMeasurements(func::FuncOp funcOp,
     Type allocTy = alloca->getResult(0).getType();
     auto loc = alloca->getLoc();
     if (isa<cudaq::quake::VeqType>(allocTy)) {
-      auto stdvecTy = cudaq::cc::StdvecType::get(measTy);
-      cudaq::quake::MzOp::create(builder, loc, stdvecTy,
+      auto sequenceTy = cudaq::cc::SequenceType::get(measTy);
+      cudaq::quake::MzOp::create(builder, loc, sequenceTy,
                                  ValueRange{alloca->getResult(0)});
     } else if (isa<cudaq::quake::RefType>(allocTy)) {
       auto val = alloca->getResult(0);

--- a/cudaq/lib/Optimizer/Transforms/CombineMeasurements.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineMeasurements.cpp
@@ -105,7 +105,7 @@ public:
   // with:
   // ```
   //   %1 = ... : !quake.veq<4>
-  //   %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+  //   %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
   // ```
   // And collect output names information:  `"[[[0,[1,"q0"]],[1,[2,"q1"]]]]"`
   LogicalResult matchAndRewrite(cudaq::quake::MzOp measure,
@@ -128,7 +128,7 @@ public:
       analysis.resultQubitVals[offset] =
           std::make_pair(idx, std::to_string(idx));
 
-      auto resultType = cudaq::cc::StdvecType::get(measure.getType(0));
+      auto resultType = cudaq::cc::SequenceType::get(measure.getType(0));
       if (measure == analysis.lastMeasurement) {
         rewriter.replaceOpWithNewOp<cudaq::quake::MzOp>(
             measure, TypeRange{resultType}, ValueRange{veq},
@@ -161,12 +161,12 @@ public:
   //   %1 = ... : !quake.veq<4>
   //   %2 = quake.subveq %1, %c1, %c2 : (!quake.veq<4>, i32, i32) ->
   //        !quake.veq<2>
-  //   %measOut = quake.mz %2 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  //   %measOut = quake.mz %2 : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   // ```
   // with:
   // ```
   //   %1 = ... : !quake.veq<4>
-  //   %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+  //   %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
   // ```
   // And collect output names information:  `"[[[0,[1,"q0"]],[1,[2,"q1"]]]]"`
   LogicalResult matchAndRewrite(cudaq::quake::MzOp measure,

--- a/cudaq/lib/Optimizer/Transforms/ConstantPropagation.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ConstantPropagation.cpp
@@ -26,30 +26,30 @@ using namespace mlir;
 
 /// Common code to determine if \p load is from a reified span over a constant
 /// array. See the examples below in the `LoadOp` patterns. If \p loadSpan is
-/// `true`, the load is loading a `!cc.stdvec<T>` type value, otherwise load
-/// must \e not load a `!cc.stdvec<T>` type value.
+/// `true`, the load is loading a `!cc.sequence<T>` type value, otherwise load
+/// must \e not load a `!cc.sequence<T>` type value.
 static LogicalResult
 checkIfLoadFromReifiedSpan(cudaq::cc::ConstantArrayOp &conArr,
                            SmallVectorImpl<std::int32_t> &indices,
                            cudaq::cc::LoadOp load, bool loadSpan) {
   Value ptrVal = load.getPtrvalue();
-  auto dataOp = [&]() -> cudaq::cc::StdvecDataOp {
+  auto dataOp = [&]() -> cudaq::cc::SequenceDataOp {
     if (auto cast = ptrVal.getDefiningOp<cudaq::cc::CastOp>()) {
       indices.push_back(0);
-      return cast.getValue().getDefiningOp<cudaq::cc::StdvecDataOp>();
+      return cast.getValue().getDefiningOp<cudaq::cc::SequenceDataOp>();
     }
     if (auto comp = ptrVal.getDefiningOp<cudaq::cc::ComputePtrOp>()) {
       if (comp.getNumOperands() != 1)
         return {};
       indices.append(comp.getRawConstantIndices().begin(),
                      comp.getRawConstantIndices().end());
-      return comp.getBase().getDefiningOp<cudaq::cc::StdvecDataOp>();
+      return comp.getBase().getDefiningOp<cudaq::cc::SequenceDataOp>();
     }
     return {};
   }();
   if (!dataOp)
     return failure();
-  auto reify = dataOp.getStdvec().getDefiningOp<cudaq::cc::ReifySpanOp>();
+  auto reify = dataOp.getSequence().getDefiningOp<cudaq::cc::ReifySpanOp>();
   if (!reify)
     return failure();
   conArr = reify.getElements().getDefiningOp<cudaq::cc::ConstantArrayOp>();
@@ -57,7 +57,7 @@ checkIfLoadFromReifiedSpan(cudaq::cc::ConstantArrayOp &conArr,
     return failure();
 
   // Verify that the data type loaded is a match.
-  return success(loadSpan == isa<cudaq::cc::StdvecType>(load.getType()));
+  return success(loadSpan == isa<cudaq::cc::SequenceType>(load.getType()));
 }
 
 namespace {
@@ -67,24 +67,24 @@ namespace {
 //   %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] :
 //           !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
 //   %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>)
-//           -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
-//   %2 = cc.stdvec_data %1 : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) ->
-//           !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
-//   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan>
-//           x ?>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
-//   %4 = cc.load %3 : !cc.ptr<!cc.stdvec<!cc.charspan>>
+//           -> !cc.sequence<!cc.sequence<!cc.charspan>>
+//   %2 = cc.sequence_data %1 : (!cc.sequence<!cc.sequence<!cc.charspan>>) ->
+//           !cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>
+//   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan>
+//           x ?>>) -> !cc.ptr<!cc.sequence<!cc.charspan>>
+//   %4 = cc.load %3 : !cc.ptr<!cc.sequence<!cc.charspan>>
 //   ─────────────────────────────────────────────────────────────────────────
 //   %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] :
 //           !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
 //   %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>)
-//           -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
-//   %2 = cc.stdvec_data %1 : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) ->
-//           !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
-//   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan>
-//           x ?>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
+//           -> !cc.sequence<!cc.sequence<!cc.charspan>>
+//   %2 = cc.sequence_data %1 : (!cc.sequence<!cc.sequence<!cc.charspan>>) ->
+//           !cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>
+//   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan>
+//           x ?>>) -> !cc.ptr<!cc.sequence<!cc.charspan>>
 //   %a = cc.const_array ["IZ", "YX"] : !cc.array<!cc.array<i8 x 3> x 2>
 //   %4 = cc.reify_span %a : (!cc.array<!cc.array<i8 x 3> x 2>)
-//           -> !cc.stdvec<!cc.charspan>
+//           -> !cc.sequence<!cc.charspan>
 //
 class ForwardConstSubArray : public OpRewritePattern<cudaq::cc::LoadOp> {
 public:
@@ -121,15 +121,15 @@ public:
 
 // If this is reifying a single dimension array, then we want to forward the
 // constant element itself. Note that we do not count the innermost array if the
-// data is a string, so in this case, there is a distinction between !cc.stdvec
-// and !cc.charspan.
+// data is a string, so in this case, there is a distinction between
+// !cc.sequence and !cc.charspan.
 //
 // Strings require two operations to get the types to check, as shown below.
 //
 //   %0 = cc.const_array ["IZ", "YX"] : !cc.array<!cc.array<i8 x 3> x 2>
 //   %1 = cc.reify_span %0 : (!cc.array<!cc.array<i8 x 3> x 2>) ->
-//           !cc.stdvec<!cc.charspan>
-//   %2 = cc.stdvec_data %1 : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<
+//           !cc.sequence<!cc.charspan>
+//   %2 = cc.sequence_data %1 : (!cc.sequence<!cc.charspan>) -> !cc.ptr<
 //           !cc.array<!cc.charspan x ?>>
 //   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.charspan x ?>>) ->
 //           !cc.ptr<!cc.charspan>
@@ -137,28 +137,28 @@ public:
 //   ─────────────────────────────────────────────────────────────────────────
 //   %0 = cc.const_array ["IZ", "YX"] : !cc.array<!cc.array<i8 x 3> x 2>
 //   %1 = cc.reify_span %0 : (!cc.array<!cc.array<i8 x 3> x 2>) ->
-//           !cc.stdvec<!cc.charspan>
-//   %2 = cc.stdvec_data %1 : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<
+//           !cc.sequence<!cc.charspan>
+//   %2 = cc.sequence_data %1 : (!cc.sequence<!cc.charspan>) -> !cc.ptr<
 //           !cc.array<!cc.charspan x ?>>
 //   %3 = cc.compute_ptr %2[0] : (!cc.ptr<!cc.array<!cc.charspan x ?>>) ->
 //           !cc.ptr<!cc.charspan>
 //   %a = cc.string_literal "IZ" : !cc.ptr<!cc.array<i8 x 3>>
-//   %4 = cc.stdvec_init %a, %c3 : (!cc.ptr<!cc.array<i8 x 3>>, i64) ->
+//   %4 = cc.sequence_init %a, %c3 : (!cc.ptr<!cc.array<i8 x 3>>, i64) ->
 //           !cc.charspan
 //
 // For a non-string array this looks like the following rewrite.
 //
 //   %0 = cc.const_array [1, 2, 4, 8] : !cc.array<i64 x 4>
-//   %1 = cc.reify_span %0 : (!cc.array<i64 x 2>) -> !cc.stdvec<i64>
-//   %2 = cc.stdvec_data %1 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-//   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
-//   %4 = cc.load %3 : !cc.ptr<i64>
+//   %1 = cc.reify_span %0 : (!cc.array<i64 x 2>) -> !cc.sequence<i64>
+//   %2 = cc.sequence_data %1 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x
+//   ?>> %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<i64 x ?>>) ->
+//   !cc.ptr<i64> %4 = cc.load %3 : !cc.ptr<i64>
 //   ─────────────────────────────────────────────────────────────────────────
 //   %0 = cc.const_array [1, 2, 4, 8] : !cc.array<i64 x 4>
-//   %1 = cc.reify_span %0 : (!cc.array<i64 x 2>) -> !cc.stdvec<i64>
-//   %2 = cc.stdvec_data %1 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-//   %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
-//   %4 = cc.constant 2 : i64
+//   %1 = cc.reify_span %0 : (!cc.array<i64 x 2>) -> !cc.sequence<i64>
+//   %2 = cc.sequence_data %1 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x
+//   ?>> %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<i64 x ?>>) ->
+//   !cc.ptr<i64> %4 = cc.constant 2 : i64
 //
 class ForwardSingleDimensionData : public OpRewritePattern<cudaq::cc::LoadOp> {
 public:
@@ -174,7 +174,7 @@ public:
 
     // The preconditions are met. At this point, we replace this load depending
     // on the type. If this is loading a charspan, we replace the load with a
-    // string_literal from conArr[indices] and stdvec_init op. Otherwise, we
+    // string_literal from conArr[indices] and sequence_init op. Otherwise, we
     // replace the load with the constant from conArr[indices].
     ArrayAttr aa = conArr.getConstantValues();
     auto numIndices = indices.size();
@@ -194,8 +194,8 @@ public:
           rewriter, loc, cudaq::cc::PointerType::get(ty), stringAttr);
       auto len = arith::ConstantIntOp::create(
           rewriter, loc, stringAttr.getValue().size() + 1, 64);
-      rewriter.replaceOpWithNewOp<cudaq::cc::StdvecInitOp>(loadSpanEle, loadTy,
-                                                           lit, len);
+      rewriter.replaceOpWithNewOp<cudaq::cc::SequenceInitOp>(loadSpanEle,
+                                                             loadTy, lit, len);
       return success();
     }
     if (auto intTy = dyn_cast<IntegerType>(loadTy)) {

--- a/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -467,7 +467,7 @@ struct ExpPauliDecomposition
               pauliWord = storeVal;
           }
           if (auto vecInit =
-                  pauliWord.getDefiningOp<cudaq::cc::StdvecInitOp>()) {
+                  pauliWord.getDefiningOp<cudaq::cc::SequenceInitOp>()) {
             auto addrOp = vecInit.getOperand(0);
             if (auto cast = addrOp.getDefiningOp<cudaq::cc::CastOp>())
               addrOp = cast.getOperand();
@@ -498,7 +498,7 @@ struct ExpPauliDecomposition
             } else if (auto lit = addrOp.getDefiningOp<
                                   cudaq::cc::CreateStringLiteralOp>()) {
               // Get the pauli word string if it was a literal wrapped in a
-              // stdvec structure.
+              // sequence structure.
               optPauliWordStr = lit.getStringLiteral();
             }
           }

--- a/cudaq/lib/Optimizer/Transforms/EraseVectorCopyCtor.cpp
+++ b/cudaq/lib/Optimizer/Transforms/EraseVectorCopyCtor.cpp
@@ -122,18 +122,18 @@ public:
 //
 // Transformation is:
 //
-//  %30 = cc.scope -> (!cc.stdvec<i1>) {
+//  %30 = cc.scope -> (!cc.sequence<i1>) {
 //    ...
 //    %34 = cc.alloca i8[%15 : i64]
 //    ...
 //    %36 = func.call @malloc(%15) : (i64) -> !cc.ptr<i8>
 //    func.call @llvm.memcpy.p0.p0.i64(%36, %34, %35, %false) :
 //      (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> () [dead]
-//    %37 = cc.stdvec_init %36, %15 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
+//    %37 = cc.sequence_init %36, %15 : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
 //    cc.continue %37
 //  }
-//  %37 = cc.stdvec_data %30 : (!stdvec<i1>) -> !cc.ptr<i8>
-//  %38 = cc.stdvec_size %30 : (!stdvec<i1>) -> i64
+//  %37 = cc.sequence_data %30 : (!sequence<i1>) -> !cc.ptr<i8>
+//  %38 = cc.sequence_size %30 : (!sequence<i1>) -> i64
 //  %39 = cc.alloca i8[%38 : i64]
 //  %40 = cc.cast %39 : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
 //  func.call @llvm.memcpy.p0.p0.i64(%40, %37, %38, %false) :
@@ -155,13 +155,13 @@ public:
       return failure();
     auto scope = dyn_cast_if_present<cudaq::cc::ScopeOp>(call->getParentOp());
     if (!(scope && scope.getResults().size() == 1 &&
-          isa<cudaq::cc::StdvecType>(scope->getResult(0).getType()) &&
+          isa<cudaq::cc::SequenceType>(scope->getResult(0).getType()) &&
           std::distance(call->getUsers().begin(), call->getUsers().end()) == 2))
       return failure();
 
     // Check call (malloc) users.
     func::CallOp copyFrom;
-    cudaq::cc::StdvecInitOp initOp;
+    cudaq::cc::SequenceInitOp initOp;
     for (auto *u : call->getUsers()) {
       auto c = dyn_cast<func::CallOp>(u);
       if (c && c.getCallee().starts_with("llvm.memcpy") &&
@@ -169,7 +169,7 @@ public:
         copyFrom = c;
         continue;
       }
-      auto io = dyn_cast<cudaq::cc::StdvecInitOp>(u);
+      auto io = dyn_cast<cudaq::cc::SequenceInitOp>(u);
       if (io && !initOp) {
         initOp = io;
         continue;
@@ -187,15 +187,15 @@ public:
     // Check scope users.
     if (std::distance(scope->getUsers().begin(), scope->getUsers().end()) != 2)
       return failure();
-    cudaq::cc::StdvecDataOp data;
-    cudaq::cc::StdvecSizeOp size;
+    cudaq::cc::SequenceDataOp data;
+    cudaq::cc::SequenceSizeOp size;
     for (auto *u : scope->getUsers()) {
-      auto d = dyn_cast<cudaq::cc::StdvecDataOp>(u);
+      auto d = dyn_cast<cudaq::cc::SequenceDataOp>(u);
       if (d && !data) {
         data = d;
         continue;
       }
-      auto s = dyn_cast<cudaq::cc::StdvecSizeOp>(u);
+      auto s = dyn_cast<cudaq::cc::SequenceSizeOp>(u);
       if (s && !size) {
         size = s;
         continue;

--- a/cudaq/lib/Optimizer/Transforms/ExpandMeasurements.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ExpandMeasurements.cpp
@@ -36,14 +36,14 @@ bool usesIndividualQubit(A x) {
 //
 // Handles both result-type families that the vector form of `quake.mz`/`mx`/
 // `my` can carry:
-//   - `!cc.stdvec<!quake.measure>` -- the legacy form. The only legitimate
+//   - `!cc.sequence<!quake.measure>` -- the legacy form. The only legitimate
 //     consumer is `quake.discriminate`, so the rewrite folds the per-element
-//     measurements straight into a `cc.stdvec_init -> !cc.stdvec<i1>`.
-//   - `!cc.stdvec<!cc.measure_handle>` -- the handle-vector value can have
+//     measurements straight into a `cc.sequence_init -> !cc.sequence<i1>`.
+//   - `!cc.sequence<!cc.measure_handle>` -- the handle-vector value can have
 //     non-discriminate consumers. Those consumers expect a value of the
-//     original handle-stdvec type, so the rewrite additionally builds a
-//     per-element handle buffer and folds it into a `cc.stdvec_init ->
-//     !cc.stdvec<!cc.measure_handle>` that replaces all remaining uses.
+//     original handle-sequence type, so the rewrite additionally builds a
+//     per-element handle buffer and folds it into a `cc.sequence_init ->
+//     !cc.sequence<!cc.measure_handle>` that replaces all remaining uses.
 template <typename A>
 class ExpandRewritePattern : public OpRewritePattern<A> {
 public:
@@ -55,14 +55,14 @@ public:
     auto *ctx = rewriter.getContext();
 
     // The dynamic-legality predicate filters out the scalar forms, so by
-    // construction the result type here is `!cc.stdvec<X>` for some X.
-    auto stdvecResTy =
-        dyn_cast<cudaq::cc::StdvecType>(measureOp.getMeasOut().getType());
+    // construction the result type here is `!cc.sequence<X>` for some X.
+    auto sequenceResTy =
+        dyn_cast<cudaq::cc::SequenceType>(measureOp.getMeasOut().getType());
     auto handleTy = cudaq::cc::MeasureHandleType::get(ctx);
     bool isHandleResult =
-        isa<cudaq::cc::MeasureHandleType>(stdvecResTy.getElementType());
+        isa<cudaq::cc::MeasureHandleType>(sequenceResTy.getElementType());
 
-    // Per-element scalar result type tracks the original stdvec element
+    // Per-element scalar result type tracks the original sequence element
     // type. For handle inputs we measure into `!cc.measure_handle` per
     // qubit.
     Type perElemTy =
@@ -82,8 +82,8 @@ public:
         hasNonDiscUser = true;
     }
     // Allocation policy:
-    //   - Legacy `!cc.stdvec<!quake.measure>` always allocates the i1 buffer.
-    //   - `!cc.stdvec<!cc.measure_handle>` allocates each buffer only when a
+    //   - Legacy `!cc.sequence<!quake.measure>` always allocates the i1 buffer.
+    //   - `!cc.sequence<!cc.measure_handle>` allocates each buffer only when a
     //   consumer in that element-type class is present.
     bool needI1Buf = !isHandleResult || !discUsers.empty();
     bool needHandleBuf = isHandleResult && hasNonDiscUser;
@@ -167,29 +167,29 @@ public:
     }
 
     // 4. Replace each `quake.discriminate` consumer with a
-    // `cc.stdvec_init -> !cc.stdvec<i1>` over the i1 buffer.
+    // `cc.sequence_init -> !cc.sequence<i1>` over the i1 buffer.
     if (needI1Buf) {
-      auto stdvecI1Ty = cudaq::cc::StdvecType::get(ctx, i1Ty);
+      auto sequenceI1Ty = cudaq::cc::SequenceType::get(ctx, i1Ty);
       auto ptrArrI1Ty =
           cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(i1Ty));
       for (auto disc : discUsers) {
         auto buffCast =
             cudaq::cc::CastOp::create(rewriter, loc, ptrArrI1Ty, i1Buff);
-        rewriter.template replaceOpWithNewOp<cudaq::cc::StdvecInitOp>(
-            disc, stdvecI1Ty, buffCast, totalToRead);
+        rewriter.template replaceOpWithNewOp<cudaq::cc::SequenceInitOp>(
+            disc, sequenceI1Ty, buffCast, totalToRead);
       }
     }
 
     // 5. For the handle path with non-discriminate consumers, build a
-    // `cc.stdvec_init -> !cc.stdvec<!cc.measure_handle>` over the handle
+    // `cc.sequence_init -> !cc.sequence<!cc.measure_handle>` over the handle
     // buffer and route the original result's remaining users to it via
     // `replaceOp` (one atomic substitution)
     Value replacementVal;
     if (needHandleBuf) {
-      auto stdvecHandleTy = cudaq::cc::StdvecType::get(ctx, handleTy);
-      auto handleStdvec = cudaq::cc::StdvecInitOp::create(
-          rewriter, loc, stdvecHandleTy, handleBuff, totalToRead);
-      replacementVal = handleStdvec.getResult();
+      auto sequenceHandleTy = cudaq::cc::SequenceType::get(ctx, handleTy);
+      auto handleSequence = cudaq::cc::SequenceInitOp::create(
+          rewriter, loc, sequenceHandleTy, handleBuff, totalToRead);
+      replacementVal = handleSequence.getResult();
     }
 
     // The pass is scheduled before wire lowering, so the variadic `$wires`
@@ -215,17 +215,17 @@ using MxRewrite = ExpandRewritePattern<cudaq::quake::MxOp>;
 using MyRewrite = ExpandRewritePattern<cudaq::quake::MyOp>;
 using MzRewrite = ExpandRewritePattern<cudaq::quake::MzOp>;
 
-// Expand `quake.discriminate : !cc.stdvec<!cc.measure_handle> ->
-// !cc.stdvec<i1>` when the input handle vector is *not* the direct result
+// Expand `quake.discriminate : !cc.sequence<!cc.measure_handle> ->
+// !cc.sequence<i1>` when the input handle vector is *not* the direct result
 // of a measurement op. The bridge emits this shape for `cudaq::to_bools`
 // applied to a handle vector that has crossed an SSA boundary
 // (e.g. function argument, kernel return), where the measurement-op
 // pattern above cannot reach the underlying `quake.mz/mx/my`. It loops
 // over the handle vector, discriminates each element, and rewraps the
-// resulting bytes as a `!cc.stdvec<i1>`. The direct-from-measurement
+// resulting bytes as a `!cc.sequence<i1>`. The direct-from-measurement
 // case stays handled by `ExpandRewritePattern` to avoid an extra
 // per-element load.
-class ExpandStdvecHandleDiscriminate
+class ExpandSequenceHandleDiscriminate
     : public OpRewritePattern<cudaq::quake::DiscriminateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -233,9 +233,9 @@ public:
   LogicalResult matchAndRewrite(cudaq::quake::DiscriminateOp disc,
                                 PatternRewriter &rewriter) const override {
     Value handleVec = disc.getMeasurement();
-    auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(handleVec.getType());
-    if (!stdvecTy ||
-        !isa<cudaq::cc::MeasureHandleType>(stdvecTy.getElementType()))
+    auto sequenceTy = dyn_cast<cudaq::cc::SequenceType>(handleVec.getType());
+    if (!sequenceTy ||
+        !isa<cudaq::cc::MeasureHandleType>(sequenceTy.getElementType()))
       return failure();
     if (handleVec.getDefiningOp<cudaq::quake::MeasurementInterface>())
       return failure();
@@ -248,10 +248,10 @@ public:
     auto handleTy = cudaq::cc::MeasureHandleType::get(ctx);
 
     Value vecSize =
-        cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, handleVec);
+        cudaq::cc::SequenceSizeOp::create(rewriter, loc, i64Ty, handleVec);
     auto handleArrPtrTy =
         cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(handleTy));
-    Value handleData = cudaq::cc::StdvecDataOp::create(
+    Value handleData = cudaq::cc::SequenceDataOp::create(
         rewriter, loc, handleArrPtrTy, handleVec);
     // Output is held in an i8 buffer, then bitcast to `!cc.ptr<!cc.array
     // <i1 x ?>>` for the wrap. This matches the convention used by the
@@ -276,13 +276,13 @@ public:
           cudaq::cc::StoreOp::create(builder, loc, bitByte, byteAddr);
         });
 
-    auto stdvecI1Ty = cudaq::cc::StdvecType::get(ctx, i1Ty);
+    auto sequenceI1Ty = cudaq::cc::SequenceType::get(ctx, i1Ty);
     auto ptrArrI1Ty =
         cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(i1Ty));
     Value buffCast =
         cudaq::cc::CastOp::create(rewriter, loc, ptrArrI1Ty, i1Buff);
-    rewriter.replaceOpWithNewOp<cudaq::cc::StdvecInitOp>(disc, stdvecI1Ty,
-                                                         buffCast, vecSize);
+    rewriter.replaceOpWithNewOp<cudaq::cc::SequenceInitOp>(disc, sequenceI1Ty,
+                                                           buffCast, vecSize);
     return success();
   }
 };
@@ -321,7 +321,7 @@ public:
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.insert<MxRewrite, MyRewrite, MzRewrite, ResetRewrite,
-                    ExpandStdvecHandleDiscriminate>(ctx);
+                    ExpandSequenceHandleDiscriminate>(ctx);
     ConversionTarget target(*ctx);
     target.addLegalDialect<cudaq::quake::QuakeDialect, cudaq::cc::CCDialect,
                            arith::ArithDialect, LLVM::LLVMDialect>();
@@ -341,19 +341,19 @@ public:
     target.addDynamicallyLegalOp<cudaq::quake::DiscriminateOp>(
         [](cudaq::quake::DiscriminateOp d) {
           // Scalar discriminate is always legal.
-          auto stdvecTy =
-              dyn_cast<cudaq::cc::StdvecType>(d.getMeasurement().getType());
-          if (!stdvecTy)
+          auto sequenceTy =
+              dyn_cast<cudaq::cc::SequenceType>(d.getMeasurement().getType());
+          if (!sequenceTy)
             return true;
           // Vector discriminate of legacy `!quake.measure` is folded as
           // a side-effect of the measurement-op rewrite (step 4); leave
           // it legal here so the driver does not look for a standalone
           // pattern.
-          if (!isa<cudaq::cc::MeasureHandleType>(stdvecTy.getElementType()))
+          if (!isa<cudaq::cc::MeasureHandleType>(sequenceTy.getElementType()))
             return true;
           // Vector discriminate of `!cc.measure_handle` whose source is
           // a measurement op is similarly folded (step 4 again). Only
-          // the indirect case needs `ExpandStdvecHandleDiscriminate`.
+          // the indirect case needs `ExpandSequenceHandleDiscriminate`.
           return d.getMeasurement()
                      .getDefiningOp<cudaq::quake::MeasurementInterface>() !=
                  nullptr;

--- a/cudaq/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -57,7 +57,7 @@ zipArgumentsWithDeviceTypes(Location loc, OpBuilder &builder, ModuleOp module,
             isa<cudaq::cc::IndirectCallableType>(ty)))
         v = cudaq::cc::LoadOp::create(builder, loc, v);
       // Python will pass a std::vector<bool> to us here. Unpack it.
-      auto pear = cudaq::opt::marshal::unpackAnyStdVectorBool(
+      auto pear = cudaq::opt::marshal::unpackAnySequenceBool(
           loc, builder, module, v, ty, heapTracker);
       v = pear.first;
       result.emplace_back(iter.index(), v, ty);
@@ -77,7 +77,7 @@ zipArgumentsWithDeviceTypes(Location loc, OpBuilder &builder, ModuleOp module,
 
       // std::vector<bool> isn't really a std::vector<>. Use the helper
       // function to unpack it so it looks like any other vector.
-      auto pear = cudaq::opt::marshal::unpackAnyStdVectorBool(
+      auto pear = cudaq::opt::marshal::unpackAnySequenceBool(
           loc, builder, module, *argIter, devTy, heapTracker);
       if (pear.second) {
         result.emplace_back(argPos, pear.first, devTy);
@@ -690,13 +690,13 @@ public:
               SmallVector<cudaq::cc::ComputePtrArg>{1});
           auto vecLen = cudaq::cc::LoadOp::create(builder, loc, gep1);
           if (spanTy.getElementType() == builder.getI1Type()) {
-            cudaq::opt::marshal::genStdvecBoolFromInitList(loc, builder, arg0,
-                                                           dataPtr, vecLen);
+            cudaq::opt::marshal::genSequenceBoolFromInitList(loc, builder, arg0,
+                                                             dataPtr, vecLen);
           } else {
             Value tSize =
                 cudaq::cc::SizeOfOp::create(builder, loc, i64Ty, eleTy);
-            cudaq::opt::marshal::genStdvecTFromInitList(loc, builder, arg0,
-                                                        dataPtr, tSize, vecLen);
+            cudaq::opt::marshal::genSequenceTFromInitList(
+                loc, builder, arg0, dataPtr, tSize, vecLen);
           }
           // free(nullptr) is defined to be a nop in the standard.
           func::CallOp::create(builder, loc, TypeRange{}, "free",
@@ -845,18 +845,18 @@ public:
       return module.emitError("could not load malloc");
     if (failed(irBuilder.loadIntrinsic(module, "free")))
       return module.emitError("could not load free");
-    if (failed(
-            irBuilder.loadIntrinsic(module, cudaq::stdvecBoolCtorFromInitList)))
-      return module.emitError(std::string("could not load ") +
-                              cudaq::stdvecBoolCtorFromInitList);
-    if (failed(
-            irBuilder.loadIntrinsic(module, cudaq::stdvecBoolUnpackToInitList)))
-      return module.emitError(std::string("could not load ") +
-                              cudaq::stdvecBoolUnpackToInitList);
     if (failed(irBuilder.loadIntrinsic(module,
-                                       cudaq::stdvecBoolFreeTemporaryLists)))
+                                       cudaq::sequenceBoolCtorFromInitList)))
       return module.emitError(std::string("could not load ") +
-                              cudaq::stdvecBoolFreeTemporaryLists);
+                              cudaq::sequenceBoolCtorFromInitList);
+    if (failed(irBuilder.loadIntrinsic(module,
+                                       cudaq::sequenceBoolUnpackToInitList)))
+      return module.emitError(std::string("could not load ") +
+                              cudaq::sequenceBoolUnpackToInitList);
+    if (failed(irBuilder.loadIntrinsic(module,
+                                       cudaq::sequenceBoolFreeTemporaryLists)))
+      return module.emitError(std::string("could not load ") +
+                              cudaq::sequenceBoolFreeTemporaryLists);
     if (failed(irBuilder.loadIntrinsic(module, cudaq::llvmMemCopyIntrinsic)))
       return module.emitError(std::string("could not load ") +
                               cudaq::llvmMemCopyIntrinsic);

--- a/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -97,7 +97,7 @@ static bool useIsReifySpans(cudaq::cc::ConstantArrayOp conarr) {
 
 static bool useDataToInitState(cudaq::cc::ReifySpanOp reify) {
   for (auto *user : reify->getUsers())
-    if (auto data = dyn_cast<cudaq::cc::StdvecDataOp>(user))
+    if (auto data = dyn_cast<cudaq::cc::SequenceDataOp>(user))
       if (std::distance(data->user_begin(), data->user_end()) == 1)
         return isa<cudaq::quake::InitializeStateOp,
                    cudaq::quake::CreateStateOp>(*data->user_begin());
@@ -227,12 +227,12 @@ struct ReifySpanPattern : public OpRewritePattern<cudaq::cc::ReifySpanOp> {
       if (useDataToInitState(reify)) {
         auto loc = reify.getLoc();
         auto eleTy =
-            cast<cudaq::cc::StdvecType>(reify.getType()).getElementType();
+            cast<cudaq::cc::SequenceType>(reify.getType()).getElementType();
         auto numEle = arith::ConstantIntOp::create(
             rewriter, loc, conArr.getConstantValues().size(), 64);
         Value buff = cudaq::cc::AllocaOp::create(rewriter, loc, eleTy, numEle);
         cudaq::cc::StoreOp::create(rewriter, loc, conArr, buff);
-        rewriter.replaceOpWithNewOp<cudaq::cc::StdvecInitOp>(
+        rewriter.replaceOpWithNewOp<cudaq::cc::SequenceInitOp>(
             reify, reify.getType(), buff, numEle);
         return success();
       }
@@ -263,7 +263,7 @@ struct ReifySpanPattern : public OpRewritePattern<cudaq::cc::ReifySpanOp> {
         auto strLit = cudaq::cc::CreateStringLiteralOp::create(
             rewriter, loc, litTy, stringAttr);
         auto size = arith::ConstantIntOp::create(rewriter, loc, len, 64);
-        members.push_back(cudaq::cc::StdvecInitOp::create(
+        members.push_back(cudaq::cc::SequenceInitOp::create(
             rewriter, loc, cudaq::cc::CharspanType::get(ctx), strLit, size));
       } else if (auto a = dyn_cast<IntegerAttr>(attr)) {
         if (auto floatTy = dyn_cast<FloatType>(eleTy)) {
@@ -310,7 +310,7 @@ struct ReifySpanPattern : public OpRewritePattern<cudaq::cc::ReifySpanOp> {
       cudaq::cc::StoreOp::create(rewriter, loc, m, ptr);
     }
     Value result =
-        cudaq::cc::StdvecInitOp::create(rewriter, loc, ty, buff, size);
+        cudaq::cc::SequenceInitOp::create(rewriter, loc, ty, buff, size);
     return result;
   }
 

--- a/cudaq/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/cudaq/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -109,8 +109,8 @@ Value makeComplexElement(OpBuilder &builder, Location argLoc,
 /// operation.
 static bool hasInitStateUse(BlockArgument argument) {
   for (auto *argUser : argument.getUsers())
-    if (auto stdvecDataOp = dyn_cast<cudaq::cc::StdvecDataOp>(argUser))
-      for (auto *dataUser : stdvecDataOp->getUsers())
+    if (auto sequenceDataOp = dyn_cast<cudaq::cc::SequenceDataOp>(argUser))
+      for (auto *dataUser : sequenceDataOp->getUsers())
         if (isa<cudaq::quake::InitializeStateOp>(dataUser))
           return true;
   return false;
@@ -178,24 +178,25 @@ synthesizeVectorArgument(OpBuilder &builder, ModuleOp module, unsigned &counter,
     return success(allLoadUsers);
   };
 
-  // Iterate over the users of this stdvec argument.
+  // Iterate over the users of this sequence argument.
   for (auto *argUser : argument.getUsers()) {
-    // Handle the StdvecSize use case.
+    // Handle the SequenceSize use case.
     // Replace a `vec.size()` with the length, which is a synthesized constant.
-    if (auto stdvecSizeOp = dyn_cast<cudaq::cc::StdvecSizeOp>(argUser)) {
+    if (auto sequenceSizeOp = dyn_cast<cudaq::cc::SequenceSizeOp>(argUser)) {
       Value length = arith::ConstantIntOp::create(
-          builder, argLoc, stdvecSizeOp.getType(), vec.size());
-      stdvecSizeOp.replaceAllUsesWith(length);
+          builder, argLoc, sequenceSizeOp.getType(), vec.size());
+      sequenceSizeOp.replaceAllUsesWith(length);
       continue;
     }
 
-    // Handle the StdvecDataOp use cases.  We expect `vec.data()` to be indexed
-    // and the value loaded, `vec.data()[c]`. Handle the cases where the offset,
-    // `c`, is a constant as well as cases when it is not. Also handle the case
-    // when the `vec.data()` is used in an arbitrary pointer expression.
-    if (auto stdvecDataOp = dyn_cast<cudaq::cc::StdvecDataOp>(argUser)) {
+    // Handle the SequenceDataOp use cases.  We expect `vec.data()` to be
+    // indexed and the value loaded, `vec.data()[c]`. Handle the cases where the
+    // offset, `c`, is a constant as well as cases when it is not. Also handle
+    // the case when the `vec.data()` is used in an arbitrary pointer
+    // expression.
+    if (auto sequenceDataOp = dyn_cast<cudaq::cc::SequenceDataOp>(argUser)) {
       bool replaceOtherUses = false;
-      for (auto *dataUser : stdvecDataOp->getUsers()) {
+      for (auto *dataUser : sequenceDataOp->getUsers()) {
         // dataUser could be a load, a computeptr, or something else. If it's a
         // load, the index is 0: get the 0-th value from the array and forward
         // it. If it's a computeptr, then we get the element from the array at
@@ -247,12 +248,12 @@ synthesizeVectorArgument(OpBuilder &builder, ModuleOp module, unsigned &counter,
       // constant array as materialized in memory.
       if (replaceOtherUses) {
         auto memArr = getArrayInMemory();
-        stdvecDataOp.replaceAllUsesWith(memArr);
+        sequenceDataOp.replaceAllUsesWith(memArr);
       }
       continue;
     }
 
-    // In the event that the stdvec value is simply used as is, we want to
+    // In the event that the sequence value is simply used as is, we want to
     // construct a new, constant vector in place and replace users of the
     // argument with it.
     generateNewValue = true;
@@ -263,7 +264,7 @@ synthesizeVectorArgument(OpBuilder &builder, ModuleOp module, unsigned &counter,
     builder.setInsertionPointAfter(memArr.getDefiningOp());
     Value size = arith::ConstantIntOp::create(builder, argLoc, vec.size(), 64);
     Value newVec =
-        cudaq::cc::StdvecInitOp::create(builder, argLoc, strTy, memArr, size);
+        cudaq::cc::SequenceInitOp::create(builder, argLoc, strTy, memArr, size);
     argument.replaceAllUsesWith(newVec);
   }
   return success();
@@ -725,13 +726,14 @@ public:
           auto spanp = cudaq::cc::ComputePtrOp::create(
               builder, loc, ptrTy, aos,
               ArrayRef<cudaq::cc::ComputePtrArg>{static_cast<std::int32_t>(i)});
-          auto spanData = cudaq::cc::StdvecInitOp::create(
+          auto spanData = cudaq::cc::SequenceInitOp::create(
               builder, loc, charSpanTy, str, strLen);
           cudaq::cc::StoreOp::create(builder, loc, spanData, spanp);
           bufferAppendix += length;
         }
-        auto svTy = cudaq::cc::StdvecType::get(charSpanTy);
-        auto ics = cudaq::cc::StdvecInitOp::create(builder, loc, svTy, aos, ns);
+        auto svTy = cudaq::cc::SequenceType::get(charSpanTy);
+        auto ics =
+            cudaq::cc::SequenceInitOp::create(builder, loc, svTy, aos, ns);
         arguments[idx].replaceAllUsesWith(ics);
         continue;
       }

--- a/cudaq/lib/Optimizer/Transforms/RealtimeDeviceCall.cpp
+++ b/cudaq/lib/Optimizer/Transforms/RealtimeDeviceCall.cpp
@@ -55,40 +55,40 @@ getSupportedRealtimePrimitiveArrayElement(Type elemTy) {
   return std::nullopt;
 }
 
-static std::optional<Type> getSupportedRealtimeStdvecElement(Type ty) {
-  auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(ty);
-  if (!stdvecTy)
+static std::optional<Type> getSupportedRealtimeSequenceElement(Type ty) {
+  auto sequenceTy = dyn_cast<cudaq::cc::SequenceType>(ty);
+  if (!sequenceTy)
     return std::nullopt;
-  Type elemTy = stdvecTy.getElementType();
+  Type elemTy = sequenceTy.getElementType();
   if (isa<cudaq::cc::MeasureHandleType>(elemTy))
     return IntegerType::get(elemTy.getContext(), 1);
   return getSupportedRealtimePrimitiveArrayElement(elemTy);
 }
 
-static std::optional<Type> getSupportedRealtimeStdvecResultElement(Type ty) {
-  auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(ty);
-  if (!stdvecTy)
+static std::optional<Type> getSupportedRealtimeSequenceResultElement(Type ty) {
+  auto sequenceTy = dyn_cast<cudaq::cc::SequenceType>(ty);
+  if (!sequenceTy)
     return std::nullopt;
-  Type elemTy = stdvecTy.getElementType();
+  Type elemTy = sequenceTy.getElementType();
   if (isa<cudaq::cc::MeasureHandleType>(elemTy))
     return std::nullopt;
   return getSupportedRealtimePrimitiveArrayElement(elemTy);
 }
 
-static bool isRealtimeStdvecArg(Value arg) {
-  return getSupportedRealtimeStdvecElement(arg.getType()).has_value();
+static bool isRealtimeSequenceArg(Value arg) {
+  return getSupportedRealtimeSequenceElement(arg.getType()).has_value();
 }
 
 static ArrayRef<std::int64_t>
-getRealtimeResponseStdvecIndices(cudaq::cc::DeviceCallOp op) {
+getRealtimeResponseSequenceIndices(cudaq::cc::DeviceCallOp op) {
   if (auto attr = op.getByRefVecArgIndicesAttr())
     return attr.asArrayRef();
   return {};
 }
 
 static std::optional<unsigned>
-getRealtimeResponseStdvecIndex(cudaq::cc::DeviceCallOp op) {
-  auto indices = getRealtimeResponseStdvecIndices(op);
+getRealtimeResponseSequenceIndex(cudaq::cc::DeviceCallOp op) {
+  auto indices = getRealtimeResponseSequenceIndices(op);
   if (indices.empty())
     return std::nullopt;
   return static_cast<unsigned>(indices.front());
@@ -110,29 +110,29 @@ static LogicalResult validateRealtimeDeviceCall(cudaq::cc::DeviceCallOp op) {
         "realtime device_call lowering supports at most one result");
 
   auto args = op.getArgs();
-  auto responseStdvecIndices = getRealtimeResponseStdvecIndices(op);
-  if (responseStdvecIndices.size() > 1)
+  auto responseSequenceIndices = getRealtimeResponseSequenceIndices(op);
+  if (responseSequenceIndices.size() > 1)
     return op.emitOpError(
-        "realtime device_call lowering supports at most one by-ref stdvec "
+        "realtime device_call lowering supports at most one by-ref sequence "
         "result argument");
-  if (!responseStdvecIndices.empty()) {
+  if (!responseSequenceIndices.empty()) {
     if (op.getNumResults() != 0)
       return op.emitOpError(
           "realtime device_call lowering does not support both scalar and "
-          "by-ref stdvec results");
+          "by-ref sequence results");
 
-    std::int64_t index = responseStdvecIndices.front();
+    std::int64_t index = responseSequenceIndices.front();
     assert(index >= 0 && static_cast<std::size_t>(index) < args.size() &&
            "DeviceCallOp verifier should have validated by-ref vec indices");
-    if (!getSupportedRealtimeStdvecResultElement(args[index].getType()))
+    if (!getSupportedRealtimeSequenceResultElement(args[index].getType()))
       return op.emitOpError("realtime device_call lowering does not support "
-                            "by-ref stdvec result type ")
+                            "by-ref sequence result type ")
              << args[index].getType();
   }
 
   for (unsigned i = 0, e = args.size(); i < e; ++i) {
     auto arg = args[i];
-    if (isRealtimeStdvecArg(arg))
+    if (isRealtimeSequenceArg(arg))
       continue;
     if (isa<cudaq::cc::PointerType>(arg.getType()))
       return op.emitOpError(
@@ -249,7 +249,7 @@ static Value computeArrayPayloadSize(OpBuilder &builder, Location loc,
 /// device_call with the given `args`.
 static Value
 computeRealtimePayloadSize(OpBuilder &builder, Location loc, ValueRange args,
-                           std::optional<unsigned> responseStdvec) {
+                           std::optional<unsigned> responseSequence) {
   auto i64Ty = builder.getI64Type();
   Value lenSize = i64Constant(builder, loc, sizeof(std::uint64_t));
   Value size = i64Constant(builder, loc, 0);
@@ -261,11 +261,11 @@ computeRealtimePayloadSize(OpBuilder &builder, Location loc, ValueRange args,
   };
   for (unsigned i = 0, e = args.size(); i < e; ++i) {
     Value arg = args[i];
-    if (auto elementTy = getSupportedRealtimeStdvecElement(arg.getType())) {
+    if (auto elementTy = getSupportedRealtimeSequenceElement(arg.getType())) {
       Value arrayLength =
-          cudaq::cc::StdvecSizeOp::create(builder, loc, i64Ty, arg);
+          cudaq::cc::SequenceSizeOp::create(builder, loc, i64Ty, arg);
       addAlignedLength();
-      if (responseStdvec && *responseStdvec == i)
+      if (responseSequence && *responseSequence == i)
         continue;
       Value arrayBytes =
           computeArrayPayloadSize(builder, loc, arrayLength, *elementTy);
@@ -282,19 +282,20 @@ computeRealtimePayloadSize(OpBuilder &builder, Location loc, ValueRange args,
   return size;
 }
 
-static Type getStdvecSourceElementType(Value stdvec) {
-  return cast<cudaq::cc::StdvecType>(stdvec.getType()).getElementType();
+static Type getSequenceSourceElementType(Value sequence) {
+  return cast<cudaq::cc::SequenceType>(sequence.getType()).getElementType();
 }
 
-static Value getStdvecLength(OpBuilder &builder, Location loc, Value stdvec) {
-  return cudaq::cc::StdvecSizeOp::create(builder, loc, builder.getI64Type(),
-                                         stdvec);
+static Value getSequenceLength(OpBuilder &builder, Location loc,
+                               Value sequence) {
+  return cudaq::cc::SequenceSizeOp::create(builder, loc, builder.getI64Type(),
+                                           sequence);
 }
 
-static Value getStdvecData(OpBuilder &builder, Location loc, Value stdvec) {
+static Value getSequenceData(OpBuilder &builder, Location loc, Value sequence) {
   auto arrayPtrTy = cudaq::cc::PointerType::get(
-      cudaq::cc::ArrayType::get(getStdvecSourceElementType(stdvec)));
-  return cudaq::cc::StdvecDataOp::create(builder, loc, arrayPtrTy, stdvec);
+      cudaq::cc::ArrayType::get(getSequenceSourceElementType(sequence)));
+  return cudaq::cc::SequenceDataOp::create(builder, loc, arrayPtrTy, sequence);
 }
 
 static Value marshalArrayArgument(OpBuilder &builder, Location loc,
@@ -348,11 +349,11 @@ static Value marshalArrayArgument(OpBuilder &builder, Location loc,
 /// Copy the raw response payload into the output vector's storage. This uses
 /// the same compatible-native-layout assumption as request marshalling, so the
 /// response bytes can be copied directly into the vector's element storage.
-static void copyResponseToStdvec(OpBuilder &builder, Location loc,
-                                 Value responseBuffer, Value responseLen,
-                                 Value stdvec) {
+static void copyResponseToSequence(OpBuilder &builder, Location loc,
+                                   Value responseBuffer, Value responseLen,
+                                   Value sequence) {
   auto ptrI8Ty = cudaq::cc::PointerType::get(builder.getI8Type());
-  Value data = getStdvecData(builder, loc, stdvec);
+  Value data = getSequenceData(builder, loc, sequence);
   Value dstPtr = cudaq::cc::CastOp::create(builder, loc, ptrI8Ty, data);
   Value srcPtr =
       cudaq::cc::CastOp::create(builder, loc, ptrI8Ty, responseBuffer);
@@ -361,13 +362,13 @@ static void copyResponseToStdvec(OpBuilder &builder, Location loc,
                        ValueRange{dstPtr, srcPtr, responseLen, notVolatile});
 }
 
-static void unpackResponseToBoolStdvec(OpBuilder &builder, Location loc,
-                                       Value responseBuffer,
-                                       Value logicalLength, Value stdvec) {
-  assert(getStdvecSourceElementType(stdvec).isInteger(1));
+static void unpackResponseToBoolSequence(OpBuilder &builder, Location loc,
+                                         Value responseBuffer,
+                                         Value logicalLength, Value sequence) {
+  assert(getSequenceSourceElementType(sequence).isInteger(1));
   // Boolean responses use the least-significant-bit first bit-packed
   // encoding. Use `__nvqpp_RealtimeUnpackBits` intrinsic to unpack.
-  Value data = getStdvecData(builder, loc, stdvec);
+  Value data = getSequenceData(builder, loc, sequence);
   func::CallOp::create(builder, loc, TypeRange{}, cudaq::realtimeUnpackBits,
                        ValueRange{data, responseBuffer, logicalLength});
 }
@@ -442,11 +443,11 @@ public:
     auto ptrI8Ty = cudaq::cc::PointerType::get(i8Ty);
 
     auto args = devcall.getArgs();
-    std::optional<unsigned> responseStdvec =
-        getRealtimeResponseStdvecIndex(devcall);
+    std::optional<unsigned> responseSequence =
+        getRealtimeResponseSequenceIndex(devcall);
     // Size the request payload
     Value requestSize =
-        computeRealtimePayloadSize(rewriter, loc, args, responseStdvec);
+        computeRealtimePayloadSize(rewriter, loc, args, responseSequence);
 
     const auto [resultTy, responseCapacity] = [&]() -> std::pair<Type, Value> {
       if (devcall.getNumResults() == 1) {
@@ -455,11 +456,11 @@ public:
             i64Constant(rewriter, loc, realtimePrimitiveSize(resultTy));
         return {resultTy, responseCapacity};
       }
-      if (responseStdvec) {
-        const Value outVector = args[*responseStdvec];
+      if (responseSequence) {
+        const Value outVector = args[*responseSequence];
         const Type elementTy =
-            *getSupportedRealtimeStdvecResultElement(outVector.getType());
-        const Value outLength = getStdvecLength(rewriter, loc, outVector);
+            *getSupportedRealtimeSequenceResultElement(outVector.getType());
+        const Value outLength = getSequenceLength(rewriter, loc, outVector);
         return {Type{},
                 computeArrayPayloadSize(rewriter, loc, outLength, elementTy)};
       }
@@ -512,7 +513,7 @@ public:
     Value requestBuffer = cudaq::cc::CastOp::create(
         rewriter, loc, payloadArrayPtrTy, requestPayload);
     const Value responseBuffer = [&] {
-      if (!resultTy && !responseStdvec)
+      if (!resultTy && !responseSequence)
         return Value{};
       const Value responsePayload =
           cudaq::cc::LoadOp::create(rewriter, loc, responsePayloadSlot);
@@ -522,22 +523,22 @@ public:
     }();
 
     // Marshal operands into the request payload. Scalars are aligned and stored
-    // directly. Supported stdvec arguments use a length prefix followed by
-    // element bytes; a response stdvec carries its extent in the request and
+    // directly. Supported sequence arguments use a length prefix followed by
+    // element bytes; a response sequence carries its extent in the request and
     // receives its elements through the response payload.
     Value cursor = i64Constant(rewriter, loc, 0);
     for (unsigned i = 0, e = args.size(); i < e; ++i) {
       auto arg = args[i];
-      if (auto elementTy = getSupportedRealtimeStdvecElement(arg.getType())) {
-        Value arrayLength = getStdvecLength(rewriter, loc, arg);
-        if (responseStdvec && *responseStdvec == i) {
+      if (auto elementTy = getSupportedRealtimeSequenceElement(arg.getType())) {
+        Value arrayLength = getSequenceLength(rewriter, loc, arg);
+        if (responseSequence && *responseSequence == i) {
           cursor = writeLengthPrefix(rewriter, loc, cursor, requestBuffer,
                                      arrayLength);
           continue;
         }
 
-        Type sourceElementTy = getStdvecSourceElementType(arg);
-        Value data = getStdvecData(rewriter, loc, arg);
+        Type sourceElementTy = getSequenceSourceElementType(arg);
+        Value data = getSequenceData(rewriter, loc, arg);
         cursor =
             marshalArrayArgument(rewriter, loc, cursor, requestBuffer, data,
                                  arrayLength, sourceElementTy, *elementTy);
@@ -563,8 +564,8 @@ public:
     emitTrapOnFailure(rewriter, loc, status.getResult(0), frameHandle);
 
     if (!resultTy) {
-      if (responseStdvec) {
-        // This is a by-ref stdvec result case.
+      if (responseSequence) {
+        // This is a by-ref sequence result case.
         Value returnedLen =
             cudaq::cc::LoadOp::create(rewriter, loc, responseLen);
         auto unexpectedResponseLen =
@@ -574,16 +575,16 @@ public:
             rewriter, loc, RealtimeRemoteErrorStatus, 32);
         emitTrapOnCondition(rewriter, loc, unexpectedResponseLen, remoteError,
                             frameHandle);
-        Value outVector = args[*responseStdvec];
+        Value outVector = args[*responseSequence];
         Type elementTy =
-            *getSupportedRealtimeStdvecResultElement(outVector.getType());
+            *getSupportedRealtimeSequenceResultElement(outVector.getType());
         if (elementTy.isInteger(1)) {
-          Value outLength = getStdvecLength(rewriter, loc, outVector);
-          unpackResponseToBoolStdvec(rewriter, loc, responseBuffer, outLength,
-                                     outVector);
+          Value outLength = getSequenceLength(rewriter, loc, outVector);
+          unpackResponseToBoolSequence(rewriter, loc, responseBuffer, outLength,
+                                       outVector);
         } else {
-          copyResponseToStdvec(rewriter, loc, responseBuffer, responseCapacity,
-                               outVector);
+          copyResponseToSequence(rewriter, loc, responseBuffer,
+                                 responseCapacity, outVector);
         }
       }
       emitReleaseFrame(rewriter, loc, frameHandle);

--- a/cudaq/lib/Optimizer/Transforms/RunSemanticsHackery.cpp
+++ b/cudaq/lib/Optimizer/Transforms/RunSemanticsHackery.cpp
@@ -69,7 +69,7 @@ public:
           fn, callOp.getCalleeAttr());
       auto calledFnTy = called.getFunctionType();
       if (!(calledFnTy.getResults().size() == 1 &&
-            isa<cudaq::cc::StdvecType>(calledFnTy.getResult(0))))
+            isa<cudaq::cc::SequenceType>(calledFnTy.getResult(0))))
         return;
       worklist.emplace_back(callOp, called);
       LLVM_DEBUG(llvm::dbgs() << "adding kernel: " << name << '\n');

--- a/cudaq/test/AST-Quake/auto_kernel-1.cpp
+++ b/cudaq/test/AST-Quake/auto_kernel-1.cpp
@@ -27,9 +27,9 @@ struct ak1 {
 // CHECK:           %[[VAL_1:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_7:.*]] = quake.discriminate %[[VAL_3]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_7]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] name "vec" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_7:.*]] = quake.discriminate %[[VAL_3]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_7]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i8>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_6]] : (i8) -> i1

--- a/cudaq/test/AST-Quake/auto_kernel-2.cpp
+++ b/cudaq/test/AST-Quake/auto_kernel-2.cpp
@@ -22,15 +22,15 @@ struct ak2 {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak2
-// CHECK-SAME: () -> !cc.stdvec<i1> attributes {
+// CHECK-SAME: () -> !cc.sequence<i1> attributes {
 // CHECK:           %[[VAL_22:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.veq<5>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_1:.*]] = quake.discriminate %[[VAL_19]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_21:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.veq<5>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_1:.*]] = quake.discriminate %[[VAL_19]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_20:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_21:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[VAL_23:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_23]], %[[VAL_21]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VAL_24]] : !cc.stdvec<i1>
+// CHECK:           %[[VAL_24:.*]] = cc.sequence_init %[[VAL_23]], %[[VAL_21]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VAL_24]] : !cc.sequence<i1>
 // CHECK:         }
 // CHECK-NOT:   func.func {{.*}} @_ZNKSt14_Bit_referencecvbEv() -> i1
 // CHECK-LABEL: func.func private @__nvqpp_vectorCopyCtor(

--- a/cudaq/test/AST-Quake/call_qpu.cpp
+++ b/cudaq/test/AST-Quake/call_qpu.cpp
@@ -19,15 +19,15 @@ std::vector<bool> func_achat(cudaq::qview<> &qv) __qpu__ {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_func_achat._Z10func_achatRN5cudaq5qviewILm2EEE(
-// CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>) -> !cc.stdvec<i1> attributes {"cudaq-kernel", no_this} {
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>) -> !cc.sequence<i1> attributes {"cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[VAL_6:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_4]], %[[VAL_5]], %[[VAL_1]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VAL_7]] : !cc.stdvec<i1>
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VAL_7]] : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -50,9 +50,9 @@ int func_shiim(cudaq::qvector<> &qv) __qpu__ {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_4:.*]] = quake.subveq %[[VAL_0]], 1, 3 : (!quake.veq<?>) -> !quake.veq<3>
 // CHECK:           %[[VAL_5:.*]] = quake.relax_size %[[VAL_4]] : (!quake.veq<3>) -> !quake.veq<?>
-// CHECK:           %[[VAL_6:.*]] = call @__nvqpp__mlirgen__function_func_achat._Z10func_achatRN5cudaq5qviewILm2EEE(%[[VAL_5]]) : (!quake.veq<?>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_6]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_8:.*]] = cc.stdvec_size %[[VAL_6]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_6:.*]] = call @__nvqpp__mlirgen__function_func_achat._Z10func_achatRN5cudaq5qviewILm2EEE(%[[VAL_5]]) : (!quake.veq<?>) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_data %[[VAL_6]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = cc.sequence_size %[[VAL_6]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[VAL_9:.*]] = cc.alloca i8{{\[}}%[[VAL_8]] : i64]
 // CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
 // CHECK:           call @__nvqpp_vectorCopyToStack(%[[VAL_10]], %[[VAL_7]], %[[VAL_8]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64) -> ()

--- a/cudaq/test/AST-Quake/character_comparison.cpp
+++ b/cudaq/test/AST-Quake/character_comparison.cpp
@@ -28,7 +28,7 @@ __qpu__ void apply_pauli(cudaq::qview<> qubits, const std::vector<char> &word) {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_apply_pauli
-// CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !cc.stdvec<i8>) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !cc.sequence<i8>) attributes
 // CHECK-DAG:           %[[VAL_2:.*]] = arith.constant 90 : i32
 // CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 89 : i32
 // CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 88 : i32
@@ -39,12 +39,12 @@ __qpu__ void apply_pauli(cudaq::qview<> qubits, const std::vector<char> &word) {
 // CHECK:             cc.store %[[VAL_5]], %[[VAL_7]] : !cc.ptr<i64>
 // CHECK:             cc.loop while {
 // CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i64>
-// CHECK:               %[[VAL_9:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<i8>) -> i64
+// CHECK:               %[[VAL_9:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<i8>) -> i64
 // CHECK:               %[[VAL_10:.*]] = arith.cmpi ult, %[[VAL_8]], %[[VAL_9]] : i64
 // CHECK:               cc.condition %[[VAL_10]]
 // CHECK:             } do {
 // CHECK:               %[[VAL_11:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i64>
-// CHECK:               %[[VAL_12:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:               %[[VAL_12:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:               %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_12]][%[[VAL_11]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:               %[[VAL_14:.*]] = cc.load %[[VAL_13]] : !cc.ptr<i8>
 // CHECK:               %[[VAL_15:.*]] = cc.cast {{.*}}%[[VAL_14]] : (i8) -> i32
@@ -55,7 +55,7 @@ __qpu__ void apply_pauli(cudaq::qview<> qubits, const std::vector<char> &word) {
 // CHECK:                 quake.x %[[VAL_18]] : (!quake.ref) -> ()
 // CHECK:               }
 // CHECK:               %[[VAL_19:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i64>
-// CHECK:               %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:               %[[VAL_20:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:               %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_20]][%[[VAL_19]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:               %[[VAL_22:.*]] = cc.load %[[VAL_21]] : !cc.ptr<i8>
 // CHECK:               %[[VAL_23:.*]] = cc.cast {{.*}}%[[VAL_22]] : (i8) -> i32
@@ -66,7 +66,7 @@ __qpu__ void apply_pauli(cudaq::qview<> qubits, const std::vector<char> &word) {
 // CHECK:                 quake.y %[[VAL_26]] : (!quake.ref) -> ()
 // CHECK:               }
 // CHECK:               %[[VAL_27:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i64>
-// CHECK:               %[[VAL_28:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:               %[[VAL_28:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:               %[[VAL_29:.*]] = cc.compute_ptr %[[VAL_28]][%[[VAL_27]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:               %[[VAL_30:.*]] = cc.load %[[VAL_29]] : !cc.ptr<i8>
 // CHECK:               %[[VAL_31:.*]] = cc.cast {{.*}}%[[VAL_30]] : (i8) -> i32

--- a/cudaq/test/AST-Quake/const_reference_extension.cpp
+++ b/cudaq/test/AST-Quake/const_reference_extension.cpp
@@ -30,7 +30,7 @@ __qpu__ uint64_t foo() {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qubit_values_to_integer.
-// CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<!cc.measure_handle>) -> i64 attributes {"cudaq-kernel", no_this}
+// CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<!cc.measure_handle>) -> i64 attributes {"cudaq-kernel", no_this}
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = cc.alloca i64
@@ -40,12 +40,12 @@ __qpu__ uint64_t foo() {
 // CHECK:             cc.store %[[VAL_2]], %[[VAL_4]] : !cc.ptr<i64>
 // CHECK:             cc.loop while {
 // CHECK:               %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:               %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<!cc.measure_handle>) -> i64
+// CHECK:               %[[VAL_6:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<!cc.measure_handle>) -> i64
 // CHECK:               %[[VAL_7:.*]] = arith.cmpi ult, %[[VAL_5]], %[[VAL_6]] : i64
 // CHECK:               cc.condition %[[VAL_7]]
 // CHECK:             } do {
 // CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:               %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:               %[[VAL_9:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:               %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_9]]{{\[}}%[[VAL_8]]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_12:.*]] = quake.discriminate %[[VAL_11]] : (!cc.measure_handle) -> i1
@@ -84,7 +84,7 @@ __qpu__ uint64_t foo() {
 // CHECK:             %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_1]] : i64
 // CHECK:             cc.continue %[[VAL_10]] : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_3]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_3]] name "results" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[VAL_12:.*]] = call @__nvqpp__mlirgen__function_qubit_values_to_integer.
 // CHECK:           return %[[VAL_12]] : i64
 // CHECK:         }

--- a/cudaq/test/AST-Quake/control_flow.cpp
+++ b/cudaq/test/AST-Quake/control_flow.cpp
@@ -106,7 +106,7 @@ struct C {
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -197,7 +197,7 @@ struct D {
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -287,7 +287,7 @@ struct E {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb7:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
 // CHECK:           return
 // clang-format on
@@ -379,7 +379,7 @@ struct F {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb8:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
 // CHECK:           return
 // clang-format on

--- a/cudaq/test/AST-Quake/ctrl_vector.cpp
+++ b/cudaq/test/AST-Quake/ctrl_vector.cpp
@@ -30,7 +30,7 @@ struct lower_ctrl_as_qreg {
 // CHECK:           quake.h [%[[VAL_0]]] %[[VAL_2]] : (!quake.veq<4>, !quake.ref) -> ()
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_0]]] %[[VAL_3]] : (!quake.veq<4>, !quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/cudaq_run.cpp
+++ b/cudaq/test/AST-Quake/cudaq_run.cpp
@@ -86,9 +86,9 @@ __qpu__ std::vector<bool> branch_vec_test() {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__K9.run()
-// CHECK:           %[[VAL_0:.*]] = call @__nvqpp__mlirgen__K9() : () -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_1:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<i1>) -> i64
-// CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_0:.*]] = call @__nvqpp__mlirgen__K9() : () -> !cc.sequence<i1>
+// CHECK:           %[[VAL_1:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<i1>) -> i64
+// CHECK:           %[[VAL_2:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
 // CHECK:           call @__quantum__rt__bool_span_record_output(%[[VAL_2]], %[[VAL_1]]) : (!cc.ptr<i8>, i64) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -210,9 +210,9 @@ __qpu__ std::vector<bool> branch_vec_test() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_unary_test_list._Z15unary_test_listi.run(
 // CHECK-SAME:      %[[VAL_0:.*]]: i32)
 // CHECK:           %[[VAL_C4:.*]] = arith.constant 4 : i32
-// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_unary_test_list._Z15unary_test_listi(%[[VAL_0]]) : (i32) -> !cc.stdvec<f32>
-// CHECK:           %[[VAL_2:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<f32>) -> i64
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<f32>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_unary_test_list._Z15unary_test_listi(%[[VAL_0]]) : (i32) -> !cc.sequence<f32>
+// CHECK:           %[[VAL_2:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<f32>) -> i64
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<f32>) -> !cc.ptr<i8>
 // CHECK:           call @__quantum__rt__float_span_record_output(%[[VAL_3]], %[[VAL_2]], %[[VAL_C4]]) : (!cc.ptr<i8>, i64, i32) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -223,9 +223,9 @@ __qpu__ std::vector<bool> branch_vec_test() {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_unary_test_list2._Z16unary_test_list2i.run(
 // CHECK-SAME:      %[[VAL_0:.*]]: i32)
-// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_unary_test_list2._Z16unary_test_list2i(%[[VAL_0]]) : (i32) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_2:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<i1>) -> i64
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_unary_test_list2._Z16unary_test_list2i(%[[VAL_0]]) : (i32) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_2:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<i1>) -> i64
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
 // CHECK:           call @__quantum__rt__bool_span_record_output(%[[VAL_3]], %[[VAL_2]]) : (!cc.ptr<i8>, i64) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -236,9 +236,9 @@ __qpu__ std::vector<bool> branch_vec_test() {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_dyn_vec_test._Z12dyn_vec_testi.run(
 // CHECK-SAME:      %[[VAL_0:.*]]: i32)
-// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_dyn_vec_test._Z12dyn_vec_testi(%[[VAL_0]]) : (i32) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_2:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<i1>) -> i64
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_dyn_vec_test._Z12dyn_vec_testi(%[[VAL_0]]) : (i32) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_2:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<i1>) -> i64
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
 // CHECK:           call @__quantum__rt__bool_span_record_output(%[[VAL_3]], %[[VAL_2]]) : (!cc.ptr<i8>, i64) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -248,9 +248,9 @@ __qpu__ std::vector<bool> branch_vec_test() {
 // CHECK:           %[[VAL_3:.*]] = constant @function_dyn_vec_test._Z12dyn_vec_testi.run.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_branch_vec_test._Z15branch_vec_testv.run()
-// CHECK:           %[[V0:.*]] = call @__nvqpp__mlirgen__function_branch_vec_test._Z15branch_vec_testv() : () -> !cc.stdvec<i1>
-// CHECK:           %[[V1:.*]] = cc.stdvec_size %[[V0]] : (!cc.stdvec<i1>) -> i64
-// CHECK:           %[[V2:.*]] = cc.stdvec_data %[[V0]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[V0:.*]] = call @__nvqpp__mlirgen__function_branch_vec_test._Z15branch_vec_testv() : () -> !cc.sequence<i1>
+// CHECK:           %[[V1:.*]] = cc.sequence_size %[[V0]] : (!cc.sequence<i1>) -> i64
+// CHECK:           %[[V2:.*]] = cc.sequence_data %[[V0]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
 // CHECK:           call @__quantum__rt__bool_span_record_output(%[[V2]], %[[V1]]) : (!cc.ptr<i8>, i64) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/AST-Quake/cudaq_types.cpp
+++ b/cudaq/test/AST-Quake/cudaq_types.cpp
@@ -36,7 +36,7 @@ struct Qernel0 {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Qernel0()
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/device_call_by_ref_vec.cpp
+++ b/cudaq/test/AST-Quake/device_call_by_ref_vec.cpp
@@ -17,22 +17,22 @@ void readVector(const std::vector<int> &in, int seed);
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_byRefVecKernel._Z14byRefVecKernel{{.*}}(
-// CHECK-SAME:      %[[ARG0:.*]]: !cc.stdvec<i32>,
-// CHECK-SAME:      %[[ARG1:.*]]: !cc.stdvec<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.sequence<i32>,
+// CHECK-SAME:      %[[ARG1:.*]]: !cc.sequence<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 13 : i32
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 42 : i32
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[CONSTANT_1]], %[[ALLOCA_0]] : !cc.ptr<i32>
 // CHECK:           %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i32>
-// CHECK:           cc.device_call @_Z10fillVector{{.*}}i(%[[ARG0]], %[[LOAD_0]]) : (!cc.stdvec<i32>, i32) -> () {by_ref_vec_arg_indices = array<i64: 0>}
+// CHECK:           cc.device_call @_Z10fillVector{{.*}}i(%[[ARG0]], %[[LOAD_0]]) : (!cc.sequence<i32>, i32) -> () {by_ref_vec_arg_indices = array<i64: 0>}
 // CHECK:           %[[ALLOCA_1:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[CONSTANT_0]], %[[ALLOCA_1]] : !cc.ptr<i32>
 // CHECK:           %[[LOAD_1:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<i32>
-// CHECK:           cc.device_call @_Z10readVector{{.*}}i(%[[ARG1]], %[[LOAD_1]]) : (!cc.stdvec<i32>, i32) -> ()
+// CHECK:           cc.device_call @_Z10readVector{{.*}}i(%[[ARG1]], %[[LOAD_1]]) : (!cc.sequence<i32>, i32) -> ()
 // CHECK:           return
 // CHECK:         }
-// CHECK:         func.func private @_Z10fillVector{{.*}}i(!cc.stdvec<i32>, i32) attributes {"cudaq-devicecall"}
-// CHECK:         func.func private @_Z10readVector{{.*}}i(!cc.stdvec<i32>, i32) attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @_Z10fillVector{{.*}}i(!cc.sequence<i32>, i32) attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @_Z10readVector{{.*}}i(!cc.sequence<i32>, i32) attributes {"cudaq-devicecall"}
 
 // CHECK-LABEL:   func.func @_Z14byRefVecKernel{{.*}}(
 // CHECK-SAME:      %[[ARG0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>,

--- a/cudaq/test/AST-Quake/grover.cpp
+++ b/cudaq/test/AST-Quake/grover.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[]) {
 // CHECK:               cc.store %[[VAL_36]], %[[VAL_30]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_37:.*]] = quake.mz %[[VAL_21]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_37:.*]] = quake.mz %[[VAL_21]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/AST-Quake/indirect_callable.cpp
+++ b/cudaq/test/AST-Quake/indirect_callable.cpp
@@ -37,7 +37,7 @@ void meanwhile_on_safari() {
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.cast signed %[[VAL_6]] : (i32) -> i64
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<?>[%[[VAL_7]] : i64]
-// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/AST-Quake/loop_unroll-3.cpp
+++ b/cudaq/test/AST-Quake/loop_unroll-3.cpp
@@ -110,7 +110,7 @@ struct Qernel {
 // CHECK:           quake.x %[[VAL_2]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
 // CHECK:           quake.x %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/measure_bell.cpp
+++ b/cudaq/test/AST-Quake/measure_bell.cpp
@@ -52,19 +52,19 @@ struct bell {
 // CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:               %[[SLOT:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:               cc.store %[[VAL_112]], %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[LD0:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[LD0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:               %[[SLOT:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:               cc.store %[[VAL_112]], %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[LD0:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[VAL_13:.*]] = cc.sequence_data %[[LD0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_35:.*]] = quake.discriminate %[[VAL_15]] : (!cc.measure_handle) -> i1
 // CHECK:               %[[VAL_16:.*]] = cc.alloca i1
 // CHECK:               cc.store %[[VAL_35]], %[[VAL_16]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i1>
-// CHECK:               %[[LD1:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[D1:.*]] = cc.stdvec_data %[[LD1]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:               %[[LD1:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[D1:.*]] = cc.sequence_data %[[LD1]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:               %[[VAL_18:.*]] = cc.compute_ptr %[[D1]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_19:.*]] = cc.load %[[VAL_18]] : !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_39:.*]] = quake.discriminate %[[VAL_19]] : (!cc.measure_handle) -> i1
@@ -123,11 +123,11 @@ struct libertybell {
 // CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:               %[[SLOT:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:               cc.store %[[VAL_112]], %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[LD0:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[LD0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:               %[[SLOT:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:               cc.store %[[VAL_112]], %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[LD0:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[VAL_13:.*]] = cc.sequence_data %[[LD0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_35:.*]] = quake.discriminate %[[VAL_15]] : (!cc.measure_handle) -> i1
@@ -191,17 +191,17 @@ struct tinkerbell {
 // CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:               %[[SLOT:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:               cc.store %[[VAL_112]], %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[LD0:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[LD0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:               %[[SLOT:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:               cc.store %[[VAL_112]], %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[LD0:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[VAL_13:.*]] = cc.sequence_data %[[LD0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[H0A:.*]] = cc.alloca !cc.measure_handle
 // CHECK:               cc.store %[[VAL_15]], %[[H0A]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[LD1:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:               %[[D1:.*]] = cc.stdvec_data %[[LD1]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:               %[[LD1:.*]] = cc.load %[[SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:               %[[D1:.*]] = cc.sequence_data %[[LD1]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:               %[[VAL_16:.*]] = cc.compute_ptr %[[D1]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<!cc.measure_handle>
 // CHECK:               %[[H1A:.*]] = cc.alloca !cc.measure_handle

--- a/cudaq/test/AST-Quake/measure_handle.cpp
+++ b/cudaq/test/AST-Quake/measure_handle.cpp
@@ -235,7 +235,7 @@ struct RegisterHandle {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__RegisterHandle()
 // CHECK:           %[[VAL_V:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %{{.*}} = quake.mz %[[VAL_V]] name "hs" : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %{{.*}} = quake.mz %[[VAL_V]] name "hs" : (!quake.veq<4>) -> !cc.sequence<!cc.measure_handle>
 // CHECK-NOT:       quake.discriminate
 // CHECK:           return
 // CHECK:         }
@@ -249,14 +249,14 @@ struct RegisterBools {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__RegisterBools() -> !cc.stdvec<i1>
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__RegisterBools() -> !cc.sequence<i1>
 // CHECK:           %[[VAL_V:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_M:.*]] = quake.mz %[[VAL_V]] : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_BV:.*]] = quake.discriminate %[[VAL_M]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           %{{.*}} = cc.stdvec_data %[[VAL_BV]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %{{.*}} = cc.stdvec_size %[[VAL_BV]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_M:.*]] = quake.mz %[[VAL_V]] : (!quake.veq<4>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_BV:.*]] = quake.discriminate %[[VAL_M]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           %{{.*}} = cc.sequence_data %[[VAL_BV]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %{{.*}} = cc.sequence_size %[[VAL_BV]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %{{.*}} = call @__nvqpp_vectorCopyCtor(
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -271,9 +271,9 @@ struct ToIntegerExplicit {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ToIntegerExplicit
-// CHECK:           %[[BOOLS:.*]] = quake.discriminate %{{.*}} : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+// CHECK:           %[[BOOLS:.*]] = quake.discriminate %{{.*}} : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
 // CHECK-NOT:       quake.discriminate
-// CHECK:           %{{.*}} = call @__nvqpp_cudaqConvertToInteger(%[[BOOLS]]) : (!cc.stdvec<i1>) -> i64
+// CHECK:           %{{.*}} = call @__nvqpp_cudaqConvertToInteger(%[[BOOLS]]) : (!cc.sequence<i1>) -> i64
 // clang-format on
 
 struct MxMyHandles {
@@ -339,14 +339,14 @@ __qpu__ std::vector<cudaq::measure_handle> single_round(cudaq::qview<> qv) {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_single_round.
-// CHECK-SAME:      -> !cc.stdvec<!cc.measure_handle>
+// CHECK-SAME:      -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[C8:.*]] = arith.constant 8 : i64
-// CHECK:           %[[M:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[D:.*]] = cc.stdvec_data %[[M]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<i8>
-// CHECK:           %[[S:.*]] = cc.stdvec_size %[[M]] : (!cc.stdvec<!cc.measure_handle>) -> i64
+// CHECK:           %[[M:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[D:.*]] = cc.sequence_data %[[M]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<i8>
+// CHECK:           %[[S:.*]] = cc.sequence_size %[[M]] : (!cc.sequence<!cc.measure_handle>) -> i64
 // CHECK:           %[[H:.*]] = call @__nvqpp_vectorCopyCtor(%[[D]], %[[S]], %[[C8]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[V:.*]] = cc.stdvec_init %[[H]], %[[S]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           return %[[V]] : !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[V:.*]] = cc.sequence_init %[[H]], %[[S]] : (!cc.ptr<i8>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           return %[[V]] : !cc.sequence<!cc.measure_handle>
 // clang-format on
 
 __qpu__ std::vector<cudaq::measure_handle> stab_round(cudaq::qview<> ancz,
@@ -356,11 +356,11 @@ __qpu__ std::vector<cudaq::measure_handle> stab_round(cudaq::qview<> ancz,
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_stab_round.
-// CHECK-SAME:      -> !cc.stdvec<!cc.measure_handle>
+// CHECK-SAME:      -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[C8:.*]] = arith.constant 8 : i64
-// CHECK:           %[[M:.*]] = quake.mz %{{.*}}, %{{.*}} : (!quake.veq<?>, !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[M:.*]] = quake.mz %{{.*}}, %{{.*}} : (!quake.veq<?>, !quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %{{.*}} = call @__nvqpp_vectorCopyCtor(%{{.*}}, %{{.*}}, %[[C8]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           return %{{.*}} : !cc.stdvec<!cc.measure_handle>
+// CHECK:           return %{{.*}} : !cc.sequence<!cc.measure_handle>
 // clang-format on
 
 struct HandleEquality {
@@ -588,7 +588,7 @@ struct CallableParamReturningHandleVec {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__CallableParamReturningHandleVec(
-// CHECK-SAME:      %{{.*}}: !cc.indirect_callable<(i64) -> !cc.stdvec<!cc.measure_handle>>
+// CHECK-SAME:      %{{.*}}: !cc.indirect_callable<(i64) -> !cc.sequence<!cc.measure_handle>>
 // CHECK-SAME:      attributes {"cudaq-entrypoint", "cudaq-kernel"
 // clang-format on
 
@@ -634,16 +634,16 @@ struct HandleVecAssignFromLvalue {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__HandleVecAssignFromLvalue()
 // CHECK:           %[[HV_C8:.*]] = arith.constant 8 : i64
-// CHECK:           %[[HV_PREV_SLOT:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %{{.*}}, %[[HV_PREV_SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[HV_CURR_SLOT:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %{{.*}}, %[[HV_CURR_SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[HV_RHS:.*]] = cc.load %[[HV_CURR_SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[HV_D:.*]] = cc.stdvec_data %[[HV_RHS]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<i8>
-// CHECK:           %[[HV_S:.*]] = cc.stdvec_size %[[HV_RHS]] : (!cc.stdvec<!cc.measure_handle>) -> i64
+// CHECK:           %[[HV_PREV_SLOT:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %{{.*}}, %[[HV_PREV_SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[HV_CURR_SLOT:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %{{.*}}, %[[HV_CURR_SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[HV_RHS:.*]] = cc.load %[[HV_CURR_SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[HV_D:.*]] = cc.sequence_data %[[HV_RHS]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<i8>
+// CHECK:           %[[HV_S:.*]] = cc.sequence_size %[[HV_RHS]] : (!cc.sequence<!cc.measure_handle>) -> i64
 // CHECK:           %[[HV_H:.*]] = call @__nvqpp_vectorCopyCtor(%[[HV_D]], %[[HV_S]], %[[HV_C8]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[HV_NEW:.*]] = cc.stdvec_init %[[HV_H]], %[[HV_S]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[HV_NEW]], %[[HV_PREV_SLOT]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[HV_NEW:.*]] = cc.sequence_init %[[HV_H]], %[[HV_S]] : (!cc.ptr<i8>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[HV_NEW]], %[[HV_PREV_SLOT]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -663,14 +663,14 @@ struct HandleVecCrossRoundLoop {
 // (`prev = curr;`) so that `prev` doesn't dangle into the next iteration.
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__HandleVecCrossRoundLoop(
-// CHECK:           %[[L_PREV:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %{{.*}}, %[[L_PREV]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[L_PREV:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %{{.*}}, %[[L_PREV]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
 // CHECK:           cc.loop while
 // CHECK:           } do {
-// CHECK:             %[[L_CURR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:             cc.store %{{.*}}, %[[L_CURR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:             %[[L_RHS:.*]] = cc.load %[[L_CURR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:             %[[L_CURR:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:             cc.store %{{.*}}, %[[L_CURR]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:             %[[L_RHS:.*]] = cc.load %[[L_CURR]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
 // CHECK:             %{{.*}} = func.call @__nvqpp_vectorCopyCtor(
-// CHECK:             %[[L_NEW:.*]] = cc.stdvec_init %{{.*}}, %{{.*}} : (!cc.ptr<i8>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:             cc.store %[[L_NEW]], %[[L_PREV]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:             %[[L_NEW:.*]] = cc.sequence_init %{{.*}}, %{{.*}} : (!cc.ptr<i8>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:             cc.store %[[L_NEW]], %[[L_PREV]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
 // clang-format on

--- a/cudaq/test/AST-Quake/measure_handle_qir.cpp
+++ b/cudaq/test/AST-Quake/measure_handle_qir.cpp
@@ -43,7 +43,7 @@ struct VectorReturn {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorReturn() -> !cc.stdvec<i1>
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorReturn() -> !cc.sequence<i1>
 // CHECK:           %[[V_C3:.*]] = arith.constant 3 : i64
 // CHECK:           %[[V_ARR:.*]] = call @__quantum__rt__qubit_allocate_array(%[[V_C3]])
 // CHECK:           cc.loop while
@@ -62,7 +62,7 @@ struct VectorReturn {
 // CHECK:             cc.store %[[V_BB]], %[[V_SP]]
 // CHECK:           %[[V_BUFP:.*]] = cc.cast %[[V_BUF]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
 // CHECK:           %[[V_HEAP:.*]] = call @__nvqpp_vectorCopyCtor(%[[V_BUFP]], %[[V_C3]], %{{.*}})
-// CHECK:           %[[V_VEC:.*]] = cc.stdvec_init %[[V_HEAP]], %[[V_C3]]
-// CHECK:           return %[[V_VEC]] : !cc.stdvec<i1>
+// CHECK:           %[[V_VEC:.*]] = cc.sequence_init %[[V_HEAP]], %[[V_C3]]
+// CHECK:           return %[[V_VEC]] : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/mz.cpp
+++ b/cudaq/test/AST-Quake/mz.cpp
@@ -20,7 +20,7 @@ struct S {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__S() attributes
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<20>
-// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<20>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<20>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -36,19 +36,19 @@ struct VectorOfStaticVeq {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorOfStaticVeq() -> !cc.stdvec<i1> attributes {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorOfStaticVeq() -> !cc.sequence<i1> attributes {
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_81:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_81:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[VAL_8:.*]] = quake.discriminate %[[VAL_81]] :
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_10:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_9:.*]] = cc.sequence_data %[[VAL_8]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = cc.sequence_size %[[VAL_8]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[VAL_12:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_12]], %[[VAL_10]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VAL_13]] : !cc.stdvec<i1>
+// CHECK:           %[[VAL_13:.*]] = cc.sequence_init %[[VAL_12]], %[[VAL_10]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VAL_13]] : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -64,7 +64,7 @@ struct VectorOfDynamicVeq {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorOfDynamicVeq(
-// CHECK-SAME:        %[[VAL_0:.*]]: i32{{.*}}, %[[VAL_1:.*]]: i32{{.*}}) -> !cc.stdvec<i1> attributes {
+// CHECK-SAME:        %[[VAL_0:.*]]: i32{{.*}}, %[[VAL_1:.*]]: i32{{.*}}) -> !cc.sequence<i1> attributes {
 // CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_2:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<i32>
@@ -78,12 +78,12 @@ struct VectorOfDynamicVeq {
 // CHECK:           %[[VAL_9:.*]] = cc.cast unsigned %[[VAL_8]] : (i32) -> i64
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%[[VAL_9]] : i64]
 // CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_112:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_112:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_12]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_13:.*]] = cc.sequence_data %[[VAL_12]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.sequence_size %[[VAL_12]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[VAL_16:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_17:.*]] = cc.stdvec_init %[[VAL_16]], %[[VAL_14]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VAL_17]] : !cc.stdvec<i1>
+// CHECK:           %[[VAL_17:.*]] = cc.sequence_init %[[VAL_16]], %[[VAL_14]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VAL_17]] : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/pauli_word.cpp
+++ b/cudaq/test/AST-Quake/pauli_word.cpp
@@ -19,13 +19,13 @@ __qpu__ void pauli_word_vec(std::vector<cudaq::pauli_word> words,
 // clang-format off
 // CHECK-LABEL:   func.func
 // @__nvqpp__mlirgen__function_pauli_word_vec._Z14pauli_word_vecSt6vectorIN5cudaq10pauli_wordESaIS1_EEd(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.charspan>,
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<!cc.charspan>,
 // CHECK-SAME:      %[[VAL_1:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_2:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<!cc.charspan>
 // CHECK:           quake.exp_pauli (%[[VAL_4]]) %[[VAL_3]] to %[[VAL_7]] : (f64, !quake.veq<4>, !cc.charspan) -> ()

--- a/cudaq/test/AST-Quake/qalloc_initialization.cpp
+++ b/cudaq/test/AST-Quake/qalloc_initialization.cpp
@@ -24,7 +24,7 @@ struct Vanilla {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vanilla() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vanilla() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
@@ -46,7 +46,7 @@ struct Vanilla {
 // CHECK:           %[[VAL_14:.*]] = quake.init_state %[[VAL_13]], %[[VAL_11]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           quake.delete_state %[[VAL_11]] : !cc.ptr<!quake.state>
 // CHECK:           %[[VAL_15:.*]] = quake.veq_size %[[VAL_14]] : (!quake.veq<?>) -> i64
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -59,7 +59,7 @@ struct VanillaBean {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VanillaBean() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VanillaBean() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
@@ -81,7 +81,7 @@ struct VanillaBean {
 // CHECK:           %[[VAL_14:.*]] = quake.init_state %[[VAL_13]], %[[VAL_11]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           quake.delete_state %[[VAL_11]] : !cc.ptr<!quake.state>
 // CHECK:           %[[VAL_15:.*]] = quake.veq_size %[[VAL_14]] : (!quake.veq<?>) -> i64
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -96,7 +96,7 @@ struct Cherry {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Cherry() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Cherry() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = complex.constant [0.000000e+00, 0.000000e+00] : complex<f64>
 // CHECK-DAG:       %[[VAL_1:.*]] = complex.constant [1.000000e+00, 0.000000e+00] : complex<f64>
 // CHECK-DAG:       %[[VAL_2:.*]] = complex.constant [6.000000e-01, 4.000000e-01] : complex<f64>
@@ -120,7 +120,7 @@ struct Cherry {
 // CHECK:           %[[VAL_16:.*]] = quake.init_state %[[VAL_15]], %[[VAL_13]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           quake.delete_state %[[VAL_13]] : !cc.ptr<!quake.state>
 // CHECK:           %[[VAL_17:.*]] = quake.veq_size %[[VAL_16]] : (!quake.veq<?>) -> i64
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -136,7 +136,7 @@ struct MooseTracks {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__MooseTracks() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__MooseTracks() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = complex.constant [0.000000e+00, 0.000000e+00] : complex<f64>
 // CHECK-DAG:       %[[VAL_1:.*]] = complex.constant [1.000000e+00, 0.000000e+00] : complex<f64>
 // CHECK-DAG:       %[[VAL_2:.*]] = complex.constant [7.500000e-01, 2.500000e-01] : complex<f64>
@@ -160,7 +160,7 @@ struct MooseTracks {
 // CHECK:           %[[VAL_16:.*]] = quake.init_state %[[VAL_15]], %[[VAL_13]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           quake.delete_state %[[VAL_13]] : !cc.ptr<!quake.state>
 // CHECK:           %[[VAL_17:.*]] = quake.veq_size %[[VAL_16]] : (!quake.veq<?>) -> i64
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -175,7 +175,7 @@ struct RockyRoad {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__RockyRoad() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__RockyRoad() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = complex.constant [0.000000e+00, 0.000000e+00] : complex<f64>
 // CHECK-DAG:       %[[VAL_1:.*]] = complex.constant [8.000000e-01, 2.000000e-01] : complex<f64>
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
@@ -209,7 +209,7 @@ struct RockyRoad {
 // CHECK:           %[[VAL_26:.*]] = quake.init_state %[[VAL_25]], %[[VAL_23]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           quake.delete_state %[[VAL_23]] : !cc.ptr<!quake.state>
 // CHECK:           %[[VAL_27:.*]] = quake.veq_size %[[VAL_26]] : (!quake.veq<?>) -> i64
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -228,9 +228,9 @@ struct Pistachio {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 8 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = call @_Z15getTwoTimesRankv() : () -> !cc.stdvec<f64>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<f64>) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @_Z15getTwoTimesRankv() : () -> !cc.sequence<f64>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<f64>) -> i64
 // CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_0]] : i64
 // CHECK:           %[[VAL_7:.*]] = cc.alloca f64{{\[}}%[[VAL_6]] : i64]
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<i8>
@@ -260,9 +260,9 @@ struct ChocolateMint {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 8 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = call @_Z15getTwoTimesRankv() : () -> !cc.stdvec<f64>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<f64>) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @_Z15getTwoTimesRankv() : () -> !cc.sequence<f64>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<f64>) -> i64
 // CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_0]] : i64
 // CHECK:           %[[VAL_7:.*]] = cc.alloca f64{{\[}}%[[VAL_6]] : i64]
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<i8>
@@ -290,13 +290,13 @@ struct Neapolitan {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Neapolitan() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Neapolitan() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 16 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = call @_Z14getComplexInitv() : () -> !cc.stdvec<complex<f64>>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<complex<f64>>) -> !cc.ptr<complex<f64>>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<complex<f64>>) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @_Z14getComplexInitv() : () -> !cc.sequence<complex<f64>>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<complex<f64>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<complex<f64>>) -> i64
 // CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_0]] : i64
 // CHECK:           %[[VAL_7:.*]] = cc.alloca complex<f64>{{\[}}%[[VAL_6]] : i64]
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<complex<f64> x ?>>) -> !cc.ptr<i8>
@@ -309,7 +309,7 @@ struct Neapolitan {
 // CHECK:           %[[VAL_14:.*]] = quake.init_state %[[VAL_13]], %[[VAL_11]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           quake.delete_state %[[VAL_11]] : !cc.ptr<!quake.state>
 // CHECK:           %[[VAL_15:.*]] = quake.veq_size %[[VAL_14]] : (!quake.veq<?>) -> i64
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -322,13 +322,13 @@ struct ButterPecan {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ButterPecan() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ButterPecan() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 16 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = call @_Z14getComplexInitv() : () -> !cc.stdvec<complex<f64>>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<complex<f64>>) -> !cc.ptr<complex<f64>>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<complex<f64>>) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @_Z14getComplexInitv() : () -> !cc.sequence<complex<f64>>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<complex<f64>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<complex<f64>>) -> i64
 // CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_0]] : i64
 // CHECK:           %[[VAL_7:.*]] = cc.alloca complex<f64>{{\[}}%[[VAL_6]] : i64]
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<complex<f64> x ?>>) -> !cc.ptr<i8>
@@ -341,7 +341,7 @@ struct ButterPecan {
 // CHECK:           %[[VAL_14:.*]] = quake.init_state %[[VAL_13]], %[[VAL_11]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           quake.delete_state %[[VAL_11]] : !cc.ptr<!quake.state>
 // CHECK:           %[[VAL_15:.*]] = quake.veq_size %[[VAL_14]] : (!quake.veq<?>) -> i64
-// CHECK:           return %{{.*}} : !cc.stdvec<i1>
+// CHECK:           return %{{.*}} : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 

--- a/cudaq/test/AST-Quake/qalloc_state.cpp
+++ b/cudaq/test/AST-Quake/qalloc_state.cpp
@@ -20,7 +20,7 @@ struct Eins {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Eins(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.sequence<i1>
 // CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
@@ -36,7 +36,7 @@ struct Zwei {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Zwei(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.sequence<i1>
 // CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
@@ -52,7 +52,7 @@ struct Drei {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Drei(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.sequence<i1>
 // CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
@@ -68,7 +68,7 @@ struct Vier {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vier(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.sequence<i1>
 // CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>

--- a/cudaq/test/AST-Quake/qec_ops.cpp
+++ b/cudaq/test/AST-Quake/qec_ops.cpp
@@ -62,7 +62,7 @@ struct DetectorVariadic {
 // clang-format on
 
 // ---------------------------------------------------------------------------
-// `cudaq::detector(vec)` — single stdvec of handles.
+// `cudaq::detector(vec)` — single sequence of handles.
 // ---------------------------------------------------------------------------
 
 struct DetectorVector {
@@ -76,11 +76,11 @@ struct DetectorVector {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__DetectorVector()
 // CHECK:           %[[VAL_QS:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_HS:.*]] = quake.mz %[[VAL_QS]] name "handles" : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           qec.detector %[[VAL_HSL]] : !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %[[VAL_QS]] name "handles" : (!quake.veq<4>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           qec.detector %[[VAL_HSL]] : !cc.sequence<!cc.measure_handle>
 // CHECK-NOT:       quake.discriminate
 // CHECK:           return
 // CHECK:         }
@@ -103,11 +103,11 @@ struct DetectorMixed {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__DetectorMixed()
 // CHECK:           %[[VAL_M:.*]] = quake.mz %{{.*}} name "h" : (!quake.ref) -> !cc.measure_handle
-// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           qec.detector %[[VAL_HSL]], %{{.*}} : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           qec.detector %[[VAL_HSL]], %{{.*}} : !cc.sequence<!cc.measure_handle>, !cc.measure_handle
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -150,10 +150,10 @@ struct ObservableVectorDefault {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableVectorDefault()
 // CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "handles"
-// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           qec.observable %[[VAL_HSL]] : !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           qec.observable %[[VAL_HSL]] : !cc.sequence<!cc.measure_handle>
 // CHECK-NOT:       index
 // CHECK:           return
 // CHECK:         }
@@ -174,10 +174,10 @@ struct ObservableVectorIndexed {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableVectorIndexed()
 // CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "handles"
-// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           qec.observable %[[VAL_HSL]] index 2 : !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           qec.observable %[[VAL_HSL]] index 2 : !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -200,7 +200,7 @@ struct ObservableConstexprIndex {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableConstexprIndex()
-// CHECK:           qec.observable %{{.*}} index 5 : !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.observable %{{.*}} index 5 : !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -215,7 +215,7 @@ struct ObservableExpressionIndex {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableExpressionIndex()
-// CHECK:           qec.observable %{{.*}} index 3 : !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.observable %{{.*}} index 3 : !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -238,11 +238,11 @@ struct ObservableMixed {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableMixed()
 // CHECK:           %[[VAL_M:.*]] = quake.mz %{{.*}} name "h" : (!quake.ref) -> !cc.measure_handle
-// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           qec.observable %[[VAL_HSL]], %{{.*}} : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_HSA:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_HS]], %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_HSL:.*]] = cc.load %[[VAL_HSA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           qec.observable %[[VAL_HSL]], %{{.*}} : !cc.sequence<!cc.measure_handle>, !cc.measure_handle
 // CHECK-NOT:       index
 // CHECK:           return
 // CHECK:         }
@@ -282,7 +282,7 @@ struct ObservableRvalueVariadic {
 // clang-format on
 
 // ---------------------------------------------------------------------------
-// `cudaq::detectors(prev, curr)` — paired stdvecs.
+// `cudaq::detectors(prev, curr)` — paired sequences.
 // ---------------------------------------------------------------------------
 
 struct PairDetectors {
@@ -296,14 +296,14 @@ struct PairDetectors {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__PairDetectors()
-// CHECK:           %[[VAL_P:.*]] = quake.mz %{{.*}} name "prev" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_PA:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_P]], %[[VAL_PA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_C:.*]] = quake.mz %{{.*}} name "curr" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_CA:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_C]], %[[VAL_CA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_PL:.*]] = cc.load %[[VAL_PA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_CL:.*]] = cc.load %[[VAL_CA]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[VAL_P:.*]] = quake.mz %{{.*}} name "prev" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_PA:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_P]], %[[VAL_PA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_C:.*]] = quake.mz %{{.*}} name "curr" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_CA:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_C]], %[[VAL_CA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_PL:.*]] = cc.load %[[VAL_PA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_CL:.*]] = cc.load %[[VAL_CA]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
 // CHECK:           qec.pair_detectors %[[VAL_PL]], %[[VAL_CL]] : <!cc.measure_handle>, <!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
@@ -403,11 +403,11 @@ struct RepCodeD3 {
 // CHECK:               cc.store %[[ADDI_0]], %[[ALLOCA_6]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[MZ_2:.*]] = quake.mz %[[ALLOCA_1]] name "readout" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[ALLOCA_R:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[MZ_2]], %[[ALLOCA_R]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[LOAD_R:.*]] = cc.load %[[ALLOCA_R]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           qec.observable %[[LOAD_R]] : !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[MZ_2:.*]] = quake.mz %[[ALLOCA_1]] name "readout" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[ALLOCA_R:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[MZ_2]], %[[ALLOCA_R]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[LOAD_R:.*]] = cc.load %[[ALLOCA_R]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           qec.observable %[[LOAD_R]] : !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/qpe.cpp
+++ b/cudaq/test/AST-Quake/qpe.cpp
@@ -329,7 +329,7 @@ int main() {
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @__nvqpp__mlirgen__function_iqft{{.*}}(%[[VAL_20]]) : (!quake.veq<?>) -> ()
-// CHECK:           %[[VAL_54:.*]] = quake.mz %[[VAL_20]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_54:.*]] = quake.mz %[[VAL_20]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/AST-Quake/range_for_measure.cpp
+++ b/cudaq/test/AST-Quake/range_for_measure.cpp
@@ -31,7 +31,7 @@ struct range_for_measure_bool {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_bool()
-// CHECK:           quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[HANDLE:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[BIT:.*]] = quake.discriminate %[[HANDLE]] : (!cc.measure_handle) -> i1
 // CHECK:           cc.store %[[BIT]], %{{.*}} : !cc.ptr<i1>
@@ -54,7 +54,7 @@ struct range_for_measure_auto {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_auto()
-// CHECK:           quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           cc.store %{{.*}}, %{{.*}} : !cc.ptr<!cc.measure_handle>
 // clang-format on
 
@@ -77,8 +77,8 @@ struct range_for_measure_named_vector {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_named_vector()
-// CHECK:           quake.mz %{{.*}} name "handles" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %{{.*}}, %{{.*}} : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           quake.mz %{{.*}} name "handles" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %{{.*}}, %{{.*}} : !cc.ptr<!cc.sequence<!cc.measure_handle>>
 // CHECK:           %[[HANDLE:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[BIT:.*]] = quake.discriminate %[[HANDLE]] : (!cc.measure_handle) -> i1
 // CHECK:           cc.store %[[BIT]], %{{.*}} : !cc.ptr<i1>
@@ -106,7 +106,7 @@ struct range_for_measure_list_init {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__range_for_measure_list_init()
 // CHECK:           quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
 // CHECK:           quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
-// CHECK:           cc.stdvec_init %{{.*}}, %{{.*}} : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.sequence_init %{{.*}}, %{{.*}} : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[HANDLE:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[BIT:.*]] = quake.discriminate %[[HANDLE]] : (!cc.measure_handle) -> i1
 // CHECK:           cc.store %[[BIT]], %{{.*}} : !cc.ptr<i1>

--- a/cudaq/test/AST-Quake/ranged_for.cpp
+++ b/cudaq/test/AST-Quake/ranged_for.cpp
@@ -33,15 +33,15 @@ struct Colonel {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Colonel(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<f64>) attributes
 // CHECK-DAG:        %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (i64)) {
 // CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i64
 // CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : i64)
@@ -86,15 +86,15 @@ struct Lt_Colonel {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Lt_Colonel(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<f64>) attributes
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (i64)) {
 // CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i64
 // CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : i64)
@@ -152,7 +152,7 @@ struct Qernel {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Qernel(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<f64>) attributes
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1.000000e+03 : f64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
@@ -160,8 +160,8 @@ struct Qernel {
 // CHECK-DAG:       %[[VAL_5:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_6:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_6]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
-// CHECK:           %[[VAL_8:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
+// CHECK:           %[[VAL_8:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_3]]) -> (i64)) {
 // CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_7]] : i64
 // CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : i64)
@@ -177,8 +177,8 @@ struct Qernel {
 // CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_2]] : i64
 // CHECK:             cc.continue %[[VAL_19]] : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[VAL_20:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
-// CHECK:           %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:           %[[VAL_20:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
+// CHECK:           %[[VAL_21:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:           %[[VAL_23:.*]] = cc.loop while ((%[[VAL_24:.*]] = %[[VAL_3]]) -> (i64)) {
 // CHECK:             %[[VAL_25:.*]] = arith.cmpi slt, %[[VAL_24]], %[[VAL_20]] : i64
 // CHECK:             cc.condition %[[VAL_25]](%[[VAL_24]] : i64)
@@ -227,23 +227,23 @@ struct Nesting {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Nesting(
-// CHECK-SAME:        %[[VAL_0:.*]]: !cc.stdvec<f64>, %[[VAL_1:.*]]: !cc.stdvec<f32>) attributes
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.sequence<f64>, %[[VAL_1:.*]]: !cc.sequence<f32>) attributes
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_5:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_6:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_6]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
-// CHECK:           %[[VAL_8:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
+// CHECK:           %[[VAL_8:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_3]]) -> (i64)) {
 // CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_7]] : i64
 // CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : i64)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_13:.*]]: i64):
 // CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
-// CHECK:             %[[VAL_16:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<f32>) -> i64
-// CHECK:             %[[VAL_17:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
+// CHECK:             %[[VAL_16:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<f32>) -> i64
+// CHECK:             %[[VAL_17:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
 // CHECK:             %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_3]]) -> (i64)) {
 // CHECK:               %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_16]] : i64
 // CHECK:               cc.condition %[[VAL_21]](%[[VAL_20]] : i64)

--- a/cudaq/test/AST-Quake/separate_compilation.cpp
+++ b/cudaq/test/AST-Quake/separate_compilation.cpp
@@ -21,5 +21,5 @@ __qpu__ uint64_t test_entry_point() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test_entry_point.
 // CHECK-SAME:      () -> i64 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-// CHECK:           %[[VAL_3:.*]] = call @{{.*}}otherKernel{{.*}}(%{{.*}}) : (!cc.stdvec<!cc.measure_handle>) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @{{.*}}otherKernel{{.*}}(%{{.*}}) : (!cc.sequence<!cc.measure_handle>) -> i64
 // clang-format on

--- a/cudaq/test/AST-Quake/simple.cpp
+++ b/cudaq/test/AST-Quake/simple.cpp
@@ -64,7 +64,7 @@ struct ghz {
 // CHECK:               cc.store %[[VAL_21]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_22:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_22:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/simple_qarray.cpp
+++ b/cudaq/test/AST-Quake/simple_qarray.cpp
@@ -77,7 +77,7 @@ int main() {
 // CHECK:               cc.store %[[VAL_16]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_17:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<5>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_17:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<5>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/slice.cpp
+++ b/cudaq/test/AST-Quake/slice.cpp
@@ -45,8 +45,8 @@ __qpu__ bool issue_3092() {
 // CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][3] : (!quake.veq<6>) -> !quake.ref
 // CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_2:.*]] = quake.subveq %[[VAL_0]], 3, 3 : (!quake.veq<6>) -> !quake.veq<1>
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[VAL_8:.*]] = quake.discriminate %[[VAL_7]] : (!cc.measure_handle) -> i1

--- a/cudaq/test/AST-Quake/string-0.cpp
+++ b/cudaq/test/AST-Quake/string-0.cpp
@@ -32,7 +32,7 @@ void test0(double theta) {
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.charspan) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.charspan) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_6]] : (!quake.ref) -> !quake.veq<1>
 // CHECK:           quake.exp_pauli %[[VAL_4]], %[[VAL_7]], %[[VAL_5]] : (f64, !quake.veq<1>, !cc.ptr<i8>) -> ()

--- a/cudaq/test/AST-Quake/struct-2.cpp
+++ b/cudaq/test/AST-Quake/struct-2.cpp
@@ -25,12 +25,12 @@ struct Qernel0 {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Qernel0(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>)
-// CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>>
-// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>>) -> !cc.ptr<!cc.stdvec<i32>>
-// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<"ProductOfVector" {!cc.sequence<i32>, !cc.sequence<f64>} [384,8]>)
+// CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<"ProductOfVector" {!cc.sequence<i32>, !cc.sequence<f64>} [384,8]>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<"ProductOfVector" {!cc.sequence<i32>, !cc.sequence<f64>} [384,8]>>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.struct<"ProductOfVector" {!cc.sequence<i32>, !cc.sequence<f64>} [384,8]>>) -> !cc.ptr<!cc.sequence<i32>>
+// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.sequence<i32>>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
 // CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x ?>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.alloca i32
@@ -92,8 +92,8 @@ struct Qernel2 {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Qernel2(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.struct<"Product" {i16, f32} [64,4]>>)
-// CHECK:           %[[VAL_1:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.struct<"Product" {i16, f32} [64,4]>>) -> !cc.ptr<!cc.array<!cc.struct<"Product" {i16, f32} [64,4]> x ?>>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<!cc.struct<"Product" {i16, f32} [64,4]>>)
+// CHECK:           %[[VAL_1:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.struct<"Product" {i16, f32} [64,4]>>) -> !cc.ptr<!cc.array<!cc.struct<"Product" {i16, f32} [64,4]> x ?>>
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.struct<"Product" {i16, f32} [64,4]> x ?>>) -> !cc.ptr<i16>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i16>
 // CHECK:           %[[VAL_5:.*]] = cc.alloca i16

--- a/cudaq/test/AST-Quake/tuple-0.cpp
+++ b/cudaq/test/AST-Quake/tuple-0.cpp
@@ -23,7 +23,7 @@ struct ArithmeticTupleQernel {
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<{[[TUP]]}{{.*}}>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<{[[TUP]]}{{.*}}>>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<1>
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -41,7 +41,7 @@ struct ArithmeticPairQernel {
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<{f32, i32} [64,4]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<{f32, i32} [64,4]>>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<1>
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -79,7 +79,7 @@ struct ArithmeticTupleQernelWithUse {
 // CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_1]] : i64
 // CHECK:             cc.continue %[[VAL_15]] : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -117,7 +117,7 @@ struct ArithmeticTupleQernelWithUse0 {
 // CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_1]] : i64
 // CHECK:             cc.continue %[[VAL_15]] : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -138,7 +138,7 @@ struct ArithmeticPairQernelWithUse {
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_4:.*]] = cc.cast signed %[[VAL_3]] : (i32) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_4]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/typename.cpp
+++ b/cudaq/test/AST-Quake/typename.cpp
@@ -19,7 +19,7 @@ struct test {
 } // namespace ns
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__name1
-// CHECK-SAME: (%{{.*}}: !cc.stdvec<f64>{{.*}}) attributes {
+// CHECK-SAME: (%{{.*}}: !cc.sequence<f64>{{.*}}) attributes {
 struct name1 {
   void operator()(std::vector<ns::test<double>::Type> variable) __qpu__ {}
 };

--- a/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops_nested.cpp
+++ b/cudaq/test/AST-Quake/unroll_only_wire_blocking_loops_nested.cpp
@@ -34,7 +34,7 @@ __qpu__ std::vector<bool> kernel() {
 // clang-format off
 // CHECK-LABEL:   quake.wire_set @wires[2147483647] attributes {sym_visibility = "private"}
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel._Z6kernelv() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel._Z6kernelv() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK-NOT:       cc.loop
 // CHECK-NOT:       quake.alloca
 // CHECK-NOT:       quake.unwrap
@@ -91,7 +91,7 @@ __qpu__ std::vector<bool> kernel() {
 // CHECK:           cc.store %[[BYTE3]], %[[PTR3]] : !cc.ptr<i8>
 // CHECK:           %[[COPY_SRC:.*]] = cc.cast %[[BITS]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
 // CHECK:           %[[COPY:.*]] = call @__nvqpp_vectorCopyCtor(%[[COPY_SRC]], %[[CONSTANT_1]], %[[CONSTANT_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[RESULT:.*]] = cc.stdvec_init %[[COPY]], %[[CONSTANT_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
+// CHECK:           %[[RESULT:.*]] = cc.sequence_init %[[COPY]], %[[CONSTANT_1]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
 // CHECK-NOT:       cc.loop
 // CHECK-NOT:       quake.alloca
 // CHECK-NOT:       quake.unwrap
@@ -103,7 +103,7 @@ __qpu__ std::vector<bool> kernel() {
 // CHECK:           quake.return_wire %[[W1]] : !quake.wire
 // CHECK:           quake.return_wire %[[W2]] : !quake.wire
 // CHECK:           quake.return_wire %[[W3]] : !quake.wire
-// CHECK:           return %[[RESULT]] : !cc.stdvec<i1>
+// CHECK:           return %[[RESULT]] : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -121,7 +121,7 @@ __qpu__ std::vector<bool> rectangular_flattened_index() {
 }
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_rectangular_flattened_index._Z27rectangular_flattened_indexv() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_rectangular_flattened_index._Z27rectangular_flattened_indexv() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK-NOT:       cc.loop
 // CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
 // CHECK:           %[[Q0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
@@ -183,7 +183,7 @@ __qpu__ std::vector<bool> grandparent_bound_separator() {
 // The grandparent-dependent separator case should unroll the outer and inner
 // loops while preserving the non-blocking middle loop as fixed-wire loops.
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_grandparent_bound_separator._Z27grandparent_bound_separatorv() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_grandparent_bound_separator._Z27grandparent_bound_separatorv() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK-NOT:       {{quake\.alloca|quake\.extract_ref|quake\.subveq|!quake\.ref|!quake\.veq}}
 // CHECK:           %[[Q0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
 // CHECK:           %[[Q1:.*]] = quake.borrow_wire @wires[1] : !quake.wire

--- a/cudaq/test/AST-Quake/vector-0.cpp
+++ b/cudaq/test/AST-Quake/vector-0.cpp
@@ -27,25 +27,25 @@ struct simple_double_rotation {
 
 // clang-format off
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__simple_double_rotation
-// CHECK-SAME: (%[[VAL_0:.*]]: !cc.stdvec<f64>{{.*}}) attributes
+// CHECK-SAME: (%[[VAL_0:.*]]: !cc.sequence<f64>{{.*}}) attributes
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
 // CHECK:           %[[VAL_4:.*]] = cc.alloca i64
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
 // CHECK:           %[[VAL_6:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_2]] : i64
 // CHECK:           %[[VAL_7:.*]] = cc.alloca i1
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_7]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<1>
 // CHECK:           %[[VAL_9:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:           %[[VAL_10:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_11]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<1>) -> !quake.ref
 // CHECK:           quake.rx (%[[VAL_12]]) %[[VAL_13]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -62,24 +62,24 @@ struct simple_float_rotation {
 
 // clang-format off
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__simple_float_rotation
-// CHECK-SAME: (%[[VAL_0:.*]]: !cc.stdvec<f32>{{.*}}) attributes
+// CHECK-SAME: (%[[VAL_0:.*]]: !cc.sequence<f32>{{.*}}) attributes
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_2:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f32>) -> i64
+// CHECK:           %[[VAL_2:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f32>) -> i64
 // CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (i64) -> i32
 // CHECK:           %[[VAL_4:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f32>) -> i64
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f32>) -> i64
 // CHECK:           %[[VAL_6:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_1]] : i64
 // CHECK:           %[[VAL_7:.*]] = cc.alloca i1
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_7]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<1>
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
+// CHECK:           %[[VAL_9:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
 // CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<f32 x ?>>) -> !cc.ptr<f32>
 // CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<f32>
 // CHECK:           %[[VAL_12:.*]] = math.absf %[[VAL_11]] : f32
 // CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<1>) -> !quake.ref
 // CHECK:           quake.rx (%[[VAL_12]]) %[[VAL_13]] : (f32, !quake.ref) -> ()
-// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -95,8 +95,8 @@ struct difficult_symphony {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__difficult_symphony(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f32>{{.*}}) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<f32>{{.*}}) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[VAL_1:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
 // CHECK:           %[[VAL_2:.*]] = cc.alloca !cc.ptr<!cc.array<f32 x ?>>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<!cc.ptr<!cc.array<f32 x ?>>>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<1>
@@ -105,7 +105,7 @@ struct difficult_symphony {
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f32>
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<1>) -> !quake.ref
 // CHECK:           quake.rx (%[[VAL_6]]) %[[VAL_7]] : (f32, !quake.ref) -> ()
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/vector_bool.cpp
+++ b/cudaq/test/AST-Quake/vector_bool.cpp
@@ -22,13 +22,13 @@ struct t1 {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t1(
-// CHECK-SAME:        %[[VAL_0:.*]]: !cc.stdvec<f64>{{.*}}) -> i1 attributes
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.sequence<f64>{{.*}}) -> i1 attributes
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_S:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[VAL_12]], %[[VAL_S]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_L:.*]] = cc.load %[[VAL_S]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_L]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_S:.*]] = cc.alloca !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[VAL_12]], %[[VAL_S]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_L:.*]] = cc.load %[[VAL_S]] : !cc.ptr<!cc.sequence<!cc.measure_handle>>
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_data %[[VAL_L]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[VAL_6:.*]] = quake.discriminate %[[VAL_5]] : (!cc.measure_handle) -> i1
@@ -45,16 +45,16 @@ struct VectorBoolReturn {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorBoolReturn() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorBoolReturn() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<4>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[VAL_6:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_4]], %[[VAL_5]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VAL_7]] : !cc.stdvec<i1>
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VAL_7]] : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on
 
@@ -67,15 +67,15 @@ struct VectorBoolResult {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorBoolResult() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorBoolResult() -> !cc.sequence<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<4>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[VAL_6:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_4]], %[[VAL_5]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VAL_7]] : !cc.stdvec<i1>
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VAL_7]] : !cc.sequence<i1>
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/vector_int-0.cpp
+++ b/cudaq/test/AST-Quake/vector_int-0.cpp
@@ -15,7 +15,7 @@ struct VectorIntReturn {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorIntReturn() -> !cc.stdvec<i32> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorIntReturn() -> !cc.sequence<i32> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 4 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 142 : i32
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 243 : i32
@@ -27,8 +27,8 @@ struct VectorIntReturn {
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_8:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_7]], %[[VAL_3]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_init %[[VAL_8]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
-// CHECK:           return %[[VAL_9]] : !cc.stdvec<i32>
+// CHECK:           %[[VAL_9:.*]] = cc.sequence_init %[[VAL_8]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i32>
+// CHECK:           return %[[VAL_9]] : !cc.sequence<i32>
 // CHECK:         }
 // clang-format on
 
@@ -41,7 +41,7 @@ struct VectorIntResult {
 };
 
 // clang-format off
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorIntResult() -> !cc.stdvec<i32> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorIntResult() -> !cc.sequence<i32> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 4 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 42 : i32
@@ -50,7 +50,7 @@ struct VectorIntResult {
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_6:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_5]], %[[VAL_0]], %[[VAL_1]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_init %[[VAL_6]], %[[VAL_0]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
-// CHECK:           return %[[VAL_7]] : !cc.stdvec<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.sequence_init %[[VAL_6]], %[[VAL_0]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i32>
+// CHECK:           return %[[VAL_7]] : !cc.sequence<i32>
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/AST-Quake/vector_int-1.cpp
+++ b/cudaq/test/AST-Quake/vector_int-1.cpp
@@ -23,7 +23,7 @@ __qpu__ void touringLondon() {
 }
 
 // clang-format off
-// CHECK-LABEL:  func.func @__nvqpp__mlirgen__function_doubleDeckerBus._Z15doubleDeckerBusv() -> !cc.stdvec<i32> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-LABEL:  func.func @__nvqpp__mlirgen__function_doubleDeckerBus._Z15doubleDeckerBusv() -> !cc.sequence<i32> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 2 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 4 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
@@ -32,15 +32,15 @@ __qpu__ void touringLondon() {
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_7:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_6]], %[[VAL_1]], %[[VAL_2]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_8:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
-// CHECK:           return %[[VAL_8]] : !cc.stdvec<i32>
+// CHECK:           %[[VAL_8:.*]] = cc.sequence_init %[[VAL_7]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i32>
+// CHECK:           return %[[VAL_8]] : !cc.sequence<i32>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_touringLondon._Z13touringLondonv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_doubleDeckerBus._Z15doubleDeckerBusv() : () -> !cc.stdvec<i32>
-// CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i32>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<i32>) -> i64
+// CHECK:           %[[VAL_1:.*]] = call @__nvqpp__mlirgen__function_doubleDeckerBus._Z15doubleDeckerBusv() : () -> !cc.sequence<i32>
+// CHECK:           %[[VAL_2:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<i32>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<i32>) -> i64
 // CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_3]], %[[VAL_0]] : i64
 // CHECK:           %[[VAL_5:.*]] = cc.alloca i32[%[[VAL_4]] : i64]
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x ?>>) -> !cc.ptr<i8>

--- a/cudaq/test/AST-Quake/vector_vector.cpp
+++ b/cudaq/test/AST-Quake/vector_vector.cpp
@@ -28,13 +28,13 @@ struct VectorVectorReader {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorVectorReader(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.stdvec<f64>>) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<!cc.sequence<f64>>) attributes
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_3:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_1]], %[[VAL_3]] : !cc.ptr<i64>
-// CHECK:             %[[VAL_4:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> i64
+// CHECK:             %[[VAL_4:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<!cc.sequence<f64>>) -> i64
 // CHECK:             %[[VAL_5:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<i64>
 // CHECK:             cc.loop while {
@@ -44,13 +44,13 @@ struct VectorVectorReader {
 // CHECK:               cc.condition %[[VAL_8]]
 // CHECK:             } do {
 // CHECK:                 %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
-// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
+// CHECK:                 %[[VAL_10:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.sequence<f64>>) -> !cc.ptr<!cc.array<!cc.sequence<f64> x ?>>
+// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.sequence<f64> x ?>>, i64) -> !cc.ptr<!cc.sequence<f64>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_12:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_1]], %[[VAL_12]] : !cc.ptr<i64>
-// CHECK:                   %[[VAL_13:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                   %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_13]] : (!cc.stdvec<f64>) -> i64
+// CHECK:                   %[[VAL_13:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.sequence<f64>>
+// CHECK:                   %[[VAL_14:.*]] = cc.sequence_size %[[VAL_13]] : (!cc.sequence<f64>) -> i64
 // CHECK:                   %[[VAL_15:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_14]], %[[VAL_15]] : !cc.ptr<i64>
 // CHECK:                   cc.loop while {
@@ -60,8 +60,8 @@ struct VectorVectorReader {
 // CHECK:                     cc.condition %[[VAL_18]]
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_19:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i64>
-// CHECK:                     %[[VAL_20:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                     %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_20]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:                     %[[VAL_20:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.sequence<f64>>
+// CHECK:                     %[[VAL_21:.*]] = cc.sequence_data %[[VAL_20]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:                     %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][%[[VAL_19]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:                     %[[VAL_23:.*]] = cc.load %[[VAL_22]] : !cc.ptr<f64>
 // CHECK:                     func.call @_Z12do_somethingd(%[[VAL_23]]) : (f64) -> ()
@@ -98,13 +98,13 @@ struct TripleVectorReader {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__TripleVectorReader(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.stdvec<!cc.stdvec<f64>>>) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<!cc.sequence<!cc.sequence<f64>>>) attributes
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_3:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_1]], %[[VAL_3]] : !cc.ptr<i64>
-// CHECK:             %[[VAL_4:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<!cc.stdvec<f64>>>) -> i64
+// CHECK:             %[[VAL_4:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<!cc.sequence<!cc.sequence<f64>>>) -> i64
 // CHECK:             %[[VAL_5:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<i64>
 // CHECK:             cc.loop while {
@@ -114,13 +114,13 @@ struct TripleVectorReader {
 // CHECK:               cc.condition %[[VAL_8]]
 // CHECK:             } do {
 // CHECK:                 %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<!cc.stdvec<f64>>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.stdvec<f64>> x ?>>
-// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.stdvec<f64>> x ?>>, i64) -> !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
+// CHECK:                 %[[VAL_10:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.sequence<!cc.sequence<f64>>>) -> !cc.ptr<!cc.array<!cc.sequence<!cc.sequence<f64>> x ?>>
+// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.sequence<!cc.sequence<f64>> x ?>>, i64) -> !cc.ptr<!cc.sequence<!cc.sequence<f64>>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_12:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_1]], %[[VAL_12]] : !cc.ptr<i64>
-// CHECK:                   %[[VAL_13:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
-// CHECK:                   %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_13]] : (!cc.stdvec<!cc.stdvec<f64>>) -> i64
+// CHECK:                   %[[VAL_13:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.sequence<!cc.sequence<f64>>>
+// CHECK:                   %[[VAL_14:.*]] = cc.sequence_size %[[VAL_13]] : (!cc.sequence<!cc.sequence<f64>>) -> i64
 // CHECK:                   %[[VAL_15:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_14]], %[[VAL_15]] : !cc.ptr<i64>
 // CHECK:                   cc.loop while {
@@ -130,14 +130,14 @@ struct TripleVectorReader {
 // CHECK:                     cc.condition %[[VAL_18]]
 // CHECK:                   } do {
 // CHECK:                       %[[VAL_19:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i64>
-// CHECK:                       %[[VAL_20:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
-// CHECK:                       %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_20]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
-// CHECK:                       %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][%[[VAL_19]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
+// CHECK:                       %[[VAL_20:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.sequence<!cc.sequence<f64>>>
+// CHECK:                       %[[VAL_21:.*]] = cc.sequence_data %[[VAL_20]] : (!cc.sequence<!cc.sequence<f64>>) -> !cc.ptr<!cc.array<!cc.sequence<f64> x ?>>
+// CHECK:                       %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][%[[VAL_19]]] : (!cc.ptr<!cc.array<!cc.sequence<f64> x ?>>, i64) -> !cc.ptr<!cc.sequence<f64>>
 // CHECK:                       cc.scope {
 // CHECK:                         %[[VAL_23:.*]] = cc.alloca i64
 // CHECK:                         cc.store %[[VAL_1]], %[[VAL_23]] : !cc.ptr<i64>
-// CHECK:                         %[[VAL_24:.*]] = cc.load %[[VAL_22]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                         %[[VAL_25:.*]] = cc.stdvec_size %[[VAL_24]] : (!cc.stdvec<f64>) -> i64
+// CHECK:                         %[[VAL_24:.*]] = cc.load %[[VAL_22]] : !cc.ptr<!cc.sequence<f64>>
+// CHECK:                         %[[VAL_25:.*]] = cc.sequence_size %[[VAL_24]] : (!cc.sequence<f64>) -> i64
 // CHECK:                         %[[VAL_26:.*]] = cc.alloca i64
 // CHECK:                         cc.store %[[VAL_25]], %[[VAL_26]] : !cc.ptr<i64>
 // CHECK:                         cc.loop while {
@@ -147,8 +147,8 @@ struct TripleVectorReader {
 // CHECK:                           cc.condition %[[VAL_29]]
 // CHECK:                         } do {
 // CHECK:                           %[[VAL_30:.*]] = cc.load %[[VAL_23]] : !cc.ptr<i64>
-// CHECK:                           %[[VAL_31:.*]] = cc.load %[[VAL_22]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                           %[[VAL_32:.*]] = cc.stdvec_data %[[VAL_31]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:                           %[[VAL_31:.*]] = cc.load %[[VAL_22]] : !cc.ptr<!cc.sequence<f64>>
+// CHECK:                           %[[VAL_32:.*]] = cc.sequence_data %[[VAL_31]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:                           %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_32]][%[[VAL_30]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:                           %[[VAL_34:.*]] = cc.load %[[VAL_33]] : !cc.ptr<f64>
 // CHECK:                           func.call @_Z12do_somethingd(%[[VAL_34]]) : (f64) -> ()
@@ -189,14 +189,14 @@ struct VectorVectorWriter {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorVectorWriter(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.stdvec<i32>>) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<!cc.sequence<i32>>) attributes
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_3:.*]] = arith.constant 42 : i32
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_4:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_1]], %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:             %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<i32>>) -> i64
+// CHECK:             %[[VAL_5:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<!cc.sequence<i32>>) -> i64
 // CHECK:             %[[VAL_6:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<i64>
 // CHECK:             cc.loop while {
@@ -206,13 +206,13 @@ struct VectorVectorWriter {
 // CHECK:               cc.condition %[[VAL_9]]
 // CHECK:             } do {
 // CHECK:                 %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
-// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
+// CHECK:                 %[[VAL_11:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.sequence<i32>>) -> !cc.ptr<!cc.array<!cc.sequence<i32> x ?>>
+// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.sequence<i32> x ?>>, i64) -> !cc.ptr<!cc.sequence<i32>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_13:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_1]], %[[VAL_13]] : !cc.ptr<i64>
-// CHECK:                   %[[VAL_14:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                   %[[VAL_15:.*]] = cc.stdvec_size %[[VAL_14]] : (!cc.stdvec<i32>) -> i64
+// CHECK:                   %[[VAL_14:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.sequence<i32>>
+// CHECK:                   %[[VAL_15:.*]] = cc.sequence_size %[[VAL_14]] : (!cc.sequence<i32>) -> i64
 // CHECK:                   %[[VAL_16:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_15]], %[[VAL_16]] : !cc.ptr<i64>
 // CHECK:                   cc.loop while {
@@ -222,8 +222,8 @@ struct VectorVectorWriter {
 // CHECK:                     cc.condition %[[VAL_19]]
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_20:.*]] = cc.load %[[VAL_13]] : !cc.ptr<i64>
-// CHECK:                     %[[VAL_21:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                     %[[VAL_22:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:                     %[[VAL_21:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.sequence<i32>>
+// CHECK:                     %[[VAL_22:.*]] = cc.sequence_data %[[VAL_21]] : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
 // CHECK:                     %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_22]][%[[VAL_20]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
 // CHECK:                     cc.store %[[VAL_3]], %[[VAL_23]] : !cc.ptr<i32>
 // CHECK:                     cc.continue
@@ -258,13 +258,13 @@ struct VectorVectorBilingual {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorVectorBilingual(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.stdvec<f64>>, %[[VAL_1:.*]]: !cc.stdvec<!cc.stdvec<i32>>)
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<!cc.sequence<f64>>, %[[VAL_1:.*]]: !cc.sequence<!cc.sequence<i32>>)
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i64
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_4:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_2]], %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:             %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<!cc.stdvec<i32>>) -> i64
+// CHECK:             %[[VAL_5:.*]] = cc.sequence_size %[[VAL_1]] : (!cc.sequence<!cc.sequence<i32>>) -> i64
 // CHECK:             %[[VAL_6:.*]] = cc.alloca i64
 // CHECK:             cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<i64>
 // CHECK:             cc.loop while {
@@ -274,16 +274,16 @@ struct VectorVectorBilingual {
 // CHECK:               cc.condition %[[VAL_9]]
 // CHECK:             } do {
 // CHECK:                 %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
-// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
+// CHECK:                 %[[VAL_11:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<!cc.sequence<i32>>) -> !cc.ptr<!cc.array<!cc.sequence<i32> x ?>>
+// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.sequence<i32> x ?>>, i64) -> !cc.ptr<!cc.sequence<i32>>
 // CHECK:                 %[[VAL_13:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_14:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
-// CHECK:                 %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]][%[[VAL_13]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
+// CHECK:                 %[[VAL_14:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.sequence<f64>>) -> !cc.ptr<!cc.array<!cc.sequence<f64> x ?>>
+// CHECK:                 %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]][%[[VAL_13]]] : (!cc.ptr<!cc.array<!cc.sequence<f64> x ?>>, i64) -> !cc.ptr<!cc.sequence<f64>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_16:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_2]], %[[VAL_16]] : !cc.ptr<i64>
-// CHECK:                   %[[VAL_17:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                   %[[VAL_18:.*]] = cc.stdvec_size %[[VAL_17]] : (!cc.stdvec<i32>) -> i64
+// CHECK:                   %[[VAL_17:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.sequence<i32>>
+// CHECK:                   %[[VAL_18:.*]] = cc.sequence_size %[[VAL_17]] : (!cc.sequence<i32>) -> i64
 // CHECK:                   %[[VAL_19:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_18]], %[[VAL_19]] : !cc.ptr<i64>
 // CHECK:                   cc.loop while {
@@ -293,12 +293,12 @@ struct VectorVectorBilingual {
 // CHECK:                     cc.condition %[[VAL_22]]
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_23:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i64>
-// CHECK:                     %[[VAL_24:.*]] = cc.load %[[VAL_15]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                     %[[VAL_25:.*]] = cc.stdvec_data %[[VAL_24]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:                     %[[VAL_24:.*]] = cc.load %[[VAL_15]] : !cc.ptr<!cc.sequence<f64>>
+// CHECK:                     %[[VAL_25:.*]] = cc.sequence_data %[[VAL_24]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:                     %[[VAL_26:.*]] = cc.compute_ptr %[[VAL_25]][%[[VAL_23]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:                     %[[VAL_27:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i64>
-// CHECK:                     %[[VAL_28:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                     %[[VAL_29:.*]] = cc.stdvec_data %[[VAL_28]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:                     %[[VAL_28:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.sequence<i32>>
+// CHECK:                     %[[VAL_29:.*]] = cc.sequence_data %[[VAL_28]] : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
 // CHECK:                     %[[VAL_30:.*]] = cc.compute_ptr %[[VAL_29]][%[[VAL_27]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
 // CHECK:                     %[[VAL_31:.*]] = cc.load %[[VAL_30]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_32:.*]] = cc.cast signed %[[VAL_31]] : (i32) -> f64

--- a/cudaq/test/AST-Quake/veq_size_init_state.cpp
+++ b/cudaq/test/AST-Quake/veq_size_init_state.cpp
@@ -57,7 +57,7 @@ struct kernel {
 // CHECK:             %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_2]] : i64
 // CHECK:             cc.continue %[[VAL_22]] : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[VAL_23:.*]] = quake.mz %[[VAL_14]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_23:.*]] = quake.mz %[[VAL_14]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/cudaq/test/NVQPP/device_call_realtime_array.cpp
+++ b/cudaq/test/NVQPP/device_call_realtime_array.cpp
@@ -78,46 +78,46 @@ __qpu__ float floatVectorKernel(std::vector<float> values) {
   return cudaq::device_call(0, sumFloatVector, values, 35.0f);
 }
 
-static bool runInputStdvecTests() {
+static bool runInputSequenceTests() {
   std::vector<bool> bits = {true, false, true,  true, false,
                             true, false, false, true, true};
   auto boolResults = cudaq::run(1, boolVectorKernel, bits);
   int boolValue = boolResults.front();
-  std::printf("device_call bool stdvec input result = %d\n", boolValue);
+  std::printf("device_call bool sequence input result = %d\n", boolValue);
 
   int measureValue = measureVectorKernel();
-  std::printf("device_call measure stdvec input result = %d\n", measureValue);
+  std::printf("device_call measure sequence input result = %d\n", measureValue);
 
   std::vector<int> intValues = {3, 4, 5, 6};
   int intValue = intVectorKernel(intValues);
-  std::printf("device_call i32 stdvec input result = %d\n", intValue);
+  std::printf("device_call i32 sequence input result = %d\n", intValue);
 
   std::vector<std::uint8_t> byteValues = {1, 2, 250};
   auto byteResults = cudaq::run(1, byteVectorKernel, byteValues);
   int byteValue = byteResults.front();
-  std::printf("device_call u8 stdvec input result = %d\n", byteValue);
+  std::printf("device_call u8 sequence input result = %d\n", byteValue);
 
   std::vector<float> floatValues = {1.5f, 2.5f, 3.0f};
   auto floatResults = cudaq::run(1, floatVectorKernel, floatValues);
   float floatValue = floatResults.front();
-  std::printf("device_call f32 stdvec input result = %.1f\n", floatValue);
+  std::printf("device_call f32 sequence input result = %.1f\n", floatValue);
 
   return boolValue == 21 && measureValue == 21 && intValue == 42 &&
          byteValue == 256 && floatValue == 42.0f;
 }
 
-static bool runByRefOutputStdvecTests() {
+static bool runByRefOutputSequenceTests() {
   std::vector<int> intValues = {3, 4, 5, 6};
   auto incrementedRuns = cudaq::run(1, incrementIntVectorKernel, intValues);
   auto incremented = incrementedRuns.front();
-  std::printf("device_call i32 stdvec by-ref output =");
+  std::printf("device_call i32 sequence by-ref output =");
   for (auto value : incremented)
     std::printf(" %d", value);
   std::printf("\n");
 
   auto binaryRuns = cudaq::run(1, binaryVectorKernel, std::uint64_t{813});
   auto bits = binaryRuns.front();
-  std::printf("device_call bool stdvec by-ref output =");
+  std::printf("device_call bool sequence by-ref output =");
   for (bool bit : bits)
     std::printf(" %d", bit ? 1 : 0);
   std::printf("\n");
@@ -130,23 +130,23 @@ static bool runByRefOutputStdvecTests() {
 
 int main(int argc, char **argv) {
   cudaq::realtime::initialize(argc, argv);
-  bool passed = runInputStdvecTests() && runByRefOutputStdvecTests();
+  bool passed = runInputSequenceTests() && runByRefOutputSequenceTests();
 
   cudaq::realtime::finalize();
   return passed ? 0 : 1;
 }
 
-// SHM: device_call bool stdvec input result = 21
-// SHM: device_call measure stdvec input result = 21
-// SHM: device_call i32 stdvec input result = 42
-// SHM: device_call u8 stdvec input result = 256
-// SHM: device_call f32 stdvec input result = 42.0
-// SHM: device_call i32 stdvec by-ref output = 4 5 6 7
-// SHM: device_call bool stdvec by-ref output = 1 0 1 1 0 1 0 0 1 1
-// HOST: device_call bool stdvec input result = 21
-// HOST: device_call measure stdvec input result = 21
-// HOST: device_call i32 stdvec input result = 42
-// HOST: device_call u8 stdvec input result = 256
-// HOST: device_call f32 stdvec input result = 42.0
-// HOST: device_call i32 stdvec by-ref output = 4 5 6 7
-// HOST: device_call bool stdvec by-ref output = 1 0 1 1 0 1 0 0 1 1
+// SHM: device_call bool sequence input result = 21
+// SHM: device_call measure sequence input result = 21
+// SHM: device_call i32 sequence input result = 42
+// SHM: device_call u8 sequence input result = 256
+// SHM: device_call f32 sequence input result = 42.0
+// SHM: device_call i32 sequence by-ref output = 4 5 6 7
+// SHM: device_call bool sequence by-ref output = 1 0 1 1 0 1 0 0 1 1
+// HOST: device_call bool sequence input result = 21
+// HOST: device_call measure sequence input result = 21
+// HOST: device_call i32 sequence input result = 42
+// HOST: device_call u8 sequence input result = 256
+// HOST: device_call f32 sequence input result = 42.0
+// HOST: device_call i32 sequence by-ref output = 4 5 6 7
+// HOST: device_call bool sequence by-ref output = 1 0 1 1 0 1 0 0 1 1

--- a/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
+++ b/cudaq/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
@@ -73,7 +73,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
     %c2_i64 = arith.constant 2 : i64
     %0 = cc.address_of @cstr.585900 : !cc.ptr<!llvm.array<3 x i8>>
     %1 = cc.cast %0 : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
-    %2 = cc.stdvec_init %1, %c2_i64 : (!cc.ptr<i8>, i64) -> !cc.charspan
+    %2 = cc.sequence_init %1, %c2_i64 : (!cc.ptr<i8>, i64) -> !cc.charspan
     %3 = quake.alloca !quake.veq<2>
     quake.exp_pauli (%cst) %3 to %2 : (f64, !quake.veq<2>, !cc.charspan) -> ()
     return

--- a/cudaq/test/Transforms/add_measurements-0.qke
+++ b/cudaq/test/Transforms/add_measurements-0.qke
@@ -57,7 +57,7 @@ func.func @__nvqpp__mlirgen__bell_pair_no_mz() attributes {"cudaq-entrypoint", "
 // CHECK:           quake.x {{\[}}%[[VAL_1]]] %[[VAL_2]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/add_measurements-1.qke
+++ b/cudaq/test/Transforms/add_measurements-1.qke
@@ -96,7 +96,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__caller = "__nvqpp
 // CHECK:           } {invariant}
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
-// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_12]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<3>) -> !cc.sequence<!quake.measure>
+// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_12]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/add_measurements-2.qke
+++ b/cudaq/test/Transforms/add_measurements-2.qke
@@ -58,7 +58,7 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
 // CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           quake.h
 // CHECK:           quake.x
-// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<2>
 // CHECK:           return
 

--- a/cudaq/test/Transforms/aggressive_inline_prevented.qke
+++ b/cudaq/test/Transforms/aggressive_inline_prevented.qke
@@ -12,24 +12,24 @@
 // doesn't throw an error on this input.
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel = "__nvqpp__mlirgen__kernel_PyKernelEntryPointRewrite"}} {
-  func.func @__nvqpp__mlirgen__trotter(%arg0: !quake.veq<?>, %arg1: f64, %arg2: !cc.stdvec<complex<f64>>, %arg3: !cc.stdvec<!cc.charspan>) attributes {"cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__trotter(%arg0: !quake.veq<?>, %arg1: f64, %arg2: !cc.sequence<complex<f64>>, %arg3: !cc.sequence<!cc.charspan>) attributes {"cudaq-kernel"} {
     %c1_i64 = arith.constant 1 : i64
     %c0_i64 = arith.constant 0 : i64
     %0 = cc.alloca f64
     cc.store %arg1, %0 : !cc.ptr<f64>
-    %1 = cc.stdvec_size %arg2 : (!cc.stdvec<complex<f64>>) -> i64
+    %1 = cc.sequence_size %arg2 : (!cc.sequence<complex<f64>>) -> i64
     %2 = cc.loop while ((%arg4 = %c0_i64) -> (i64)) {
       %3 = arith.cmpi slt, %arg4, %1 : i64
       cc.condition %3(%arg4 : i64)
     } do {
     ^bb0(%arg4: i64):
-      %3 = cc.stdvec_data %arg2 : (!cc.stdvec<complex<f64>>) -> !cc.ptr<!cc.array<complex<f64> x ?>>
+      %3 = cc.sequence_data %arg2 : (!cc.sequence<complex<f64>>) -> !cc.ptr<!cc.array<complex<f64> x ?>>
       %4 = cc.compute_ptr %3[%arg4] : (!cc.ptr<!cc.array<complex<f64> x ?>>, i64) -> !cc.ptr<complex<f64>>
       %5 = cc.load %4 : !cc.ptr<complex<f64>>
       %6 = complex.re %5 : complex<f64>
       %7 = cc.load %0 : !cc.ptr<f64>
       %8 = arith.mulf %6, %7 : f64
-      %9 = cc.stdvec_data %arg3 : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
+      %9 = cc.sequence_data %arg3 : (!cc.sequence<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
       %10 = cc.compute_ptr %9[%arg4] : (!cc.ptr<!cc.array<!cc.charspan x ?>>, i64) -> !cc.ptr<!cc.charspan>
       %11 = cc.load %10 : !cc.ptr<!cc.charspan>
       quake.exp_pauli (%8) %arg0 to %11 : (f64, !quake.veq<?>, !cc.charspan) -> ()
@@ -41,7 +41,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel = "__nvqpp
     } {invariant}
     return
   }
-  func.func @__nvqpp__mlirgen__kernel(%arg0: i64, %arg1: !cc.stdvec<complex<f64>>, %arg2: !cc.stdvec<!cc.charspan>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__kernel(%arg0: i64, %arg1: !cc.sequence<complex<f64>>, %arg2: !cc.sequence<!cc.charspan>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %c1_i64 = arith.constant 1 : i64
     %c0_i64 = arith.constant 0 : i64
     %cst = arith.constant 1.000000e+00 : f64
@@ -67,7 +67,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel = "__nvqpp
     } do {
     ^bb0(%arg3: i64):
       %12 = cc.load %9 : !cc.ptr<f64>
-      func.call @__nvqpp__mlirgen__trotter(%4, %12, %arg1, %arg2) : (!quake.veq<?>, f64, !cc.stdvec<complex<f64>>, !cc.stdvec<!cc.charspan>) -> ()
+      func.call @__nvqpp__mlirgen__trotter(%4, %12, %arg1, %arg2) : (!quake.veq<?>, f64, !cc.sequence<complex<f64>>, !cc.sequence<!cc.charspan>) -> ()
       cc.continue %arg3 : i64
     } step {
     ^bb0(%arg3: i64):

--- a/cudaq/test/Transforms/arg_subst-1.txt
+++ b/cudaq/test/Transforms/arg_subst-1.txt
@@ -10,7 +10,7 @@ cc.arg_subst[0] {
   %0 = cc.address_of @cstr.48692C2074686572652100 : !cc.ptr<!llvm.array<11 x i8>>
   %1 = cc.cast %0 : (!cc.ptr<!llvm.array<11 x i8>>) -> !cc.ptr<i8>
   %c10_i64 = arith.constant 10 : i64
-  %2 = cc.stdvec_init %1, %c10_i64 : (!cc.ptr<i8>, i64) -> !cc.charspan
+  %2 = cc.sequence_init %1, %c10_i64 : (!cc.ptr<i8>, i64) -> !cc.charspan
 }
 
 llvm.mlir.global private constant @cstr.48692C2074686572652100("Hi, there!\00") {addr_space = 0 : i32}

--- a/cudaq/test/Transforms/arg_subst-2.txt
+++ b/cudaq/test/Transforms/arg_subst-2.txt
@@ -21,5 +21,5 @@ cc.arg_subst[0] {
   %4 = cc.compute_ptr %0[3] : (!cc.ptr<!cc.array<i32 x 4>>) -> !cc.ptr<i32>
   cc.store %c48879_i32, %4 : !cc.ptr<i32>
   %c4_i64 = arith.constant 4 : i64
-  %5 = cc.stdvec_init %0, %c4_i64 : (!cc.ptr<!cc.array<i32 x 4>>, i64) -> !cc.stdvec<i32>
+  %5 = cc.sequence_init %0, %c4_i64 : (!cc.ptr<!cc.array<i32 x 4>>, i64) -> !cc.sequence<i32>
 }

--- a/cudaq/test/Transforms/arg_subst-4.txt
+++ b/cudaq/test/Transforms/arg_subst-4.txt
@@ -42,5 +42,5 @@ cc.arg_subst[0] {
   %18 = cc.compute_ptr %0[2] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>) -> !cc.ptr<!cc.struct<{i32, f64, i8, i16}>>
   cc.store %17, %18 : !cc.ptr<!cc.struct<{i32, f64, i8, i16}>>
   %c3_i64 = arith.constant 3 : i64
-  %19 = cc.stdvec_init %0, %c3_i64 : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>, i64) -> !cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>
+  %19 = cc.sequence_init %0, %c3_i64 : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>, i64) -> !cc.sequence<!cc.struct<{i32, f64, i8, i16}>>
 }

--- a/cudaq/test/Transforms/arg_subst_func.qke
+++ b/cudaq/test/Transforms/arg_subst_func.qke
@@ -49,14 +49,14 @@ func.func @testy1(%arg0: !cc.charspan) {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 10 : i64
 // CHECK:           %[[VAL_1:.*]] = cc.address_of @cstr.48692C2074686572652100 : !cc.ptr<!llvm.array<11 x i8>>
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!llvm.array<11 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_init %[[VAL_2]], %[[VAL_0]] : (!cc.ptr<i8>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_init %[[VAL_2]], %[[VAL_0]] : (!cc.ptr<i8>, i64) -> !cc.charspan
 // CHECK:           call @callee1(%[[VAL_3]]) : (!cc.charspan) -> ()
 // CHECK:           return
 // CHECK:         }
 
-func.func private @callee2(!cc.stdvec<i32>)
-func.func @testy2(%arg0: !cc.stdvec<i32>) {
-  call @callee2(%arg0) : (!cc.stdvec<i32>) -> ()
+func.func private @callee2(!cc.sequence<i32>)
+func.func @testy2(%arg0: !cc.sequence<i32>) {
+  call @callee2(%arg0) : (!cc.sequence<i32>) -> ()
   return
 }
 
@@ -75,8 +75,8 @@ func.func @testy2(%arg0: !cc.stdvec<i32>) {
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_5]][3] : (!cc.ptr<!cc.array<i32 x 4>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_10:.*]] = cc.stdvec_init %[[VAL_5]], %[[VAL_0]] : (!cc.ptr<!cc.array<i32 x 4>>, i64) -> !cc.stdvec<i32>
-// CHECK:           call @callee2(%[[VAL_10]]) : (!cc.stdvec<i32>) -> ()
+// CHECK:           %[[VAL_10:.*]] = cc.sequence_init %[[VAL_5]], %[[VAL_0]] : (!cc.ptr<!cc.array<i32 x 4>>, i64) -> !cc.sequence<i32>
+// CHECK:           call @callee2(%[[VAL_10]]) : (!cc.sequence<i32>) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -100,9 +100,9 @@ func.func @testy3(%arg0: !cc.struct<{i32, f64, i8, i16}>) {
 // CHECK:           return
 // CHECK:         }
 
-func.func private @callee4(!cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>)
-func.func @testy4(%arg0: !cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>) {
-  call @callee4(%arg0) : (!cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>) -> ()
+func.func private @callee4(!cc.sequence<!cc.struct<{i32, f64, i8, i16}>>)
+func.func @testy4(%arg0: !cc.sequence<!cc.struct<{i32, f64, i8, i16}>>) {
+  call @callee4(%arg0) : (!cc.sequence<!cc.struct<{i32, f64, i8, i16}>>) -> ()
   return
 }
 
@@ -142,8 +142,8 @@ func.func @testy4(%arg0: !cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>) {
 // CHECK:           %[[VAL_30:.*]] = cc.insert_value %[[VAL_29]][3], %[[VAL_1]] : (!cc.struct<{i32, f64, i8, i16}>, i16) -> !cc.struct<{i32, f64, i8, i16}>
 // CHECK:           %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_13]][2] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>) -> !cc.ptr<!cc.struct<{i32, f64, i8, i16}>>
 // CHECK:           cc.store %[[VAL_30]], %[[VAL_31]] : !cc.ptr<!cc.struct<{i32, f64, i8, i16}>>
-// CHECK:           %[[VAL_32:.*]] = cc.stdvec_init %[[VAL_13]], %[[VAL_0]] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>, i64) -> !cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>
-// CHECK:           call @callee4(%[[VAL_32]]) : (!cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>) -> ()
+// CHECK:           %[[VAL_32:.*]] = cc.sequence_init %[[VAL_13]], %[[VAL_0]] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>, i64) -> !cc.sequence<!cc.struct<{i32, f64, i8, i16}>>
+// CHECK:           call @callee4(%[[VAL_32]]) : (!cc.sequence<!cc.struct<{i32, f64, i8, i16}>>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/canonical-2.qke
+++ b/cudaq/test/Transforms/canonical-2.qke
@@ -37,16 +37,16 @@ func.func @canonicalize_scope(%arg0: !quake.ref) attributes {"cudaq-kernel"} {
 // CHECK:           quake.compute_action %[[VAL_0]], %[[VAL_1]]
 
 // Test here is that this does not crash.
-func.func @cast_to_stdvec() {
+func.func @cast_to_sequence() {
     %c0_i64 = arith.constant 0 : i64
     %c2_i64 = arith.constant 2 : i64
     %ptr = cc.cast %c0_i64 : (i64) -> !cc.ptr<i64>
-    %vector = cc.stdvec_init %ptr, %c0_i64 : (!cc.ptr<i64>, i64) -> !cc.stdvec<i64>
-    %size = cc.stdvec_size %vector : (!cc.stdvec<i64>) -> i64
+    %vector = cc.sequence_init %ptr, %c0_i64 : (!cc.ptr<i64>, i64) -> !cc.sequence<i64>
+    %size = cc.sequence_size %vector : (!cc.sequence<i64>) -> i64
     return
 }
 
-// CHECK-LABEL:   func.func @cast_to_stdvec() {
+// CHECK-LABEL:   func.func @cast_to_sequence() {
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/classical_optimization.qke
+++ b/cudaq/test/Transforms/classical_optimization.qke
@@ -68,8 +68,8 @@ func.func @test_nested_loop_unroll() {
     %25 = arith.addi %arg0, %c1_i64 : i64
     cc.continue %25 : i64
   } {invariant}
-  %7 = cc.stdvec_init %5, %c2_i64 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.stdvec<i64>
-  %8 = cc.stdvec_size %7 : (!cc.stdvec<i64>) -> i64
+  %7 = cc.sequence_init %5, %c2_i64 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.sequence<i64>
+  %8 = cc.sequence_size %7 : (!cc.sequence<i64>) -> i64
   %9 = arith.subi %8, %c1_i64 : i64
   %10:2 = cc.loop while ((%arg0 = %c0_i64, %arg1 = %c0_i64) -> (i64, i64)) {
     %25 = arith.cmpi slt, %arg0, %9 : i64
@@ -125,7 +125,7 @@ func.func @test_nested_loop_unroll() {
     %25 = arith.addi %arg0, %c1_i64 : i64
     cc.continue %25 : i64
   } {invariant}
-  %16 = cc.stdvec_init %14, %10#1 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.stdvec<i64>
+  %16 = cc.sequence_init %14, %10#1 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.sequence<i64>
   %17 = cc.alloca i64[%11 : i64]
   %18:2 = cc.loop while ((%arg0 = %c0_i64, %arg1 = %c0_i64) -> (i64, i64)) {
     %25 = arith.cmpi slt, %arg0, %10#1 : i64
@@ -155,7 +155,7 @@ func.func @test_nested_loop_unroll() {
     %25 = arith.addi %arg0, %c1_i64 : i64
     cc.continue %25 : i64
   } {invariant}
-  %21 = cc.stdvec_init %19, %10#1 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.stdvec<i64>
+  %21 = cc.sequence_init %19, %10#1 : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.sequence<i64>
   %22:2 = cc.loop while ((%arg0 = %c0_i64, %arg1 = %c0_i64) -> (i64, i64)) {
     %25 = arith.cmpi slt, %arg0, %9 : i64
     cc.condition %25(%arg0, %arg1 : i64, i64)
@@ -167,13 +167,13 @@ func.func @test_nested_loop_unroll() {
       cc.condition %27(%arg2, %arg3 : i64, i64)
     } do {
     ^bb0(%arg2: i64, %arg3: i64):
-      %27 = cc.stdvec_data %16 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+      %27 = cc.sequence_data %16 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
       %28 = cc.compute_ptr %27[%arg3] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
-      %29 = cc.stdvec_data %7 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+      %29 = cc.sequence_data %7 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
       %30 = cc.compute_ptr %29[%arg0] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
       %31 = cc.load %30 : !cc.ptr<i64>
       cc.store %31, %28 : !cc.ptr<i64>
-      %32 = cc.stdvec_data %21 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+      %32 = cc.sequence_data %21 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
       %33 = cc.compute_ptr %32[%arg3] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
       %34 = cc.compute_ptr %29[%arg2] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
       %35 = cc.load %34 : !cc.ptr<i64>
@@ -191,16 +191,16 @@ func.func @test_nested_loop_unroll() {
     %25 = arith.addi %arg0, %c1_i64 : i64
     cc.continue %25, %arg1 : i64, i64
   } {invariant}
-  %23 = cc.stdvec_size %16 : (!cc.stdvec<i64>) -> i64
+  %23 = cc.sequence_size %16 : (!cc.sequence<i64>) -> i64
   %24 = cc.loop while ((%arg0 = %c0_i64) -> (i64)) {
     %25 = arith.cmpi slt, %arg0, %23 : i64
     cc.condition %25(%arg0 : i64)
   } do {
   ^bb0(%arg0: i64):
-    %25 = cc.stdvec_data %16 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+    %25 = cc.sequence_data %16 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
     %26 = cc.compute_ptr %25[%arg0] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
     %27 = cc.load %26 : !cc.ptr<i64>
-    %28 = cc.stdvec_data %21 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+    %28 = cc.sequence_data %21 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
     %29 = cc.compute_ptr %28[%arg0] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
     %30 = cc.load %29 : !cc.ptr<i64>
     %31 = arith.cmpi slt, %27, %30 : i64

--- a/cudaq/test/Transforms/combine_measurements.qke
+++ b/cudaq/test/Transforms/combine_measurements.qke
@@ -20,7 +20,7 @@ func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint"} {
 
 // CHECK-LABEL: func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint", output_names = "{{\[\[\[0,\[0,\\220\\22\]\],\[1,\[1,\\221\\22\]\]\]\]}}"} {
 // CHECK:         %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
-// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:         return
 // CHECK:       }
 
@@ -36,7 +36,7 @@ func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint"} {
   }
 // CHECK-LABEL: func.func @mz_2bits_extract_cst_op_index() attributes {"cudaq-entrypoint", output_names = "{{\[\[\[0,\[0,\\220\\22\]\],\[1,\[1,\\221\\22\]\]\]\]}}"} {
 // CHECK:         %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
-// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:         return
 // CHECK:       }
 
@@ -51,7 +51,7 @@ func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint"} {
 
 // CHECK-LABEL: func.func @mz_2bits_extract_non_consecutive() attributes {"cudaq-entrypoint", output_names = "{{\[\[\[0,\[0,\\220\\22\]\],\[1,\[2,\\222\\22\]\]\]\]}}"} {
 // CHECK:         %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
-// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.sequence<!quake.measure>
 // CHECK:         return
 // CHECK:       }
 
@@ -59,13 +59,13 @@ func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint"} {
     %c1_i64 = arith.constant 1 : i64
     %0 = quake.alloca !quake.veq<4>
     %1 = quake.subveq %0, %c1_i64, %c1_i64 : (!quake.veq<4>, i64, i64) -> !quake.veq<1>
-    %measOut = quake.mz %1 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+    %measOut = quake.mz %1 : (!quake.veq<1>) -> !cc.sequence<!quake.measure>
     return
   }
 
 // CHECK-LABEL: func.func @subveq_4_1() attributes {"cudaq-entrypoint", output_names = "{{\[\[\[0,\[1,\\221\\22\]\]\]\]}}"} {
 // CHECK:         %[[VAL_0:.*]] = quake.alloca !quake.veq<4>
-// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
 // CHECK:         return
 // CHECK:       }
 
@@ -74,13 +74,13 @@ func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint"} {
     %c2_i64 = arith.constant 2 : i64
     %0 = quake.alloca !quake.veq<4>
     %1 = quake.subveq %0, %c1_i64, %c2_i64 : (!quake.veq<4>, i64, i64) -> !quake.veq<2>
-    %measOut = quake.mz %1 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+    %measOut = quake.mz %1 : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
     return
   }
 
 // CHECK-LABEL: func.func @subveq_4_2() attributes {"cudaq-entrypoint", output_names = "{{\[\[\[0,\[1,\\221\\22\]\],\[1,\[2,\\222\\22\]\]\]\]}}"} {
 // CHECK:         %[[VAL_0:.*]] = quake.alloca !quake.veq<4>
-// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
 // CHECK:         return
 // CHECK:       }
 
@@ -89,13 +89,13 @@ func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint"} {
     %c3_i64 = arith.constant 3 : i64
     %0 = quake.alloca !quake.veq<4>
     %1 = quake.subveq %0, %c0_i64, %c3_i64 : (!quake.veq<4>, i64, i64) -> !quake.veq<4>
-    %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+    %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
     return
   }
 
 // CHECK-LABEL: func.func @subveq_4_4() attributes {"cudaq-entrypoint", output_names = "{{\[\[\[0,\[0,\\220\\22\]\],\[1,\[1,\\221\\22\]\],\[2,\[2,\\222\\22\]\],\[3,\[3,\\223\\22\]\]\]\]}}"} {
 // CHECK:         %[[VAL_0:.*]] = quake.alloca !quake.veq<4>
-// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
 // CHECK:         return
 // CHECK:       }
 
@@ -104,15 +104,15 @@ func.func @mz_2bits_extract_cst_index() attributes {"cudaq-entrypoint"} {
     %1 = quake.extract_ref %0[1] : (!quake.veq<4>) -> !quake.ref
     %2 = quake.extract_ref %0[2] : (!quake.veq<4>) -> !quake.ref
     %3 = quake.subveq %0, 0, 1 : (!quake.veq<4>) -> !quake.veq<2>
-    %measOut = quake.mz %3 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+    %measOut = quake.mz %3 : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
     %4 = quake.subveq %0, 2, 2 : (!quake.veq<4>) -> !quake.veq<1>
-    %measOut_0 = quake.mz %4 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+    %measOut_0 = quake.mz %4 : (!quake.veq<1>) -> !cc.sequence<!quake.measure>
     return
   }
 
 // CHECK-LABEL: func.func @mz_2subveqs_extract() attributes {"cudaq-entrypoint", output_names = "{{\[\[\[0,\[0,\\220\\22\]\],\[1,\[1,\\221\\22\]\],\[2,\[2,\\222\\22\]\]\]\]}}"} {
 // CHECK:         %[[VAL_0:.*]] = quake.alloca !quake.veq<4>
-// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
 // CHECK:         return
 // CHECK:       }
 }

--- a/cudaq/test/Transforms/const_prop_complex.qke
+++ b/cudaq/test/Transforms/const_prop_complex.qke
@@ -70,7 +70,7 @@ func.func @__nvqpp__mlirgen__function_test_complex_constant_array._Z27test_compl
 
 func.func private @__nvqpp_vectorCopyCtor(%0: !cc.ptr<i8>, %1: i64, %2: i64) -> !cc.ptr<i8>
 
-func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.stdvec<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.sequence<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
   %cst = arith.constant -0.70710678118654757 : f64
   %c16_i64 = arith.constant 16 : i64
   %c4_i64 = arith.constant 4 : i64
@@ -91,11 +91,11 @@ func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generato
   cc.store %3, %8 : !cc.ptr<complex<f64>>
   %9 = cc.cast %4 : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<i8>
   %10 = call @__nvqpp_vectorCopyCtor(%9, %c4_i64, %c16_i64) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-  %11 = cc.stdvec_init %10, %c4_i64 : (!cc.ptr<i8>, i64) -> !cc.stdvec<complex<f64>>
-  return %11 : !cc.stdvec<complex<f64>>
+  %11 = cc.sequence_init %10, %c4_i64 : (!cc.ptr<i8>, i64) -> !cc.sequence<complex<f64>>
+  return %11 : !cc.sequence<complex<f64>>
 }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.stdvec<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.sequence<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK-DAG:       %[[VAL_0:.*]] = complex.constant [0.70710678118654757, 0.000000e+00] : complex<f64>
 // CHECK-DAG:       %[[VAL_1:.*]] = complex.constant [-0.70710678118654757, 0.000000e+00] : complex<f64>
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 16 : i64
@@ -111,8 +111,8 @@ func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generato
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_8]] : !cc.ptr<complex<f64>>
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_9]], %[[VAL_3]], %[[VAL_2]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_11:.*]] = cc.stdvec_init %[[VAL_10]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<complex<f64>>
-// CHECK:           return %[[VAL_11]] : !cc.stdvec<complex<f64>>
+// CHECK:           %[[VAL_11:.*]] = cc.sequence_init %[[VAL_10]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.sequence<complex<f64>>
+// CHECK:           return %[[VAL_11]] : !cc.sequence<complex<f64>>
 // CHECK:         }
 
 

--- a/cudaq/test/Transforms/cse.qke
+++ b/cudaq/test/Transforms/cse.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-opt --canonicalize --cse %s | FileCheck %s
 
-func.func @__nvqpp__mlirgen__deuteron_n3_ansatz2(%arg0: !cc.stdvec<f64>) {
+func.func @__nvqpp__mlirgen__deuteron_n3_ansatz2(%arg0: !cc.sequence<f64>) {
   %c0_i64 = arith.constant 0 : i64
   %c1_i64 = arith.constant 1 : i64
   %c2_i64 = arith.constant 2 : i64
@@ -16,18 +16,18 @@ func.func @__nvqpp__mlirgen__deuteron_n3_ansatz2(%arg0: !cc.stdvec<f64>) {
   %0 = quake.alloca  !quake.veq<3>
   %1 = quake.extract_ref %0[%c0_i64] : (!quake.veq<3>,i64) -> !quake.ref
   quake.x %1 : (!quake.ref) -> ()
-  %2 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr
+  %2 = cc.sequence_data %arg0 : (!cc.sequence<f64>) -> !llvm.ptr
   %3 = llvm.load %2 : !llvm.ptr -> f64
   %4 = quake.extract_ref %0[%c1_i64] : (!quake.veq<3>,i64) -> !quake.ref
   quake.ry (%3) %4 : (f64, !quake.ref) -> ()
-  %5 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr
+  %5 = cc.sequence_data %arg0 : (!cc.sequence<f64>) -> !llvm.ptr
   %6 = llvm.getelementptr %5[1] : (!llvm.ptr) -> !llvm.ptr, f64
   %7 = llvm.load %6 : !llvm.ptr -> f64
   %8 = quake.extract_ref %0[%c2_i64] : (!quake.veq<3>, i64) -> !quake.ref
   quake.ry (%7) %8 : (f64, !quake.ref) -> ()
   quake.x [%8] %1 : (!quake.ref, !quake.ref) -> ()
   quake.x [%1] %4 : (!quake.ref, !quake.ref) -> ()
-  %9 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr
+  %9 = cc.sequence_data %arg0 : (!cc.sequence<f64>) -> !llvm.ptr
   %10 = llvm.load %9 : !llvm.ptr -> f64
   %11 = arith.mulf %10, %cst : f64
   quake.ry (%11) %4 : (f64, !quake.ref) -> ()
@@ -37,8 +37,8 @@ func.func @__nvqpp__mlirgen__deuteron_n3_ansatz2(%arg0: !cc.stdvec<f64>) {
 }
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__deuteron_n3_ansatz2
-// CHECK: cc.stdvec_data
-// CHECK-NOT: cc.stdvec_data
+// CHECK: cc.sequence_data
+// CHECK-NOT: cc.sequence_data
 // CHECK: return
 
 func.func @test_2() -> i1 {
@@ -63,13 +63,13 @@ func.func private @device_kernel(!quake.veq<?>)
 func.func @canonicalize_concat() {
   %q1 = quake.alloca !quake.ref
   %q2 = quake.concat %q1 : (!quake.ref) -> !quake.veq<1>
-  %b1 = quake.mz %q2 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+  %b1 = quake.mz %q2 : (!quake.veq<1>) -> !cc.sequence<!quake.measure>
   %q3 = quake.alloca !quake.veq<1>
   %q4 = quake.concat %q3 : (!quake.veq<1>) -> !quake.veq<1>
-  %b2 = quake.mz %q4 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+  %b2 = quake.mz %q4 : (!quake.veq<1>) -> !cc.sequence<!quake.measure>
   %q5 = quake.alloca !quake.veq<1>
   %q6 = quake.concat %q5 : (!quake.veq<1>) -> !quake.veq<?>
-  %b3 = quake.mz %q6 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
+  %b3 = quake.mz %q6 : (!quake.veq<?>) -> !cc.sequence<!quake.measure>
   %q7 = quake.alloca !quake.veq<2>
   %q8 = quake.concat %q7 : (!quake.veq<2>) -> !quake.veq<?>
   call @device_kernel(%q8) : (!quake.veq<?>) -> ()
@@ -83,11 +83,11 @@ func.func @canonicalize_concat() {
 // CHECK-LABEL:   func.func @canonicalize_concat() {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_1:.*]] = quake.concat %[[VAL_0]] : (!quake.ref) -> !quake.veq<1>
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<1>) -> !cc.sequence<!quake.measure>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<1>
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<1>) -> !cc.sequence<!quake.measure>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<1>
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.veq<1>) -> !cc.sequence<!quake.measure>
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_8:.*]] = quake.relax_size %[[VAL_7]] : (!quake.veq<2>) -> !quake.veq<?>
 // CHECK:           call @device_kernel(%[[VAL_8]]) : (!quake.veq<?>) -> ()
@@ -101,13 +101,13 @@ func.func @canonicalize_multiple_concat() {
   %q1 = quake.alloca !quake.ref
   %p1 = quake.alloca !quake.ref
   %q2 = quake.concat %q1, %p1 : (!quake.ref, !quake.ref) -> !quake.veq<2>
-  %b1 = quake.mz %q2 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %b1 = quake.mz %q2 : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   %q3 = quake.alloca !quake.veq<1>
   %q4 = quake.concat %q1, %p1, %q3 : (!quake.ref, !quake.ref, !quake.veq<1>) -> !quake.veq<3>
-  %b2 = quake.mz %q4 : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
+  %b2 = quake.mz %q4 : (!quake.veq<3>) -> !cc.sequence<!quake.measure>
   %q5 = quake.alloca !quake.veq<1>
   %q6 = quake.concat %q3, %q5 : (!quake.veq<1>, !quake.veq<1>) -> !quake.veq<?>
-  %b3 = quake.mz %q6 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
+  %b3 = quake.mz %q6 : (!quake.veq<?>) -> !cc.sequence<!quake.measure>
   %q7 = quake.alloca !quake.veq<2>
   %q8 = quake.concat %q3, %q7 : (!quake.veq<1>, !quake.veq<2>) -> !quake.veq<?>
   call @device_kernel(%q8) : (!quake.veq<?>) -> ()
@@ -122,13 +122,13 @@ func.func @canonicalize_multiple_concat() {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_2:.*]] = quake.concat %[[VAL_0]], %[[VAL_1]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<1>
 // CHECK:           %[[VAL_5:.*]] = quake.concat %[[VAL_0]], %[[VAL_1]], %[[VAL_4]] : (!quake.ref, !quake.ref, !quake.veq<1>) -> !quake.veq<3>
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.veq<3>) -> !cc.sequence<!quake.measure>
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<1>
 // CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_4]], %[[VAL_7]] : (!quake.veq<1>, !quake.veq<1>) -> !quake.veq<2>
-// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_11:.*]] = quake.concat %[[VAL_4]], %[[VAL_10]] : (!quake.veq<1>, !quake.veq<2>) -> !quake.veq<3>
 // CHECK:           %[[VAL_12:.*]] = quake.relax_size %[[VAL_11]] : (!quake.veq<3>) -> !quake.veq<?>

--- a/cudaq/test/Transforms/device_call_by_ref_vec_attr_verifier_errors.qke
+++ b/cudaq/test/Transforms/device_call_by_ref_vec_attr_verifier_errors.qke
@@ -11,27 +11,27 @@
 func.func private @scalarArg(i32)
 
 func.func @badScalarIndex(%arg0: i32) {
-  // expected-error @+1 {{'cc.device_call' op by_ref_vec_arg_indices references non-stdvec argument index 0}}
+  // expected-error @+1 {{'cc.device_call' op by_ref_vec_arg_indices references non-sequence argument index 0}}
   cc.device_call @scalarArg(%arg0) : (i32) -> () {by_ref_vec_arg_indices = array<i64: 0>}
   return
 }
 
 // -----
 
-func.func private @vectorArg(!cc.stdvec<i32>)
+func.func private @vectorArg(!cc.sequence<i32>)
 
-func.func @badDuplicateIndex(%arg0: !cc.stdvec<i32>) {
+func.func @badDuplicateIndex(%arg0: !cc.sequence<i32>) {
   // expected-error @+1 {{'cc.device_call' op by_ref_vec_arg_indices contains duplicate argument index 0}}
-  cc.device_call @vectorArg(%arg0) : (!cc.stdvec<i32>) -> () {by_ref_vec_arg_indices = array<i64: 0, 0>}
+  cc.device_call @vectorArg(%arg0) : (!cc.sequence<i32>) -> () {by_ref_vec_arg_indices = array<i64: 0, 0>}
   return
 }
 
 // -----
 
-func.func private @oneVectorArg(!cc.stdvec<i32>)
+func.func private @oneVectorArg(!cc.sequence<i32>)
 
-func.func @badOutOfRangeIndex(%arg0: !cc.stdvec<i32>) {
+func.func @badOutOfRangeIndex(%arg0: !cc.sequence<i32>) {
   // expected-error @+1 {{'cc.device_call' op by_ref_vec_arg_indices contains out-of-range argument index 1}}
-  cc.device_call @oneVectorArg(%arg0) : (!cc.stdvec<i32>) -> () {by_ref_vec_arg_indices = array<i64: 1>}
+  cc.device_call @oneVectorArg(%arg0) : (!cc.sequence<i32>) -> () {by_ref_vec_arg_indices = array<i64: 1>}
   return
 }

--- a/cudaq/test/Transforms/device_call_realtime_bitpacked.qke
+++ b/cudaq/test/Transforms/device_call_realtime_bitpacked.qke
@@ -8,15 +8,15 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(canonicalize,realtime-device-call,cse,canonicalize)' %s | FileCheck %s
 
-func.func @boolInput(%arg0 : !cc.stdvec<i1>) -> i32 attributes {
+func.func @boolInput(%arg0 : !cc.sequence<i1>) -> i32 attributes {
   "cudaq-entrypoint", "cudaq-kernel", no_this
 } {
-  %0 = cc.device_call @countBits(%arg0) : (!cc.stdvec<i1>) -> i32
+  %0 = cc.device_call @countBits(%arg0) : (!cc.sequence<i1>) -> i32
   return %0 : i32
 }
 
 // CHECK-LABEL:   func.func @boolInput(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i1>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i1>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 6 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : i32
@@ -24,7 +24,7 @@ func.func @boolInput(%arg0 : !cc.stdvec<i1>) -> i32 attributes {
 // CHECK:           %[[CONSTANT_4:.*]] = arith.constant 4 : i64
 // CHECK:           %[[CONSTANT_5:.*]] = arith.constant 7 : i64
 // CHECK:           %[[CONSTANT_6:.*]] = arith.constant 8 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_5]] : i64
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_6]] : i64
 // CHECK:           %[[ADDI_1:.*]] = arith.addi %[[DIVUI_0]], %[[CONSTANT_6]] : i64
@@ -43,7 +43,7 @@ func.func @boolInput(%arg0 : !cc.stdvec<i1>) -> i32 attributes {
 // CHECK:           %[[LOAD_1:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:           %[[LOAD_2:.*]] = cc.load %[[ALLOCA_2]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
 // CHECK:           %[[CAST_2:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[STDVEC_SIZE_0]], %[[CAST_2]] : !cc.ptr<i64>
 // CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[CAST_1]][8] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
@@ -68,22 +68,22 @@ func.func @boolInput(%arg0 : !cc.stdvec<i1>) -> i32 attributes {
 // CHECK:           return %[[LOAD_4]] : i32
 // CHECK:         }
 
-func.func @measureInput(%arg0 : !cc.stdvec<!cc.measure_handle>) attributes {
+func.func @measureInput(%arg0 : !cc.sequence<!cc.measure_handle>) attributes {
   "cudaq-entrypoint", "cudaq-kernel", no_this
 } {
   cc.device_call @consumeMeasures(%arg0) :
-      (!cc.stdvec<!cc.measure_handle>) -> ()
+      (!cc.sequence<!cc.measure_handle>) -> ()
   return
 }
 
 // CHECK-LABEL:   func.func @measureInput(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<!cc.measure_handle>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1456080960 : i32
 // CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[CONSTANT_3:.*]] = arith.constant 7 : i64
 // CHECK:           %[[CONSTANT_4:.*]] = arith.constant 8 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<!cc.measure_handle>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<!cc.measure_handle>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_3]] : i64
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_4]] : i64
 // CHECK:           %[[ADDI_1:.*]] = arith.addi %[[DIVUI_0]], %[[CONSTANT_4]] : i64
@@ -101,7 +101,7 @@ func.func @measureInput(%arg0 : !cc.stdvec<!cc.measure_handle>) attributes {
 // CHECK:           %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[LOAD_1:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:           %[[CAST_2:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[STDVEC_SIZE_0]], %[[CAST_2]] : !cc.ptr<i64>
 // CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[CAST_1]][8] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
@@ -118,24 +118,24 @@ func.func @measureInput(%arg0 : !cc.stdvec<!cc.measure_handle>) attributes {
 // CHECK:           return
 // CHECK:         }
 
-func.func @boolOutput(%arg0 : !cc.stdvec<i1>) attributes {
+func.func @boolOutput(%arg0 : !cc.sequence<i1>) attributes {
   "cudaq-entrypoint", "cudaq-kernel", no_this
 } {
-  cc.device_call @produceBits(%arg0) : (!cc.stdvec<i1>) -> () {
+  cc.device_call @produceBits(%arg0) : (!cc.sequence<i1>) -> () {
     by_ref_vec_arg_indices = array<i64: 0>
   }
   return
 }
 
 // CHECK-LABEL:   func.func @boolOutput(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i1>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i1>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 6 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[CONSTANT_3:.*]] = arith.constant 2120391579 : i32
 // CHECK:           %[[CONSTANT_4:.*]] = arith.constant 7 : i64
 // CHECK:           %[[CONSTANT_5:.*]] = arith.constant 8 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_4]] : i64
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_5]] : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<i8>
@@ -168,14 +168,14 @@ func.func @boolOutput(%arg0 : !cc.stdvec<i1>) attributes {
 // CHECK:             func.call @__cudaq_device_call_safely_release_realtime_frame(%[[LOAD_0]]) : (!cc.ptr<i8>) -> ()
 // CHECK:             func.call @__quantum__qis__trap(%[[CONSTANT_0]]) : (i64) -> ()
 // CHECK:           }
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
 // CHECK:           call @__nvqpp_RealtimeUnpackBits(%[[STDVEC_DATA_0]], %[[CAST_1]], %[[STDVEC_SIZE_0]]) : (!cc.ptr<!cc.array<i1 x ?>>, !cc.ptr<!cc.array<i8 x ?>>, i64) -> ()
 // CHECK:           call @__cudaq_device_call_safely_release_realtime_frame(%[[LOAD_0]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
-// CHECK:         func.func private @countBits(!cc.stdvec<i1>) -> i32 attributes {"cudaq-devicecall"}
-// CHECK:         func.func private @consumeMeasures(!cc.stdvec<!cc.measure_handle>) attributes {"cudaq-devicecall"}
-// CHECK:         func.func private @produceBits(!cc.stdvec<i1>) attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @countBits(!cc.sequence<i1>) -> i32 attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @consumeMeasures(!cc.sequence<!cc.measure_handle>) attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @produceBits(!cc.sequence<i1>) attributes {"cudaq-devicecall"}
 // CHECK:         func.func private @__cudaq_device_call_acquire_realtime_frame(i32, i32, i64, i64, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i32
 // CHECK:         func.func private @__cudaq_device_call_dispatch_realtime_frame(!cc.ptr<i8>, !cc.ptr<i64>) -> i32
 // CHECK:         func.func private @__cudaq_device_call_safely_release_realtime_frame(!cc.ptr<i8>)
@@ -185,12 +185,12 @@ func.func @boolOutput(%arg0 : !cc.stdvec<i1>) attributes {
 // CHECK:         func.func private @__nvqpp_RealtimeUnpackBits(%{{.*}}: !cc.ptr<!cc.array<i1 x ?>>, %{{.*}}: !cc.ptr<!cc.array<i8 x ?>>, %{{.*}}: i64) {
 // CHECK:         func.func private @__quantum__qis__trap(i64)
 
-func.func private @countBits(!cc.stdvec<i1>) -> i32 attributes {
+func.func private @countBits(!cc.sequence<i1>) -> i32 attributes {
   "cudaq-devicecall"
 }
-func.func private @consumeMeasures(!cc.stdvec<!cc.measure_handle>) attributes {
+func.func private @consumeMeasures(!cc.sequence<!cc.measure_handle>) attributes {
   "cudaq-devicecall"
 }
-func.func private @produceBits(!cc.stdvec<i1>) attributes {
+func.func private @produceBits(!cc.sequence<i1>) attributes {
   "cudaq-devicecall"
 }

--- a/cudaq/test/Transforms/device_call_realtime_by_ref_errors.qke
+++ b/cudaq/test/Transforms/device_call_realtime_by_ref_errors.qke
@@ -8,20 +8,20 @@
 
 // RUN: cudaq-opt %s -split-input-file -verify-diagnostics -pass-pipeline='builtin.module(realtime-device-call)'
 
-func.func private @twoOutputVectors(!cc.stdvec<i32>, !cc.stdvec<i32>) attributes {"cudaq-devicecall"}
+func.func private @twoOutputVectors(!cc.sequence<i32>, !cc.sequence<i32>) attributes {"cudaq-devicecall"}
 
-func.func @multipleByRefResults(%arg0: !cc.stdvec<i32>, %arg1: !cc.stdvec<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  // expected-error @+1 {{'cc.device_call' op realtime device_call lowering supports at most one by-ref stdvec result argument}}
-  cc.device_call @twoOutputVectors(%arg0, %arg1) : (!cc.stdvec<i32>, !cc.stdvec<i32>) -> () {by_ref_vec_arg_indices = array<i64: 0, 1>}
+func.func @multipleByRefResults(%arg0: !cc.sequence<i32>, %arg1: !cc.sequence<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  // expected-error @+1 {{'cc.device_call' op realtime device_call lowering supports at most one by-ref sequence result argument}}
+  cc.device_call @twoOutputVectors(%arg0, %arg1) : (!cc.sequence<i32>, !cc.sequence<i32>) -> () {by_ref_vec_arg_indices = array<i64: 0, 1>}
   return
 }
 
 // -----
 
-func.func private @scalarAndOutput(!cc.stdvec<i32>) -> i32 attributes {"cudaq-devicecall"}
+func.func private @scalarAndOutput(!cc.sequence<i32>) -> i32 attributes {"cudaq-devicecall"}
 
-func.func @scalarAndByRefResult(%arg0: !cc.stdvec<i32>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  // expected-error @+1 {{'cc.device_call' op realtime device_call lowering does not support both scalar and by-ref stdvec results}}
-  %0 = cc.device_call @scalarAndOutput(%arg0) : (!cc.stdvec<i32>) -> i32 {by_ref_vec_arg_indices = array<i64: 0>}
+func.func @scalarAndByRefResult(%arg0: !cc.sequence<i32>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  // expected-error @+1 {{'cc.device_call' op realtime device_call lowering does not support both scalar and by-ref sequence results}}
+  %0 = cc.device_call @scalarAndOutput(%arg0) : (!cc.sequence<i32>) -> i32 {by_ref_vec_arg_indices = array<i64: 0>}
   return %0 : i32
 }

--- a/cudaq/test/Transforms/device_call_realtime_stdvec.qke
+++ b/cudaq/test/Transforms/device_call_realtime_stdvec.qke
@@ -8,13 +8,13 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(canonicalize,realtime-device-call,cse,canonicalize)' %s | FileCheck %s
 
-func.func @stdvecInputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : i32) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  %0 = cc.device_call @sumIntVector(%arg0, %arg1) : (!cc.stdvec<i32>, i32) -> i32
+func.func @sequenceInputKernel(%arg0 : !cc.sequence<i32>, %arg1 : i32) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  %0 = cc.device_call @sumIntVector(%arg0, %arg1) : (!cc.sequence<i32>, i32) -> i32
   return %0 : i32
 }
 
-// CHECK-LABEL:   func.func @stdvecInputKernel(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i32>,
+// CHECK-LABEL:   func.func @sequenceInputKernel(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i32>,
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 6 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 11 : i64
@@ -24,7 +24,7 @@ func.func @stdvecInputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : i32) -> i32 attrib
 // CHECK:           %[[CONSTANT_5:.*]] = arith.constant -126072298 : i32
 // CHECK:           %[[CONSTANT_6:.*]] = arith.constant -4 : i64
 // CHECK:           %[[CONSTANT_7:.*]] = arith.constant 4 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i32>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i32>) -> i64
 // CHECK:           %[[MULI_0:.*]] = arith.muli %[[STDVEC_SIZE_0]], %[[CONSTANT_7]] : i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[MULI_0]], %[[CONSTANT_1]] : i64
 // CHECK:           %[[ANDI_0:.*]] = arith.andi %[[ADDI_0]], %[[CONSTANT_6]] : i64
@@ -44,7 +44,7 @@ func.func @stdvecInputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : i32) -> i32 attrib
 // CHECK:           %[[LOAD_1:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:           %[[LOAD_2:.*]] = cc.load %[[ALLOCA_2]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
 // CHECK:           %[[CAST_2:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[STDVEC_SIZE_0]], %[[CAST_2]] : !cc.ptr<i64>
 // CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[CAST_1]][8] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
@@ -72,13 +72,13 @@ func.func @stdvecInputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : i32) -> i32 attrib
 // CHECK:           return %[[LOAD_4]] : i32
 // CHECK:         }
 
-func.func @stdvecBoolInputKernel(%arg0 : !cc.stdvec<i1>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  %0 = cc.device_call @countBoolVector(%arg0) : (!cc.stdvec<i1>) -> i32
+func.func @sequenceBoolInputKernel(%arg0 : !cc.sequence<i1>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  %0 = cc.device_call @countBoolVector(%arg0) : (!cc.sequence<i1>) -> i32
   return %0 : i32
 }
 
-// CHECK-LABEL:   func.func @stdvecBoolInputKernel(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i1>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-LABEL:   func.func @sequenceBoolInputKernel(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i1>) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 6 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : i32
@@ -86,7 +86,7 @@ func.func @stdvecBoolInputKernel(%arg0 : !cc.stdvec<i1>) -> i32 attributes {"cud
 // CHECK:           %[[CONSTANT_4:.*]] = arith.constant 4 : i64
 // CHECK:           %[[CONSTANT_5:.*]] = arith.constant 7 : i64
 // CHECK:           %[[CONSTANT_6:.*]] = arith.constant 8 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_5]] : i64
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_6]] : i64
 // CHECK:           %[[ADDI_1:.*]] = arith.addi %[[DIVUI_0]], %[[CONSTANT_6]] : i64
@@ -105,7 +105,7 @@ func.func @stdvecBoolInputKernel(%arg0 : !cc.stdvec<i1>) -> i32 attributes {"cud
 // CHECK:           %[[LOAD_1:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:           %[[LOAD_2:.*]] = cc.load %[[ALLOCA_2]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
 // CHECK:           %[[CAST_2:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[STDVEC_SIZE_0]], %[[CAST_2]] : !cc.ptr<i64>
 // CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[CAST_1]][8] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
@@ -130,13 +130,13 @@ func.func @stdvecBoolInputKernel(%arg0 : !cc.stdvec<i1>) -> i32 attributes {"cud
 // CHECK:           return %[[LOAD_4]] : i32
 // CHECK:         }
 
-func.func @stdvecMeasureKernel(%arg0 : !cc.stdvec<!cc.measure_handle>, %arg1 : i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  cc.device_call @enqueueMeasures(%arg0, %arg1) : (!cc.stdvec<!cc.measure_handle>, i64) -> ()
+func.func @sequenceMeasureKernel(%arg0 : !cc.sequence<!cc.measure_handle>, %arg1 : i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  cc.device_call @enqueueMeasures(%arg0, %arg1) : (!cc.sequence<!cc.measure_handle>, i64) -> ()
   return
 }
 
-// CHECK-LABEL:   func.func @stdvecMeasureKernel(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<!cc.measure_handle>,
+// CHECK-LABEL:   func.func @sequenceMeasureKernel(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<!cc.measure_handle>,
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 15 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i32
@@ -145,7 +145,7 @@ func.func @stdvecMeasureKernel(%arg0 : !cc.stdvec<!cc.measure_handle>, %arg1 : i
 // CHECK:           %[[CONSTANT_4:.*]] = arith.constant -8 : i64
 // CHECK:           %[[CONSTANT_5:.*]] = arith.constant 7 : i64
 // CHECK:           %[[CONSTANT_6:.*]] = arith.constant 8 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<!cc.measure_handle>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<!cc.measure_handle>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_5]] : i64
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_6]] : i64
 // CHECK:           %[[ADDI_1:.*]] = arith.addi %[[DIVUI_0]], %[[CONSTANT_0]] : i64
@@ -165,7 +165,7 @@ func.func @stdvecMeasureKernel(%arg0 : !cc.stdvec<!cc.measure_handle>, %arg1 : i
 // CHECK:           %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[LOAD_1:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:           %[[CAST_2:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[STDVEC_SIZE_0]], %[[CAST_2]] : !cc.ptr<i64>
 // CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[CAST_1]][8] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
@@ -185,13 +185,13 @@ func.func @stdvecMeasureKernel(%arg0 : !cc.stdvec<!cc.measure_handle>, %arg1 : i
 // CHECK:           return
 // CHECK:         }
 
-func.func @stdvecBoolOutputKernel(%arg0 : !cc.stdvec<i1>, %arg1 : i1) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  cc.device_call @getCorrections(%arg0, %arg1) : (!cc.stdvec<i1>, i1) -> () {by_ref_vec_arg_indices = array<i64: 0>}
+func.func @sequenceBoolOutputKernel(%arg0 : !cc.sequence<i1>, %arg1 : i1) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  cc.device_call @getCorrections(%arg0, %arg1) : (!cc.sequence<i1>, i1) -> () {by_ref_vec_arg_indices = array<i64: 0>}
   return
 }
 
-// CHECK-LABEL:   func.func @stdvecBoolOutputKernel(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i1>,
+// CHECK-LABEL:   func.func @sequenceBoolOutputKernel(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i1>,
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 6 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
@@ -200,7 +200,7 @@ func.func @stdvecBoolOutputKernel(%arg0 : !cc.stdvec<i1>, %arg1 : i1) attributes
 // CHECK:           %[[CONSTANT_4:.*]] = arith.constant 8 : i64
 // CHECK:           %[[CONSTANT_5:.*]] = arith.constant 7 : i64
 // CHECK:           %[[CONSTANT_6:.*]] = arith.constant 9 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i1>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_5]] : i64
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_4]] : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<i8>
@@ -237,20 +237,20 @@ func.func @stdvecBoolOutputKernel(%arg0 : !cc.stdvec<i1>, %arg1 : i1) attributes
 // CHECK:             func.call @__cudaq_device_call_safely_release_realtime_frame(%[[LOAD_0]]) : (!cc.ptr<i8>) -> ()
 // CHECK:             func.call @__quantum__qis__trap(%[[CONSTANT_0]]) : (i64) -> ()
 // CHECK:           }
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
 // CHECK:           call @__nvqpp_RealtimeUnpackBits(%[[STDVEC_DATA_0]], %[[CAST_2]], %[[STDVEC_SIZE_0]]) : (!cc.ptr<!cc.array<i1 x ?>>, !cc.ptr<!cc.array<i8 x ?>>, i64) -> ()
 // CHECK:           call @__cudaq_device_call_safely_release_realtime_frame(%[[LOAD_0]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
 
-func.func @stdvecI32OutputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : !cc.stdvec<i32>, %arg2 : i32) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  cc.device_call @incrementIntVector(%arg0, %arg1, %arg2) : (!cc.stdvec<i32>, !cc.stdvec<i32>, i32) -> () {by_ref_vec_arg_indices = array<i64: 0>}
+func.func @sequenceI32OutputKernel(%arg0 : !cc.sequence<i32>, %arg1 : !cc.sequence<i32>, %arg2 : i32) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  cc.device_call @incrementIntVector(%arg0, %arg1, %arg2) : (!cc.sequence<i32>, !cc.sequence<i32>, i32) -> () {by_ref_vec_arg_indices = array<i64: 0>}
   return
 }
 
-// CHECK-LABEL:   func.func @stdvecI32OutputKernel(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i32>,
-// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i32>,
+// CHECK-LABEL:   func.func @sequenceI32OutputKernel(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i32>,
 // CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 6 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 19 : i64
@@ -260,12 +260,12 @@ func.func @stdvecI32OutputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : !cc.stdvec<i32
 // CHECK:           %[[CONSTANT_5:.*]] = arith.constant 1446610828 : i32
 // CHECK:           %[[CONSTANT_6:.*]] = arith.constant -4 : i64
 // CHECK:           %[[CONSTANT_7:.*]] = arith.constant 4 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i32>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i32>) -> i64
 // CHECK:           %[[MULI_0:.*]] = arith.muli %[[STDVEC_SIZE_0]], %[[CONSTANT_7]] : i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[MULI_0]], %[[CONSTANT_1]] : i64
 // CHECK:           %[[ANDI_0:.*]] = arith.andi %[[ADDI_0]], %[[CONSTANT_6]] : i64
 // CHECK:           %[[ADDI_1:.*]] = arith.addi %[[ANDI_0]], %[[CONSTANT_7]] : i64
-// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i32>) -> i64
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i32>) -> i64
 // CHECK:           %[[MULI_1:.*]] = arith.muli %[[STDVEC_SIZE_1]], %[[CONSTANT_7]] : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<i8>
 // CHECK:           %[[ALLOCA_1:.*]] = cc.alloca !cc.ptr<i8>
@@ -284,7 +284,7 @@ func.func @stdvecI32OutputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : !cc.stdvec<i32
 // CHECK:           %[[LOAD_2:.*]] = cc.load %[[ALLOCA_2]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[CAST_2:.*]] = cc.cast %[[LOAD_1]] : (!cc.ptr<i8>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[STDVEC_SIZE_1]], %[[CAST_2]] : !cc.ptr<i64>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG1]] : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
 // CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[CAST_1]][8] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
 // CHECK:           %[[CAST_3:.*]] = cc.cast %[[COMPUTE_PTR_0]] : (!cc.ptr<i8>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[STDVEC_SIZE_0]], %[[CAST_3]] : !cc.ptr<i64>
@@ -307,17 +307,17 @@ func.func @stdvecI32OutputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : !cc.stdvec<i32
 // CHECK:             func.call @__cudaq_device_call_safely_release_realtime_frame(%[[LOAD_0]]) : (!cc.ptr<i8>) -> ()
 // CHECK:             func.call @__quantum__qis__trap(%[[CONSTANT_0]]) : (i64) -> ()
 // CHECK:           }
-// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
 // CHECK:           %[[CAST_7:.*]] = cc.cast %[[STDVEC_DATA_1]] : (!cc.ptr<!cc.array<i32 x ?>>) -> !cc.ptr<i8>
 // CHECK:           call @llvm.memcpy.p0.p0.i64(%[[CAST_7]], %[[LOAD_2]], %[[MULI_1]], %[[CONSTANT_2]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
 // CHECK:           call @__cudaq_device_call_safely_release_realtime_frame(%[[LOAD_0]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
-// CHECK:         func.func private @sumIntVector(!cc.stdvec<i32>, i32) -> i32 attributes {"cudaq-devicecall"}
-// CHECK:         func.func private @countBoolVector(!cc.stdvec<i1>) -> i32 attributes {"cudaq-devicecall"}
-// CHECK:         func.func private @enqueueMeasures(!cc.stdvec<!cc.measure_handle>, i64) attributes {"cudaq-devicecall"}
-// CHECK:         func.func private @getCorrections(!cc.stdvec<i1>, i1) attributes {"cudaq-devicecall"}
-// CHECK:         func.func private @incrementIntVector(!cc.stdvec<i32>, !cc.stdvec<i32>, i32) attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @sumIntVector(!cc.sequence<i32>, i32) -> i32 attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @countBoolVector(!cc.sequence<i1>) -> i32 attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @enqueueMeasures(!cc.sequence<!cc.measure_handle>, i64) attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @getCorrections(!cc.sequence<i1>, i1) attributes {"cudaq-devicecall"}
+// CHECK:         func.func private @incrementIntVector(!cc.sequence<i32>, !cc.sequence<i32>, i32) attributes {"cudaq-devicecall"}
 // CHECK:         func.func private @__cudaq_device_call_acquire_realtime_frame(i32, i32, i64, i64, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i32
 // CHECK:         func.func private @__cudaq_device_call_dispatch_realtime_frame(!cc.ptr<i8>, !cc.ptr<i64>) -> i32
 // CHECK:         func.func private @__cudaq_device_call_safely_release_realtime_frame(!cc.ptr<i8>)
@@ -327,8 +327,8 @@ func.func @stdvecI32OutputKernel(%arg0 : !cc.stdvec<i32>, %arg1 : !cc.stdvec<i32
 // CHECK:         func.func private @__nvqpp_RealtimeUnpackBits(%{{.*}}: !cc.ptr<!cc.array<i1 x ?>>, %{{.*}}: !cc.ptr<!cc.array<i8 x ?>>, %{{.*}}: i64) {
 // CHECK:         func.func private @__quantum__qis__trap(i64)
 
-func.func private @sumIntVector(!cc.stdvec<i32>, i32) -> i32 attributes {"cudaq-devicecall"}
-func.func private @countBoolVector(!cc.stdvec<i1>) -> i32 attributes {"cudaq-devicecall"}
-func.func private @enqueueMeasures(!cc.stdvec<!cc.measure_handle>, i64) attributes {"cudaq-devicecall"}
-func.func private @getCorrections(!cc.stdvec<i1>, i1) attributes {"cudaq-devicecall"}
-func.func private @incrementIntVector(!cc.stdvec<i32>, !cc.stdvec<i32>, i32) attributes {"cudaq-devicecall"}
+func.func private @sumIntVector(!cc.sequence<i32>, i32) -> i32 attributes {"cudaq-devicecall"}
+func.func private @countBoolVector(!cc.sequence<i1>) -> i32 attributes {"cudaq-devicecall"}
+func.func private @enqueueMeasures(!cc.sequence<!cc.measure_handle>, i64) attributes {"cudaq-devicecall"}
+func.func private @getCorrections(!cc.sequence<i1>, i1) attributes {"cudaq-devicecall"}
+func.func private @incrementIntVector(!cc.sequence<i32>, !cc.sequence<i32>, i32) attributes {"cudaq-devicecall"}

--- a/cudaq/test/Transforms/discriminate_issue_4527.qke
+++ b/cudaq/test/Transforms/discriminate_issue_4527.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-opt --cse %s | FileCheck %s
 
-func.func @vector_handle_discriminate_with_store(%h0: !cc.measure_handle, %h1: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+func.func @vector_handle_discriminate_with_store(%h0: !cc.measure_handle, %h1: !cc.measure_handle) -> (!cc.sequence<i1>, !cc.sequence<i1>) {
   %c2 = arith.constant 2 : i64
   %data = cc.alloca !cc.array<!cc.measure_handle x 2>
   %slot0 = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
@@ -16,16 +16,16 @@ func.func @vector_handle_discriminate_with_store(%h0: !cc.measure_handle, %h1: !
   cc.store %h0, %slot0 : !cc.ptr<!cc.measure_handle>
   cc.store %h0, %slot1 : !cc.ptr<!cc.measure_handle>
   %dataPtr = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-  %vec = cc.stdvec_init %dataPtr, %c2 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-  %bits0 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+  %vec = cc.sequence_init %dataPtr, %c2 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+  %bits0 = quake.discriminate %vec : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
   cc.store %h1, %slot1 : !cc.ptr<!cc.measure_handle>
-  %bits1 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-  return %bits0, %bits1 : !cc.stdvec<i1>, !cc.stdvec<i1>
+  %bits1 = quake.discriminate %vec : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+  return %bits0, %bits1 : !cc.sequence<i1>, !cc.sequence<i1>
 }
 
 // CHECK-LABEL:   func.func @vector_handle_discriminate_with_store(
 // CHECK-SAME:      %[[ARG0:.*]]: !cc.measure_handle,
-// CHECK-SAME:      %[[ARG1:.*]]: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+// CHECK-SAME:      %[[ARG1:.*]]: !cc.measure_handle) -> (!cc.sequence<i1>, !cc.sequence<i1>) {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.measure_handle x 2>
 // CHECK:           %[[CAST_0:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
@@ -33,11 +33,11 @@ func.func @vector_handle_discriminate_with_store(%h0: !cc.measure_handle, %h1: !
 // CHECK:           cc.store %[[ARG0]], %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
 // CHECK:           cc.store %[[ARG0]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-// CHECK:           %[[STDVEC_INIT_0:.*]] = cc.stdvec_init %[[CAST_1]], %[[CONSTANT_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+// CHECK:           %[[STDVEC_INIT_0:.*]] = cc.sequence_init %[[CAST_1]], %[[CONSTANT_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
 // CHECK:           cc.store %[[ARG1]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
-// CHECK:           %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           return %[[DISCRIMINATE_0]], %[[DISCRIMINATE_1]] : !cc.stdvec<i1>, !cc.stdvec<i1>
+// CHECK:           %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           return %[[DISCRIMINATE_0]], %[[DISCRIMINATE_1]] : !cc.sequence<i1>, !cc.sequence<i1>
 // CHECK:         }
 
 
@@ -54,7 +54,7 @@ func.func @scalar_handle_discriminate_folds(%h: !cc.measure_handle)-> (i1, i1) {
 // CHECK:         }
 
 
-func.func @vector_handle_discriminate_no_store_folds(%h: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+func.func @vector_handle_discriminate_no_store_folds(%h: !cc.measure_handle) -> (!cc.sequence<i1>, !cc.sequence<i1>) {
   %c2 = arith.constant 2 : i64
   %data = cc.alloca !cc.array<!cc.measure_handle x 2>
   %slot0 = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
@@ -62,14 +62,14 @@ func.func @vector_handle_discriminate_no_store_folds(%h: !cc.measure_handle) -> 
   cc.store %h, %slot0 : !cc.ptr<!cc.measure_handle>
   cc.store %h, %slot1 : !cc.ptr<!cc.measure_handle>
   %dataPtr = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-  %vec = cc.stdvec_init %dataPtr, %c2 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-  %bits0 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-  %bits1 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-  return %bits0, %bits1 : !cc.stdvec<i1>, !cc.stdvec<i1>
+  %vec = cc.sequence_init %dataPtr, %c2 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+  %bits0 = quake.discriminate %vec : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+  %bits1 = quake.discriminate %vec : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+  return %bits0, %bits1 : !cc.sequence<i1>, !cc.sequence<i1>
 }
 
 // CHECK-LABEL:   func.func @vector_handle_discriminate_no_store_folds(
-// CHECK-SAME:      %[[ARG0:.*]]: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.measure_handle) -> (!cc.sequence<i1>, !cc.sequence<i1>) {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.measure_handle x 2>
 // CHECK:           %[[CAST_0:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
@@ -77,7 +77,7 @@ func.func @vector_handle_discriminate_no_store_folds(%h: !cc.measure_handle) -> 
 // CHECK:           cc.store %[[ARG0]], %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
 // CHECK:           cc.store %[[ARG0]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-// CHECK:           %[[STDVEC_INIT_0:.*]] = cc.stdvec_init %[[CAST_1]], %[[CONSTANT_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           return %[[DISCRIMINATE_0]], %[[DISCRIMINATE_0]] : !cc.stdvec<i1>, !cc.stdvec<i1>
+// CHECK:           %[[STDVEC_INIT_0:.*]] = cc.sequence_init %[[CAST_1]], %[[CONSTANT_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           return %[[DISCRIMINATE_0]], %[[DISCRIMINATE_0]] : !cc.sequence<i1>, !cc.sequence<i1>
 // CHECK:         }

--- a/cudaq/test/Transforms/erase-qec.qke
+++ b/cudaq/test/Transforms/erase-qec.qke
@@ -11,16 +11,16 @@
 
 func.func @qec_kernel(%h0 : !cc.measure_handle,
                       %h1 : !cc.measure_handle,
-                      %v : !cc.stdvec<!cc.measure_handle>) -> i1 {
+                      %v : !cc.sequence<!cc.measure_handle>) -> i1 {
   %q = quake.alloca !quake.ref
   quake.h %q : (!quake.ref) -> ()
   %m = quake.mz %q : (!quake.ref) -> !quake.measure
   qec.detector %h0 : !cc.measure_handle
   qec.detector %h0, %h1 : !cc.measure_handle, !cc.measure_handle
-  qec.detector %v : !cc.stdvec<!cc.measure_handle>
+  qec.detector %v : !cc.sequence<!cc.measure_handle>
   qec.observable %h0 : !cc.measure_handle
-  qec.observable %v index 1 : !cc.stdvec<!cc.measure_handle>
-  qec.pair_detectors %v, %v : !cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>
+  qec.observable %v index 1 : !cc.sequence<!cc.measure_handle>
+  qec.pair_detectors %v, %v : !cc.sequence<!cc.measure_handle>, !cc.sequence<!cc.measure_handle>
   %r = quake.discriminate %m : (!quake.measure) -> i1
   return %r : i1
 }
@@ -28,7 +28,7 @@ func.func @qec_kernel(%h0 : !cc.measure_handle,
 // CHECK-LABEL:   func.func @qec_kernel(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle,
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle,
-// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<!cc.measure_handle>) -> i1 {
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<!cc.measure_handle>) -> i1 {
 // CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.h %[[ALLOCA_0]] : (!quake.ref) -> ()
 // CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.ref) -> !quake.measure

--- a/cudaq/test/Transforms/erase_vcc_with_scope.qke
+++ b/cudaq/test/Transforms/erase_vcc_with_scope.qke
@@ -39,7 +39,7 @@ func.func @__nvqpp__mlirgen__function_repro._Z5reprov.run() attributes {"cudaq-e
     quake.h %8 : (!quake.ref) -> ()
     %9 = quake.extract_ref %1[7] : (!quake.veq<8>) -> !quake.ref
     quake.h %9 : (!quake.ref) -> ()
-    %10 = cc.scope -> (!cc.stdvec<i1>) {
+    %10 = cc.scope -> (!cc.sequence<i1>) {
       %16 = cc.alloca !cc.array<i8 x 8>
       %17 = cc.device_call @_Z13packed_sourcem(%c0_i64) : (i64) -> i64
       %18 = cc.cast %16 : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
@@ -96,11 +96,11 @@ func.func @__nvqpp__mlirgen__function_repro._Z5reprov.run() attributes {"cudaq-e
       cc.scope {
         func.call @llvm.memcpy.p0.p0.i64(%57, %18, %c8_i64, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
       }
-      %58 = cc.stdvec_init %57, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-      cc.continue %58 : !cc.stdvec<i1>
+      %58 = cc.sequence_init %57, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+      cc.continue %58 : !cc.sequence<i1>
     }
-    %11 = cc.stdvec_data %10 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-    %12 = cc.stdvec_size %10 : (!cc.stdvec<i1>) -> i64
+    %11 = cc.sequence_data %10 : (!cc.sequence<i1>) -> !cc.ptr<i8>
+    %12 = cc.sequence_size %10 : (!cc.sequence<i1>) -> i64
     %13 = cc.alloca i8[%12 : i64]
     %14 = cc.cast %13 : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
     cc.scope {

--- a/cudaq/test/Transforms/expand_measurements_handle.qke
+++ b/cudaq/test/Transforms/expand_measurements_handle.qke
@@ -8,13 +8,13 @@
 
 // RUN: cudaq-opt --expand-measurements %s | FileCheck %s
 
-func.func @handle_return(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle> {
-  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-  return %mz : !cc.stdvec<!cc.measure_handle>
+func.func @handle_return(%v: !quake.veq<?>) -> !cc.sequence<!cc.measure_handle> {
+  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+  return %mz : !cc.sequence<!cc.measure_handle>
 }
 
 // CHECK-LABEL:   func.func @handle_return(
-// CHECK-SAME:        %[[V:.*]]: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK-SAME:        %[[V:.*]]: !quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[N:.*]] = quake.veq_size %[[V]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[BUF:.*]] = cc.alloca !cc.measure_handle{{\[}}%{{.*}} : i64]
 // CHECK:           cc.loop while (({{.*}}) -> (i64)) {
@@ -33,15 +33,15 @@ func.func @handle_return(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle> {
 // CHECK:             %{{.*}} = arith.addi %[[SV]], %{{.*}} : i64
 // CHECK:             cc.continue %{{.*}} : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[VEC:.*]] = cc.stdvec_init %[[BUF]]
-// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           return %[[VEC]] : !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VEC:.*]] = cc.sequence_init %[[BUF]]
+// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           return %[[VEC]] : !cc.sequence<!cc.measure_handle>
 
 
-func.func @handle_disc(%v: !quake.veq<?>) -> !cc.stdvec<i1> {
-  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-  %d = quake.discriminate %mz : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-  return %d : !cc.stdvec<i1>
+func.func @handle_disc(%v: !quake.veq<?>) -> !cc.sequence<i1> {
+  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+  %d = quake.discriminate %mz : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+  return %d : !cc.sequence<i1>
 }
 
 // CHECK-LABEL:   func.func @handle_disc(
@@ -65,17 +65,17 @@ func.func @handle_disc(%v: !quake.veq<?>) -> !cc.stdvec<i1> {
 // CHECK:             cc.continue %{{.*}} : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[CAST:.*]] = cc.cast %[[I8BUF]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<i1 x ?>>
-// CHECK:           %[[VEC:.*]] = cc.stdvec_init %[[CAST]]
-// CHECK-SAME:        : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VEC]] : !cc.stdvec<i1>
+// CHECK:           %[[VEC:.*]] = cc.sequence_init %[[CAST]]
+// CHECK-SAME:        : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VEC]] : !cc.sequence<i1>
 
 
-func.func @handle_mixed(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle> {
-  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-  %d = quake.discriminate %mz : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-  %slot = cc.alloca !cc.stdvec<i1>
-  cc.store %d, %slot : !cc.ptr<!cc.stdvec<i1>>
-  return %mz : !cc.stdvec<!cc.measure_handle>
+func.func @handle_mixed(%v: !quake.veq<?>) -> !cc.sequence<!cc.measure_handle> {
+  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+  %d = quake.discriminate %mz : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+  %slot = cc.alloca !cc.sequence<i1>
+  cc.store %d, %slot : !cc.ptr<!cc.sequence<i1>>
+  return %mz : !cc.sequence<!cc.measure_handle>
 }
 
 // CHECK-LABEL:   func.func @handle_mixed(
@@ -98,16 +98,16 @@ func.func @handle_mixed(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle> {
 // CHECK:             %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i64
 // CHECK:             cc.continue %{{.*}} : i64
 // CHECK:           } {invariant}
-// CHECK:           cc.stdvec_init %{{.*}} : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.stdvec<i1>
-// CHECK:           %[[HVEC:.*]] = cc.stdvec_init %[[HBUF]]
-// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           return %[[HVEC]] : !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.sequence_init %{{.*}} : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.sequence<i1>
+// CHECK:           %[[HVEC:.*]] = cc.sequence_init %[[HBUF]]
+// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           return %[[HVEC]] : !cc.sequence<!cc.measure_handle>
 
 
 func.func @handle_store(%v: !quake.veq<?>) {
-  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-  %slot = cc.alloca !cc.stdvec<!cc.measure_handle>
-  cc.store %mz, %slot : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+  %mz = quake.mz %v : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+  %slot = cc.alloca !cc.sequence<!cc.measure_handle>
+  cc.store %mz, %slot : !cc.ptr<!cc.sequence<!cc.measure_handle>>
   return
 }
 
@@ -128,14 +128,14 @@ func.func @handle_store(%v: !quake.veq<?>) {
 // CHECK:             %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i64
 // CHECK:             cc.continue %{{.*}} : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[HVEC:.*]] = cc.stdvec_init %[[HBUF]]
-// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           cc.store %[[HVEC]], %{{.*}} : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[HVEC:.*]] = cc.sequence_init %[[HBUF]]
+// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+// CHECK:           cc.store %[[HVEC]], %{{.*}} : !cc.ptr<!cc.sequence<!cc.measure_handle>>
 
 
-func.func @handle_ref_and_veq(%q: !quake.ref, %v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle> {
-  %mz = quake.mz %q, %v : (!quake.ref, !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-  return %mz : !cc.stdvec<!cc.measure_handle>
+func.func @handle_ref_and_veq(%q: !quake.ref, %v: !quake.veq<?>) -> !cc.sequence<!cc.measure_handle> {
+  %mz = quake.mz %q, %v : (!quake.ref, !quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+  return %mz : !cc.sequence<!cc.measure_handle>
 }
 
 // CHECK-LABEL:   func.func @handle_ref_and_veq(
@@ -159,13 +159,13 @@ func.func @handle_ref_and_veq(%q: !quake.ref, %v: !quake.veq<?>) -> !cc.stdvec<!
 // CHECK:             %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i64
 // CHECK:             cc.continue %{{.*}} : i64
 // CHECK:           } {invariant}
-// CHECK:           cc.stdvec_init %[[HBUF]]
-// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.sequence_init %[[HBUF]]
+// CHECK-SAME:        : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
 
 
-func.func @handle_return_mx(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle> {
-  %mx = quake.mx %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-  return %mx : !cc.stdvec<!cc.measure_handle>
+func.func @handle_return_mx(%v: !quake.veq<?>) -> !cc.sequence<!cc.measure_handle> {
+  %mx = quake.mx %v : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+  return %mx : !cc.sequence<!cc.measure_handle>
 }
 
 // CHECK-LABEL:   func.func @handle_return_mx(
@@ -174,12 +174,12 @@ func.func @handle_return_mx(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
 // CHECK:             quake.mx %{{.*}} : (!quake.ref) -> !cc.measure_handle
 // CHECK:           } step {
 // CHECK:           } {invariant}
-// CHECK:           cc.stdvec_init %{{.*}} : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.sequence_init %{{.*}} : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
 
 
-func.func @handle_return_my(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle> {
-  %my = quake.my %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-  return %my : !cc.stdvec<!cc.measure_handle>
+func.func @handle_return_my(%v: !quake.veq<?>) -> !cc.sequence<!cc.measure_handle> {
+  %my = quake.my %v : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+  return %my : !cc.sequence<!cc.measure_handle>
 }
 
 // CHECK-LABEL:   func.func @handle_return_my(
@@ -188,19 +188,19 @@ func.func @handle_return_my(%v: !quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
 // CHECK:             quake.my %{{.*}} : (!quake.ref) -> !cc.measure_handle
 // CHECK:           } step {
 // CHECK:           } {invariant}
-// CHECK:           cc.stdvec_init %{{.*}} : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.sequence_init %{{.*}} : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
 
 
-func.func @to_bools_indirect(%hv: !cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1> {
-  %d = quake.discriminate %hv : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-  return %d : !cc.stdvec<i1>
+func.func @to_bools_indirect(%hv: !cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1> {
+  %d = quake.discriminate %hv : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+  return %d : !cc.sequence<i1>
 }
 
 // CHECK-LABEL:   func.func @to_bools_indirect(
-// CHECK-SAME:        %[[HV:.*]]: !cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:           %[[N:.*]] = cc.stdvec_size %[[HV]] : (!cc.stdvec<!cc.measure_handle>) -> i64
-// CHECK:           %[[HDATA:.*]] = cc.stdvec_data %[[HV]]
-// CHECK-SAME:        : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK-SAME:        %[[HV:.*]]: !cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:           %[[N:.*]] = cc.sequence_size %[[HV]] : (!cc.sequence<!cc.measure_handle>) -> i64
+// CHECK:           %[[HDATA:.*]] = cc.sequence_data %[[HV]]
+// CHECK-SAME:        : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
 // CHECK:           %[[I8BUF:.*]] = cc.alloca i8{{\[}}%[[N]] : i64]
 // CHECK:           cc.loop while (({{.*}}) -> (i64)) {
 // CHECK:             %{{.*}} = arith.cmpi slt, %{{.*}}, %[[N]] : i64
@@ -222,6 +222,6 @@ func.func @to_bools_indirect(%hv: !cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<
 // CHECK:             cc.continue %{{.*}} : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[CAST:.*]] = cc.cast %[[I8BUF]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<i1 x ?>>
-// CHECK:           %[[VEC:.*]] = cc.stdvec_init %[[CAST]], %[[N]]
-// CHECK-SAME:        : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.stdvec<i1>
-// CHECK:           return %[[VEC]] : !cc.stdvec<i1>
+// CHECK:           %[[VEC:.*]] = cc.sequence_init %[[CAST]], %[[N]]
+// CHECK-SAME:        : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.sequence<i1>
+// CHECK:           return %[[VEC]] : !cc.sequence<i1>

--- a/cudaq/test/Transforms/invalid.qke
+++ b/cudaq/test/Transforms/invalid.qke
@@ -230,7 +230,7 @@ func.func private @wonk(!quake.veq<18>, i32) -> f64
 // -----
 
 func.func @mz_handle_register_scalar_result(%v: !quake.veq<?>) {
-  // expected-error@+1 {{must return `!cc.stdvec<!quake.measure>` or `!cc.stdvec<!cc.measure_handle>`}}
+  // expected-error@+1 {{must return `!cc.sequence<!quake.measure>` or `!cc.sequence<!cc.measure_handle>`}}
   %m = quake.mz %v : (!quake.veq<?>) -> !cc.measure_handle
   return
 }

--- a/cudaq/test/Transforms/jit_pipeline_no_loop_unroll.qke
+++ b/cudaq/test/Transforms/jit_pipeline_no_loop_unroll.qke
@@ -55,13 +55,13 @@ func.func @__nvqpp__mlirgen__function_loop_payload_stress() -> i64 attributes {"
     cc.continue %i : i64
   }
 
-  %meas = quake.mz %q : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
-  %bits = quake.discriminate %meas : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
-  %result = call @__nvqpp_cudaqConvertToInteger(%bits) : (!cc.stdvec<i1>) -> i64
+  %meas = quake.mz %q : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
+  %bits = quake.discriminate %meas : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
+  %result = call @__nvqpp_cudaqConvertToInteger(%bits) : (!cc.sequence<i1>) -> i64
   return %result : i64
 }
 
-func.func private @__nvqpp_cudaqConvertToInteger(!cc.stdvec<i1>) -> i64
+func.func private @__nvqpp_cudaqConvertToInteger(!cc.sequence<i1>) -> i64
 
 // PRESERVE-LABEL: func.func @__nvqpp__mlirgen__function_loop_payload_stress
 // PRESERVE:         cc.loop while

--- a/cudaq/test/Transforms/kernel_exec-2.qke
+++ b/cudaq/test/Transforms/kernel_exec-2.qke
@@ -13,12 +13,12 @@ __nvqpp__mlirgen__function_hawaiian = "shirt",
 __nvqpp__mlirgen__function_cargo = "pants"}} {
 
   // pure devive kernel: cargo. C++ function: pants.
-  func.func @__nvqpp__mlirgen__function_cargo(%arg0: !cc.stdvec<i32>, %arg1: !quake.ref) attributes {"cudaq-kernel", no_this} {
+  func.func @__nvqpp__mlirgen__function_cargo(%arg0: !cc.sequence<i32>, %arg1: !quake.ref) attributes {"cudaq-kernel", no_this} {
     return
   }
 
   // entry-point kernel: hawaiian. C++ function: shirt.
-  func.func @__nvqpp__mlirgen__function_hawaiian(%arg0: i1, %arg1: !cc.stdvec<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  func.func @__nvqpp__mlirgen__function_hawaiian(%arg0: i1, %arg1: !cc.sequence<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
     %0 = quake.alloca !quake.ref
     %1 = quake.alloca !quake.ref
     %2 = quake.alloca !quake.ref
@@ -26,7 +26,7 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
       quake.x %2 : (!quake.ref) -> ()
     } else {
     }
-    call @__nvqpp__mlirgen__function_cargo(%arg1, %2) : (!cc.stdvec<i32>, !quake.ref) -> ()
+    call @__nvqpp__mlirgen__function_cargo(%arg1, %2) : (!cc.sequence<i32>, !quake.ref) -> ()
     return
   }
 
@@ -37,21 +37,21 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_cargo(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<i32>,
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<i32>,
 // CHECK-SAME:      %[[VAL_1:.*]]: !quake.ref) attributes {"cudaq-kernel", no_this} {
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_hawaiian(
 // CHECK-SAME:      %[[VAL_0:.*]]: i1,
-// CHECK-SAME:      %[[VAL_1:.*]]: !cc.stdvec<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-SAME:      %[[VAL_1:.*]]: !cc.sequence<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK:           cc.if(%[[VAL_0]]) {
 // CHECK:             quake.x %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:           }
-// CHECK:           call @__nvqpp__mlirgen__function_cargo(%[[VAL_1]], %[[VAL_4]]) : (!cc.stdvec<i32>, !quake.ref) -> ()
+// CHECK:           call @__nvqpp__mlirgen__function_cargo(%[[VAL_1]], %[[VAL_4]]) : (!cc.sequence<i32>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -185,10 +185,10 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i64>
 // CHECK:           %[[VAL_11:.*]] = arith.divsi %[[VAL_10]], %[[VAL_9]] : i64
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_12]], %[[VAL_11]] : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_13:.*]] = cc.sequence_init %[[VAL_12]], %[[VAL_11]] : (!cc.ptr<i32>, i64) -> !cc.sequence<i32>
 // CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
 // CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]]{{\[}}%[[VAL_10]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           call @__nvqpp__mlirgen__function_hawaiian(%[[VAL_7]], %[[VAL_13]]) : (i1, !cc.stdvec<i32>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__function_hawaiian(%[[VAL_7]], %[[VAL_13]]) : (i1, !cc.sequence<i32>) -> ()
 // CHECK:           %[[VAL_16:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_16]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         }

--- a/cudaq/test/Transforms/lift_array.qke
+++ b/cudaq/test/Transforms/lift_array.qke
@@ -45,7 +45,7 @@ func.func @__nvqpp__mlirgen__function_test_complex_constant_array._Z27test_compl
 
 func.func private @__nvqpp_vectorCopyCtor(!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
 
-func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.stdvec<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.sequence<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
   %cst = complex.constant [0.70710678118654757, 0.000000e+00] : complex<f64>
   %cst_0 = complex.constant [-0.70710678118654757, 0.000000e+00] : complex<f64>
   %c16_i64 = arith.constant 16 : i64
@@ -61,11 +61,11 @@ func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generato
   cc.store %cst_0, %4 : !cc.ptr<complex<f64>>
   %5 = cc.cast %0 : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<i8>
   %6 = call @__nvqpp_vectorCopyCtor(%5, %c4_i64, %c16_i64) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-  %7 = cc.stdvec_init %6, %c4_i64 : (!cc.ptr<i8>, i64) -> !cc.stdvec<complex<f64>>
-  return %7 : !cc.stdvec<complex<f64>>
+  %7 = cc.sequence_init %6, %c4_i64 : (!cc.ptr<i8>, i64) -> !cc.sequence<complex<f64>>
+  return %7 : !cc.sequence<complex<f64>>
 }
   
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.stdvec<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.sequence<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 16 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_2:.*]] = cc.const_array {{\[\[}}0.70710678118654757, 0.000000e+00], [0.70710678118654757, 0.000000e+00], [0.70710678118654757, 0.000000e+00], [-0.70710678118654757, 0.000000e+00]] : !cc.array<complex<f64> x 4>
@@ -73,18 +73,18 @@ func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generato
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_3]] : !cc.ptr<!cc.array<complex<f64> x 4>>
 // CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_5:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_4]], %[[VAL_1]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_6:.*]] = cc.stdvec_init %[[VAL_5]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<complex<f64>>
-// CHECK:           return %[[VAL_6]] : !cc.stdvec<complex<f64>>
+// CHECK:           %[[VAL_6:.*]] = cc.sequence_init %[[VAL_5]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.sequence<complex<f64>>
+// CHECK:           return %[[VAL_6]] : !cc.sequence<complex<f64>>
 // CHECK:         }
 
-// GLOBAL-LABEL:   func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.stdvec<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// GLOBAL-LABEL:   func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.sequence<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // GLOBAL:           %[[VAL_0:.*]] = arith.constant 16 : i64
 // GLOBAL:           %[[VAL_1:.*]] = arith.constant 4 : i64
 // GLOBAL:           %[[VAL_2:.*]] = cc.address_of @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v.rodata_{{[0-9]+}} : !cc.ptr<!cc.array<complex<f64> x 4>>
 // GLOBAL:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<i8>
 // GLOBAL:           %[[VAL_4:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_3]], %[[VAL_1]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-// GLOBAL:           %[[VAL_5:.*]] = cc.stdvec_init %[[VAL_4]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<complex<f64>>
-// GLOBAL:           return %[[VAL_5]] : !cc.stdvec<complex<f64>>
+// GLOBAL:           %[[VAL_5:.*]] = cc.sequence_init %[[VAL_4]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.sequence<complex<f64>>
+// GLOBAL:           return %[[VAL_5]] : !cc.sequence<complex<f64>>
 // GLOBAL:         }
 
 func.func @test2() -> !quake.veq<2> {

--- a/cudaq/test/Transforms/loop.qke
+++ b/cudaq/test/Transforms/loop.qke
@@ -412,7 +412,7 @@ func.func @empty_step() {
     } step {
     }
   }
-  %2 = quake.mz %1 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
+  %2 = quake.mz %1 : (!quake.veq<?>) -> !cc.sequence<!quake.measure>
   return
 }
 

--- a/cudaq/test/Transforms/mapping_non_unitaries.qke
+++ b/cudaq/test/Transforms/mapping_non_unitaries.qke
@@ -30,7 +30,7 @@ func.func @test_measurement() {
   %3:2 = quake.x [%1] %0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %4:2 = quake.x [%3#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5:2 = quake.x [%4#1] %3#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  %bits, %wires:3 = quake.mz %5#1, %4#0, %5#0 name "result": (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
+  %bits, %wires:3 = quake.mz %5#1, %4#0, %5#0 name "result": (!quake.wire, !quake.wire, !quake.wire) -> (!cc.sequence<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
   quake.return_wire %wires#0 : !quake.wire
   quake.return_wire %wires#1 : !quake.wire
   quake.return_wire %wires#2 : !quake.wire
@@ -45,7 +45,7 @@ func.func @test_measurement() {
 // CHECK:           %[[VAL_4:.*]]:2 = quake.x {{\[}}%[[VAL_3]]#0] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_5:.*]]:2 = quake.swap %[[VAL_4]]#1, %[[VAL_4]]#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_6:.*]]:2 = quake.x {{\[}}%[[VAL_5]]#1] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]]:3 = quake.mz %[[VAL_6]]#1, %[[VAL_5]]#0, %[[VAL_6]]#0 name "result" : (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]]:3 = quake.mz %[[VAL_6]]#1, %[[VAL_5]]#0, %[[VAL_6]]#0 name "result" : (!quake.wire, !quake.wire, !quake.wire) -> (!cc.sequence<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
 // CHECK-DAG:       quake.return_wire %[[VAL_8]]#0 : !quake.wire
 // CHECK-DAG:       quake.return_wire %[[VAL_8]]#1 : !quake.wire
 // CHECK-DAG:       quake.return_wire %[[VAL_8]]#2 : !quake.wire

--- a/cudaq/test/Transforms/memtoreg-2.qke
+++ b/cudaq/test/Transforms/memtoreg-2.qke
@@ -182,7 +182,7 @@ func.func @classical_if06(%veq : !quake.veq<2>, %c1: i1) {
     %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>, i32) -> !quake.ref
     quake.y %q1 : (!quake.ref) -> ()
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   return
 }
 
@@ -201,7 +201,7 @@ func.func @classical_if06(%veq : !quake.veq<2>, %c1: i1) {
 // CHECK:             quake.wrap %[[VAL_9]] to %[[VAL_7]] : !quake.wire, !quake.ref
 // CHECK:           } else {
 // CHECK:           }
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -216,7 +216,7 @@ func.func @classical_if07(%veq : !quake.veq<2>, %c1: i1, %c2: i1) {
       quake.reset %veq : (!quake.veq<2>) -> ()
     }
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   return
 }
 
@@ -236,7 +236,7 @@ func.func @classical_if07(%veq : !quake.veq<2>, %c1: i1, %c2: i1) {
 // CHECK:             }
 // CHECK:           } else {
 // CHECK:           }
-// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -329,7 +329,7 @@ func.func @scope_local_extract_and_vec_measurement(%veq : !quake.veq<2>) {
     %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>,i32) -> !quake.ref
     quake.y %q1 : (!quake.ref) -> ()
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   return
 }
 
@@ -344,7 +344,7 @@ func.func @scope_local_extract_and_vec_measurement(%veq : !quake.veq<2>) {
 // CHECK:             %[[VAL_6:.*]] = quake.unwrap %[[VAL_5]] : (!quake.ref) -> !quake.wire
 // CHECK:             %[[VAL_7:.*]] = quake.y %[[VAL_6]] : (!quake.wire) -> !quake.wire
 // CHECK:           }
-// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -356,7 +356,7 @@ func.func @vec_op_in_nested_scope(%veq : !quake.veq<2>) {
       quake.reset %veq : (!quake.veq<2>)-> ()
     }
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   return
 }
 
@@ -370,7 +370,7 @@ func.func @vec_op_in_nested_scope(%veq : !quake.veq<2>) {
 // CHECK:               quake.reset %[[VAL_0]] : (!quake.veq<2>) -> ()
 // CHECK:             }
 // CHECK:           }
-// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -384,7 +384,7 @@ func.func @vec_op_in_nested_scope_and_local_extraction(%veq : !quake.veq<2>) {
       quake.reset %veq : (!quake.veq<2>) -> ()
     }
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   return
 }
 
@@ -401,7 +401,7 @@ func.func @vec_op_in_nested_scope_and_local_extraction(%veq : !quake.veq<2>) {
 // CHECK:               quake.reset %[[VAL_0]] : (!quake.veq<2>) -> ()
 // CHECK:             }
 // CHECK:           }
-// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -524,7 +524,7 @@ func.func @raw_cfg05(%c1: i1) {
 ^bb2:
   cf.br ^bb3
 ^bb3:
-  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -541,7 +541,7 @@ func.func @raw_cfg05(%c1: i1) {
 // CHECK:         ^bb2:
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
-// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -562,7 +562,7 @@ func.func @raw_cfg06(%c1: i1) {
   %q2 = quake.extract_ref %veq[%c1_i64] : (!quake.veq<2>, i64) -> !quake.ref
   cf.br ^bb5
 ^bb5:
-  %reg = quake.mz %veq: (!quake.veq<2>)-> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq: (!quake.veq<2>)-> !cc.sequence<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -588,7 +588,7 @@ func.func @raw_cfg06(%c1: i1) {
 // CHECK:           %[[VAL_9:.*]] = quake.unwrap %[[VAL_8]] : (!quake.ref) -> !quake.wire
 // CHECK:           cf.br ^bb5
 // CHECK:         ^bb5:
-// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -605,7 +605,7 @@ func.func @raw_cfg07(%c1: i1) {
   quake.reset %veq: (!quake.veq<2>)->()
   cf.br ^bb3
 ^bb3:
-  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -626,7 +626,7 @@ func.func @raw_cfg07(%c1: i1) {
 // CHECK:           quake.reset %[[VAL_3]] : (!quake.veq<2>) -> ()
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
-// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -730,7 +730,7 @@ func.func @mz_and_reset_veq_with_extracted_refs() {
   %0 = quake.alloca !quake.veq<2>
   %q0 = quake.extract_ref %0[%c_0] : (!quake.veq<2>, i32) -> !quake.ref
   %q1 = quake.extract_ref %0[%c_1] : (!quake.veq<2>, i32) -> !quake.ref
-  %reg = quake.mz %0 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %reg = quake.mz %0 : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   quake.reset %0 : (!quake.veq<2>) -> ()
   quake.dealloc %0 : !quake.veq<2>
   return
@@ -744,7 +744,7 @@ func.func @mz_and_reset_veq_with_extracted_refs() {
 // CHECK:           %[[VAL_4:.*]] = quake.unwrap %[[VAL_3]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = quake.unwrap %[[VAL_5]] : (!quake.ref) -> !quake.wire
-// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           quake.reset %[[VAL_2]] : (!quake.veq<2>) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -817,7 +817,7 @@ func.func @floop_with_vector_and_qextract() {
     %4 = arith.addi %3, %c1_i64 : i64
     cc.store %4, %alloca : !cc.ptr<i64>
   }
-  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -843,7 +843,7 @@ func.func @floop_with_vector_and_qextract() {
 // CHECK:             %[[VAL_14:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i64
 // CHECK:             cc.continue %[[VAL_14]] : i64
 // CHECK:           }
-// CHECK:           %[[VAL_15:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_15:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           quake.dealloc %[[VAL_3]] : !quake.veq<2>
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/memtoreg-3.qke
+++ b/cudaq/test/Transforms/memtoreg-3.qke
@@ -83,7 +83,7 @@ func.func @promote_induction_variable() {
     %4 = arith.addi %3, %c1_i64 : i64
     cc.store %4, %alloca : !cc.ptr<i64>
   }
-  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -109,7 +109,7 @@ func.func @promote_induction_variable() {
 // CHECK:             %[[VAL_14:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i64
 // CHECK:             cc.continue %[[VAL_14]] : i64
 // CHECK:           }
-// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           quake.dealloc %[[VAL_3]] : !quake.veq<2>
 // CHECK:           return
 // CHECK:         }
@@ -133,7 +133,7 @@ func.func @promote_induction_variable() {
 // TOMEM:             %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_1]] : i64
 // TOMEM:             cc.continue %[[VAL_12]] : i64
 // TOMEM:           }
-// TOMEM:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// TOMEM:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // TOMEM:           quake.dealloc %[[VAL_3]] : !quake.veq<2>
 // TOMEM:           return
 // TOMEM:         }

--- a/cudaq/test/Transforms/memtoreg-6.qke
+++ b/cudaq/test/Transforms/memtoreg-6.qke
@@ -39,7 +39,7 @@ func.func @__nvqpp__mlirgen__dummy() {
 // CHECK:           return
 // CHECK:         }
 
-func.func @test_2(%arg0: !quake.veq<?>, %arg1: !quake.veq<?>, %arg2: !quake.veq<?>, %arg3: i64, %arg4: !cc.stdvec<i64>, %arg5: !cc.stdvec<i64>, %arg6: i1, %arg7: i1, %arg8: f64, %arg9: !cc.stdvec<i64>, %arg10: i32) attributes {"cudaq-kernel", no_this} {
+func.func @test_2(%arg0: !quake.veq<?>, %arg1: !quake.veq<?>, %arg2: !quake.veq<?>, %arg3: i64, %arg4: !cc.sequence<i64>, %arg5: !cc.sequence<i64>, %arg6: i1, %arg7: i1, %arg8: f64, %arg9: !cc.sequence<i64>, %arg10: i32) attributes {"cudaq-kernel", no_this} {
   %false = arith.constant false
   %cst = arith.constant 0.000000e+00 : f64
   %c1_i64 = arith.constant 1 : i64
@@ -67,23 +67,23 @@ func.func @test_2(%arg0: !quake.veq<?>, %arg1: !quake.veq<?>, %arg2: !quake.veq<
       cc.condition %12
     } do {
       cc.scope {
-        %10 = func.call @test_2.a(%9, %arg5) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
-        %11 = cc.stdvec_data %10 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-        %12 = cc.stdvec_size %10 : (!cc.stdvec<i1>) -> i64
+        %10 = func.call @test_2.a(%9, %arg5) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.sequence<i64>) -> !cc.sequence<i1>
+        %11 = cc.sequence_data %10 : (!cc.sequence<i1>) -> !cc.ptr<i8>
+        %12 = cc.sequence_size %10 : (!cc.sequence<i1>) -> i64
         %13 = cc.alloca i8[%12 : i64]
         %14 = cc.cast %13 : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
         func.call @test_2.b(%14, %11, %12) : (!cc.ptr<i8>, !cc.ptr<i8>, i64) -> ()
-        %15 = cc.stdvec_init %13, %12 : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.stdvec<i1>
-        %16 = func.call @test_2.c(%9, %arg4) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
-        %17 = cc.stdvec_data %16 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-        %18 = cc.stdvec_size %16 : (!cc.stdvec<i1>) -> i64
+        %15 = cc.sequence_init %13, %12 : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.sequence<i1>
+        %16 = func.call @test_2.c(%9, %arg4) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.sequence<i64>) -> !cc.sequence<i1>
+        %17 = cc.sequence_data %16 : (!cc.sequence<i1>) -> !cc.ptr<i8>
+        %18 = cc.sequence_size %16 : (!cc.sequence<i1>) -> i64
         %19 = cc.alloca i8[%18 : i64]
         %20 = cc.cast %19 : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
         func.call @test_2.b(%20, %17, %18) : (!cc.ptr<i8>, !cc.ptr<i8>, i64) -> ()
-        %21 = cc.stdvec_init %19, %18 : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.stdvec<i1>
-        %22 = func.call @test_2.d(%15) : (!cc.stdvec<i1>) -> i64
+        %21 = cc.sequence_init %19, %18 : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.sequence<i1>
+        %22 = func.call @test_2.d(%15) : (!cc.sequence<i1>) -> i64
         cc.store %22, %3 : !cc.ptr<i64>
-        %23 = func.call @test_2.d(%21) : (!cc.stdvec<i1>) -> i64
+        %23 = func.call @test_2.d(%21) : (!cc.sequence<i1>) -> i64
         cc.store %23, %2 : !cc.ptr<i64>
         %24 = cc.load %2 : !cc.ptr<i64>
         %25 = arith.shli %24, %12 : i64
@@ -93,7 +93,7 @@ func.func @test_2(%arg0: !quake.veq<?>, %arg1: !quake.veq<?>, %arg2: !quake.veq<
         %28 = cc.load %1 : !cc.ptr<i64>
         %29 = cc.load %8 : !cc.ptr<i32>
         %30 = cc.cast signed %29 : (i32) -> i64
-        %31 = cc.stdvec_data %arg9 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+        %31 = cc.sequence_data %arg9 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
         %32 = cc.compute_ptr %31[%30] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
         %33 = cc.load %32 : !cc.ptr<i64>
         %34 = arith.xori %28, %33 : i64
@@ -112,7 +112,7 @@ func.func @test_2(%arg0: !quake.veq<?>, %arg1: !quake.veq<?>, %arg2: !quake.veq<
         }
         %36 = cc.load %8 : !cc.ptr<i32>
         %37 = cc.cast signed %36 : (i32) -> i64
-        %38 = cc.stdvec_data %arg9 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+        %38 = cc.sequence_data %arg9 : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
         %39 = cc.compute_ptr %38[%37] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
         %40 = cc.load %1 : !cc.ptr<i64>
         cc.store %40, %39 : !cc.ptr<i64>
@@ -141,10 +141,10 @@ func.func @test_2(%arg0: !quake.veq<?>, %arg1: !quake.veq<?>, %arg2: !quake.veq<
   return
 }
 
-func.func private @test_2.a(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
+func.func private @test_2.a(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.sequence<i64>) -> !cc.sequence<i1>
 func.func private @test_2.b(!cc.ptr<i8>, !cc.ptr<i8>, i64) -> ()
-func.func private @test_2.c(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
-func.func private @test_2.d(!cc.stdvec<i1>) -> i64
+func.func private @test_2.c(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.sequence<i64>) -> !cc.sequence<i1>
+func.func private @test_2.d(!cc.sequence<i1>) -> i64
 func.func private @test_2.e(i64, i1, i1, i64, i64) -> ()
 func.func private @test_2.f(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, f64, f64, f64) -> ()
 

--- a/cudaq/test/Transforms/memtoreg-7.qke
+++ b/cudaq/test/Transforms/memtoreg-7.qke
@@ -30,11 +30,11 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
     %7 = cc.load %1 : !cc.ptr<i1>
     %8 = arith.cmpi eq, %7, %false : i1
     cc.if(%8) {
-      %measOut_0 = quake.mz %0 name "inner_mz" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
-      %9 = quake.discriminate %measOut_0 : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+      %measOut_0 = quake.mz %0 name "inner_mz" : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
+      %9 = quake.discriminate %measOut_0 : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
       cc.scope {
-        %10 = cc.alloca !cc.stdvec<i1>
-        cc.store %9, %10 : !cc.ptr<!cc.stdvec<i1>>
+        %10 = cc.alloca !cc.sequence<i1>
+        cc.store %9, %10 : !cc.ptr<!cc.sequence<i1>>
       }
     }
     cc.continue %arg0 : i64
@@ -46,11 +46,11 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
   %3 = cc.load %1 : !cc.ptr<i1>
   %4 = arith.cmpi eq, %3, %true : i1
   cc.if(%4) {
-    %measOut = quake.mz %0 name "outer_mz" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
-    %5 = quake.discriminate %measOut : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+    %measOut = quake.mz %0 name "outer_mz" : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
+    %5 = quake.discriminate %measOut : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
     cc.scope {
-      %6 = cc.alloca !cc.stdvec<i1>
-      cc.store %5, %6 : !cc.ptr<!cc.stdvec<i1>>
+      %6 = cc.alloca !cc.sequence<i1>
+      cc.store %5, %6 : !cc.ptr<!cc.sequence<i1>>
     }
   }
   return
@@ -76,10 +76,10 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
 // CHECK:             %[[VAL_17:.*]] = quake.discriminate %[[VAL_15]] : (!quake.measure) -> i1
 // CHECK:             %[[VAL_18:.*]] = arith.cmpi eq, %[[VAL_17]], %[[VAL_0]] : i1
 // CHECK:             cc.if(%[[VAL_18]]) {
-// CHECK:               %[[VAL_19:.*]] = quake.mz %[[VAL_5]] name "inner_mz" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
-// CHECK:               %[[VAL_20:.*]] = quake.discriminate %[[VAL_19]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+// CHECK:               %[[VAL_19:.*]] = quake.mz %[[VAL_5]] name "inner_mz" : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
+// CHECK:               %[[VAL_20:.*]] = quake.discriminate %[[VAL_19]] : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
 // CHECK:               cc.scope {
-// CHECK:                 %[[VAL_21:.*]] = cc.undef !cc.stdvec<i1>
+// CHECK:                 %[[VAL_21:.*]] = cc.undef !cc.sequence<i1>
 // CHECK:               }
 // CHECK:             }
 // CHECK:             cc.continue %[[VAL_11]], %[[VAL_17]] : i64, i1
@@ -89,10 +89,10 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
 // CHECK:             cc.continue %[[VAL_24]], %[[VAL_23]] : i64, i1
 // CHECK:           } {invariant}
 // CHECK:           cc.if(%[[VAL_26:.*]]#1) {
-// CHECK:             %[[VAL_27:.*]] = quake.mz %[[VAL_5]] name "outer_mz" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
-// CHECK:             %[[VAL_28:.*]] = quake.discriminate %[[VAL_27]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+// CHECK:             %[[VAL_27:.*]] = quake.mz %[[VAL_5]] name "outer_mz" : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
+// CHECK:             %[[VAL_28:.*]] = quake.discriminate %[[VAL_27]] : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
 // CHECK:             cc.scope {
-// CHECK:               %[[VAL_29:.*]] = cc.undef !cc.stdvec<i1>
+// CHECK:               %[[VAL_29:.*]] = cc.undef !cc.sequence<i1>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return
@@ -121,9 +121,9 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
 // CANOE:             %[[VAL_17:.*]] = cc.cast unsigned %[[VAL_15]] : (i1) -> i8
 // CANOE:             cc.store %[[VAL_17]], %[[VAL_16]] : !cc.ptr<i8>
 // CANOE:             %[[VAL_18:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x 2>>) -> !cc.ptr<!cc.array<i1 x ?>>
-// CANOE:             %[[VAL_19:.*]] = cc.stdvec_init %[[VAL_18]], %[[VAL_0]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.stdvec<i1>
+// CANOE:             %[[VAL_19:.*]] = cc.sequence_init %[[VAL_18]], %[[VAL_0]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.sequence<i1>
 // CANOE:             cc.scope {
-// CANOE:               %[[VAL_20:.*]] = cc.undef !cc.stdvec<i1>
+// CANOE:               %[[VAL_20:.*]] = cc.undef !cc.sequence<i1>
 // CANOE:             }
 // CANOE:           }
 // CANOE:           %[[VAL_21:.*]] = quake.mz %[[VAL_4]] name "res" : (!quake.ref) -> !quake.measure
@@ -142,9 +142,9 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
 // CANOE:             %[[VAL_32:.*]] = cc.cast unsigned %[[VAL_30]] : (i1) -> i8
 // CANOE:             cc.store %[[VAL_32]], %[[VAL_31]] : !cc.ptr<i8>
 // CANOE:             %[[VAL_33:.*]] = cc.cast %[[VAL_24]] : (!cc.ptr<!cc.array<i8 x 2>>) -> !cc.ptr<!cc.array<i1 x ?>>
-// CANOE:             %[[VAL_34:.*]] = cc.stdvec_init %[[VAL_33]], %[[VAL_0]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.stdvec<i1>
+// CANOE:             %[[VAL_34:.*]] = cc.sequence_init %[[VAL_33]], %[[VAL_0]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.sequence<i1>
 // CANOE:             cc.scope {
-// CANOE:               %[[VAL_35:.*]] = cc.undef !cc.stdvec<i1>
+// CANOE:               %[[VAL_35:.*]] = cc.undef !cc.sequence<i1>
 // CANOE:             }
 // CANOE:           }
 // CANOE:           cc.if(%[[VAL_22]]) {
@@ -160,9 +160,9 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
 // CANOE:             %[[VAL_45:.*]] = cc.cast unsigned %[[VAL_43]] : (i1) -> i8
 // CANOE:             cc.store %[[VAL_45]], %[[VAL_44]] : !cc.ptr<i8>
 // CANOE:             %[[VAL_46:.*]] = cc.cast %[[VAL_39]] : (!cc.ptr<!cc.array<i8 x 2>>) -> !cc.ptr<!cc.array<i1 x ?>>
-// CANOE:             %[[VAL_47:.*]] = cc.stdvec_init %[[VAL_46]], %[[VAL_0]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.stdvec<i1>
+// CANOE:             %[[VAL_47:.*]] = cc.sequence_init %[[VAL_46]], %[[VAL_0]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.sequence<i1>
 // CANOE:             cc.scope {
-// CANOE:               %[[VAL_48:.*]] = cc.undef !cc.stdvec<i1>
+// CANOE:               %[[VAL_48:.*]] = cc.undef !cc.sequence<i1>
 // CANOE:             }
 // CANOE:           }
 // CANOE:           return

--- a/cudaq/test/Transforms/mz.qke
+++ b/cudaq/test/Transforms/mz.qke
@@ -13,7 +13,7 @@ func.func @static.mz_test() {
   %1 = quake.alloca  !quake.veq<4>
   %2 = quake.alloca  !quake.veq<2>
   %3 = quake.alloca  !quake.ref
-  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<!quake.measure>
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.sequence<!quake.measure>
   return
 }
 
@@ -22,7 +22,7 @@ func.func @static.mz_test() {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -31,7 +31,7 @@ func.func @dynamic.mz_test(%arg0 : i32, %arg1 : i32) {
   %1 = quake.alloca !quake.veq<?>[%arg0 : i32]
   %2 = quake.alloca !quake.veq<?>[%arg1 : i32]
   %3 = quake.alloca  !quake.ref
-  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<!quake.measure>
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.sequence<!quake.measure>
   return
 }
 
@@ -41,7 +41,7 @@ func.func @dynamic.mz_test(%arg0 : i32, %arg1 : i32) {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<?>[%[[VAL_0]] : i32]
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<?>[%[[VAL_1]] : i32]
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/propagate_metadata_apply.qke
+++ b/cudaq/test/Transforms/propagate_metadata_apply.qke
@@ -15,7 +15,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__controlled_operat
     quake.h %1 : (!quake.ref) -> ()
     %2 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
     quake.apply %arg0 [%1] %2 : (!quake.ref, !quake.ref) -> ()
-    %measOut = quake.mz %0 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+    %measOut = quake.mz %0 : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
     return
   }
 }
@@ -29,6 +29,6 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__controlled_operat
 // CHECK:           quake.h %[[VAL_2]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.apply %[[VAL_0]] {{\[}}%[[VAL_2]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.sequence<!quake.measure>
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/qec-errors.qke
+++ b/cudaq/test/Transforms/qec-errors.qke
@@ -8,10 +8,10 @@
 
 // RUN: cudaq-opt %s -split-input-file -verify-diagnostics
 
-func.func @bad_detectors_elem(%bad : !cc.stdvec<i32>,
-                              %good : !cc.stdvec<!cc.measure_handle>) {
-  // expected-error @+1 {{must be stdvec of}}
-  qec.pair_detectors %bad, %good : !cc.stdvec<i32>, !cc.stdvec<!cc.measure_handle>
+func.func @bad_detectors_elem(%bad : !cc.sequence<i32>,
+                              %good : !cc.sequence<!cc.measure_handle>) {
+  // expected-error @+1 {{must be sequence of}}
+  qec.pair_detectors %bad, %good : !cc.sequence<i32>, !cc.sequence<!cc.measure_handle>
   return
 }
 
@@ -25,8 +25,8 @@ func.func @bad_detector_elem(%bad : i32) {
 
 // -----
 
-func.func @bad_observable_elem(%bad : !cc.stdvec<i32>) {
+func.func @bad_observable_elem(%bad : !cc.sequence<i32>) {
   // expected-error @+1 {{must be variadic of}}
-  qec.observable %bad : !cc.stdvec<i32>
+  qec.observable %bad : !cc.sequence<i32>
   return
 }

--- a/cudaq/test/Transforms/qec-roundtrip-ops.qke
+++ b/cudaq/test/Transforms/qec-roundtrip-ops.qke
@@ -10,29 +10,29 @@
 
 func.func @det_obs_roundtrip(%h0 : !cc.measure_handle,
                               %h1 : !cc.measure_handle,
-                              %v : !cc.stdvec<!cc.measure_handle>) {
+                              %v : !cc.sequence<!cc.measure_handle>) {
   qec.detector %h0 : !cc.measure_handle {flag = "Hi"}
   qec.detector %h0, %h1 : !cc.measure_handle, !cc.measure_handle
-  qec.detector %v : !cc.stdvec<!cc.measure_handle>
-  qec.detector %h0, %v : !cc.measure_handle, !cc.stdvec<!cc.measure_handle>
+  qec.detector %v : !cc.sequence<!cc.measure_handle>
+  qec.detector %h0, %v : !cc.measure_handle, !cc.sequence<!cc.measure_handle>
   qec.observable %h0 : !cc.measure_handle
   qec.observable %h0 index 0 : !cc.measure_handle
   qec.observable %h0 index 1 : !cc.measure_handle
-  qec.observable %v index 2 : !cc.stdvec<!cc.measure_handle>
-  qec.pair_detectors %v, %v : !cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>
+  qec.observable %v index 2 : !cc.sequence<!cc.measure_handle>
+  qec.pair_detectors %v, %v : !cc.sequence<!cc.measure_handle>, !cc.sequence<!cc.measure_handle>
   return
 }
 
 // CHECK-LABEL:   func.func @det_obs_roundtrip(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle, %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle, %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<!cc.measure_handle>) {
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle, %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle, %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<!cc.measure_handle>) {
 // CHECK:           qec.detector %[[ARG0]] : !cc.measure_handle {flag = "Hi"}
 // CHECK:           qec.detector %[[ARG0]], %[[ARG1]] : !cc.measure_handle, !cc.measure_handle
-// CHECK:           qec.detector %[[ARG2]] : !cc.stdvec<!cc.measure_handle>
-// CHECK:           qec.detector %[[ARG0]], %[[ARG2]] : !cc.measure_handle, !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.detector %[[ARG2]] : !cc.sequence<!cc.measure_handle>
+// CHECK:           qec.detector %[[ARG0]], %[[ARG2]] : !cc.measure_handle, !cc.sequence<!cc.measure_handle>
 // CHECK:           qec.observable %[[ARG0]] : !cc.measure_handle
 // CHECK:           qec.observable %[[ARG0]] : !cc.measure_handle
 // CHECK:           qec.observable %[[ARG0]] index 1 : !cc.measure_handle
-// CHECK:           qec.observable %[[ARG2]] index 2 : !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.observable %[[ARG2]] index 2 : !cc.sequence<!cc.measure_handle>
 // CHECK:           qec.pair_detectors %[[ARG2]], %[[ARG2]] : <!cc.measure_handle>, <!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/qir_api_measure_handle.qke
+++ b/cudaq/test/Transforms/qir_api_measure_handle.qke
@@ -141,15 +141,15 @@ func.func @handle_dynamic_array(%n: i64) attributes {"cudaq-kernel"} {
 // CHECK:           cc.alloca i64{{\[}}%[[VAL_N]] : i64]
 
 // -----
-// Function returning `cc.stdvec<measure_handle>` (recursive container rule).
+// Function returning `cc.sequence<measure_handle>` (recursive container rule).
 
-func.func @stdvec_handle(%arg: !cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<!cc.measure_handle> attributes {"cudaq-kernel"} {
-  return %arg : !cc.stdvec<!cc.measure_handle>
+func.func @sequence_handle(%arg: !cc.sequence<!cc.measure_handle>) -> !cc.sequence<!cc.measure_handle> attributes {"cudaq-kernel"} {
+  return %arg : !cc.sequence<!cc.measure_handle>
 }
 
-// CHECK-LABEL:   func.func @stdvec_handle(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<i64>) -> !cc.stdvec<i64>
-// CHECK:           return %[[VAL_0]] : !cc.stdvec<i64>
+// CHECK-LABEL:   func.func @sequence_handle(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<i64>) -> !cc.sequence<i64>
+// CHECK:           return %[[VAL_0]] : !cc.sequence<i64>
 
 // -----
 // Negative: a kernel without any handle types is left alone.
@@ -212,31 +212,31 @@ func.func @handle_array_rw(%h: !cc.measure_handle, %i: i64) -> i1 attributes {"c
 // WIRE:              llvm.return %[[VAL_B]] : i1
 
 // -----
-// `cc.stdvec_init` + `cc.stdvec_data` + `cc.stdvec_size` over a handle buffer.
+// `cc.sequence_init` + `cc.sequence_data` + `cc.sequence_size` over a handle buffer.
 
-func.func @handle_stdvec_init(%n: i64) -> !cc.stdvec<!cc.measure_handle> attributes {"cudaq-kernel"} {
+func.func @handle_sequence_init(%n: i64) -> !cc.sequence<!cc.measure_handle> attributes {"cudaq-kernel"} {
   %0 = cc.alloca !cc.measure_handle[%n : i64]
-  %1 = cc.stdvec_init %0, %n : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
-  return %1 : !cc.stdvec<!cc.measure_handle>
+  %1 = cc.sequence_init %0, %n : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
+  return %1 : !cc.sequence<!cc.measure_handle>
 }
 
-// CHECK-LABEL:   func.func @handle_stdvec_init(
-// CHECK-SAME:      %[[VAL_N:.*]]: i64) -> !cc.stdvec<i64>
+// CHECK-LABEL:   func.func @handle_sequence_init(
+// CHECK-SAME:      %[[VAL_N:.*]]: i64) -> !cc.sequence<i64>
 // CHECK:           %[[VAL_BUF:.*]] = cc.alloca i64{{\[}}%[[VAL_N]] : i64]
-// CHECK:           %[[VAL_VEC:.*]] = cc.stdvec_init %[[VAL_BUF]], %[[VAL_N]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.stdvec<i64>
-// CHECK:           return %[[VAL_VEC]] : !cc.stdvec<i64>
+// CHECK:           %[[VAL_VEC:.*]] = cc.sequence_init %[[VAL_BUF]], %[[VAL_N]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.sequence<i64>
+// CHECK:           return %[[VAL_VEC]] : !cc.sequence<i64>
 
-func.func @handle_stdvec_consume(%v: !cc.stdvec<!cc.measure_handle>) -> i1 attributes {"cudaq-kernel"} {
-  %0 = cc.stdvec_data %v : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+func.func @handle_sequence_consume(%v: !cc.sequence<!cc.measure_handle>) -> i1 attributes {"cudaq-kernel"} {
+  %0 = cc.sequence_data %v : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
   %1 = cc.cast %0 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
   %2 = cc.load %1 : !cc.ptr<!cc.measure_handle>
   %3 = quake.discriminate %2 : (!cc.measure_handle) -> i1
   return %3 : i1
 }
 
-// CHECK-LABEL:   func.func @handle_stdvec_consume(
-// CHECK-SAME:      %[[VAL_V:.*]]: !cc.stdvec<i64>) -> i1
-// CHECK:           %[[VAL_DATA:.*]] = cc.stdvec_data %[[VAL_V]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK-LABEL:   func.func @handle_sequence_consume(
+// CHECK-SAME:      %[[VAL_V:.*]]: !cc.sequence<i64>) -> i1
+// CHECK:           %[[VAL_DATA:.*]] = cc.sequence_data %[[VAL_V]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
 // CHECK:           %[[VAL_PTR:.*]] = cc.cast %[[VAL_DATA]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_LD:.*]] = cc.load %[[VAL_PTR]] : !cc.ptr<i64>
 

--- a/cudaq/test/Transforms/qir_api_qec.qke
+++ b/cudaq/test/Transforms/qir_api_qec.qke
@@ -66,45 +66,45 @@ func.func @detector_multi(%h0: !cc.measure_handle,
 // CHECK:         }
 
 // -----
-// Single stdvec: pass-through via `cc.stdvec_data` + `cc.stdvec_size`.
+// Single sequence: pass-through via `cc.sequence_data` + `cc.sequence_size`.
 
-func.func @detector_stdvec(%v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
-  qec.detector %v : !cc.stdvec<!cc.measure_handle>
+func.func @detector_sequence(%v: !cc.sequence<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.detector %v : !cc.sequence<!cc.measure_handle>
   return
 }
 
-// CHECK-LABEL:   func.func @detector_stdvec(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK-LABEL:   func.func @detector_sequence(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
 // CHECK:           call @__quantum__qis__detector(%[[CAST_0]], %[[STDVEC_SIZE_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // -----
-// Mixed scalar + stdvec: dynamic total size, scalar stored at running
-// offset, stdvec contents copied via an invariant `cc.loop`.
+// Mixed scalar + sequence: dynamic total size, scalar stored at running
+// offset, sequence contents copied via an invariant `cc.loop`.
 
 func.func @detector_mixed(%h: !cc.measure_handle,
-                          %v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
-  qec.detector %h, %v : !cc.measure_handle, !cc.stdvec<!cc.measure_handle>
+                          %v: !cc.sequence<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.detector %h, %v : !cc.measure_handle, !cc.sequence<!cc.measure_handle>
   return
 }
 
 // CHECK-LABEL:   func.func @detector_mixed(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
-// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>) attributes {"cudaq-kernel", "qir-api"} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_1]] : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<!llvm.struct<"Result", opaque>>{{\[}}%[[ADDI_0]] : i64]
 // CHECK:           %[[CAST_0:.*]] = cc.cast %[[ARG0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
 // CHECK:           cc.store %[[CAST_0]], %[[CAST_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG1]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_0]]) -> (i64)) {
 // CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[STDVEC_SIZE_1]] : i64
 // CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]] : i64)
@@ -128,27 +128,27 @@ func.func @detector_mixed(%h: !cc.measure_handle,
 // CHECK:         }
 
 // -----
-// Two stdvecs (no scalars): general path also fires here because the
-// fast path requires exactly one operand. Each stdvec is copied via
+// Two sequences (no scalars): general path also fires here because the
+// fast path requires exactly one operand. Each sequence is copied via
 // its own `cc.loop`; the size is the runtime sum.
 
-func.func @detector_two_stdvec(%a: !cc.stdvec<!cc.measure_handle>,
-                               %b: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
-  qec.detector %a, %b : !cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>
+func.func @detector_two_sequence(%a: !cc.sequence<!cc.measure_handle>,
+                               %b: !cc.sequence<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.detector %a, %b : !cc.sequence<!cc.measure_handle>, !cc.sequence<!cc.measure_handle>
   return
 }
 
-// CHECK-LABEL:   func.func @detector_two_stdvec(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>,
-// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK-LABEL:   func.func @detector_two_sequence(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>) attributes {"cudaq-kernel", "qir-api"} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
-// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i64>) -> i64
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[STDVEC_SIZE_1]] : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<!llvm.struct<"Result", opaque>>{{\[}}%[[ADDI_0]] : i64]
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_2:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_2:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_0]]) -> (i64)) {
 // CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[STDVEC_SIZE_2]] : i64
 // CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]] : i64)
@@ -165,8 +165,8 @@ func.func @detector_two_stdvec(%a: !cc.stdvec<!cc.measure_handle>,
 // CHECK:             %[[ADDI_1:.*]] = arith.addi %[[VAL_2]], %[[CONSTANT_1]] : i64
 // CHECK:             cc.continue %[[ADDI_1]] : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_3:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.sequence_data %[[ARG1]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_3:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[LOOP_1:.*]] = cc.loop while ((%[[VAL_3:.*]] = %[[CONSTANT_0]]) -> (i64)) {
 // CHECK:             %[[CMPI_1:.*]] = arith.cmpi slt, %[[VAL_3]], %[[STDVEC_SIZE_3]] : i64
 // CHECK:             cc.condition %[[CMPI_1]](%[[VAL_3]] : i64)
@@ -237,48 +237,48 @@ func.func @observable_multi_indexed(%h0: !cc.measure_handle,
 // CHECK:         }
 
 // -----
-// Observable, single stdvec, explicit `index 2`.
+// Observable, single sequence, explicit `index 2`.
 
-func.func @observable_stdvec_indexed(%v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
-  qec.observable %v index 2 : !cc.stdvec<!cc.measure_handle>
+func.func @observable_sequence_indexed(%v: !cc.sequence<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.observable %v index 2 : !cc.sequence<!cc.measure_handle>
   return
 }
 
-// CHECK-LABEL:   func.func @observable_stdvec_indexed(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK-LABEL:   func.func @observable_sequence_indexed(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>) attributes {"cudaq-kernel", "qir-api"} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2 : i64
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
 // CHECK:           call @__quantum__qis__logical_observable(%[[CAST_0]], %[[STDVEC_SIZE_0]], %[[CONSTANT_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, i64) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // -----
-// Observable with mixed scalar + stdvec operand and explicit index:
+// Observable with mixed scalar + sequence operand and explicit index:
 // general path produces a single buffer + size, then the call appends
 // the observable index.
 
 func.func @observable_mixed_indexed(%h: !cc.measure_handle,
-                                    %v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
-  qec.observable %h, %v index 3 : !cc.measure_handle, !cc.stdvec<!cc.measure_handle>
+                                    %v: !cc.sequence<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.observable %h, %v index 3 : !cc.measure_handle, !cc.sequence<!cc.measure_handle>
   return
 }
 
 // CHECK-LABEL:   func.func @observable_mixed_indexed(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
-// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>) attributes {"cudaq-kernel", "qir-api"} {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 3 : i64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[CONSTANT_2:.*]] = arith.constant 1 : i64
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_2]] : i64
 // CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<!llvm.struct<"Result", opaque>>{{\[}}%[[ADDI_0]] : i64]
 // CHECK:           %[[CAST_0:.*]] = cc.cast %[[ARG0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
 // CHECK:           cc.store %[[CAST_0]], %[[CAST_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG1]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]]) -> (i64)) {
 // CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[STDVEC_SIZE_1]] : i64
 // CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]] : i64)
@@ -302,23 +302,23 @@ func.func @observable_mixed_indexed(%h: !cc.measure_handle,
 // CHECK:         }
 
 // -----
-// `pair_detectors`: two stdvecs as `(data, size)` pairs.
+// `pair_detectors`: two sequences as `(data, size)` pairs.
 
-func.func @pair_detectors(%prev: !cc.stdvec<!cc.measure_handle>,
-                          %curr: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+func.func @pair_detectors(%prev: !cc.sequence<!cc.measure_handle>,
+                          %curr: !cc.sequence<!cc.measure_handle>) attributes {"cudaq-kernel"} {
   qec.pair_detectors %prev, %curr
-    : !cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>
+    : !cc.sequence<!cc.measure_handle>, !cc.sequence<!cc.measure_handle>
   return
 }
 
 // CHECK-LABEL:   func.func @pair_detectors(
-// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>,
-// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
-// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.sequence<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.sequence_data %[[ARG0]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.sequence_size %[[ARG0]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
-// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.sequence_data %[[ARG1]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.sequence_size %[[ARG1]] : (!cc.sequence<i64>) -> i64
 // CHECK:           %[[CAST_1:.*]] = cc.cast %[[STDVEC_DATA_1]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
 // CHECK:           call @__quantum__qis__pair_detectors(%[[CAST_0]], %[[STDVEC_SIZE_0]], %[[CAST_1]], %[[STDVEC_SIZE_1]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
 // CHECK:           return

--- a/cudaq/test/Transforms/reify_span-0.qke
+++ b/cudaq/test/Transforms/reify_span-0.qke
@@ -8,11 +8,11 @@
 
 // RUN: cudaq-opt --argument-synthesis=functions=testfun:%S/reify_span-0.txt -canonicalize %s | FileCheck %s
 
-func.func @testfun(%arg : !cc.stdvec<!cc.stdvec<!cc.charspan>>, %i : i64) {
-  %0 = cc.stdvec_data %arg : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
-  %1 = cc.compute_ptr %0[1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
-  %2 = cc.load %1 : !cc.ptr<!cc.stdvec<!cc.charspan>>
-  %3 = cc.stdvec_data %2 : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
+func.func @testfun(%arg : !cc.sequence<!cc.sequence<!cc.charspan>>, %i : i64) {
+  %0 = cc.sequence_data %arg : (!cc.sequence<!cc.sequence<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>
+  %1 = cc.compute_ptr %0[1] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>) -> !cc.ptr<!cc.sequence<!cc.charspan>>
+  %2 = cc.load %1 : !cc.ptr<!cc.sequence<!cc.charspan>>
+  %3 = cc.sequence_data %2 : (!cc.sequence<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
   %4 = cc.cast %3 : (!cc.ptr<!cc.array<!cc.charspan x ?>>) -> !cc.ptr<!cc.charspan>
   %5 = quake.alloca !quake.ref
   %6 = cc.load %4 : !cc.ptr<!cc.charspan>
@@ -24,11 +24,11 @@ func.func @testfun(%arg : !cc.stdvec<!cc.stdvec<!cc.charspan>>, %i : i64) {
 // CHECK-LABEL:   func.func @testfun() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 3.300000e+00 : f64
 // CHECK:           %[[VAL_1:.*]] = cc.const_array {{\[\[}}"XY", "ZI"], ["IZ", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
-// CHECK:           %[[VAL_2:.*]] = cc.reify_span %[[VAL_1]] : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
-// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.stdvec<!cc.charspan>>
-// CHECK:           %[[VAL_6:.*]] = cc.stdvec_data %[[VAL_5]] : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
+// CHECK:           %[[VAL_2:.*]] = cc.reify_span %[[VAL_1]] : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.sequence<!cc.sequence<!cc.charspan>>
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_data %[[VAL_2]] : (!cc.sequence<!cc.sequence<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>) -> !cc.ptr<!cc.sequence<!cc.charspan>>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.sequence<!cc.charspan>>
+// CHECK:           %[[VAL_6:.*]] = cc.sequence_data %[[VAL_5]] : (!cc.sequence<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
 // CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_7]] : !cc.ptr<!cc.charspan>

--- a/cudaq/test/Transforms/reify_span-0.txt
+++ b/cudaq/test/Transforms/reify_span-0.txt
@@ -8,7 +8,7 @@
 
 cc.arg_subst[0] {
   %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
-  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
+  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.sequence<!cc.sequence<!cc.charspan>>
 }
 
 cc.arg_subst[1] {

--- a/cudaq/test/Transforms/reify_span-1.qke
+++ b/cudaq/test/Transforms/reify_span-1.qke
@@ -11,11 +11,11 @@
 func.func @covered_wagon() {
   %cst = arith.constant 3.300000e+00 : f64
   %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
-  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
-  %2 = cc.stdvec_data %1 : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
-  %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
-  %4 = cc.load %3 : !cc.ptr<!cc.stdvec<!cc.charspan>>
-  %5 = cc.stdvec_data %4 : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
+  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.sequence<!cc.sequence<!cc.charspan>>
+  %2 = cc.sequence_data %1 : (!cc.sequence<!cc.sequence<!cc.charspan>>) -> !cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>
+  %3 = cc.compute_ptr %2[1] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>) -> !cc.ptr<!cc.sequence<!cc.charspan>>
+  %4 = cc.load %3 : !cc.ptr<!cc.sequence<!cc.charspan>>
+  %5 = cc.sequence_data %4 : (!cc.sequence<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
   %6 = cc.cast %5 : (!cc.ptr<!cc.array<!cc.charspan x ?>>) -> !cc.ptr<!cc.charspan>
   %7 = quake.alloca !quake.ref
   %8 = cc.load %6 : !cc.ptr<!cc.charspan>

--- a/cudaq/test/Transforms/reify_span-2.qke
+++ b/cudaq/test/Transforms/reify_span-2.qke
@@ -8,12 +8,12 @@
 
 // RUN: cudaq-opt -globalize-array-values -canonicalize %s | FileCheck %s
 
-func.func private @pony_express(!cc.stdvec<!cc.stdvec<!cc.charspan>>)
+func.func private @pony_express(!cc.sequence<!cc.sequence<!cc.charspan>>)
 
 func.func @covered_wagon() {
   %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
-  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
-  call @pony_express(%1) : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> ()
+  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.sequence<!cc.sequence<!cc.charspan>>
+  call @pony_express(%1) : (!cc.sequence<!cc.sequence<!cc.charspan>>) -> ()
   return
 }
 
@@ -21,35 +21,35 @@ func.func @covered_wagon() {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 3 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 2 : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = cc.string_literal "XY" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_init %[[VAL_2]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_init %[[VAL_2]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_4:.*]] = cc.string_literal "ZI" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_init %[[VAL_4]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_init %[[VAL_4]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_6:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
 // CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_8]] : !cc.ptr<!cc.charspan>
 // CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           cc.store %[[VAL_5]], %[[VAL_9]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_10:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>, i64) -> !cc.stdvec<!cc.charspan>
+// CHECK:           %[[VAL_10:.*]] = cc.sequence_init %[[VAL_7]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>, i64) -> !cc.sequence<!cc.charspan>
 // CHECK:           %[[VAL_11:.*]] = cc.string_literal "IZ" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_11]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_12:.*]] = cc.sequence_init %[[VAL_11]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_13:.*]] = cc.string_literal "YX" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_14:.*]] = cc.stdvec_init %[[VAL_13]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_14:.*]] = cc.sequence_init %[[VAL_13]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_15:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
 // CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
 // CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           cc.store %[[VAL_12]], %[[VAL_17]] : !cc.ptr<!cc.charspan>
 // CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_15]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           cc.store %[[VAL_14]], %[[VAL_18]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_19:.*]] = cc.stdvec_init %[[VAL_16]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>, i64) -> !cc.stdvec<!cc.charspan>
-// CHECK:           %[[VAL_20:.*]] = cc.alloca !cc.array<!cc.stdvec<!cc.charspan> x 2>
-// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x 2>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
-// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x 2>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
-// CHECK:           cc.store %[[VAL_10]], %[[VAL_22]] : !cc.ptr<!cc.stdvec<!cc.charspan>>
-// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_20]][1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x 2>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
-// CHECK:           cc.store %[[VAL_19]], %[[VAL_23]] : !cc.ptr<!cc.stdvec<!cc.charspan>>
-// CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_21]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>, i64) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
-// CHECK:           call @pony_express(%[[VAL_24]]) : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> ()
+// CHECK:           %[[VAL_19:.*]] = cc.sequence_init %[[VAL_16]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>, i64) -> !cc.sequence<!cc.charspan>
+// CHECK:           %[[VAL_20:.*]] = cc.alloca !cc.array<!cc.sequence<!cc.charspan> x 2>
+// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x 2>>) -> !cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>
+// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x 2>>) -> !cc.ptr<!cc.sequence<!cc.charspan>>
+// CHECK:           cc.store %[[VAL_10]], %[[VAL_22]] : !cc.ptr<!cc.sequence<!cc.charspan>>
+// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_20]][1] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x 2>>) -> !cc.ptr<!cc.sequence<!cc.charspan>>
+// CHECK:           cc.store %[[VAL_19]], %[[VAL_23]] : !cc.ptr<!cc.sequence<!cc.charspan>>
+// CHECK:           %[[VAL_24:.*]] = cc.sequence_init %[[VAL_21]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.sequence<!cc.charspan> x ?>>, i64) -> !cc.sequence<!cc.sequence<!cc.charspan>>
+// CHECK:           call @pony_express(%[[VAL_24]]) : (!cc.sequence<!cc.sequence<!cc.charspan>>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/reify_span-3.qke
+++ b/cudaq/test/Transforms/reify_span-3.qke
@@ -17,14 +17,14 @@
 //   +Inf: 0x7FF0000000000000 = 9218868437227405312 (i64)
 //   -Inf: 0xFFF0000000000000 = -4503599627370496   (i64)
 
-func.func private @use_f64_vec(!cc.stdvec<f64>)
+func.func private @use_f64_vec(!cc.sequence<f64>)
 
 func.func @reify_f64_span_integer_attrs_for_nan_inf() {
   %0 = cc.const_array [9221120237041090560 : i64, 9218868437227405312 : i64,
                         -4503599627370496 : i64, 1.0 : f64]
        : !cc.array<f64 x 4>
-  %1 = cc.reify_span %0 : (!cc.array<f64 x 4>) -> !cc.stdvec<f64>
-  call @use_f64_vec(%1) : (!cc.stdvec<f64>) -> ()
+  %1 = cc.reify_span %0 : (!cc.array<f64 x 4>) -> !cc.sequence<f64>
+  call @use_f64_vec(%1) : (!cc.sequence<f64>) -> ()
   return
 }
 

--- a/cudaq/test/Transforms/resource_count_preprocess.qke
+++ b/cudaq/test/Transforms/resource_count_preprocess.qke
@@ -58,7 +58,7 @@ func.func @kernel2() {
 // CHECK: Preprocessing h(0) for 9 counts
 // CHECK-LABEL:   func.func @kernel3() {
 // CHECK:     %0 = quake.alloca !quake.veq<10>
-// CHECK:     %measOut = quake.mz %0 : (!quake.veq<10>) -> !cc.stdvec<!quake.measure>
+// CHECK:     %measOut = quake.mz %0 : (!quake.veq<10>) -> !cc.sequence<!quake.measure>
 // CHECK:     return
 // CHECK:   }
 
@@ -82,7 +82,7 @@ func.func @kernel3() {
     %2 = arith.addi %arg0, %c1_i64 : i64
     cc.continue %2 : i64
   }
-  %measOut = quake.mz %0 : (!quake.veq<10>) -> !cc.stdvec<!quake.measure>
+  %measOut = quake.mz %0 : (!quake.veq<10>) -> !cc.sequence<!quake.measure>
   return
 }
 

--- a/cudaq/test/Transforms/return_vector.qke
+++ b/cudaq/test/Transforms/return_vector.qke
@@ -15,12 +15,12 @@ module attributes{ quake.mangled_name_map = {
 
 func.func private @malloc(i64) -> !cc.ptr<i8>
 
-func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.stdvec<i32> {
+func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.sequence<i32> {
   %0 = arith.constant 256 : i64
   %1 = call @malloc(%0) : (i64) -> !cc.ptr<i8>
   %2 = arith.constant 8 : i64
-  %3 = cc.stdvec_init %1, %2 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
-  return %3 : !cc.stdvec<i32>
+  %3 = cc.sequence_init %1, %2 : (!cc.ptr<i8>, i64) -> !cc.sequence<i32>
+  return %3 : !cc.sequence<i32>
 }
 
 func.func @test_0(%0: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>> {llvm.sret = !cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>}, %1: !cc.ptr<i8>, %2: i32) {
@@ -28,12 +28,12 @@ func.func @test_0(%0: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i3
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_0(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> !cc.stdvec<i32> {
+// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> !cc.sequence<i32> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 8 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 256 : i64
 // CHECK:           %[[VAL_3:.*]] = call @malloc(%[[VAL_2]]) : (i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_3]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
-// CHECK:           return %[[VAL_4]] : !cc.stdvec<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_init %[[VAL_3]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i32>
+// CHECK:           return %[[VAL_4]] : !cc.sequence<i32>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_0(
@@ -113,12 +113,12 @@ func.func @test_0(%0: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i3
 // CHECK:           return
 // CHECK:         }
 
-func.func @__nvqpp__mlirgen__test_1(%arg0: i32) -> !cc.stdvec<f64> {
+func.func @__nvqpp__mlirgen__test_1(%arg0: i32) -> !cc.sequence<f64> {
   %0 = arith.constant 520 : i64
   %1 = call @malloc(%0) : (i64) -> !cc.ptr<i8>
   %2 = arith.constant 9 : i64
-  %3 = cc.stdvec_init %1, %2 : (!cc.ptr<i8>, i64) -> !cc.stdvec<f64>
-  return %3 : !cc.stdvec<f64>
+  %3 = cc.sequence_init %1, %2 : (!cc.ptr<i8>, i64) -> !cc.sequence<f64>
+  return %3 : !cc.sequence<f64>
 }
 
 func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>}, %1: !cc.ptr<i8>, %2: i32) {
@@ -126,12 +126,12 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_1(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> !cc.stdvec<f64> {
+// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> !cc.sequence<f64> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 9 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 520 : i64
 // CHECK:           %[[VAL_3:.*]] = call @malloc(%[[VAL_2]]) : (i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_3]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<f64>
-// CHECK:           return %[[VAL_4]] : !cc.stdvec<f64>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_init %[[VAL_3]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.sequence<f64>
+// CHECK:           return %[[VAL_4]] : !cc.sequence<f64>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_1(
@@ -270,10 +270,10 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
 // CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = cc.noinline_call @__nvqpp__mlirgen__test_0(%[[VAL_5]]) : (i32) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.noinline_call @__nvqpp__mlirgen__test_0(%[[VAL_5]]) : (i32) -> !cc.sequence<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
-// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.stdvec<i32>>
-// CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<!cc.stdvec<i32>>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.sequence<i32>>
+// CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<!cc.sequence<i32>>
 // CHECK:           cf.cond_br %[[VAL_1]], ^bb1, ^bb2
 // CHECK:         ^bb1:
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
@@ -325,10 +325,10 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
 // CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = cc.noinline_call @__nvqpp__mlirgen__test_1(%[[VAL_5]]) : (i32) -> !cc.stdvec<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.noinline_call @__nvqpp__mlirgen__test_1(%[[VAL_5]]) : (i32) -> !cc.sequence<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
-// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.stdvec<f64>>
-// CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<!cc.stdvec<f64>>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.sequence<f64>>
+// CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<!cc.sequence<f64>>
 // CHECK:           cf.cond_br %[[VAL_1]], ^bb1, ^bb2
 // CHECK:         ^bb1:
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>

--- a/cudaq/test/Transforms/roundtrip-ops.qke
+++ b/cudaq/test/Transforms/roundtrip-ops.qke
@@ -73,10 +73,10 @@ func.func @quantum_ops() {
   quake.u3 (%f, %g, %h) %7 : (f32, f32, f32, !quake.ref) -> ()
 
   %15 = quake.mx %4 : (!quake.ref) -> !quake.measure
-  %16 = quake.my %5 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
-  %17 = quake.mz %6 : (!quake.veq<5>) -> !cc.stdvec<!quake.measure>
+  %16 = quake.my %5 : (!quake.veq<?>) -> !cc.sequence<!quake.measure>
+  %17 = quake.mz %6 : (!quake.veq<5>) -> !cc.sequence<!quake.measure>
   %z15 = quake.discriminate %15 : (!quake.measure) -> i1
-  %z16 = quake.discriminate %16 : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+  %z16 = quake.discriminate %16 : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
 
   // Quantum operations, wire form
   %19 = cc.undef i32 {wires = true}
@@ -223,10 +223,10 @@ cc.global constant private @quantum_ops.rodata_synth_0 (dense<[(0.707106769,0.00
 // CHECK:           %[[VAL_22:.*]] = arith.constant 3.400000e+01 : f32
 // CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.ref) -> ()
 // CHECK:           %[[VAL_23:.*]] = quake.mx %[[VAL_5]] : (!quake.ref) -> !quake.measure
-// CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
-// CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.veq<5>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.veq<?>) -> !cc.sequence<!quake.measure>
+// CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.veq<5>) -> !cc.sequence<!quake.measure>
 // CHECK:           %[[VAL_123:.*]] = quake.discriminate %[[VAL_23]] : (!quake.measure) -> i1
-// CHECK:           %[[VAL_124:.*]] = quake.discriminate %[[VAL_24]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_124:.*]] = quake.discriminate %[[VAL_24]] : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
 // CHECK:           %[[VAL_26:.*]] = cc.undef i32 {wires = true}
 // CHECK:           %[[VAL_27:.*]] = quake.null_wire
 // CHECK:           %[[VAL_28:.*]] = quake.null_wire
@@ -301,16 +301,16 @@ cc.global constant private @quantum_ops.rodata_synth_0 (dense<[(0.707106769,0.00
 
 // CHECK-LABEL:   func.func @quake_op1(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.ptr<f64>, %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_1]] : (!cc.ptr<f64>, i64) -> !cc.stdvec<f64>
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_size %[[VAL_2]] : (!cc.stdvec<f64>) -> i64
+// CHECK:           %[[VAL_2:.*]] = cc.sequence_init %[[VAL_0]], %[[VAL_1]] : (!cc.ptr<f64>, i64) -> !cc.sequence<f64>
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_data %[[VAL_2]] : (!cc.sequence<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_size %[[VAL_2]] : (!cc.sequence<f64>) -> i64
 // CHECK:           return %[[VAL_4]] : i64
 // CHECK:         }
 
 func.func @quake_op1(%a : !cc.ptr<f64>, %b : i64) -> i64 {
-  %svec = cc.stdvec_init %a, %b : (!cc.ptr<f64>, i64) -> !cc.stdvec<f64>
-  %dp = cc.stdvec_data %svec : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-  %len = cc.stdvec_size %svec : (!cc.stdvec<f64>) -> i64
+  %svec = cc.sequence_init %a, %b : (!cc.ptr<f64>, i64) -> !cc.sequence<f64>
+  %dp = cc.sequence_data %svec : (!cc.sequence<f64>) -> !cc.ptr<f64>
+  %len = cc.sequence_size %svec : (!cc.sequence<f64>) -> i64
   return %len : i64
 }
 
@@ -1020,16 +1020,16 @@ func.func @measure_handle_mz_one(%q : !quake.ref) -> i1 {
 // CHECK:         return %[[VAL_2]] : i1
 // CHECK:       }
 
-func.func @measure_handle_mx_vec(%v : !quake.veq<?>) -> !cc.stdvec<i1> {
-  %m = quake.mx %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+func.func @measure_handle_mx_vec(%v : !quake.veq<?>) -> !cc.sequence<i1> {
+  %m = quake.mx %v : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
   %b = quake.discriminate %m
-      : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-  return %b : !cc.stdvec<i1>
+      : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+  return %b : !cc.sequence<i1>
 }
 
 // CHECK-LABEL: func.func @measure_handle_mx_vec(
-// CHECK-SAME:    %[[VAL_0:.*]]: !quake.veq<?>) -> !cc.stdvec<i1> {
-// CHECK:         %[[VAL_1:.*]] = quake.mx %[[VAL_0]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:         %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-// CHECK:         return %[[VAL_2]] : !cc.stdvec<i1>
+// CHECK-SAME:    %[[VAL_0:.*]]: !quake.veq<?>) -> !cc.sequence<i1> {
+// CHECK:         %[[VAL_1:.*]] = quake.mx %[[VAL_0]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+// CHECK:         %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+// CHECK:         return %[[VAL_2]] : !cc.sequence<i1>
 // CHECK:       }

--- a/cudaq/test/Transforms/run_semantics_hackery.qke
+++ b/cudaq/test/Transforms/run_semantics_hackery.qke
@@ -9,7 +9,7 @@
 // RUN: cudaq-opt --run-semantics-hackery %s | FileCheck %s
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7de5b482e030 = "__nvqpp__mlirgen__kernel..0x7de5b482e030_PyKernelEntryPointRewrite", __nvqpp__mlirgen__kernel..0x7de5b482e030.run = "__nvqpp__mlirgen__kernel..0x7de5b482e030.run.entry"}} {
-  func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030(%arg0: i64 {quake.pylifted}) -> !cc.stdvec<i64> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030(%arg0: i64 {quake.pylifted}) -> !cc.sequence<i64> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %c8_i64 = arith.constant 8 : i64
     %cst = arith.constant 1.5707963267948966 : f64
     %c1_i64 = arith.constant 1 : i64
@@ -34,10 +34,10 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7de5b48
     quake.s %4 : (!quake.ref) -> ()
     %5 = quake.extract_ref %1[1] : (!quake.veq<?>) -> !quake.ref
     quake.r1 (%cst) %5 : (f64, !quake.ref) -> ()
-    %measOut = quake.mz %1 name "a" : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
-    %6 = quake.discriminate %measOut : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
-    %7 = cc.stdvec_data %6 : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
-    %8 = cc.stdvec_size %6 : (!cc.stdvec<i1>) -> i64
+    %measOut = quake.mz %1 name "a" : (!quake.veq<?>) -> !cc.sequence<!quake.measure>
+    %6 = quake.discriminate %measOut : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
+    %7 = cc.sequence_data %6 : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
+    %8 = cc.sequence_size %6 : (!cc.sequence<i1>) -> i64
     %9 = cc.alloca i64[%8 : i64]
     %10 = cc.loop while ((%arg1 = %c0_i64) -> (i64)) {
       %14 = arith.cmpi slt, %arg1, %8 : i64
@@ -57,9 +57,9 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7de5b48
     } {invariant}
     %11 = cc.cast %9 : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i8>
     %12 = call @__nvqpp_vectorCopyCtor(%11, %8, %c8_i64) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-    %13 = cc.stdvec_init %12, %8 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i64>
+    %13 = cc.sequence_init %12, %8 : (!cc.ptr<i8>, i64) -> !cc.sequence<i64>
     quake.dealloc %1 : !quake.veq<?>
-    return %13 : !cc.stdvec<i64>
+    return %13 : !cc.sequence<i64>
   }
   func.func private @llvm.memcpy.p0.p0.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
   func.func private @malloc(i64) -> !cc.ptr<i8>
@@ -114,9 +114,9 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7de5b48
   func.func private @__nvqpp_getStringSize(!cc.ptr<i8>) -> i64
   func.func private @_ZNK5cudaq10pauli_word11_nvqpp_sizeEv(!cc.ptr<i8>) -> i64
   func.func private @__nvqpp_cleanup_arrays()
-  func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.run(%arg0: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [!cc.stdvec<i64>]} {
-    %0 = call @__nvqpp__mlirgen__kernel..0x7de5b482e030(%arg0) : (i64) -> !cc.stdvec<i64>
-    cc.log_output %0 : !cc.stdvec<i64>
+  func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.run(%arg0: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [!cc.sequence<i64>]} {
+    %0 = call @__nvqpp__mlirgen__kernel..0x7de5b482e030(%arg0) : (i64) -> !cc.sequence<i64>
+    cc.log_output %0 : !cc.sequence<i64>
     return
   }
   func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.run.entry(%arg0: i64) attributes {no_this} {
@@ -125,13 +125,13 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7de5b48
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.run(
-// CHECK-SAME:      %[[ARG0:.*]]: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [!cc.stdvec<i64>]} {
-// CHECK:           %[[VAL_0:.*]] = call @__nvqpp__mlirgen__kernel..0x7de5b482e030.ruined(%[[ARG0]]) : (i64) -> !cc.stdvec<i64>
-// CHECK:           cc.log_output %[[VAL_0]] : !cc.stdvec<i64>
+// CHECK-SAME:      %[[ARG0:.*]]: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [!cc.sequence<i64>]} {
+// CHECK:           %[[VAL_0:.*]] = call @__nvqpp__mlirgen__kernel..0x7de5b482e030.ruined(%[[ARG0]]) : (i64) -> !cc.sequence<i64>
+// CHECK:           cc.log_output %[[VAL_0]] : !cc.sequence<i64>
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.ruined(
-// CHECK-SAME:      %[[ARG0:.*]]: i64 {quake.pylifted}) -> !cc.stdvec<i64> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-SAME:      %[[ARG0:.*]]: i64 {quake.pylifted}) -> !cc.sequence<i64> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-NOT:       __nvqpp_vectorCopyCtor
-// CHECK:           return {{.*}}: !cc.stdvec<i64>
+// CHECK:           return {{.*}}: !cc.sequence<i64>

--- a/cudaq/test/Transforms/unroll_only_wire_blocking_loops_invalid.qke
+++ b/cudaq/test/Transforms/unroll_only_wire_blocking_loops_invalid.qke
@@ -51,9 +51,9 @@ module {
         cc.continue %13 : i32
       }
     }
-    %measOut = quake.mz %5 name "m" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-    %6 = cc.undef !cc.stdvec<!cc.measure_handle>
-    %7 = cc.stdvec_data %measOut : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+    %measOut = quake.mz %5 name "m" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+    %6 = cc.undef !cc.sequence<!cc.measure_handle>
+    %7 = cc.sequence_data %measOut : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
     %8 = cc.cast %7 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
     %9 = cc.load %8 : !cc.ptr<!cc.measure_handle>
     %10 = quake.discriminate %9 : (!cc.measure_handle) -> i1
@@ -81,7 +81,7 @@ module {
         %6 = cc.cast signed %arg1 : (i32) -> i64
         %7 = arith.addi %6, %c1_i64 : i64
         %8 = quake.subveq %4, %6, %7 : (!quake.veq<2>, i64, i64) -> !quake.veq<2>
-        quake.mz %8 : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+        quake.mz %8 : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
         cc.continue %arg1 : i32
       } step {
       ^bb0(%arg1: i32):

--- a/cudaq/test/Transforms/unroll_only_wire_blocking_loops_predicate.qke
+++ b/cudaq/test/Transforms/unroll_only_wire_blocking_loops_predicate.qke
@@ -29,13 +29,13 @@ module {
     %2 = cc.compute_ptr %0[1] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
     cc.store %arg1, %2 : !cc.ptr<!cc.measure_handle>
     %3 = cc.cast %0 : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-    %4 = cc.stdvec_init %3, %c2_i64 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+    %4 = cc.sequence_init %3, %c2_i64 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.sequence<!cc.measure_handle>
     %5:2 = cc.loop while ((%arg2 = %c0_i32, %arg3 = %false) -> (i32, i1)) {
       %6 = arith.cmpi slt, %arg2, %c2_i32 : i32
       cc.condition %6(%arg2, %arg3 : i32, i1)
     } do {
     ^bb0(%arg2: i32, %arg3: i1):
-      %6 = cc.stdvec_data %4 : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+      %6 = cc.sequence_data %4 : (!cc.sequence<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
       %7 = cc.cast signed %arg2 : (i32) -> i64
       %8 = cc.compute_ptr %6[%7] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.ptr<!cc.measure_handle>
       %9 = cc.load %8 : !cc.ptr<!cc.measure_handle>
@@ -164,7 +164,7 @@ module {
       ^bb0(%arg0: i32):
         %6 = cc.cast signed %arg0 : (i32) -> i64
         %7 = quake.subveq %4, %6, %6 : (!quake.veq<2>, i64, i64) -> !quake.veq<1>
-        quake.mz %7 : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+        quake.mz %7 : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
         cc.continue %arg0 : i32
       } step {
       ^bb0(%arg0: i32):
@@ -182,9 +182,9 @@ module {
 // CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[CONCAT_0:.*]] = quake.concat %[[ALLOCA_0]], %[[ALLOCA_1]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
 // CHECK:           %[[SUBVEQ_0:.*]] = quake.subveq %[[CONCAT_0]], 0, 0 : (!quake.veq<2>) -> !quake.veq<1>
-// CHECK:           %[[MZ_0:.*]] = quake.mz %[[SUBVEQ_0]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[SUBVEQ_0]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           %[[SUBVEQ_1:.*]] = quake.subveq %[[CONCAT_0]], 1, 1 : (!quake.veq<2>) -> !quake.veq<1>
-// CHECK:           %[[MZ_1:.*]] = quake.mz %[[SUBVEQ_1]] : (!quake.veq<1>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[MZ_1:.*]] = quake.mz %[[SUBVEQ_1]] : (!quake.veq<1>) -> !cc.sequence<!cc.measure_handle>
 // CHECK:           return
 // CHECK:         }
 }

--- a/cudaq/test/Transforms/vector.qke
+++ b/cudaq/test/Transforms/vector.qke
@@ -13,24 +13,24 @@
 // Blindly assume that %vecvec and %retval are ragged matrices with identical
 // structure and lengths. Convert ints from %vecvec to doubles and copy the
 // values into %retval. Does not create any new std::vectors.
-func.func @vector_vector(%vecvec : !cc.stdvec<!cc.stdvec<i32>>, %retval : !cc.stdvec<!cc.stdvec<f64>>) {
+func.func @vector_vector(%vecvec : !cc.sequence<!cc.sequence<i32>>, %retval : !cc.sequence<!cc.sequence<f64>>) {
   %0 = arith.constant 0 : i64
   %one = arith.constant 1 : i64
-  %vecvecsz = cc.stdvec_size %vecvec : (!cc.stdvec<!cc.stdvec<i32>>) -> i64
-  %resvecs = cc.stdvec_data %retval : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
+  %vecvecsz = cc.sequence_size %vecvec : (!cc.sequence<!cc.sequence<i32>>) -> i64
+  %resvecs = cc.sequence_data %retval : (!cc.sequence<!cc.sequence<f64>>) -> !cc.ptr<!cc.array<!cc.sequence<f64> x ?>>
   cc.loop while ((%arg0 = %0) -> i64) {
     %c = arith.cmpi ult, %arg0, %vecvecsz : i64
     cc.condition %c (%arg0 : i64)
   } do {
    ^bb0(%arg0 : i64):
-    %vec = cc.stdvec_data %vecvec : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
-    %vecpt = cc.compute_ptr %vec[%arg0] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
-    %inner = cc.load %vecpt : !cc.ptr<!cc.stdvec<i32>>
-    %ints = cc.stdvec_data %inner : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
-    %vecsz = cc.stdvec_size %inner : (!cc.stdvec<i32>) -> i64
-    %resultvec = cc.compute_ptr %resvecs[%arg0] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
-    %resuvec = cc.load %resultvec : !cc.ptr<!cc.stdvec<f64>>
-    %dubs = cc.stdvec_data %resuvec : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+    %vec = cc.sequence_data %vecvec : (!cc.sequence<!cc.sequence<i32>>) -> !cc.ptr<!cc.array<!cc.sequence<i32> x ?>>
+    %vecpt = cc.compute_ptr %vec[%arg0] : (!cc.ptr<!cc.array<!cc.sequence<i32> x ?>>, i64) -> !cc.ptr<!cc.sequence<i32>>
+    %inner = cc.load %vecpt : !cc.ptr<!cc.sequence<i32>>
+    %ints = cc.sequence_data %inner : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+    %vecsz = cc.sequence_size %inner : (!cc.sequence<i32>) -> i64
+    %resultvec = cc.compute_ptr %resvecs[%arg0] : (!cc.ptr<!cc.array<!cc.sequence<f64> x ?>>, i64) -> !cc.ptr<!cc.sequence<f64>>
+    %resuvec = cc.load %resultvec : !cc.ptr<!cc.sequence<f64>>
+    %dubs = cc.sequence_data %resuvec : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
     cc.loop while ((%arg1 = %0) -> i64) {
       %c = arith.cmpi ult, %arg1, %vecsz : i64
       cc.condition %c (%arg1 : i64)
@@ -57,24 +57,24 @@ func.func @vector_vector(%vecvec : !cc.stdvec<!cc.stdvec<i32>>, %retval : !cc.st
 }
 
 // CHECK-LABEL:   func.func @vector_vector(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.stdvec<i32>>, %[[VAL_1:.*]]: !cc.stdvec<!cc.stdvec<f64>>) {
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<!cc.sequence<i32>>, %[[VAL_1:.*]]: !cc.sequence<!cc.sequence<f64>>) {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<i32>>) -> i64
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
+// CHECK:           %[[VAL_4:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<!cc.sequence<i32>>) -> i64
+// CHECK:           %[[VAL_5:.*]] = cc.sequence_data %[[VAL_1]] : (!cc.sequence<!cc.sequence<f64>>) -> !cc.ptr<!cc.array<!cc.sequence<f64> x ?>>
 // CHECK:           cf.br ^bb1(%[[VAL_2]] : i64)
 // CHECK:         ^bb1(%[[VAL_6:.*]]: i64):
 // CHECK:           %[[VAL_7:.*]] = arith.cmpi ult, %[[VAL_6]], %[[VAL_4]] : i64
 // CHECK:           cf.cond_br %[[VAL_7]], ^bb2(%[[VAL_6]] : i64), ^bb6
 // CHECK:         ^bb2(%[[VAL_8:.*]]: i64):
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
-// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_9]]{{\[}}%[[VAL_8]]] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
-// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:           %[[VAL_12:.*]] = cc.stdvec_data %[[VAL_11]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_size %[[VAL_11]] : (!cc.stdvec<i32>) -> i64
-// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_8]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
-// CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_15]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:           %[[VAL_9:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<!cc.sequence<i32>>) -> !cc.ptr<!cc.array<!cc.sequence<i32> x ?>>
+// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_9]]{{\[}}%[[VAL_8]]] : (!cc.ptr<!cc.array<!cc.sequence<i32> x ?>>, i64) -> !cc.ptr<!cc.sequence<i32>>
+// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.sequence<i32>>
+// CHECK:           %[[VAL_12:.*]] = cc.sequence_data %[[VAL_11]] : (!cc.sequence<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:           %[[VAL_13:.*]] = cc.sequence_size %[[VAL_11]] : (!cc.sequence<i32>) -> i64
+// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_8]]] : (!cc.ptr<!cc.array<!cc.sequence<f64> x ?>>, i64) -> !cc.ptr<!cc.sequence<f64>>
+// CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.sequence<f64>>
+// CHECK:           %[[VAL_16:.*]] = cc.sequence_data %[[VAL_15]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 // CHECK:           cf.br ^bb3(%[[VAL_2]] : i64)
 // CHECK:         ^bb3(%[[VAL_17:.*]]: i64):
 // CHECK:           %[[VAL_18:.*]] = arith.cmpi ult, %[[VAL_17]], %[[VAL_13]] : i64

--- a/cudaq/test/Translate/OpenQASM/basic.qke
+++ b/cudaq/test/Translate/OpenQASM/basic.qke
@@ -71,7 +71,7 @@ module {
 
     quake.apply @umaj %cout, %b0, %a0 : (!quake.ref, !quake.ref, !quake.ref) -> ()
 
-    %ans = quake.mz %b : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+    %ans = quake.mz %b : (!quake.veq<4>) -> !cc.sequence<!quake.measure>
     %ans_cout = quake.mz %cout : (!quake.ref) -> !quake.measure
     return
   }

--- a/cudaq/test/Translate/argument.qke
+++ b/cudaq/test/Translate/argument.qke
@@ -18,9 +18,9 @@ module
 
 func.func private @anchor(!cc.ptr<none>, i64)
 
-func.func @__nvqpp__mlirgen__test_0(%arg0: !cc.stdvec<!cc.struct<{i32, f64}>>) {
-  %0 = cc.stdvec_data %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-  %1 = cc.stdvec_size %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> i64
+func.func @__nvqpp__mlirgen__test_0(%arg0: !cc.sequence<!cc.struct<{i32, f64}>>) {
+  %0 = cc.sequence_data %arg0 : (!cc.sequence<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+  %1 = cc.sequence_size %arg0 : (!cc.sequence<!cc.struct<{i32, f64}>>) -> i64
   %2 = cc.cast %0 : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<none>
   call @anchor(%2, %1) : (!cc.ptr<none>, i64) -> ()
   return
@@ -66,15 +66,15 @@ func.func @test_0(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 // CHECK:         ret void
 // CHECK:       }
 
-func.func @__nvqpp__mlirgen__test_1(%arg0 : !cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) {
-  %0 = cc.extract_value %arg0[0] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<i16>
-  %1 = cc.stdvec_data %0 : (!cc.stdvec<i16>) -> !cc.ptr<!cc.array<i16 x ?>>
-  %2 = cc.stdvec_size %0 : (!cc.stdvec<i16>) -> i64
+func.func @__nvqpp__mlirgen__test_1(%arg0 : !cc.struct<{!cc.sequence<i16>, !cc.sequence<f32>}>) {
+  %0 = cc.extract_value %arg0[0] : (!cc.struct<{!cc.sequence<i16>, !cc.sequence<f32>}>) -> !cc.sequence<i16>
+  %1 = cc.sequence_data %0 : (!cc.sequence<i16>) -> !cc.ptr<!cc.array<i16 x ?>>
+  %2 = cc.sequence_size %0 : (!cc.sequence<i16>) -> i64
   %3 = cc.cast %1 : (!cc.ptr<!cc.array<i16 x ?>>) -> !cc.ptr<none>
   call @anchor(%3, %2) : (!cc.ptr<none>, i64) -> ()
-  %4 = cc.extract_value %arg0[1] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<f32>
-  %5 = cc.stdvec_data %4 : (!cc.stdvec<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
-  %6 = cc.stdvec_size %4 : (!cc.stdvec<f32>) -> i64
+  %4 = cc.extract_value %arg0[1] : (!cc.struct<{!cc.sequence<i16>, !cc.sequence<f32>}>) -> !cc.sequence<f32>
+  %5 = cc.sequence_data %4 : (!cc.sequence<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
+  %6 = cc.sequence_size %4 : (!cc.sequence<f32>) -> i64
   %7 = cc.cast %5 : (!cc.ptr<!cc.array<f32 x ?>>) -> !cc.ptr<none>
   call @anchor(%7, %6) : (!cc.ptr<none>, i64) -> ()
   return
@@ -137,9 +137,9 @@ func.func @test_1(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         ret void
 // CHECK:       }
 
-func.func @__nvqpp__mlirgen__test_2(%arg0: !cc.stdvec<!cc.struct<{i32, f64}>>) {
-  %0 = cc.stdvec_data %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-  %1 = cc.stdvec_size %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> i64
+func.func @__nvqpp__mlirgen__test_2(%arg0: !cc.sequence<!cc.struct<{i32, f64}>>) {
+  %0 = cc.sequence_data %arg0 : (!cc.sequence<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+  %1 = cc.sequence_size %arg0 : (!cc.sequence<!cc.struct<{i32, f64}>>) -> i64
   %2 = cc.cast %0 : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<none>
   call @anchor(%2, %1) : (!cc.ptr<none>, i64) -> ()
   return
@@ -185,15 +185,15 @@ func.func @test_2(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 // CHECK:         ret void
 // CHECK:       }
 
-func.func @__nvqpp__mlirgen__test_3(%arg0 : !cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) {
-  %0 = cc.extract_value %arg0[0] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<i16>
-  %1 = cc.stdvec_data %0 : (!cc.stdvec<i16>) -> !cc.ptr<i16>
-  %2 = cc.stdvec_size %0 : (!cc.stdvec<i16>) -> i64
+func.func @__nvqpp__mlirgen__test_3(%arg0 : !cc.struct<{!cc.sequence<i16>, !cc.sequence<f32>}>) {
+  %0 = cc.extract_value %arg0[0] : (!cc.struct<{!cc.sequence<i16>, !cc.sequence<f32>}>) -> !cc.sequence<i16>
+  %1 = cc.sequence_data %0 : (!cc.sequence<i16>) -> !cc.ptr<i16>
+  %2 = cc.sequence_size %0 : (!cc.sequence<i16>) -> i64
   %3 = cc.cast %1 : (!cc.ptr<i16>) -> !cc.ptr<none>
   call @anchor(%3, %2) : (!cc.ptr<none>, i64) -> ()
-  %5 = cc.extract_value %arg0[1] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<f32>
-  %6 = cc.stdvec_data %5 : (!cc.stdvec<f32>) -> !cc.ptr<f32>
-  %7 = cc.stdvec_size %5 : (!cc.stdvec<f32>) -> i64
+  %5 = cc.extract_value %arg0[1] : (!cc.struct<{!cc.sequence<i16>, !cc.sequence<f32>}>) -> !cc.sequence<f32>
+  %6 = cc.sequence_data %5 : (!cc.sequence<f32>) -> !cc.ptr<f32>
+  %7 = cc.sequence_size %5 : (!cc.sequence<f32>) -> i64
   %8 = cc.cast %6 : (!cc.ptr<f32>) -> !cc.ptr<none>
   call @anchor(%8, %7) : (!cc.ptr<none>, i64) -> ()
   return

--- a/cudaq/test/Translate/const_array.qke
+++ b/cudaq/test/Translate/const_array.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-translate --convert-to=qir %s | FileCheck %s
 
-func.func private @g(%0 : !cc.stdvec<i32>)
+func.func private @g(%0 : !cc.sequence<i32>)
 func.func @f() {
   %0 = cc.const_array [0, 1, 0] : !cc.array<i32 x 3>
   %1 = arith.constant 1 : i32
@@ -17,8 +17,8 @@ func.func @f() {
   cc.store %0, %3 : !cc.ptr<!cc.array<i32 x 3>>
   %4 = arith.constant 3 : i64
   %5 = cc.cast %3 : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
-  %6 = cc.stdvec_init %5, %4 : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
-  call @g(%6) : (!cc.stdvec<i32>) -> ()
+  %6 = cc.sequence_init %5, %4 : (!cc.ptr<i32>, i64) -> !cc.sequence<i32>
+  call @g(%6) : (!cc.sequence<i32>) -> ()
   return
 }
 

--- a/cudaq/test/Translate/custom_operation_unresolved.qke
+++ b/cudaq/test/Translate/custom_operation_unresolved.qke
@@ -21,7 +21,7 @@
 // RUN: not cudaq-translate --convert-to=qir %s 2>&1 | FileCheck %s
 
 module {
-  func.func private @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1RKSt6vectorIdSaIdEE(!cc.stdvec<f64>) -> !cc.stdvec<complex<f64>>
+  func.func private @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1RKSt6vectorIdSaIdEE(!cc.sequence<f64>) -> !cc.sequence<complex<f64>>
 
   func.func @__nvqpp__mlirgen__function_kernel._Z6kernelv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
     %0 = quake.alloca !quake.ref

--- a/cudaq/test/Translate/qalloc_initfloat.qke
+++ b/cudaq/test/Translate/qalloc_initfloat.qke
@@ -8,10 +8,10 @@
 
 // RUN: cudaq-translate --convert-to=qir %s | FileCheck %s
 
-func.func @__nvqpp__mlirgen__function_test._Z4testSt6vectorIfSaIfEE(%arg0: !cc.stdvec<f32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-  %0 = cc.stdvec_size %arg0 : (!cc.stdvec<f32>) -> i64
+func.func @__nvqpp__mlirgen__function_test._Z4testSt6vectorIfSaIfEE(%arg0: !cc.sequence<f32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  %0 = cc.sequence_size %arg0 : (!cc.sequence<f32>) -> i64
   %1 = math.cttz %0 : i64
-  %2 = cc.stdvec_data %arg0 : (!cc.stdvec<f32>) -> !cc.ptr<f32>
+  %2 = cc.sequence_data %arg0 : (!cc.sequence<f32>) -> !cc.ptr<f32>
   %3 = quake.alloca !quake.veq<?>[%1 : i64]
   %4 = quake.init_state %3, %2 : (!quake.veq<?>, !cc.ptr<f32>) -> !quake.veq<?>
   return

--- a/cudaq/test/Translate/qalloc_initialization.qke
+++ b/cudaq/test/Translate/qalloc_initialization.qke
@@ -19,12 +19,12 @@ module attributes {
     cc.store %s0, %s1 : !cc.ptr<!cc.array<f64 x 4>>
     %s2 = arith.constant 4 : i64
     %s3 = cc.cast %s1 : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
-    %arg0 = cc.stdvec_init %s3, %s2 : (!cc.ptr<f64>, i64) -> !cc.stdvec<f64>
+    %arg0 = cc.sequence_init %s3, %s2 : (!cc.ptr<f64>, i64) -> !cc.sequence<f64>
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
     %0 = arith.constant 4 : i64
     %1 = math.cttz %0 : i64
-    %2 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !cc.ptr<f64>
+    %2 = cc.sequence_data %arg0 : (!cc.sequence<f64>) -> !cc.ptr<f64>
     %3 = quake.alloca !quake.veq<?>[%1 : i64]
     %4 = quake.init_state %3, %2 : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
     %5 = quake.veq_size %4 : (!quake.veq<?>) -> i64

--- a/cudaq/test/Translate/return_values.qke
+++ b/cudaq/test/Translate/return_values.qke
@@ -23,7 +23,7 @@ module attributes{ quake.mangled_name_map = {
 func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8> , %arg1: i64 , %arg2: i64 ) -> !cc.ptr<i8>
 
 // vector<bool> -> struct ptr sret
-func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.stdvec<i1> {
+func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.sequence<i1> {
   %c1_i64 = arith.constant 1 : i64
   %c1 = arith.constant 1 : i64
   %c0 = arith.constant 0 : i64
@@ -46,13 +46,13 @@ func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.stdvec<i1> {
     %12 = arith.addi %arg1, %c1 : i64
     cc.continue %12 : i64
   } {invariant}
-  %measOut = quake.mz %3 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
-  %7 = quake.discriminate %measOut : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
-  %8 = cc.stdvec_data %7 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-  %9 = cc.stdvec_size %7 : (!cc.stdvec<i1>) -> i64
+  %measOut = quake.mz %3 : (!quake.veq<?>) -> !cc.sequence<!quake.measure>
+  %7 = quake.discriminate %measOut : (!cc.sequence<!quake.measure>) -> !cc.sequence<i1>
+  %8 = cc.sequence_data %7 : (!cc.sequence<i1>) -> !cc.ptr<i8>
+  %9 = cc.sequence_size %7 : (!cc.sequence<i1>) -> i64
   %10 = call @__nvqpp_vectorCopyCtor(%8, %9, %c1_i64) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
-  %11 = cc.stdvec_init %10, %9 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-  return %11 : !cc.stdvec<i1>
+  %11 = cc.sequence_init %10, %9 : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+  return %11 : !cc.sequence<i1>
 }
 
 func.func @test_0(%1: !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>> {llvm.sret = !cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>}, %this: !cc.ptr<i8>, %2: i32) {

--- a/cudaq/unittests/Optimizer/UnitaryOpGroupingTest.cpp
+++ b/cudaq/unittests/Optimizer/UnitaryOpGroupingTest.cpp
@@ -515,7 +515,7 @@ TEST_F(BuilderUnitaryOpGroupingAnalysisTest, VeqSizeBreaksBetweenGroups) {
 //   func.func @veq_measurement_break(%vec: !quake.veq<3>, %q: !quake.ref)
 //   attributes {"cudaq-kernel"} {
 //     quake.h %q : (!quake.ref) -> ()
-//     %m = quake.mz %vec : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+//     %m = quake.mz %vec : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 //     quake.x %q : (!quake.ref) -> ()
 //     return
 //   }
@@ -537,7 +537,7 @@ TEST_F(BuilderUnitaryOpGroupingAnalysisTest,
   Value vec = func.getArgument(0);
   Value q = func.getArgument(1);
   Type measureVecTy =
-      cudaq::cc::StdvecType::get(cudaq::cc::MeasureHandleType::get(&context));
+      cudaq::cc::SequenceType::get(cudaq::cc::MeasureHandleType::get(&context));
   auto *h = cudaq::quake::HOp::create(builder, loc, q).getOperation();
   auto *mz = cudaq::quake::MzOp::create(builder, loc, TypeRange{measureVecTy},
                                         ValueRange{vec}, StringAttr{})

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -364,7 +364,7 @@ def to_bools(handles):
     ``list[bool]``. Device-only: this Python symbol exists so kernel
     code can call ``cudaq.to_bools(...)``; the AST bridge intercepts
     the call and lowers it to a vector form ``quake.discriminate`` on
-    ``!cc.stdvec<!cc.measure_handle>``. Host-side invocation raises a
+    ``!cc.sequence<!cc.measure_handle>``. Host-side invocation raises a
     ``RuntimeError``.
     """
     raise RuntimeError(_KERNEL_ONLY_ERROR_MESSAGE.format("cudaq.to_bools"))

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -555,9 +555,9 @@ class PyASTBridge(ast.NodeVisitor):
     def containsList(self, ty, innerListsOnly=False):
         """Returns true if the give type is a vector or contains items that are
         vectors."""
-        if cc.StdvecType.isinstance(ty):
+        if cc.SequenceType.isinstance(ty):
             return (not innerListsOnly or
-                    self.containsList(cc.StdvecType.getElementType(ty)))
+                    self.containsList(cc.SequenceType.getElementType(ty)))
         if not cc.StructType.isinstance(ty):
             return False
         eleTys = cc.StructType.getTypes(ty)
@@ -698,11 +698,11 @@ class PyASTBridge(ast.NodeVisitor):
                                    F64Type.isinstance(ty)):
             disc = self.__discriminateIfMeasureHandle(operand, self.currentNode)
             return self.changeOperandToType(ty, disc, allowDemotion)
-        if (cc.StdvecType.isinstance(ty) and
-                cc.StdvecType.getElementType(ty) == i1Type and
-                cc.StdvecType.isinstance(operand.type) and
+        if (cc.SequenceType.isinstance(ty) and
+                cc.SequenceType.getElementType(ty) == i1Type and
+                cc.SequenceType.isinstance(operand.type) and
                 cc.MeasureHandleType.isinstance(
-                    cc.StdvecType.getElementType(operand.type))):
+                    cc.SequenceType.getElementType(operand.type))):
             return self.__discriminateIfMeasureHandle(operand, self.currentNode)
         if cc.CallableType.isinstance(ty):
             fctTy = cc.CallableType.getFunctionType(ty)
@@ -735,9 +735,9 @@ class PyASTBridge(ast.NodeVisitor):
                 imag = self.getConstantFloatWithType(0.0, floatType)
                 return complex.CreateOp(complexType, real, imag).result
 
-        if (cc.StdvecType.isinstance(ty)):
-            if cc.StdvecType.isinstance(operand.type):
-                eleTy = cc.StdvecType.getElementType(ty)
+        if (cc.SequenceType.isinstance(ty)):
+            if cc.SequenceType.isinstance(operand.type):
+                eleTy = cc.SequenceType.getElementType(ty)
                 return self.__copyVectorAndConvertElements(
                     operand,
                     eleTy,
@@ -956,9 +956,9 @@ class PyASTBridge(ast.NodeVisitor):
         return sawStore
 
     def __discriminateIfMeasureHandle(self, value, node):
-        """If `value` is a `!cc.measure_handle` (or `stdvec` thereof) at a
+        """If `value` is a `!cc.measure_handle` (or `sequence` thereof) at a
         `bool`-coercion context, insert a `quake.discriminate` and return
-        the `i1`/`stdvec<i1>` result.
+        the `i1`/`sequence<i1>` result.
         """
         if value is None:
             return value
@@ -968,10 +968,10 @@ class PyASTBridge(ast.NodeVisitor):
                 self.emitFatalError(
                     'discriminating an unbound measurement handle', node)
             return quake.DiscriminateOp(self.getIntegerType(1), value).result
-        if cc.StdvecType.isinstance(ty) and cc.MeasureHandleType.isinstance(
-                cc.StdvecType.getElementType(ty)):
+        if cc.SequenceType.isinstance(ty) and cc.MeasureHandleType.isinstance(
+                cc.SequenceType.getElementType(ty)):
             return quake.DiscriminateOp(
-                cc.StdvecType.get(self.getIntegerType(1)), value).result
+                cc.SequenceType.get(self.getIntegerType(1)), value).result
         return value
 
     def __isUnitaryGate(self, id):
@@ -982,7 +982,7 @@ class PyASTBridge(ast.NodeVisitor):
                 id in ['swap', 'u3', 'exp_pauli'] or
                 id in globalRegisteredOperations)
 
-    def __createStdvecWithKnownValues(self, listElementValues):
+    def __createSequenceWithKnownValues(self, listElementValues):
         assert (len(set((v.type for v in listElementValues))) == 1)
         arrSize = self.getConstantInt(len(listElementValues))
         elemTy = listElementValues[0].type
@@ -1004,10 +1004,11 @@ class PyASTBridge(ast.NodeVisitor):
                 v = self.changeOperandToType(self.getIntegerType(8), v)
             cc.StoreOp(v, eleAddr)
 
-        # We still use `i1` as the vector element type for `cc.StdvecInitOp`.
-        vecTy = cc.StdvecType.get(elemTy) if not isBool else cc.StdvecType.get(
-            self.getIntegerType(1))
-        return cc.StdvecInitOp(vecTy, alloca, length=arrSize).result
+        # We still use `i1` as the vector element type for `cc.SequenceInitOp`.
+        vecTy = cc.SequenceType.get(
+            elemTy) if not isBool else cc.SequenceType.get(
+                self.getIntegerType(1))
+        return cc.SequenceInitOp(vecTy, alloca, length=arrSize).result
 
     def __createStructWithKnownValues(self, mlirVals, name=None):
         structTy = mlirTryCreateStructType([item.type for item in mlirVals],
@@ -1107,8 +1108,8 @@ class PyASTBridge(ast.NodeVisitor):
         be used to create a deep copy).
         """
 
-        assert cc.StdvecType.isinstance(source.type)
-        sourceEleType = cc.StdvecType.getElementType(source.type)
+        assert cc.SequenceType.isinstance(source.type)
+        sourceEleType = cc.SequenceType.getElementType(source.type)
         if not targetEleType:
             targetEleType = sourceEleType
         if not alwaysCopy and sourceEleType == targetEleType:
@@ -1121,8 +1122,8 @@ class PyASTBridge(ast.NodeVisitor):
             targetEleType = self.getIntegerType(8)
 
         sourceArrPtrTy = cc.PointerType.get(cc.ArrayType.get(sourceEleType))
-        sourceDataPtr = cc.StdvecDataOp(sourceArrPtrTy, source).result
-        sourceSize = cc.StdvecSizeOp(self.getIntegerType(), source).result
+        sourceDataPtr = cc.SequenceDataOp(sourceArrPtrTy, source).result
+        sourceSize = cc.SequenceSizeOp(self.getIntegerType(), source).result
         targetPtr = cc.AllocaOp(cc.PointerType.get(
             cc.ArrayType.get(targetEleType)),
                                 TypeAttr.get(targetEleType),
@@ -1146,11 +1147,11 @@ class PyASTBridge(ast.NodeVisitor):
 
         self.createInvariantForLoop(bodyBuilder, sourceSize)
 
-        # We still use `i1` as the vector element type for `cc.StdvecInitOp`.
-        vecTy = cc.StdvecType.get(
-            targetEleType) if not isTargetBool else cc.StdvecType.get(
+        # We still use `i1` as the vector element type for `cc.SequenceInitOp`.
+        vecTy = cc.SequenceType.get(
+            targetEleType) if not isTargetBool else cc.SequenceType.get(
                 self.getIntegerType(1))
-        return cc.StdvecInitOp(vecTy, targetPtr, length=sourceSize).result
+        return cc.SequenceInitOp(vecTy, targetPtr, length=sourceSize).result
 
     def __copyAndValidateContainer(self, value, pyVal, deepCopy, dataType=None):
         """Helper function to implement deep and shallow copies for structs and
@@ -1172,7 +1173,7 @@ class PyASTBridge(ast.NodeVisitor):
         if deepCopy:
 
             def conversion(idx, structItem):
-                if cc.StdvecType.isinstance(structItem.type):
+                if cc.SequenceType.isinstance(structItem.type):
                     structItem = self.__copyVectorAndConvertElements(
                         structItem, alwaysCopy=True, conversion=conversion)
                 elif (cc.StructType.isinstance(structItem.type) and
@@ -1187,7 +1188,7 @@ class PyASTBridge(ast.NodeVisitor):
                 self.__validate_container_entry(structItem, pyVal)
                 return structItem
 
-        if cc.StdvecType.isinstance(value.type):
+        if cc.SequenceType.isinstance(value.type):
             listVal = self.__copyVectorAndConvertElements(value,
                                                           dataType,
                                                           alwaysCopy=True,
@@ -1212,12 +1213,12 @@ class PyASTBridge(ast.NodeVisitor):
 
         Does an in-place replacement for list elements.
         """
-        if cc.StdvecType.isinstance(value.type):
-            eleTy = cc.StdvecType.getElementType(value.type)
+        if cc.SequenceType.isinstance(value.type):
+            eleTy = cc.SequenceType.getElementType(value.type)
             if self.containsList(eleTy):
-                size = cc.StdvecSizeOp(self.getIntegerType(), value).result
+                size = cc.SequenceSizeOp(self.getIntegerType(), value).result
                 ptrTy = cc.PointerType.get(cc.ArrayType.get(eleTy))
-                iterable = cc.StdvecDataOp(ptrTy, value).result
+                iterable = cc.SequenceDataOp(ptrTy, value).result
 
                 def bodyBuilder(iterVar):
                     eleAddr = cc.ComputePtrOp(
@@ -1332,8 +1333,8 @@ class PyASTBridge(ast.NodeVisitor):
         Returns:
             MLIR Value containing the loaded element
         """
-        if cc.StdvecType.isinstance(vector.type):
-            elem_ty = cc.StdvecType.getElementType(vector.type)
+        if cc.SequenceType.isinstance(vector.type):
+            elem_ty = cc.SequenceType.getElementType(vector.type)
             is_bool = elem_ty == self.getIntegerType(1)
             # std::vector<bool> is a special case in C++ where each element is
             # stored as a single bit, but the underlying array is actually an
@@ -1341,7 +1342,7 @@ class PyASTBridge(ast.NodeVisitor):
             if is_bool:
                 # `i1` elements are stored as `i8` in the underlying array.
                 elem_ty = self.getIntegerType(8)
-            data_ptr = cc.StdvecDataOp(
+            data_ptr = cc.SequenceDataOp(
                 cc.PointerType.get(cc.ArrayType.get(elem_ty)), vector).result
             load_val = cc.LoadOp(
                 cc.ComputePtrOp(cc.PointerType.get(elem_ty), data_ptr, [index],
@@ -1531,13 +1532,13 @@ class PyASTBridge(ast.NodeVisitor):
                 getItem = lambda idx: quake.GetMemberOp(
                     argTypes[idx], value,
                     IntegerAttr.get(self.getIntegerType(32), idx)).result
-            elif cc.StdvecType.isinstance(value.type):
+            elif cc.SequenceType.isinstance(value.type):
                 # We will get a runtime error for out of bounds access
-                eleTy = cc.StdvecType.getElementType(value.type)
+                eleTy = cc.SequenceType.getElementType(value.type)
                 elePtrTy = cc.PointerType.get(eleTy)
                 arrTy = cc.ArrayType.get(eleTy)
                 ptrArrTy = cc.PointerType.get(arrTy)
-                vecPtr = cc.StdvecDataOp(ptrArrTy, value).result
+                vecPtr = cc.SequenceDataOp(ptrArrTy, value).result
                 attr = DenseI32ArrayAttr.get([kDynamicPtrIndex],
                                              context=self.ctx)
                 nrArgs = len(target.elts)
@@ -1773,7 +1774,7 @@ class PyASTBridge(ast.NodeVisitor):
             self.emitFatalError(
                 "cudaq.contrib.angular_encode: first argument must be a "
                 "cudaq.qvector or qview", node)
-        if not cc.StdvecType.isinstance(angles.type):
+        if not cc.SequenceType.isinstance(angles.type):
             self.emitFatalError(
                 "cudaq.contrib.angular_encode: angles must be a list[float]",
                 node)
@@ -1788,11 +1789,11 @@ class PyASTBridge(ast.NodeVisitor):
                     "match the number of qubits", node)
 
         float_ty = self.getFloatType()
-        angle_ele_ty = cc.StdvecType.getElementType(angles.type)
+        angle_ele_ty = cc.SequenceType.getElementType(angles.type)
         angle_arr_ty = cc.ArrayType.get(angle_ele_ty)
         angle_ptr_ty = cc.PointerType.get(angle_ele_ty)
         angle_arr_ptr_ty = cc.PointerType.get(angle_arr_ty)
-        angles_ptr = cc.StdvecDataOp(angle_arr_ptr_ty, angles).result
+        angles_ptr = cc.SequenceDataOp(angle_arr_ptr_ty, angles).result
         ptr_attr = DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx)
 
         veq_size = quake.VeqSizeOp(self.getIntegerType(), q).result
@@ -1855,7 +1856,7 @@ class PyASTBridge(ast.NodeVisitor):
             # We need to give a proper error if we try to assign a mutable
             # `dataclass` to an item in another container. Allowing this would
             # lead to incorrect behavior (i.e. inconsistent with Python) unless
-            # we change the representation of structs to be like `StdvecType`
+            # we change the representation of structs to be like `SequenceType`
             # where we have a container that is passed by value wrapping the
             # actual pointer, thus ensuring that the reference behavior actually
             # works across function boundaries.
@@ -2140,7 +2141,7 @@ class PyASTBridge(ast.NodeVisitor):
 
         For all assignments, the variable name will be used as a key for the
         symbol table, mapping to the corresponding MLIR Value. Quantum values,
-        measurements results, `cc.callable`, and `cc.stdvec` will be stored as
+        measurements results, `cc.callable`, and `cc.sequence` will be stored as
         values in the symbol table.  For all other values, the variable will be
         allocated with a `cc.alloca` op, and the pointer will be stored in
         the symbol table.
@@ -2160,26 +2161,26 @@ class PyASTBridge(ast.NodeVisitor):
             # function argument items.
             containerFuncArg = (not self.buildingFunctionBody and
                                 (cc.StructType.isinstance(varTy) or
-                                 cc.StdvecType.isinstance(varTy)))
+                                 cc.SequenceType.isinstance(varTy)))
             # FIXME: Consider storing vectors and callables as pointers like
             # other variables.
-            # A local `!cc.stdvec<!cc.measure_handle>` is backed by a stack slot
+            # A local `!cc.sequence<!cc.measure_handle>` is backed by a stack slot
             # (like a scalar `!cc.measure_handle`) so it can be reassigned from a
             # child block. Function-argument handle vectors stay value-backed via
             # `containerFuncArg`; every other vector stays value-backed so
             # reassigning a general list across scopes is still rejected.
             # See https://github.com/NVIDIA/cuda-quantum/issues/4601.
-            # Discriminated measurement results (`i1` / `stdvec<i1>` produced by
+            # Discriminated measurement results (`i1` / `sequence<i1>` produced by
             # `quake.discriminate`) are stored like any other value: the
             # `!cc.measure_handle` type now carries the "is a measurement"
             # distinction, so they no longer need a value-storage carve-out to
             # preserve their discriminate origin.
-            isLocalHandleVec = (cc.StdvecType.isinstance(varTy) and
+            isLocalHandleVec = (cc.SequenceType.isinstance(varTy) and
                                 cc.MeasureHandleType.isinstance(
-                                    cc.StdvecType.getElementType(varTy)))
+                                    cc.SequenceType.getElementType(varTy)))
             storeAsVal = (containerFuncArg or self.isQuantumType(varTy) or
                           cc.CallableType.isinstance(varTy) or
-                          (cc.StdvecType.isinstance(varTy) and
+                          (cc.SequenceType.isinstance(varTy) and
                            not isLocalHandleVec))
             # Nothing should ever produce a pointer to a type we store as value
             # in the symbol table.
@@ -2256,7 +2257,7 @@ class PyASTBridge(ast.NodeVisitor):
                             "only literals can be assigned to variables defined"
                             " in parent scope - use `.copy(deep)` to create a "
                             "new value that can be assigned", node)
-                if cc.StdvecType.isinstance(destination.type):
+                if cc.SequenceType.isinstance(destination.type):
                     # In this case, we are assigning a list to a variable in a
                     #  parent scope.
                     assert isinstance(target, ast.Name)
@@ -2282,7 +2283,7 @@ class PyASTBridge(ast.NodeVisitor):
                 # NOTE: The assignment is subject to the usual restrictions for
                 # container items - these should be validated before calling
                 # update_in_parent_block.
-                if not cc.StdvecType.isinstance(
+                if not cc.SequenceType.isinstance(
                         value.type) and storedAsValue(destination):
                     # We can't properly deal with this, since there is no way to ensure that
                     # the target in the symbol table is updated conditionally on the child
@@ -2331,7 +2332,7 @@ class PyASTBridge(ast.NodeVisitor):
                     # by the caller, if the return value contains any
                     # lists. This is problematic for reasons commented in
                     # `__validate_container_entry`.
-                    if (cc.StdvecType.isinstance(value.type) and
+                    if (cc.SequenceType.isinstance(value.type) and
                             self.signature.return_type and
                             self.containsList(self.signature.return_type)):
                         # We loose this information if we assign an item of a
@@ -2599,7 +2600,7 @@ class PyASTBridge(ast.NodeVisitor):
             return
 
         if (quake.VeqType.isinstance(valType) or
-                cc.StdvecType.isinstance(valType)):
+                cc.SequenceType.isinstance(valType)):
             if self.__isSupportedVectorFunction(node.attr):
                 if self.pushPointerValue:
                     self.emitFatalError(
@@ -2628,9 +2629,9 @@ class PyASTBridge(ast.NodeVisitor):
                 self.pushValue(
                     quake.VeqSizeOp(self.getIntegerType(), value).result)
                 return
-            if cc.StdvecType.isinstance(value.type):
+            if cc.SequenceType.isinstance(value.type):
                 self.pushValue(
-                    cc.StdvecSizeOp(self.getIntegerType(), value).result)
+                    cc.SequenceSizeOp(self.getIntegerType(), value).result)
                 return
 
         self.emitFatalError("unrecognized attribute {}".format(node.attr), node)
@@ -2741,15 +2742,15 @@ class PyASTBridge(ast.NodeVisitor):
         def copy_list_to_stack(value):
             symName = '__nvqpp_vectorCopyToStack'
             load_intrinsic(self.module, symName)
-            elemTy = cc.StdvecType.getElementType(value.type)
+            elemTy = cc.SequenceType.getElementType(value.type)
             if elemTy == self.getIntegerType(1):
                 elemTy = self.getIntegerType(8)
             ptrTy = cc.PointerType.get(self.getIntegerType(8))
             ptrArrTy = cc.PointerType.get(cc.ArrayType.get(elemTy))
-            resBuf = cc.StdvecDataOp(ptrArrTy, value).result
+            resBuf = cc.SequenceDataOp(ptrArrTy, value).result
             eleSize = cc.SizeOfOp(self.getIntegerType(),
                                   TypeAttr.get(elemTy)).result
-            dynSize = cc.StdvecSizeOp(self.getIntegerType(), value).result
+            dynSize = cc.SequenceSizeOp(self.getIntegerType(), value).result
             resBuf = cc.CastOp(cc.PointerType.get(elemTy), resBuf)
             stackCopy = cc.AllocaOp(cc.PointerType.get(
                 cc.ArrayType.get(elemTy)),
@@ -2760,7 +2761,8 @@ class PyASTBridge(ast.NodeVisitor):
                 cc.CastOp(ptrTy, resBuf).result,
                 arith.MulIOp(dynSize, eleSize).result
             ])
-            return cc.StdvecInitOp(value.type, stackCopy, length=dynSize).result
+            return cc.SequenceInitOp(value.type, stackCopy,
+                                     length=dynSize).result
 
         def convertArguments(expectedArgTypes, values):
             assert len(expectedArgTypes) == len(values)
@@ -3105,9 +3107,10 @@ class PyASTBridge(ast.NodeVisitor):
             if node.func.id == 'len':
                 listVal = self.__groupValues(node.args, [1])
 
-                if cc.StdvecType.isinstance(listVal.type):
+                if cc.SequenceType.isinstance(listVal.type):
                     self.pushValue(
-                        cc.StdvecSizeOp(self.getIntegerType(), listVal).result)
+                        cc.SequenceSizeOp(self.getIntegerType(),
+                                          listVal).result)
                     return
                 if quake.VeqType.isinstance(listVal.type):
                     self.pushValue(
@@ -3167,9 +3170,9 @@ class PyASTBridge(ast.NodeVisitor):
                                             endVal=endVal,
                                             isDecrementing=isDecrementing)
 
-                vect = cc.StdvecInitOp(cc.StdvecType.get(iTy),
-                                       iterable,
-                                       length=totalSize).result
+                vect = cc.SequenceInitOp(cc.SequenceType.get(iTy),
+                                         iterable,
+                                         length=totalSize).result
                 self.pushValue(vect)
                 return
 
@@ -3189,16 +3192,16 @@ class PyASTBridge(ast.NodeVisitor):
                                                   iterable,
                                                   -1,
                                                   index=idxVal).result
-                elif cc.StdvecType.isinstance(iterable.type):
-                    iterEleTy = cc.StdvecType.getElementType(iterable.type)
-                    totalSize = cc.StdvecSizeOp(self.getIntegerType(),
-                                                iterable).result
+                elif cc.SequenceType.isinstance(iterable.type):
+                    iterEleTy = cc.SequenceType.getElementType(iterable.type)
+                    totalSize = cc.SequenceSizeOp(self.getIntegerType(),
+                                                  iterable).result
 
                     def extractFunctor(idxVal):
                         arrEleTy = cc.ArrayType.get(iterEleTy)
                         elePtrTy = cc.PointerType.get(iterEleTy)
                         arrPtrTy = cc.PointerType.get(arrEleTy)
-                        vecPtr = cc.StdvecDataOp(arrPtrTy, iterable).result
+                        vecPtr = cc.SequenceDataOp(arrPtrTy, iterable).result
                         eleAddr = cc.ComputePtrOp(
                             elePtrTy, vecPtr, [idxVal],
                             DenseI32ArrayAttr.get([kDynamicPtrIndex],
@@ -3239,9 +3242,9 @@ class PyASTBridge(ast.NodeVisitor):
                     cc.StoreOp(element, eleAddr)
 
                 self.createInvariantForLoop(bodyBuilder, totalSize)
-                vect = cc.StdvecInitOp(cc.StdvecType.get(structTy),
-                                       enumIterable,
-                                       length=totalSize).result
+                vect = cc.SequenceInitOp(cc.SequenceType.get(structTy),
+                                         enumIterable,
+                                         length=totalSize).result
                 self.pushValue(vect)
                 return
 
@@ -3307,14 +3310,14 @@ class PyASTBridge(ast.NodeVisitor):
                     label = registerName or None
                     # `mx`/`my`/`mz` are the single measurement API: they emit
                     # `quake.{mx,my,mz}` producing `!cc.measure_handle` (scalar)
-                    # or `!cc.stdvec<!cc.measure_handle>` (vector form on a
+                    # or `!cc.sequence<!cc.measure_handle>` (vector form on a
                     # `qvector`/`qview`).
                     handleEleTy = cc.MeasureHandleType.get()
                     if len(qubits) == 1 and quake.RefType.isinstance(
                             qubits[0].type):
                         measTy = handleEleTy
                     else:
-                        measTy = cc.StdvecType.get(handleEleTy)
+                        measTy = cc.SequenceType.get(handleEleTy)
                     handle = processQuantumOperation(node.func.id.title(), [],
                                                      qubits,
                                                      measTy,
@@ -3540,7 +3543,7 @@ class PyASTBridge(ast.NodeVisitor):
                 # Just to be nice and give a dedicated error.
                 if (node.func.attr == 'append' and
                     (quake.VeqType.isinstance(funcVal.type) or
-                     cc.StdvecType.isinstance(funcVal.type))):
+                     cc.SequenceType.isinstance(funcVal.type))):
                     self.emitFatalError(
                         "CUDA-Q does not allow dynamic resizing or lists, "
                         "arrays, or qvectors.", node)
@@ -3796,7 +3799,7 @@ class PyASTBridge(ast.NodeVisitor):
                         valueTy = value.type
                         if cc.PointerType.isinstance(value.type):
                             valueTy = cc.PointerType.getElementType(value.type)
-                        if cc.StdvecType.isinstance(valueTy):
+                        if cc.SequenceType.isinstance(valueTy):
                             self.pushValue(value)
                             return
 
@@ -3820,7 +3823,7 @@ class PyASTBridge(ast.NodeVisitor):
                                 self.pushValue(qubits)
                                 return
 
-                            if cc.StdvecType.isinstance(value.type):
+                            if cc.SequenceType.isinstance(value.type):
 
                                 # handle `cudaq.qvector(initState)`
                                 def check_vector_init():
@@ -3856,12 +3859,13 @@ class PyASTBridge(ast.NodeVisitor):
                                                 node)
 
                                 check_vector_init()
-                                eleTy = cc.StdvecType.getElementType(value.type)
+                                eleTy = cc.SequenceType.getElementType(
+                                    value.type)
                                 arrTy = cc.ArrayType.get(eleTy)
                                 ptrArrTy = cc.PointerType.get(arrTy)
-                                data = cc.StdvecDataOp(ptrArrTy, value).result
+                                data = cc.SequenceDataOp(ptrArrTy, value).result
                                 intTy = self.getIntegerType()
-                                size = cc.StdvecSizeOp(intTy, value).result
+                                size = cc.SequenceSizeOp(intTy, value).result
                                 stateTy = cc.PointerType.get(cc.StateType.get())
                                 state = quake.CreateStateOp(
                                     stateTy, data, size).result
@@ -3933,13 +3937,13 @@ class PyASTBridge(ast.NodeVisitor):
                                 node)
                         handle = self.__groupValues(node.args, [1])
                         ty = handle.type
-                        if not (cc.StdvecType.isinstance(ty) and
+                        if not (cc.SequenceType.isinstance(ty) and
                                 cc.MeasureHandleType.isinstance(
-                                    cc.StdvecType.getElementType(ty))):
+                                    cc.SequenceType.getElementType(ty))):
                             self.emitFatalError(
                                 'cudaq.to_bools expects a '
                                 'list[cudaq.measure_handle] argument', node)
-                        resTy = cc.StdvecType.get(self.getIntegerType(1))
+                        resTy = cc.SequenceType.get(self.getIntegerType(1))
                         self.pushValue(
                             quake.DiscriminateOp(resTy, handle).result)
                         return
@@ -4137,9 +4141,9 @@ class PyASTBridge(ast.NodeVisitor):
                     if node.func.attr == 'to_integer':
                         # `cudaq.to_integer` consumes a `list[bool]`
                         boolVec = self.__groupValues(node.args, [1])
-                        if (cc.StdvecType.isinstance(boolVec.type) and
+                        if (cc.SequenceType.isinstance(boolVec.type) and
                                 cc.MeasureHandleType.isinstance(
-                                    cc.StdvecType.getElementType(
+                                    cc.SequenceType.getElementType(
                                         boolVec.type))):
                             self.emitFatalError(
                                 '`cudaq.to_integer` does not accept a '
@@ -4147,7 +4151,7 @@ class PyASTBridge(ast.NodeVisitor):
                                 '`cudaq.to_integer(cudaq.to_bools(handles))`',
                                 node)
                         args = convertArguments(
-                            [cc.StdvecType.get(self.getIntegerType(1))],
+                            [cc.SequenceType.get(self.getIntegerType(1))],
                             [boolVec])
                         cudaqConvertToInteger = "__nvqpp_cudaqConvertToInteger"
                         load_intrinsic(self.module, cudaqConvertToInteger)
@@ -4317,12 +4321,12 @@ class PyASTBridge(ast.NodeVisitor):
         self.visit(node.generators[0].iter)
         iterable = self.popValue()
         orig_iterable_type = iterable.type
-        if cc.StdvecType.isinstance(iterable.type):
-            iterableSize = cc.StdvecSizeOp(self.getIntegerType(),
-                                           iterable).result
-            iterTy = cc.StdvecType.getElementType(iterable.type)
+        if cc.SequenceType.isinstance(iterable.type):
+            iterableSize = cc.SequenceSizeOp(self.getIntegerType(),
+                                             iterable).result
+            iterTy = cc.SequenceType.getElementType(iterable.type)
             iterArrPtrTy = cc.PointerType.get(cc.ArrayType.get(iterTy))
-            iterable = cc.StdvecDataOp(iterArrPtrTy, iterable).result
+            iterable = cc.SequenceDataOp(iterArrPtrTy, iterable).result
         elif quake.VeqType.isinstance(iterable.type):
             iterableSize = quake.VeqSizeOp(self.getIntegerType(),
                                            iterable).result
@@ -4416,8 +4420,8 @@ class PyASTBridge(ast.NodeVisitor):
                 parentType = get_item_type(pyval.value)
                 if cc.PointerType.isinstance(parentType):
                     parentType = cc.PointerType.getElementType(parentType)
-                if cc.StdvecType.isinstance(parentType):
-                    return cc.StdvecType.getElementType(parentType)
+                if cc.SequenceType.isinstance(parentType):
+                    return cc.SequenceType.getElementType(parentType)
                 elif quake.VeqType.isinstance(parentType):
                     return quake.RefType.get()
                 self.emitFatalError(
@@ -4439,7 +4443,7 @@ class PyASTBridge(ast.NodeVisitor):
                             self.emitFatalError(
                                 f"non-homogenous list not allowed - must all be "
                                 f"same type: {elts}", node)
-                return cc.StdvecType.get(base_elTy)
+                return cc.SequenceType.get(base_elTy)
             elif isinstance(pyval, ast.Call):
                 if isinstance(pyval.func, ast.Name):
                     from .kernel_decorator import isa_kernel_decorator
@@ -4565,7 +4569,7 @@ class PyASTBridge(ast.NodeVisitor):
             if quake.VeqType.isinstance(orig_iterable_type) and not hasFilter:
                 self.pushValue(iterable)
                 return
-            if (cc.StdvecType.isinstance(orig_iterable_type) or
+            if (cc.SequenceType.isinstance(orig_iterable_type) or
                     quake.VeqType.isinstance(orig_iterable_type)):
                 i64Ty = self.getIntegerType()
                 veqTy = self.getVeqType()
@@ -4625,7 +4629,7 @@ class PyASTBridge(ast.NodeVisitor):
                 "unsupported list comprehension producing qubit references",
                 node)
 
-        resultVecTy = cc.StdvecType.get(listElemTy)
+        resultVecTy = cc.SequenceType.get(listElemTy)
         if listElemTy == self.getIntegerType(1):
             listElemTy = self.getIntegerType(8)
         listTy = cc.ArrayType.get(listElemTy)
@@ -4665,8 +4669,8 @@ class PyASTBridge(ast.NodeVisitor):
                 self.symbolTable.endBlock()
 
             self.createInvariantForLoop(bodyBuilder, iterableSize)
-            res = cc.StdvecInitOp(resultVecTy, listValue,
-                                  length=iterableSize).result
+            res = cc.SequenceInitOp(resultVecTy, listValue,
+                                    length=iterableSize).result
             self.pushValue(res)
             return
 
@@ -4698,7 +4702,8 @@ class PyASTBridge(ast.NodeVisitor):
                 IntegerAttr.get(i64Ty, 2), args[0], iterableSize).result,
             lambda args: [arith.AddIOp(args[0], c1).result, args[1]])
         finalCount = loop.results[1]
-        res = cc.StdvecInitOp(resultVecTy, listValue, length=finalCount).result
+        res = cc.SequenceInitOp(resultVecTy, listValue,
+                                length=finalCount).result
         self.pushValue(res)
         return
 
@@ -4774,8 +4779,8 @@ class PyASTBridge(ast.NodeVisitor):
                 for v in listElementValues
             ]
 
-        # Turn this List into a StdVec<T>
-        self.pushValue(self.__createStdvecWithKnownValues(listElementValues))
+        # Turn this List into a Sequence<T>
+        self.pushValue(self.__createSequenceWithKnownValues(listElementValues))
 
     def visit_Constant(self, node):
         """Convert constant values in the code to constant values in the
@@ -4821,14 +4826,14 @@ class PyASTBridge(ast.NodeVisitor):
         `q[1:3]`) to corresponding extraction or slice code in the MLIR.
 
         This method
-        handles extraction for `veq` types and `stdvec` types.
+        handles extraction for `veq` types and `sequence` types.
         """
 
         def get_size(val):
             if quake.VeqType.isinstance(val.type):
                 return quake.VeqSizeOp(self.getIntegerType(), val).result
-            elif cc.StdvecType.isinstance(val.type):
-                return cc.StdvecSizeOp(self.getIntegerType(), val).result
+            elif cc.SequenceType.isinstance(val.type):
+                return cc.SequenceSizeOp(self.getIntegerType(), val).result
             return None
 
         def fix_negative_idx(idx, get_size):
@@ -4867,7 +4872,7 @@ class PyASTBridge(ast.NodeVisitor):
                 upperVal = fix_negative_idx(self.popValue(), lambda: vectorSize)
             else:
                 if not quake.VeqType.isinstance(
-                        var.type) and not cc.StdvecType.isinstance(var.type):
+                        var.type) and not cc.SequenceType.isinstance(var.type):
                     self.emitFatalError(
                         f"unhandled upper slice == None, can't handle "
                         f"type {var.type}", node)
@@ -4899,8 +4904,8 @@ class PyASTBridge(ast.NodeVisitor):
                     subv = cc.UndefOp(self.getVeqType())
                     cc.ContinueOp([subv.result])
                 self.pushValue(ifOp.result)
-            elif cc.StdvecType.isinstance(var.type):
-                eleTy = cc.StdvecType.getElementType(var.type)
+            elif cc.SequenceType.isinstance(var.type):
+                eleTy = cc.SequenceType.getElementType(var.type)
                 # Use `i8` for boolean elements
                 if eleTy == self.getIntegerType(1):
                     eleTy = self.getIntegerType(8)
@@ -4910,16 +4915,17 @@ class PyASTBridge(ast.NodeVisitor):
                 nElementsVal = arith.SubIOp(upperVal, lowerVal).result
 
                 # need to compute the distance between `upperVal` and `lowerVal`
-                # then slice is `stdvecdataOp + computeptr[lower] +`
-                # `stdvecinit[ptr,distance]`
+                # then slice is `sequenceDataOp + computeptr[lower] +`
+                # `sequence_init[ptr,distance]`
 
-                vecPtr = cc.StdvecDataOp(ptrArrTy, var).result
+                vecPtr = cc.SequenceDataOp(ptrArrTy, var).result
                 ptr = cc.ComputePtrOp(
                     ptrTy, vecPtr, [lowerVal],
                     DenseI32ArrayAttr.get([kDynamicPtrIndex],
                                           context=self.ctx)).result
                 self.pushValue(
-                    cc.StdvecInitOp(var.type, ptr, length=nElementsVal).result)
+                    cc.SequenceInitOp(var.type, ptr,
+                                      length=nElementsVal).result)
             else:
                 self.emitFatalError(
                     f"unhandled slice operation, cannot handle type {var.type}",
@@ -5007,7 +5013,7 @@ class PyASTBridge(ast.NodeVisitor):
             # We should only ever get a pointer if we explicitly asked for it.
             assert self.pushPointerValue
             varType = cc.PointerType.getElementType(var.type)
-            if cc.StdvecType.isinstance(varType):
+            if cc.SequenceType.isinstance(varType):
                 # We can get a pointer to a vector (only) if we are updating a
                 # struct item that is a pointer.
                 if self.pushPointerValue:
@@ -5040,16 +5046,16 @@ class PyASTBridge(ast.NodeVisitor):
                     self.pushValue(eleAddr)
                     return
 
-        if cc.StdvecType.isinstance(var.type):
+        if cc.SequenceType.isinstance(var.type):
             idx = fix_negative_idx(idx, lambda: get_size(var))
-            eleTy = cc.StdvecType.getElementType(var.type)
+            eleTy = cc.SequenceType.getElementType(var.type)
             isBool = eleTy == self.getIntegerType(1)
             if isBool:
                 eleTy = self.getIntegerType(8)
             elePtrTy = cc.PointerType.get(eleTy)
             arrTy = cc.ArrayType.get(eleTy)
             ptrArrTy = cc.PointerType.get(arrTy)
-            vecPtr = cc.StdvecDataOp(ptrArrTy, var).result
+            vecPtr = cc.SequenceDataOp(ptrArrTy, var).result
             eleAddr = cc.ComputePtrOp(
                 elePtrTy, vecPtr, [idx],
                 DenseI32ArrayAttr.get([kDynamicPtrIndex],
@@ -5126,7 +5132,7 @@ class PyASTBridge(ast.NodeVisitor):
 
         This node represents the typical Python for
         statement, `for VAR in ITERABLE`. Currently supported ITERABLEs are the
-        `veq` type, the `stdvec` type, and the result of range() and
+        `veq` type, the `sequence` type, and the result of range() and
         enumerate().
         """
 
@@ -5167,7 +5173,7 @@ class PyASTBridge(ast.NodeVisitor):
             stepVal = self.getConstantInt(1)
             relevantVals = getValues or (lambda iterVar, v: v)
 
-            # we currently handle `veq` and `stdvec` types
+            # we currently handle `veq` and `sequence` types
             if quake.VeqType.isinstance(iterable.type):
                 size = quake.VeqType.getSize(iterable.type)
                 if quake.VeqType.hasSpecifiedSize(iterable.type):
@@ -5185,18 +5191,19 @@ class PyASTBridge(ast.NodeVisitor):
 
                 getValues = loadElement
 
-            elif cc.StdvecType.isinstance(iterable.type):
-                iterEleTy = cc.StdvecType.getElementType(iterable.type)
+            elif cc.SequenceType.isinstance(iterable.type):
+                iterEleTy = cc.SequenceType.getElementType(iterable.type)
                 isBool = iterEleTy == self.getIntegerType(1)
                 if isBool:
                     iterEleTy = self.getIntegerType(8)
-                endVal = cc.StdvecSizeOp(self.getIntegerType(), iterable).result
+                endVal = cc.SequenceSizeOp(self.getIntegerType(),
+                                           iterable).result
 
                 def loadElement(iterVar):
                     elePtrTy = cc.PointerType.get(iterEleTy)
                     arrTy = cc.ArrayType.get(iterEleTy)
                     ptrArrTy = cc.PointerType.get(arrTy)
-                    vecPtr = cc.StdvecDataOp(ptrArrTy, iterable).result
+                    vecPtr = cc.SequenceDataOp(ptrArrTy, iterable).result
                     eleAddr = cc.ComputePtrOp(
                         elePtrTy, vecPtr, [iterVar],
                         DenseI32ArrayAttr.get([kDynamicPtrIndex],
@@ -5437,10 +5444,10 @@ class PyASTBridge(ast.NodeVisitor):
         if isinstance(op, (ast.In, ast.NotIn)):
 
             # Type validation and vector initialization
-            if not cc.StdvecType.isinstance(right.type):
+            if not cc.SequenceType.isinstance(right.type):
                 self.emitFatalError(
                     "Right operand must be a list/vector for 'in' comparison")
-            vectSize = cc.StdvecSizeOp(self.getIntegerType(), right).result
+            vectSize = cc.SequenceSizeOp(self.getIntegerType(), right).result
 
             # Loop setup
             i1_type = self.getIntegerType(1)
@@ -5593,20 +5600,21 @@ class PyASTBridge(ast.NodeVisitor):
         def copy_list_to_heap(value):
             symName = '__nvqpp_vectorCopyCtor'
             load_intrinsic(self.module, symName)
-            elemTy = cc.StdvecType.getElementType(value.type)
+            elemTy = cc.SequenceType.getElementType(value.type)
             if elemTy == self.getIntegerType(1):
                 elemTy = self.getIntegerType(8)
             ptrTy = cc.PointerType.get(self.getIntegerType(8))
             arrTy = cc.ArrayType.get(self.getIntegerType(8))
             ptrArrTy = cc.PointerType.get(arrTy)
-            resBuf = cc.StdvecDataOp(ptrArrTy, value).result
+            resBuf = cc.SequenceDataOp(ptrArrTy, value).result
             eleSize = cc.SizeOfOp(self.getIntegerType(),
                                   TypeAttr.get(elemTy)).result
-            dynSize = cc.StdvecSizeOp(self.getIntegerType(), value).result
+            dynSize = cc.SequenceSizeOp(self.getIntegerType(), value).result
             resBuf = cc.CastOp(ptrTy, resBuf)
             heapCopy = func.CallOp([ptrTy], symName,
                                    [resBuf, dynSize, eleSize]).result
-            return cc.StdvecInitOp(value.type, heapCopy, length=dynSize).result
+            return cc.SequenceInitOp(value.type, heapCopy,
+                                     length=dynSize).result
 
         rootVal = self.__get_root_value(node.value)
         if rootVal and self.isFunctionArgument(rootVal):

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -169,8 +169,8 @@ def __singleTargetSingleParameterControlOperation(self,
 
 
 def supportCommonCast(mlirType, otherTy, arg, FromType, ToType, PyType):
-    argEleTy = cc.StdvecType.getElementType(mlirType)
-    eleTy = cc.StdvecType.getElementType(otherTy)
+    argEleTy = cc.SequenceType.getElementType(mlirType)
+    eleTy = cc.SequenceType.getElementType(otherTy)
     if ToType.isinstance(eleTy) and FromType.isinstance(argEleTy):
         return [PyType(i) for i in arg]
     return None
@@ -431,8 +431,8 @@ class PyKernel(object):
             return slot
         return value
 
-    def __createStdvecWithKnownValues(self, listElementValues):
-        # Turn this List into a StdVec<T>
+    def __createSequenceWithKnownValues(self, listElementValues):
+        # Turn this List into a Sequence<T>
         arrSize = self.getConstantInt(len(listElementValues))
         elemTy = listElementValues[0].type if len(
             listElementValues) > 0 else self.getFloatType()
@@ -452,8 +452,9 @@ class PyKernel(object):
         if cc.PointerType.isinstance(vecTy):
             vecTy = cc.PointerType.getElementType(vecTy)
 
-        return cc.StdvecInitOp(cc.StdvecType.get(vecTy), alloca,
-                               length=arrSize).result
+        return cc.SequenceInitOp(cc.SequenceType.get(vecTy),
+                                 alloca,
+                                 length=arrSize).result
 
     def promoteOperandType(self, ty, operand):
         if ComplexType.isinstance(ty):
@@ -514,9 +515,9 @@ class PyKernel(object):
                                            self.getConstantFloat(
                                                arg.imag)).result
 
-        if cc.StdvecType.isinstance(mlirType):
+        if cc.SequenceType.isinstance(mlirType):
             size = self.getConstantInt(len(arg))
-            eleTy = cc.StdvecType.getElementType(mlirType)
+            eleTy = cc.SequenceType.getElementType(mlirType)
             arrTy = cc.ArrayType.get(eleTy, context=self.ctx)
             alloca = cc.AllocaOp(cc.PointerType.get(arrTy, self.ctx),
                                  TypeAttr.get(eleTy),
@@ -533,7 +534,7 @@ class PyKernel(object):
                     elementVal = self.getConstantInt(element)
                 elif F64Type.isinstance(eleTy):
                     elementVal = self.getConstantFloat(element)
-                elif cc.StdvecType.isinstance(eleTy):
+                elif cc.SequenceType.isinstance(eleTy):
                     elementVal = self.__getMLIRValueFromPythonArg(
                         element, eleTy)
                 else:
@@ -547,9 +548,9 @@ class PyKernel(object):
 
             body.counter = 0
             self.createInvariantForLoop(size, body)
-            return cc.StdvecInitOp(cc.StdvecType.get(eleTy, self.ctx),
-                                   alloca,
-                                   length=size).result
+            return cc.SequenceInitOp(cc.SequenceType.get(eleTy, self.ctx),
+                                     alloca,
+                                     length=size).result
 
         emitFatalError(
             f"CUDA-Q kernel builder could not translate runtime argument of "
@@ -868,7 +869,7 @@ class PyKernel(object):
                 return self.__createQuakeValue(init)
 
             # If the initializer is a QuakeValue, see if it is
-            # an integer or a `stdvec` type
+            # an integer or a `sequence` type
             if isinstance(initializer, QuakeValue):
                 veqTy = quake.VeqType.get()
                 if IntegerType.isinstance(initializer.mlirValue.type):
@@ -877,13 +878,13 @@ class PyKernel(object):
                         quake.AllocaOp(veqTy,
                                        size=initializer.mlirValue).result)
 
-                if cc.StdvecType.isinstance(initializer.mlirValue.type):
+                if cc.SequenceType.isinstance(initializer.mlirValue.type):
                     value = initializer.mlirValue
-                    eleTy = cc.StdvecType.getElementType(value.type)
+                    eleTy = cc.SequenceType.getElementType(value.type)
                     ptrTy = cc.PointerType.get(eleTy)
-                    data = cc.StdvecDataOp(ptrTy, value).result
+                    data = cc.SequenceDataOp(ptrTy, value).result
                     intTy = self.getIntegerType()
-                    size = cc.StdvecSizeOp(intTy, value).result
+                    size = cc.SequenceSizeOp(intTy, value).result
                     stateTy = cc.PointerType.get(cc.StateType.get())
                     state = quake.CreateStateOp(stateTy, data, size).result
                     numQubits = quake.GetNumberOfQubitsOp(intTy, state).result
@@ -1132,7 +1133,7 @@ class PyKernel(object):
         with self.ctx, self.insertPoint, self.loc:
             measTy = cc.MeasureHandleType.get()
             if quake.VeqType.isinstance(target.mlirValue.type):
-                measTy = cc.StdvecType.get(measTy)
+                measTy = cc.SequenceType.get(measTy)
             if regName is not None:
                 res = opClass(measTy, [], [target.mlirValue],
                               registerName=StringAttr.get(regName,
@@ -1242,7 +1243,7 @@ class PyKernel(object):
     def __qecOperandValue(self, qv, opName):
         """Normalize a builder-side QEC operand: must be a
         ``QuakeValue`` whose MLIR type is ``!cc.measure_handle`` or
-        ``!cc.stdvec<!cc.measure_handle>`` (the value forms produced by
+        ``!cc.sequence<!cc.measure_handle>`` (the value forms produced by
         ``mz`` / ``mx`` / ``my`` for scalar and ``qvector`` targets)."""
         if not isinstance(qv, QuakeValue):
             emitFatalError(
@@ -1250,8 +1251,9 @@ class PyKernel(object):
                 f"measurement handles (returned by kernel.mz / mx / my)")
         ty = qv.mlirValue.type
         ok = (cc.MeasureHandleType.isinstance(ty) or
-              (cc.StdvecType.isinstance(ty) and cc.MeasureHandleType.isinstance(
-                  cc.StdvecType.getElementType(ty))))
+              (cc.SequenceType.isinstance(ty) and
+               cc.MeasureHandleType.isinstance(
+                   cc.SequenceType.getElementType(ty))))
         if not ok:
             emitFatalError(
                 f"kernel.{opName} arguments must each be a "
@@ -1316,7 +1318,7 @@ class PyKernel(object):
             prevV = self.__qecOperandValue(prev, "detectors")
             currV = self.__qecOperandValue(curr, "detectors")
             for v in (prevV, currV):
-                if not cc.StdvecType.isinstance(v.type):
+                if not cc.SequenceType.isinstance(v.type):
                     emitFatalError("kernel.detectors arguments must each be a "
                                    "list[cudaq.measure_handle]")
             qec.DetectorsOp(prevV, currV)
@@ -1701,7 +1703,7 @@ class PyKernel(object):
                             emitFatalError("Invalid qubit operand type")
                         target_qubits.append(p.mlirValue)
 
-            params = self.__createStdvecWithKnownValues(noise_channel_params)
+            params = self.__createSequenceWithKnownValues(noise_channel_params)
             asVeq = quake.ConcatOp(quake.VeqType.get(), target_qubits).result
             channel_key = hash(noise_channel)
             quake.ApplyNoiseOp([params], [asVeq],
@@ -1813,9 +1815,9 @@ class PyKernel(object):
                 listType = list[type(arg[0])]
             mlirType = mlirTypeFromPyType(argType, self.ctx)
 
-            if cc.StdvecType.isinstance(mlirType):
+            if cc.SequenceType.isinstance(mlirType):
                 # Support passing `list[int]` to a `list[float]` argument
-                if cc.StdvecType.isinstance(self.mlirArgTypes[i]):
+                if cc.SequenceType.isinstance(self.mlirArgTypes[i]):
                     maybeCasted = supportCommonCast(mlirType,
                                                     self.mlirArgTypes[i], arg,
                                                     IntegerType, F64Type, float)
@@ -1840,7 +1842,7 @@ class PyKernel(object):
                     f" {mlirTypeToPyType(self.mlirArgTypes[i])} required)")
 
             # Convert `numpy` arrays to lists
-            if cc.StdvecType.isinstance(mlirType):
+            if cc.SequenceType.isinstance(mlirType):
                 # Validate that the length of this argument is greater than or
                 # equal to the number of unique quake value extractions
                 if len(arg) < len(self.arguments[i].knownUniqueExtractions):

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -409,10 +409,10 @@ class PyKernelDecorator(object):
 
         # Support passing `list[int]` to a `list[float]` argument and
         # passing `list[int]` or `list[float]` to a `list[complex]` argument.
-        if cc.StdvecType.isinstance(fromTy):
-            if cc.StdvecType.isinstance(toTy):
-                fromEleTy = cc.StdvecType.getElementType(fromTy)
-                toEleTy = cc.StdvecType.getElementType(toTy)
+        if cc.SequenceType.isinstance(fromTy):
+            if cc.SequenceType.isinstance(toTy):
+                fromEleTy = cc.SequenceType.getElementType(fromTy)
+                toEleTy = cc.SequenceType.getElementType(toTy)
 
                 return self.isCastablePyType(fromEleTy, toEleTy)
 
@@ -449,10 +449,10 @@ class PyKernelDecorator(object):
 
             # Support passing `list[int]` to a `list[float]` argument and
             # passing `list[int]` or `list[float]` to a `list[complex]` argument
-            if cc.StdvecType.isinstance(fromTy):
-                if cc.StdvecType.isinstance(toTy):
-                    fromEleTy = cc.StdvecType.getElementType(fromTy)
-                    toEleTy = cc.StdvecType.getElementType(toTy)
+            if cc.SequenceType.isinstance(fromTy):
+                if cc.SequenceType.isinstance(toTy):
+                    fromEleTy = cc.SequenceType.getElementType(fromTy)
+                    toEleTy = cc.SequenceType.getElementType(toTy)
 
                     if self.isCastablePyType(fromEleTy, toEleTy):
                         return [
@@ -718,8 +718,8 @@ class PyKernelDecorator(object):
 
         # Validate size limit for list[complex] arguments used for `qvector`
         # state initialization.
-        if cc.StdvecType.isinstance(arg_type):
-            eleTy = cc.StdvecType.getElementType(arg_type)
+        if cc.SequenceType.isinstance(arg_type):
+            eleTy = cc.SequenceType.getElementType(arg_type)
             if ComplexType.isinstance(eleTy) and hasattr(
                     arg, '__len__') and len(arg) > 2**10:
                 num_qubits = int(np.log2(len(arg)))
@@ -736,7 +736,7 @@ class PyKernelDecorator(object):
                            f"{mlirTypeToPyType(arg_type)} was expected.")
 
         # Convert `numpy` arrays to lists
-        if cc.StdvecType.isinstance(mlirType) and hasattr(arg, "tolist"):
+        if cc.SequenceType.isinstance(mlirType) and hasattr(arg, "tolist"):
             if arg.ndim != 1:
                 emitFatalError(
                     f"CUDA-Q kernels only support array arguments from NumPy "

--- a/python/cudaq/kernel/quake_value.py
+++ b/python/cudaq/kernel/quake_value.py
@@ -40,21 +40,21 @@ class QuakeValue(object):
 
     def size(self):
         """
-        Return the size of `self` (:class:`QuakeValue`), if it is of the type `stdvec` or `veq`.
+        Return the size of `self` (:class:`QuakeValue`), if it is of the type `sequence` or `veq`.
 
         Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not `stdvec` or `veq`.
+	        RuntimeError: if the underlying :class:`QuakeValue` type is not `sequence` or `veq`.
 
         """
         with self.ctx, Location.unknown(), self.pyKernel.insertPoint:
-            # assert this is a `stdvec` type or a `veq` type
+            # assert this is a `sequence` type or a `veq` type
             # See if we know the size of the `veq`
-            # return `stdvecsizeop` or `veqsizeop`
+            # return `sequence_size` op or `veqsizeop`
             type = self.mlirValue.type
             if not quake.VeqType.isinstance(
-                    type) and not cc.StdvecType.isinstance(type):
+                    type) and not cc.SequenceType.isinstance(type):
                 raise RuntimeError(
-                    "QuakeValue.size only valid for veq and stdvec types.")
+                    "QuakeValue.size only valid for veq and sequence types.")
 
             if quake.VeqType.isinstance(type):
                 size = quake.VeqType.getSize(type)
@@ -64,9 +64,9 @@ class QuakeValue(object):
                     quake.VeqSizeOp(self.intType, self.mlirValue).result,
                     self.pyKernel)
 
-            # Must be a `stdvec` type
+            # Must be a `sequence` type
             return QuakeValue(
-                cc.StdvecSizeOp(self.intType, self.mlirValue).result,
+                cc.SequenceSizeOp(self.intType, self.mlirValue).result,
                 self.pyKernel)
 
     def __intToFloat(self, intVal):
@@ -328,11 +328,11 @@ class QuakeValue(object):
 	        RuntimeError: if `self` is a non-subscriptable :class:`QuakeValue`.
         """
         with self.ctx, Location.unknown(), self.pyKernel.insertPoint:
-            if cc.StdvecType.isinstance(self.mlirValue.type):
-                eleTy = cc.StdvecType.getElementType(self.mlirValue.type)
+            if cc.SequenceType.isinstance(self.mlirValue.type):
+                eleTy = cc.SequenceType.getElementType(self.mlirValue.type)
                 arrTy = cc.ArrayType.get(eleTy)
                 arrPtrTy = cc.PointerType.get(arrTy)
-                vecPtr = cc.StdvecDataOp(arrPtrTy, self.mlirValue).result
+                vecPtr = cc.SequenceDataOp(arrPtrTy, self.mlirValue).result
                 elePtrTy = cc.PointerType.get(eleTy)
                 eleAddr = None
                 i64Ty = IntegerType.get_signless(64)

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -62,8 +62,8 @@ def containsMeasureHandle(ty, _seen=None):
         return containsMeasureHandle(cc.PointerType.getElementType(ty), _seen)
     if cc.ArrayType.isinstance(ty):
         return containsMeasureHandle(cc.ArrayType.getElementType(ty), _seen)
-    if cc.StdvecType.isinstance(ty):
-        return containsMeasureHandle(cc.StdvecType.getElementType(ty), _seen)
+    if cc.SequenceType.isinstance(ty):
+        return containsMeasureHandle(cc.SequenceType.getElementType(ty), _seen)
     if cc.StructType.isinstance(ty):
         return any(
             containsMeasureHandle(t, _seen) for t in cc.StructType.getTypes(ty))
@@ -460,7 +460,7 @@ def mlirTypeFromAnnotation(annotation,
 
             if annotation.value.id in ['numpy', 'np']:
                 if annotation.attr in ['array', 'ndarray']:
-                    return cc.StdvecType.get(F64Type.get())
+                    return cc.SequenceType.get(F64Type.get())
                 if annotation.attr == 'complex128':
                     return ComplexType.get(F64Type.get())
                 if annotation.attr == 'complex64':
@@ -527,7 +527,7 @@ def mlirTypeFromAnnotation(annotation,
                                                ctx,
                                                raiseError=raiseError,
                                                cudaqAliases=cudaqAliases)
-            return cc.StdvecType.get(listEleTy)
+            return cc.SequenceType.get(listEleTy)
 
         if isinstance(annotation,
                       ast.Subscript) and (annotation.value.id == 'tuple' or
@@ -697,15 +697,15 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
         pyEleTy = get_args(argType)
         if len(pyEleTy) == 1:
             eleTy = mlirTypeFromPyType(pyEleTy[0], ctx)
-            return cc.StdvecType.get(eleTy, ctx)
+            return cc.SequenceType.get(eleTy, ctx)
         argType = list
 
     if argType in [list, np.ndarray, List]:
         if 'argInstance' not in kwargs:
-            return cc.StdvecType.get(mlirTypeFromPyType(float, ctx), ctx)
+            return cc.SequenceType.get(mlirTypeFromPyType(float, ctx), ctx)
         if argType != np.ndarray:
             if kwargs['argInstance'] == None:
-                return cc.StdvecType.get(mlirTypeFromPyType(float, ctx), ctx)
+                return cc.SequenceType.get(mlirTypeFromPyType(float, ctx), ctx)
 
         argInstance = kwargs['argInstance']
         argTypeToCompareTo = kwargs[
@@ -715,30 +715,30 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
             if isinstance(argInstance, np.ndarray):
                 eleTy = mlirTypeFromPyType(argInstance.dtype.type, ctx)
                 for _ in range(argInstance.ndim - 1):
-                    eleTy = cc.StdvecType.get(eleTy, ctx)
-                return cc.StdvecType.get(eleTy, ctx)
+                    eleTy = cc.SequenceType.get(eleTy, ctx)
+                return cc.SequenceType.get(eleTy, ctx)
 
             if argTypeToCompareTo == None:
                 emitFatalError('Cannot infer runtime argument type')
 
-            eleTy = cc.StdvecType.getElementType(argTypeToCompareTo)
-            return cc.StdvecType.get(eleTy, ctx)
+            eleTy = cc.SequenceType.getElementType(argTypeToCompareTo)
+            return cc.SequenceType.get(eleTy, ctx)
 
         if isinstance(argInstance[0], list):
-            return cc.StdvecType.get(
+            return cc.SequenceType.get(
                 mlirTypeFromPyType(
                     type(argInstance[0]),
                     ctx,
                     argInstance=argInstance[0],
                     argTypeToCompareTo=(
-                        cc.StdvecType.getElementType(argTypeToCompareTo)
+                        cc.SequenceType.getElementType(argTypeToCompareTo)
                         if argTypeToCompareTo is not None else None)), ctx)
 
         if isinstance(argInstance[0], str):
-            return cc.StdvecType.get(cc.CharspanType.get(ctx), ctx)
+            return cc.SequenceType.get(cc.CharspanType.get(ctx), ctx)
 
-        return cc.StdvecType.get(mlirTypeFromPyType(type(argInstance[0]), ctx),
-                                 ctx)
+        return cc.SequenceType.get(
+            mlirTypeFromPyType(type(argInstance[0]), ctx), ctx)
 
     if get_origin(argType) == tuple:
         eleTypes = []
@@ -809,9 +809,9 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
 
     if 'argInstance' not in kwargs:
         if argType == list[int]:
-            return cc.StdvecType.get(mlirTypeFromPyType(int, ctx), ctx)
+            return cc.SequenceType.get(mlirTypeFromPyType(int, ctx), ctx)
         if argType == list[float]:
-            return cc.StdvecType.get(mlirTypeFromPyType(float, ctx), ctx)
+            return cc.SequenceType.get(mlirTypeFromPyType(float, ctx), ctx)
 
     emitFatalError(
         f"Cannot handle conversion of python type {argType} to MLIR type.")
@@ -858,8 +858,8 @@ def mlirTypeToPyType(argType):
     if cc.MeasureHandleType.isinstance(argType):
         return measure_handle
 
-    if cc.StdvecType.isinstance(argType):
-        eleTy = cc.StdvecType.getElementType(argType)
+    if cc.SequenceType.isinstance(argType):
+        eleTy = cc.SequenceType.getElementType(argType)
         if cc.CharspanType.isinstance(eleTy):
             return list[pauli_word]
 

--- a/python/cudaq/runtime/utils.py
+++ b/python/cudaq/runtime/utils.py
@@ -62,14 +62,14 @@ def __isBroadcast(kernel, *args):
                     )
 
         firstArg = args[0]
-        firstArgTypeIsFlatStdvec = cc.StdvecType.isinstance(argTypes[0])
+        firstArgTypeIsFlatSequence = cc.SequenceType.isinstance(argTypes[0])
         if (isinstance(firstArg, list) or
-                isinstance(firstArg, List)) and not firstArgTypeIsFlatStdvec:
+                isinstance(firstArg, List)) and not firstArgTypeIsFlatSequence:
             return True
 
         if hasattr(firstArg, "shape"):
             shape = firstArg.shape
-            if len(shape) == 1 and not firstArgTypeIsFlatStdvec:
+            if len(shape) == 1 and not firstArgTypeIsFlatSequence:
                 return True
 
             if len(shape) == 2:
@@ -97,14 +97,14 @@ def __isBroadcast(kernel, *args):
                     )
 
         firstArg = args[0]
-        firstArgTypeIsFlatStdvec = cc.StdvecType.isinstance(argTypes[0])
+        firstArgTypeIsFlatSequence = cc.SequenceType.isinstance(argTypes[0])
         if (isinstance(firstArg, list) or
-                isinstance(firstArg, List)) and not firstArgTypeIsFlatStdvec:
+                isinstance(firstArg, List)) and not firstArgTypeIsFlatSequence:
             return True
 
         if hasattr(firstArg, "shape"):
             shape = firstArg.shape
-            if len(shape) == 1 and not firstArgTypeIsFlatStdvec:
+            if len(shape) == 1 and not firstArgTypeIsFlatSequence:
                 return True
 
             if len(shape) == 2:

--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -84,9 +84,9 @@ static detail::RunResultSpan pyRunTheKernel(
   auto returnTy = recoverReturnType(mod, name);
   // Disallow returning nested vectors/vectors of structs from entry-point
   // kernels.
-  if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(returnTy)) {
+  if (auto vecTy = dyn_cast<cudaq::cc::SequenceType>(returnTy)) {
     auto elemTy = vecTy.getElementType();
-    if (mlir::isa<cudaq::cc::StdvecType>(elemTy))
+    if (mlir::isa<cudaq::cc::SequenceType>(elemTy))
       throw std::runtime_error(
           "`cudaq.run` does not yet support returning nested `list` from "
           "entry-point kernels.");

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -204,11 +204,11 @@ void cudaq::handleStructMemberVariable(void *data, std::size_t offset,
       .Case([&](mlir::Float64Type ty) {
         appendValue(data, nanobind::cast<double>(value), offset);
       })
-      .Case([&](cudaq::cc::StdvecType ty) {
+      .Case([&](cudaq::cc::SequenceType ty) {
         // Nested vectors aren't supported in the synthesis (argument
         // substitution) path.
         if constexpr (style == cudaq::PackingStyle::synthesis)
-          if (isa<cudaq::cc::StdvecType>(ty.getElementType()))
+          if (isa<cudaq::cc::SequenceType>(ty.getElementType()))
             throw std::runtime_error(
                 "Type not supported for custom struct in kernel.");
 
@@ -315,7 +315,7 @@ void *cudaq::handleVectorElements(mlir::Type eleTy, nanobind::list list) {
               return nanobind::cast<std::complex<float>>(v);
             });
       })
-      .Case([&](cudaq::cc::StdvecType ty) {
+      .Case([&](cudaq::cc::SequenceType ty) {
         auto appendVectorValue = []<typename T>(mlir::Type eleTy,
                                                 nanobind::list list) -> void * {
           auto *values = new std::vector<std::vector<T>>();
@@ -378,7 +378,7 @@ static void deleteVectorElements(mlir::Type eleTy, void *ptr) {
         else
           deleteAs.template operator()<std::complex<float>>();
       })
-      .Case([&](cudaq::cc::StdvecType ty) {
+      .Case([&](cudaq::cc::SequenceType ty) {
         // Nested vectors: `handleVectorElements` collapses the inner element
         // type to `std::size_t` (or `BoolVecElem` for bools), so mirror that
         // here to match the actual allocation.
@@ -521,7 +521,7 @@ void cudaq::packArgs(
           }
           argData.emplace_back(allocatedArg, [](void *ptr) { std::free(ptr); });
         })
-        .Case([&](cc::StdvecType ty) {
+        .Case([&](cc::SequenceType ty) {
           checkArgumentType<nanobind::list>(arg, i);
           auto list = nanobind::cast<nanobind::list>(arg);
           auto eleTy = ty.getElementType();
@@ -902,13 +902,13 @@ nanobind::object cudaq::convertResult(ModuleOp module, Type ty, char *data) {
       .Case([&](Float32Type ty) -> nanobind::object {
         return readPyObject<float>(ty, data);
       })
-      .Case([&](cudaq::cc::StdvecType ty) -> nanobind::object {
+      .Case([&](cudaq::cc::SequenceType ty) -> nanobind::object {
         auto eleTy = ty.getElementType();
-        // Nested StdvecType elements have a different in-memory size than
+        // Nested SequenceType elements have a different in-memory size than
         // scalar types: span ({ptr,size_t} = 16 bytes) in direct-call context,
         // std::vector ({ptr,ptr,ptr} = 24 bytes) in run context.
         auto getEleByteSize = [&](Type eTy) -> std::size_t {
-          if (isa<cudaq::cc::StdvecType>(eTy))
+          if (isa<cudaq::cc::SequenceType>(eTy))
             return isRunContext ? 3 * sizeof(void *)
                                 : sizeof(char *) + sizeof(std::size_t);
           return byteSize(eTy);

--- a/python/runtime/mlir/py_register_dialects.cpp
+++ b/python/runtime/mlir/py_register_dialects.cpp
@@ -357,26 +357,26 @@ static void registerCCDialectAndTypes(nanobind::module_ &m) {
             return wrap(callTy.getSignature());
           });
 
-  mlir_type_subclass(ccMod, "StdvecType",
+  mlir_type_subclass(ccMod, "SequenceType",
                      [](MlirType type) {
-                       return mlir::isa<cudaq::cc::StdvecType>(unwrap(type));
+                       return mlir::isa<cudaq::cc::SequenceType>(unwrap(type));
                      })
       .def_classmethod(
           "getElementType",
           [](nanobind::object cls, MlirType type) {
             auto ty = unwrap(type);
-            auto casted = dyn_cast<cudaq::cc::StdvecType>(ty);
+            auto casted = dyn_cast<cudaq::cc::SequenceType>(ty);
             if (!casted)
               throw std::runtime_error(
-                  "invalid type passed to StdvecType.getElementType(), must "
+                  "invalid type passed to SequenceType.getElementType(), must "
                   "be cc.array type.");
             return wrap(casted.getElementType());
           })
       .def_classmethod(
           "get",
           [](nanobind::object cls, MlirType elementType, MlirContext context) {
-            return wrap(cudaq::cc::StdvecType::get(unwrap(context),
-                                                   unwrap(elementType)));
+            return wrap(cudaq::cc::SequenceType::get(unwrap(context),
+                                                     unwrap(elementType)));
           },
           nanobind::arg("cls"), nanobind::arg("elementType"),
           nanobind::arg("context") = nanobind::none());

--- a/python/tests/kernel/test_assignments.py
+++ b/python/tests/kernel/test_assignments.py
@@ -1214,7 +1214,7 @@ def test_var_scopes():
 
         test4(True)
 
-    assert "variable of type !cc.stdvec<i64> is defined in a prior block and cannot be accessed" in str(
+    assert "variable of type !cc.sequence<i64> is defined in a prior block and cannot be accessed" in str(
         e.value)
     assert "(offending source -> ls)" in str(e.value)
 

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -1927,7 +1927,7 @@ def test_bad_attr_call_error():
     assert "offending source -> kernel.h(q[0])" in repr(e)
 
 
-def test_bad_return_value_with_stdvec_arg():
+def test_bad_return_value_with_sequence_arg():
 
     @cudaq.kernel
     def test_param(i: int, l: List[int]) -> int:
@@ -2020,7 +2020,7 @@ def test_measure_variadic_qubits():
     assert len(counts) == 1 and '101' in counts
 
 
-def test_bad_return_value_with_stdvec_arg():
+def test_bad_return_value_with_sequence_arg():
 
     @cudaq.kernel
     def test_param(i: int, l: List[int]) -> int:
@@ -2872,7 +2872,7 @@ def test_struct_list_int_member():
     """Test that list[int] members in a struct are correctly marshaled.
 
     Regression test for a bug in handleStructMemberVariable where
-    the StdvecType branch always created std::vector<double> regardless
+    the SequenceType branch always created std::vector<double> regardless
     of the actual element type T. This caused list[int] values to be
     stored as doubles; the kernel then read the IEEE 754 bit pattern
     as int64, producing garbage values.

--- a/python/tests/kernel/test_measure_handle.py
+++ b/python/tests/kernel/test_measure_handle.py
@@ -46,7 +46,7 @@ def test_host_to_bools_raises_runtime_error():
 
 
 # ---------------------------------------------------------------------------
-# `cudaq.to_integer` rejects a raw `!cc.stdvec<!cc.measure_handle>`
+# `cudaq.to_integer` rejects a raw `!cc.sequence<!cc.measure_handle>`
 # without an intervening `cudaq.to_bools`.
 # ---------------------------------------------------------------------------
 

--- a/python/tests/mlir/adjoint.py
+++ b/python/tests/mlir/adjoint.py
@@ -192,15 +192,15 @@ def test_kernel_adjoint_list_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"
-# CHECK:           quake.apply<adj> @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}} %[[VAL_0]] : (!cc.stdvec<f64>) -> ()
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint"
+# CHECK:           quake.apply<adj> @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}} %[[VAL_0]] : (!cc.sequence<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) {{.*}}{
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) {{.*}}{
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_2:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
@@ -302,7 +302,7 @@ def test_sample_adjoint_qreg():
 # CHECK:           } {invariant}
 # CHECK:           call @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}}(%[[VAL_3]]) : (!quake.veq<?>) -> ()
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}} %[[VAL_3]] : (!quake.veq<?>) -> ()
-# CHECK:           %[[VAL_13:.*]] = quake.mz %0 : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VAL_13:.*]] = quake.mz %0 : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/ast_elif.py
+++ b/python/tests/mlir/ast_elif.py
@@ -30,7 +30,7 @@ def test_elif():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__cost..
-# CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+# CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 # CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f64
 # CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 2.000000e+00 : f64
 # CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
@@ -39,13 +39,13 @@ def test_elif():
 # CHECK-DAG:       %[[VAL_6:.*]] = cc.undef f64
 # CHECK-DAG:       %[[VAL_7:.*]] = cc.undef i64
 # CHECK-DAG:       %[[VAL_8:.*]] = quake.alloca !quake.veq<4>
-# CHECK-DAG:       %[[VAL_9:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
+# CHECK-DAG:       %[[VAL_9:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
 # CHECK:           %[[VAL_10:.*]]:3 = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_4]], %[[VAL_12:.*]] = %[[VAL_7]], %[[VAL_13:.*]] = %[[VAL_6]]) -> (i64, i64, f64)) {
 # CHECK:             %[[VAL_14:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_9]] : i64
 # CHECK:             cc.condition %[[VAL_14]](%[[VAL_11]], %[[VAL_12]], %[[VAL_13]] : i64, i64, f64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_15:.*]]: i64, %[[VAL_16:.*]]: i64, %[[VAL_17:.*]]: f64):
-# CHECK:             %[[VAL_18:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:             %[[VAL_18:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:             %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_18]]{{\[}}%[[VAL_15]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 # CHECK:             %[[VAL_20:.*]] = cc.load %[[VAL_19]] : !cc.ptr<f64>
 # CHECK:             %[[VAL_21:.*]] = cc.cast signed %[[VAL_15]] : (i64) -> f64

--- a/python/tests/mlir/ast_for_nd_array.py
+++ b/python/tests/mlir/ast_for_nd_array.py
@@ -28,18 +28,18 @@ def test_for_ndarray():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__cost..
-# CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+# CHECK-SAME:      %[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 # CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 # CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 # CHECK-DAG:       %[[VAL_3:.*]] = cc.undef f64
 # CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
-# CHECK-DAG:       %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
+# CHECK-DAG:       %[[VAL_5:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<f64>) -> i64
 # CHECK:           %[[VAL_6:.*]]:3 = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_2]], %[[VAL_8:.*]] = %[[VAL_3]], %[[VAL_9:.*]] = %[[VAL_2]]) -> (i64, f64, i64)) {
 # CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_5]] : i64
 # CHECK:             cc.condition %[[VAL_10]](%[[VAL_7]], %[[VAL_8]], %[[VAL_9]] : i64, f64, i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_11:.*]]: i64, %[[VAL_12:.*]]: f64, %[[VAL_13:.*]]: i64):
-# CHECK:             %[[VAL_14:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:             %[[VAL_14:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]]{{\[}}%[[VAL_11]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 # CHECK:             %[[VAL_16:.*]] = cc.load %[[VAL_15]] : !cc.ptr<f64>
 # CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.veq<4>, i64) -> !quake.ref

--- a/python/tests/mlir/ast_list_comprehension.py
+++ b/python/tests/mlir/ast_list_comprehension.py
@@ -601,13 +601,13 @@ def test_list_comprehension_capture_list():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernelg1
-# CHECK-SAME: (%[[VAL_0:.*]]: !cc.stdvec<i1> {quake.pylifted}) -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel"}
+# CHECK-SAME: (%[[VAL_0:.*]]: !cc.sequence<i1> {quake.pylifted}) -> i1 attributes {"cudaq-entrypoint", "cudaq-kernel"}
 # CHECK: return
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernelg2
-# CHECK-SAME: (%[[VAL_0:.*]]: !cc.stdvec<f64> {quake.pylifted}) -> f64 attributes {"cudaq-entrypoint", "cudaq-kernel"}
+# CHECK-SAME: (%[[VAL_0:.*]]: !cc.sequence<f64> {quake.pylifted}) -> f64 attributes {"cudaq-entrypoint", "cudaq-kernel"}
 # CHECK: return
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernelg3
-# CHECK-SAME: (%[[VAL_45:.*]]: !cc.stdvec<complex<f64>> {quake.pylifted}) -> f64 attributes {"cudaq-entrypoint", "cudaq-kernel"}
+# CHECK-SAME: (%[[VAL_45:.*]]: !cc.sequence<complex<f64>> {quake.pylifted}) -> f64 attributes {"cudaq-entrypoint", "cudaq-kernel"}
 # CHECK: return
 
 
@@ -1023,7 +1023,7 @@ def test_list_comprehension_expressions():
 # CHECK-SAME: () -> f64 attributes {"cudaq-entrypoint", "cudaq-kernel"}
 # CHECK: return
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernelm7
-# CHECK-SAME: (%[[VAL_0:.*]]: !cc.stdvec<i1>, %[[VAL_1:.*]]: !cc.callable<(!quake.veq<?>, f64, !cc.stdvec<i1>) -> ()> {quake.pylifted}) attributes {"cudaq-entrypoint", "cudaq-kernel"
+# CHECK-SAME: (%[[VAL_0:.*]]: !cc.sequence<i1>, %[[VAL_1:.*]]: !cc.callable<(!quake.veq<?>, f64, !cc.sequence<i1>) -> ()> {quake.pylifted}) attributes {"cudaq-entrypoint", "cudaq-kernel"
 # CHECK: return
 
 
@@ -1129,7 +1129,7 @@ def test_list_comprehension_qubit_refs():
 # CHECK: quake.concat
 # CHECK: return
 # CHECK-LABEL: func.func @__nvqpp__mlirgen__kerneln6..
-# CHECK: cc.stdvec_size
+# CHECK: cc.sequence_size
 # CHECK: cc.loop
 # CHECK: quake.concat
 # CHECK: return
@@ -1196,22 +1196,22 @@ def test_list_comprehension_filter():
 # CHECK-LABEL: test_list_comprehension_filter:
 # CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel1..
 # CHECK: cc.loop
-# CHECK: cc.stdvec_init
+# CHECK: cc.sequence_init
 # CHECK: return
 # CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel2..
 # CHECK: cc.loop
 # CHECK: cc.if
-# CHECK: cc.stdvec_init
+# CHECK: cc.sequence_init
 # CHECK: return
 # CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel3..
 # CHECK: cc.loop
 # CHECK: cc.if
-# CHECK: cc.stdvec_init
+# CHECK: cc.sequence_init
 # CHECK: return
 # CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel4..
 # CHECK: cc.loop
 # CHECK: cc.if
-# CHECK: cc.stdvec_init
+# CHECK: cc.sequence_init
 # CHECK: return
 # CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel5..
 # CHECK: cc.loop

--- a/python/tests/mlir/ast_list_int.py
+++ b/python/tests/mlir/ast_list_int.py
@@ -16,7 +16,7 @@ def test_list_int():
     @cudaq.kernel
     def oracle(register: cudaq.qview, auxillary_qubit: cudaq.qubit,
                hidden_bitstring: list[int]):
-        # Also test out len() here, should convert to stdvec_size
+        # Also test out len() here, should convert to sequence_size
         n = len(hidden_bitstring)
         for index, bit in enumerate(hidden_bitstring):
             if bit == 1:
@@ -26,18 +26,18 @@ def test_list_int():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__oracle..
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.ref, %[[VAL_2:.*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel"} {
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.ref, %[[VAL_2:.*]]: !cc.sequence<i64>) attributes {"cudaq-kernel"} {
 # CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
 # CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
 # CHECK-DAG:       %[[VAL_5:.*]] = cc.undef i64
 # CHECK-DAG:       %[[VAL_6:.*]] = cc.undef i64
-# CHECK-DAG:       %[[VAL_7:.*]] = cc.stdvec_size %[[VAL_2]] : (!cc.stdvec<i64>) -> i64
+# CHECK-DAG:       %[[VAL_7:.*]] = cc.sequence_size %[[VAL_2]] : (!cc.sequence<i64>) -> i64
 # CHECK:           %[[VAL_8:.*]]:3 = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_4]], %[[VAL_10:.*]] = %[[VAL_6]], %[[VAL_11:.*]] = %[[VAL_5]]) -> (i64, i64, i64)) {
 # CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_7]] : i64
 # CHECK:             cc.condition %[[VAL_12]](%[[VAL_9]], %[[VAL_10]], %[[VAL_11]] : i64, i64, i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_13:.*]]: i64, %[[VAL_14:.*]]: i64, %[[VAL_15:.*]]: i64):
-# CHECK:             %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+# CHECK:             %[[VAL_16:.*]] = cc.sequence_data %[[VAL_2]] : (!cc.sequence<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
 # CHECK:             %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_16]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
 # CHECK:             %[[VAL_18:.*]] = cc.load %[[VAL_17]] : !cc.ptr<i64>
 # CHECK:             %[[VAL_19:.*]] = arith.cmpi eq, %[[VAL_18]], %[[VAL_3]] : i64

--- a/python/tests/mlir/bug_1777.py
+++ b/python/tests/mlir/bug_1777.py
@@ -36,36 +36,36 @@ def test_bug_1777():
 # CHECK-DAG:       %[[CONSTANT_2:.*]] = arith.constant 0 : i64
 # CHECK-DAG:       %[[CONSTANT_3:.*]] = arith.constant true
 # CHECK-DAG:       %[[CONSTANT_4:.*]] = arith.constant 2 : i64
-# CHECK-DAG:       %[[UNDEF_0:.*]] = cc.undef !cc.stdvec<!cc.measure_handle>
-# CHECK-DAG:       %[[UNDEF_1:.*]] = cc.undef !cc.stdvec<!cc.measure_handle>
+# CHECK-DAG:       %[[UNDEF_0:.*]] = cc.undef !cc.sequence<!cc.measure_handle>
+# CHECK-DAG:       %[[UNDEF_1:.*]] = cc.undef !cc.sequence<!cc.measure_handle>
 # CHECK-DAG:       %[[UNDEF_2:.*]] = cc.undef i64
 # CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<2>
-# CHECK:           %[[LOOP_0:.*]]:4 = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_2]], %[[VAL_1:.*]] = %[[UNDEF_2]], %[[VAL_2:.*]] = %[[CONSTANT_3]], %[[VAL_3:.*]] = %[[UNDEF_1]]) -> (i64, i64, i1, !cc.stdvec<!cc.measure_handle>)) {
+# CHECK:           %[[LOOP_0:.*]]:4 = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_2]], %[[VAL_1:.*]] = %[[UNDEF_2]], %[[VAL_2:.*]] = %[[CONSTANT_3]], %[[VAL_3:.*]] = %[[UNDEF_1]]) -> (i64, i64, i1, !cc.sequence<!cc.measure_handle>)) {
 # CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[CONSTANT_4]] : i64
-# CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : i64, i64, i1, !cc.stdvec<!cc.measure_handle>)
+# CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : i64, i64, i1, !cc.sequence<!cc.measure_handle>)
 # CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_4:.*]]: i64, %[[VAL_5:.*]]: i64, %[[VAL_6:.*]]: i1, %[[VAL_7:.*]]: !cc.stdvec<!cc.measure_handle>):
+# CHECK:           ^bb0(%[[VAL_4:.*]]: i64, %[[VAL_5:.*]]: i64, %[[VAL_6:.*]]: i1, %[[VAL_7:.*]]: !cc.sequence<!cc.measure_handle>):
 # CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_0]]{{\[}}%[[VAL_4]]] : (!quake.veq<2>, i64) -> !quake.ref
 # CHECK:             %[[MZ_0:.*]] = quake.mz %[[EXTRACT_REF_0]] name "res" : (!quake.ref) -> !cc.measure_handle
 # CHECK:             %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[MZ_0]] : (!cc.measure_handle) -> i1
 # CHECK:             %[[CMPI_1:.*]] = arith.cmpi eq, %[[DISCRIMINATE_0]], %[[CONSTANT_0]] : i1
-# CHECK:             %[[IF_0:.*]] = cc.if(%[[CMPI_1]]) -> !cc.stdvec<!cc.measure_handle> {
-# CHECK:               %[[MZ_1:.*]] = quake.mz %[[ALLOCA_0]] name "inner_mz" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:               cc.continue %[[MZ_1]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:             %[[IF_0:.*]] = cc.if(%[[CMPI_1]]) -> !cc.sequence<!cc.measure_handle> {
+# CHECK:               %[[MZ_1:.*]] = quake.mz %[[ALLOCA_0]] name "inner_mz" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:               cc.continue %[[MZ_1]] : !cc.sequence<!cc.measure_handle>
 # CHECK:             } else {
-# CHECK:               cc.continue %[[VAL_7]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:               cc.continue %[[VAL_7]] : !cc.sequence<!cc.measure_handle>
 # CHECK:             }
-# CHECK:             cc.continue %[[VAL_4]], %[[VAL_4]], %[[DISCRIMINATE_0]], %[[IF_0]] : i64, i64, i1, !cc.stdvec<!cc.measure_handle>
+# CHECK:             cc.continue %[[VAL_4]], %[[VAL_4]], %[[DISCRIMINATE_0]], %[[IF_0]] : i64, i64, i1, !cc.sequence<!cc.measure_handle>
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_8:.*]]: i64, %[[VAL_9:.*]]: i64, %[[VAL_10:.*]]: i1, %[[VAL_11:.*]]: !cc.stdvec<!cc.measure_handle>):
+# CHECK:           ^bb0(%[[VAL_8:.*]]: i64, %[[VAL_9:.*]]: i64, %[[VAL_10:.*]]: i1, %[[VAL_11:.*]]: !cc.sequence<!cc.measure_handle>):
 # CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_8]], %[[CONSTANT_1]] : i64
-# CHECK:             cc.continue %[[ADDI_0]], %[[VAL_9]], %[[VAL_10]], %[[VAL_11]] : i64, i64, i1, !cc.stdvec<!cc.measure_handle>
+# CHECK:             cc.continue %[[ADDI_0]], %[[VAL_9]], %[[VAL_10]], %[[VAL_11]] : i64, i64, i1, !cc.sequence<!cc.measure_handle>
 # CHECK:           }
-# CHECK:           %[[IF_1:.*]] = cc.if(%[[VAL_12:.*]]#2) -> !cc.stdvec<!cc.measure_handle> {
-# CHECK:             %[[MZ_2:.*]] = quake.mz %[[ALLOCA_0]] name "outer_mz" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:             cc.continue %[[MZ_2]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[IF_1:.*]] = cc.if(%[[VAL_12:.*]]#2) -> !cc.sequence<!cc.measure_handle> {
+# CHECK:             %[[MZ_2:.*]] = quake.mz %[[ALLOCA_0]] name "outer_mz" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:             cc.continue %[[MZ_2]] : !cc.sequence<!cc.measure_handle>
 # CHECK:           } else {
-# CHECK:             cc.continue %[[UNDEF_0]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:             cc.continue %[[UNDEF_0]] : !cc.sequence<!cc.measure_handle>
 # CHECK:           }
 # CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<2>
 # CHECK:           return

--- a/python/tests/mlir/call.py
+++ b/python/tests/mlir/call.py
@@ -187,15 +187,15 @@ def test_kernel_apply_call_list_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"
-# CHECK:           call @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}}(%[[VAL_0]]) : (!cc.stdvec<f64>) -> ()
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint"
+# CHECK:           call @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}}(%[[VAL_0]]) : (!cc.sequence<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) {{.*}}{
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) {{.*}}{
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_2:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64,

--- a/python/tests/mlir/call_qpu.py
+++ b/python/tests/mlir/call_qpu.py
@@ -53,22 +53,22 @@ def test_qpu_call_return_vector():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__func_achat..
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>) -> !cc.stdvec<i1> attributes {"cudaq-kernel", qubitMeasurementFeedback = true} {
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>) -> !cc.sequence<i1> attributes {"cudaq-kernel", qubitMeasurementFeedback = true} {
 # CHECK:           %[[VAL_1:.*]] = arith.constant false
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-# CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
-# CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<i1>) -> i64
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+# CHECK:           %[[VAL_4:.*]] = cc.sequence_data %[[VAL_3]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
+# CHECK:           %[[VAL_5:.*]] = cc.sequence_size %[[VAL_3]] : (!cc.sequence<i1>) -> i64
 # CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
 # CHECK:           %[[VAL_7:.*]] = call @malloc(%[[VAL_5]]) : (i64) -> !cc.ptr<i8>
 # CHECK:           call @llvm.memcpy.p0.p0.i64(%[[VAL_7]], %[[VAL_6]], %[[VAL_5]], %[[VAL_1]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
-# CHECK:           %[[VAL_8:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
-# CHECK:           return %[[VAL_8]] : !cc.stdvec<i1>
+# CHECK:           %[[VAL_8:.*]] = cc.sequence_init %[[VAL_7]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.sequence<i1>
+# CHECK:           return %[[VAL_8]] : !cc.sequence<i1>
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__func_shiim..
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>,
-# CHECK-SAME:      %[[VAL_1:.*]]: !cc.callable<(!quake.veq<?>) -> !cc.stdvec<i1>> {quake.pylifted}) -> i64 attributes {"cudaq-kernel"} {
+# CHECK-SAME:      %[[VAL_1:.*]]: !cc.callable<(!quake.veq<?>) -> !cc.sequence<i1>> {quake.pylifted}) -> i64 attributes {"cudaq-kernel"} {
 # CHECK-DAG:       %[[VAL_2:.*]] = arith.constant false
 # CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
 # CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i8
@@ -76,9 +76,9 @@ def test_qpu_call_return_vector():
 # CHECK-DAG:       %[[VAL_6:.*]] = cc.undef i1
 # CHECK:           %[[VAL_7:.*]] = quake.subveq %[[VAL_0]], 1, 2 : (!quake.veq<?>) -> !quake.veq<2>
 # CHECK:           %[[VAL_8:.*]] = quake.relax_size %[[VAL_7]] : (!quake.veq<2>) -> !quake.veq<?>
-# CHECK:           %[[VAL_9:.*]] = cc.call_callable %[[VAL_1]], %[[VAL_8]] : (!cc.callable<(!quake.veq<?>) -> !cc.stdvec<i1>>, !quake.veq<?>) -> !cc.stdvec<i1> {symbol = "func_achat"}
-# CHECK:           %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_9]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
-# CHECK:           %[[VAL_11:.*]] = cc.stdvec_size %[[VAL_9]] : (!cc.stdvec<i1>) -> i64
+# CHECK:           %[[VAL_9:.*]] = cc.call_callable %[[VAL_1]], %[[VAL_8]] : (!cc.callable<(!quake.veq<?>) -> !cc.sequence<i1>>, !quake.veq<?>) -> !cc.sequence<i1> {symbol = "func_achat"}
+# CHECK:           %[[VAL_10:.*]] = cc.sequence_data %[[VAL_9]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
+# CHECK:           %[[VAL_11:.*]] = cc.sequence_size %[[VAL_9]] : (!cc.sequence<i1>) -> i64
 # CHECK:           %[[VAL_13:.*]] = cc.alloca i8{{\[}}%[[VAL_11]] : i64]
 # CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
 # CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>

--- a/python/tests/mlir/control.py
+++ b/python/tests/mlir/control.py
@@ -213,16 +213,16 @@ def test_kernel_control_list_args(qubit_count):
 
 # CHECK-LABEL: test_kernel_control_list_args
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint"
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<1>
-# CHECK:           quake.apply @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.veq<1>, !cc.stdvec<f64>) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.veq<1>, !cc.sequence<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) {{.*}}{
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) {{.*}}{
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_2:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
@@ -230,16 +230,16 @@ def test_kernel_control_list_args(qubit_count):
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint"
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.veq<5>, !cc.stdvec<f64>) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen__PythonKernelBuilderInstance{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.veq<5>, !cc.sequence<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) {{.*}}{
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) {{.*}}{
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_2:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()

--- a/python/tests/mlir/ctrl_gates.py
+++ b/python/tests/mlir/ctrl_gates.py
@@ -85,7 +85,7 @@ def test_kernel_ctrl_rotation():
 
 # CHECK-LABEL: test_kernel_ctrl_rotation
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME: (%[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"
+# CHECK-SAME: (%[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint"
 # CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 3.000000e+00 : f64
 # CHECK-DAG:           %[[VAL_2:.*]] = arith.constant 2.000000e+00 : f64
 # CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 1.000000e+00 : f64
@@ -93,7 +93,7 @@ def test_kernel_ctrl_rotation():
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][1] : (!quake.veq<2>) -> !quake.ref
-# CHECK:           %[[VAL_8:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_8:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 # CHECK:           quake.r1 (%[[VAL_10]]) {{\[}}%[[VAL_6]]] %[[VAL_7]] : (f64, !quake.ref, !quake.ref) -> ()
@@ -229,7 +229,7 @@ def test_kernel_rotation_ctrl_register():
 
 # CHECK-LABEL: test_kernel_rotation_ctrl_register
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"
+# CHECK-SAME:      (%[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint"
 # CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 3 : i64
 # CHECK-DAG:           %[[VAL_2:.*]] = arith.constant 3.000000e+00 : f64
 # CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 2.000000e+00 : f64
@@ -258,7 +258,7 @@ def test_kernel_rotation_ctrl_register():
 # CHECK:           quake.rx (%[[VAL_4]]) {{\[}}%[[VAL_8]]] %[[VAL_11]] : (f64, !quake.veq<3>, !quake.ref) -> ()
 # CHECK:           quake.ry (%[[VAL_3]]) {{\[}}%[[VAL_8]]] %[[VAL_10]] : (f64, !quake.veq<3>, !quake.ref) -> ()
 # CHECK:           quake.rz (%[[VAL_2]]) {{\[}}%[[VAL_8]]] %[[VAL_11]] : (f64, !quake.veq<3>, !quake.ref) -> ()
-# CHECK:           %[[VAL_19:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_19:.*]] = cc.sequence_data %[[VAL_0]] : (!cc.sequence<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
 # CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_19]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_20]] : !cc.ptr<f64>
 # CHECK:           quake.r1 (%[[VAL_21]]) [%[[VAL_8]]] %[[VAL_10]] : (f64, !quake.veq<3>, !quake.ref) -> ()

--- a/python/tests/mlir/list.py
+++ b/python/tests/mlir/list.py
@@ -30,7 +30,7 @@ def test_make_kernel_list():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:    (%[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"
+# CHECK-SAME:    (%[[VAL_0:.*]]: !cc.sequence<f64>) attributes {"cudaq-entrypoint"
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/measure.py
+++ b/python/tests/mlir/measure.py
@@ -72,9 +72,9 @@ def test_kernel_measure_qreg():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
 # CHECK-SAME: () attributes {"cudaq-entrypoint"
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_1:.*]] = quake.mx %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           %[[VAL_2:.*]] = quake.my %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VAL_1:.*]] = quake.mx %[[VAL_0]] : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           %[[VAL_2:.*]] = quake.my %[[VAL_0]] : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/measure_handle.py
+++ b/python/tests/mlir/measure_handle.py
@@ -75,7 +75,7 @@ def test_scalar_my_emits_handle():
 # CHECK:         }
 
 
-def test_vector_mz_emits_stdvec_of_handles():
+def test_vector_mz_emits_sequence_of_handles():
 
     @cudaq.kernel
     def kernel_vector_mz():
@@ -88,7 +88,7 @@ def test_vector_mz_emits_stdvec_of_handles():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_vector_mz
 # CHECK-SAME:      attributes {"cudaq-entrypoint"
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "hs" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "hs" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return
 # CHECK:         }
@@ -308,8 +308,8 @@ def test_or_short_circuits_second_discriminate():
 # ---------------------------------------------------------------------------
 # `cudaq.to_bools` (vector discrimination) and composition with
 # `cudaq.to_integer`. The vector discriminate lowers to a single
-# `quake.discriminate` taking `!cc.stdvec<!cc.measure_handle>` and
-# producing `!cc.stdvec<i1>`.
+# `quake.discriminate` taking `!cc.sequence<!cc.measure_handle>` and
+# producing `!cc.sequence<i1>`.
 # ---------------------------------------------------------------------------
 
 
@@ -324,11 +324,11 @@ def test_to_bools_lowers_to_vectorized_discriminate():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_to_bools
-# CHECK-SAME:      -> !cc.stdvec<i1>
+# CHECK-SAME:      -> !cc.sequence<i1>
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-# CHECK:           return %{{.*}} : !cc.stdvec<i1>
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+# CHECK:           return %{{.*}} : !cc.sequence<i1>
 # CHECK:         }
 
 
@@ -345,10 +345,10 @@ def test_to_integer_composes_with_to_bools():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_to_integer
 # CHECK-SAME:      -> i64
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
-# CHECK:           cc.stdvec_size %[[VAL_2]] : (!cc.stdvec<i1>) -> i64
-# CHECK:           cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.sequence<!cc.measure_handle>) -> !cc.sequence<i1>
+# CHECK:           cc.sequence_size %[[VAL_2]] : (!cc.sequence<i1>) -> i64
+# CHECK:           cc.sequence_data %[[VAL_2]] : (!cc.sequence<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return %{{.*}} : i64
 # CHECK:         }
@@ -376,7 +376,7 @@ def test_builder_scalar_mz_emits_handle():
 # CHECK:         }
 
 
-def test_builder_vector_mz_emits_stdvec_of_handles():
+def test_builder_vector_mz_emits_sequence_of_handles():
     kernel = cudaq.make_kernel()
     qv = kernel.qalloc(3)
     kernel.h(qv)
@@ -387,7 +387,7 @@ def test_builder_vector_mz_emits_stdvec_of_handles():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
 # CHECK-SAME:      () attributes {"cudaq-entrypoint"
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "vectorHandle" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "vectorHandle" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return
 # CHECK:         }
@@ -467,9 +467,9 @@ def test_handle_vector_cross_round_reassignment():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_handle_vec_cross_round
 # CHECK-SAME:      attributes {"cudaq-entrypoint"
 # CHECK:           %[[VEQ:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[MVEC:.*]] = quake.mz %[[VEQ]] name "mvec" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[MVEC:.*]] = quake.mz %[[VEQ]] name "mvec" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:           cc.loop while
-# CHECK:             %[[MNEW:.*]] = quake.mz %[[VEQ]] name "m_new" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:             %[[MNEW:.*]] = quake.mz %[[VEQ]] name "m_new" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:             cc.continue {{.*}}%[[MNEW]], %[[MNEW]]
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return

--- a/python/tests/mlir/mixed_args.py
+++ b/python/tests/mlir/mixed_args.py
@@ -29,7 +29,7 @@ def test_make_kernel_mixed_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK-SAME:     (%[[VAL_0:.*]]: !cc.stdvec<f64>,
+# CHECK-SAME:     (%[[VAL_0:.*]]: !cc.sequence<f64>,
 # CHECK-SAME:    %[[VAL_1:.*]]: f64) attributes {"cudaq-entrypoint"
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/qec_ops.py
+++ b/python/tests/mlir/qec_ops.py
@@ -67,7 +67,7 @@ def test_detector_variadic():
 # CHECK:         }
 
 # ---------------------------------------------------------------------------
-# `cudaq.detector(vec)` — single stdvec of handles.
+# `cudaq.detector(vec)` — single sequence of handles.
 # ---------------------------------------------------------------------------
 
 
@@ -83,8 +83,8 @@ def test_detector_vector():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_detector_vector
-# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.detector %[[VS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<4>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.detector %[[VS]] : !cc.sequence<!cc.measure_handle>
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return
 # CHECK:         }
@@ -133,8 +133,8 @@ def test_observable_vector():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_observable_vector_default
-# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.observable %[[VS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.observable %[[VS]] : !cc.sequence<!cc.measure_handle>
 # CHECK-NOT:       index
 # CHECK:           return
 # CHECK:         }
@@ -156,8 +156,8 @@ def test_observable_indexed():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_observable_explicit_idx
-# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.observable %[[VS]] index 2 : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.observable %[[VS]] index 2 : !cc.sequence<!cc.measure_handle>
 # CHECK:           return
 # CHECK:         }
 
@@ -186,7 +186,7 @@ def test_detector_nested_mz():
 # ---------------------------------------------------------------------------
 # Mixed shape: scalar handles + handle lists in the same call. The dialect
 # op accepts any combination (`Variadic<AnyTypeOf<[scalar, list]>>`) and
-# Q3's QIR conversion (`packMeasurementHandles` mixed-or-multi-stdvec
+# Q3's QIR conversion (`packMeasurementHandles` mixed-or-multi-sequence
 # branch) flattens the mix into a single `Result**` array, so a natural
 # QEC-source-code call like "combine these stabilizers (list) with the
 # boundary readout (scalar)" lowers cleanly.
@@ -208,14 +208,14 @@ def test_detector_mixed():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_detector_mixed
 # CHECK:           %[[VAL_M:.*]] = quake.mz %{{.*}} name "h" : (!quake.ref) -> !cc.measure_handle
-# CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.detector %[[VAL_HS]], %[[VAL_M]] : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+# CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.detector %[[VAL_HS]], %[[VAL_M]] : !cc.sequence<!cc.measure_handle>, !cc.measure_handle
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return
 # CHECK:         }
 
 # ---------------------------------------------------------------------------
-# `cudaq.detectors(prev, curr)` — paired stdvecs.
+# `cudaq.detectors(prev, curr)` — paired sequences.
 # ---------------------------------------------------------------------------
 
 
@@ -233,8 +233,8 @@ def test_pair_detectors():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_pair_detectors
-# CHECK:           %[[P:.*]] = quake.mz %{{.*}} name "prev" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           %[[C:.*]] = quake.mz %{{.*}} name "curr" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[P:.*]] = quake.mz %{{.*}} name "prev" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           %[[C:.*]] = quake.mz %{{.*}} name "curr" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:           qec.pair_detectors %[[P]], %[[C]] : <!cc.measure_handle>, <!cc.measure_handle>
 # CHECK:           return
 # CHECK:         }
@@ -314,8 +314,8 @@ def test_rep_code_d3():
 # CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_12]], %[[CONSTANT_0]] : i64
 # CHECK:             cc.continue %[[ADDI_0]], %[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_16]], %[[VAL_17]] : i64, i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
 # CHECK:           }
-# CHECK:           %[[MZ_2:.*]] = quake.mz %[[ALLOCA_0]] name "readout" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.observable %[[MZ_2]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[MZ_2:.*]] = quake.mz %[[ALLOCA_0]] name "readout" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.observable %[[MZ_2]] : !cc.sequence<!cc.measure_handle>
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return
 # CHECK:         }
@@ -348,8 +348,8 @@ def test_b_detector_vector():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.detector %[[HS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<4>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.detector %[[HS]] : !cc.sequence<!cc.measure_handle>
 # CHECK:           return
 
 
@@ -365,8 +365,8 @@ def test_b_detector_mixed():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
 # CHECK:           %[[H:.*]] = quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
-# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.detector %[[HS]], %[[H]] : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.detector %[[HS]], %[[H]] : !cc.sequence<!cc.measure_handle>, !cc.measure_handle
 # CHECK:           return
 
 
@@ -397,8 +397,8 @@ def test_b_observable_vector():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.observable %[[HS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.observable %[[HS]] : !cc.sequence<!cc.measure_handle>
 # CHECK-NOT:       index
 # CHECK:           return
 
@@ -412,8 +412,8 @@ def test_b_observable_indexed():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           qec.observable %[[HS]] index 2 : !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           qec.observable %[[HS]] index 2 : !cc.sequence<!cc.measure_handle>
 # CHECK:           return
 
 
@@ -428,7 +428,7 @@ def test_b_pair_detectors():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
-# CHECK:           %[[P:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
-# CHECK:           %[[C:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[P:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
+# CHECK:           %[[C:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:           qec.pair_detectors %[[P]], %[[C]] : <!cc.measure_handle>, <!cc.measure_handle>
 # CHECK:           return

--- a/python/tests/mlir/swap.py
+++ b/python/tests/mlir/swap.py
@@ -40,7 +40,7 @@ def test_swap_2q():
 # CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
 # CHECK:           quake.swap %[[VAL_1]], %[[VAL_2]] : (!quake.ref, !quake.ref) -> ()
-# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -169,14 +169,14 @@ void packArgs(OpaqueArguments &argData, nanobind::args args,
 /// `float`, `list`, so must check if `args[i]` is a `list` or `ndarray`.
 inline bool isBroadcastRequest(kernel_builder<> &builder,
                                nanobind::args &args) {
-  // FIXME: The use of isArgStdVec in this function inhibits moving this code
+  // FIXME: The use of isArgSequence in this function inhibits moving this code
   // out of the header file.
   if (args.empty())
     return false;
 
   auto arg = args[0];
   // Just need to check the leading argument
-  if (nanobind::isinstance<nanobind::list>(arg) && !builder.isArgStdVec(0))
+  if (nanobind::isinstance<nanobind::list>(arg) && !builder.isArgSequence(0))
     return true;
 
   if (nanobind::hasattr(arg, "tolist")) {
@@ -184,7 +184,7 @@ inline bool isBroadcastRequest(kernel_builder<> &builder,
       return false;
 
     auto shape = nanobind::cast<nanobind::tuple>(arg.attr("shape"));
-    if (shape.size() == 1 && !builder.isArgStdVec(0))
+    if (shape.size() == 1 && !builder.isArgSequence(0))
       return true;
 
     // // If shape is 2, then we know its a list of list

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -39,13 +39,13 @@ public:
   ~ValueHolder() = default;
 
   /// @brief Whenever we encounter an extract on a
-  /// StdVec QuakeValue, we want to record it here. This
+  /// Sequence QuakeValue, we want to record it here. This
   /// allows us to validate later that the number of runtime
   /// std::vector elements are correct.
   void addUniqueExtraction(std::size_t idx) {
-    if (!isa<cc::StdvecType>(value.getType()))
+    if (!isa<cc::SequenceType>(value.getType()))
       throw std::runtime_error(
-          "Tracking unique extraction on non-stdvec type.");
+          "Tracking unique extraction on non-sequence type.");
 
     uniqueExtractions.insert(idx);
   }
@@ -89,20 +89,21 @@ QuakeValue::QuakeValue(mlir::ImplicitLocOpBuilder &builder, double v)
 QuakeValue::QuakeValue(mlir::ImplicitLocOpBuilder &builder, Value v)
     : value(std::make_shared<QuakeValue::ValueHolder>(v)), opBuilder(builder) {}
 
-bool QuakeValue::isStdVec() {
-  return isa<cc::StdvecType>(value->asMLIR().getType());
+bool QuakeValue::isSequence() {
+  return isa<cc::SequenceType>(value->asMLIR().getType());
 }
 
 std::size_t QuakeValue::getRequiredElements() {
-  if (!isStdVec())
-    throw std::runtime_error("Tracking unique extraction on non-stdvec type.");
+  if (!isSequence())
+    throw std::runtime_error(
+        "Tracking unique extraction on non-sequence type.");
   return value->countUniqueExtractions();
 }
 
 QuakeValue QuakeValue::operator[](const std::size_t idx) {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type)) {
+  if (!isa<cc::SequenceType, cudaq::quake::VeqType>(type)) {
     std::string typeName;
     {
       llvm::raw_string_ostream os(typeName);
@@ -125,10 +126,10 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
   value->addUniqueExtraction(idx);
 
   Type eleTy =
-      mlir::cast<cc::StdvecType>(vectorValue.getType()).getElementType();
+      mlir::cast<cc::SequenceType>(vectorValue.getType()).getElementType();
 
   auto arrPtrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
-  Value vecPtr = cc::StdvecDataOp::create(opBuilder, arrPtrTy, vectorValue);
+  Value vecPtr = cc::SequenceDataOp::create(opBuilder, arrPtrTy, vectorValue);
   std::int32_t idx32 = static_cast<std::int32_t>(idx);
   auto elePtrTy = cc::PointerType::get(eleTy);
   Value eleAddr = cc::ComputePtrOp::create(opBuilder, elePtrTy, vecPtr,
@@ -140,7 +141,7 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
 QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type)) {
+  if (!isa<cc::SequenceType, cudaq::quake::VeqType>(type)) {
     std::string typeName;
     {
       llvm::raw_string_ostream os(typeName);
@@ -164,9 +165,9 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
   canValidateVectorNumElements = false;
 
   Type eleTy =
-      mlir::cast<cc::StdvecType>(vectorValue.getType()).getElementType();
+      mlir::cast<cc::SequenceType>(vectorValue.getType()).getElementType();
   auto arrEleTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
-  Value vecPtr = cc::StdvecDataOp::create(opBuilder, arrEleTy, vectorValue);
+  Value vecPtr = cc::SequenceDataOp::create(opBuilder, arrEleTy, vectorValue);
   auto elePtrTy = cc::PointerType::get(eleTy);
   Value eleAddr = cc::ComputePtrOp::create(
       opBuilder, elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{indexVar});
@@ -177,13 +178,13 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
 QuakeValue QuakeValue::size() {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type))
+  if (!isa<cc::SequenceType, cudaq::quake::VeqType>(type))
     throw std::runtime_error("This QuakeValue does not expose .size().");
 
   Type i64Ty = opBuilder.getI64Type();
   Value ret;
-  if (isa<cc::StdvecType>(type))
-    ret = cc::StdvecSizeOp::create(opBuilder, i64Ty, vectorValue);
+  if (isa<cc::SequenceType>(type))
+    ret = cc::SequenceSizeOp::create(opBuilder, i64Ty, vectorValue);
   else
     ret = cudaq::quake::VeqSizeOp::create(opBuilder, i64Ty, vectorValue);
 
@@ -202,7 +203,7 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
                              const std::size_t count) {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type))
+  if (!isa<cc::SequenceType, cudaq::quake::VeqType>(type))
     throw std::runtime_error("This QuakeValue is not sliceable.");
 
   if (count == 0)
@@ -226,8 +227,8 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
     return QuakeValue(opBuilder, subVeq);
   }
 
-  // must be a stdvec type
-  auto svecTy = dyn_cast<cc::StdvecType>(vectorValue.getType());
+  // must be a sequence type
+  auto svecTy = dyn_cast<cc::SequenceType>(vectorValue.getType());
   auto eleTy = svecTy.getElementType();
   assert(!isa<cc::ArrayType>(eleTy));
   Value vecPtr;
@@ -237,7 +238,7 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
     // actually appear in CodeGen when lowering this to the LLVM-IR dialect.
     eleTy = opBuilder.getI8Type();
     auto ptrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
-    vecPtr = cc::StdvecDataOp::create(opBuilder, ptrTy, vectorValue);
+    vecPtr = cc::SequenceDataOp::create(opBuilder, ptrTy, vectorValue);
     auto bits = svecTy.getElementType().getIntOrFloatBitWidth();
     assert(bits > 0);
     auto scale = arith::ConstantIntOp::create(
@@ -245,14 +246,14 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
     offset = arith::MulIOp::create(opBuilder, scale, startIdxValue);
   } else {
     auto ptrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
-    vecPtr = cc::StdvecDataOp::create(opBuilder, ptrTy, vectorValue);
+    vecPtr = cc::SequenceDataOp::create(opBuilder, ptrTy, vectorValue);
     offset = startIdxValue;
   }
   auto ptr =
       cc::ComputePtrOp::create(opBuilder, cudaq::cc::PointerType::get(eleTy),
                                vecPtr, ArrayRef<cc::ComputePtrArg>{offset});
-  Value subVeqInit = cc::StdvecInitOp::create(opBuilder, vectorValue.getType(),
-                                              ptr, countValue);
+  Value subVeqInit = cc::SequenceInitOp::create(
+      opBuilder, vectorValue.getType(), ptr, countValue);
 
   // If this is a slice, then we know we have
   // unique extraction on the elements of the slice,

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -39,7 +39,7 @@ protected:
   /// @brief Pointer to the OpBuilder we are using
   mlir::ImplicitLocOpBuilder &opBuilder;
 
-  /// @brief For Values of StdVecType, we might be able
+  /// @brief For Values of SequenceType, we might be able
   /// to validate that the number of required unique elements
   /// is equal to the number provided as input at runtime.
   bool canValidateVectorNumElements = true;
@@ -66,7 +66,7 @@ public:
   /// @brief Dump the QuakeValue to the given output stream.
   void dump(std::ostream &);
 
-  /// @brief Return true if this QuakeValue of StdVecType can
+  /// @brief Return true if this QuakeValue of SequenceType can
   /// validate its number of unique elements. We cannot do this in the
   /// case of QuakeValue extractions within for loops where we do not know
   /// the bounds of the loop.
@@ -76,7 +76,7 @@ public:
   /// starting at the given startIdx and including the following count elements.
   QuakeValue slice(const std::size_t startIdx, const std::size_t count);
 
-  /// @brief For a QuakeValue with type StdVec or Veq, return
+  /// @brief For a QuakeValue with type Sequence or Veq, return
   /// the size QuakeValue.
   QuakeValue size();
 
@@ -84,22 +84,22 @@ public:
   /// if it is of Veq type.
   std::optional<std::size_t> constantSize();
 
-  /// @brief Return true if this QuakeValue is of type StdVec.
+  /// @brief Return true if this QuakeValue is of type Sequence.
   /// @return
-  bool isStdVec();
+  bool isSequence();
 
-  /// @brief For a QuakeValue of type StdVec, return the
+  /// @brief For a QuakeValue of type Sequence, return the
   /// number of required elements, i.e. the number of unique
   /// extractions observed.
   std::size_t getRequiredElements();
 
   /// @brief Return a new QuakeValue when the current value
-  /// is indexed, specifically for QuakeValues of type StdVecType
+  /// is indexed, specifically for QuakeValues of type SequenceType
   /// and VeqType.
   QuakeValue operator[](const std::size_t idx);
 
   /// @brief Return a new QuakeValue when the current value
-  /// is indexed, specifically for QuakeValues of type StdVecType
+  /// is indexed, specifically for QuakeValues of type SequenceType
   /// and VeqType.
   QuakeValue operator[](const QuakeValue &idx);
 

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -64,7 +64,7 @@ KernelBuilderType convertArgumentTypeToMLIR(int &e) {
 
 KernelBuilderType convertArgumentTypeToMLIR(std::vector<double> &e) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::StdvecType::get(ctx, Float64Type::get(ctx));
+    return cudaq::cc::SequenceType::get(ctx, Float64Type::get(ctx));
   });
 }
 
@@ -75,20 +75,20 @@ KernelBuilderType convertArgumentTypeToMLIR(std::size_t &e) {
 
 KernelBuilderType convertArgumentTypeToMLIR(std::vector<int> &e) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::StdvecType::get(ctx, mlir::IntegerType::get(ctx, 32));
+    return cudaq::cc::SequenceType::get(ctx, mlir::IntegerType::get(ctx, 32));
   });
 }
 
 KernelBuilderType convertArgumentTypeToMLIR(std::vector<std::size_t> &e) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::StdvecType::get(ctx, mlir::IntegerType::get(ctx, 64));
+    return cudaq::cc::SequenceType::get(ctx, mlir::IntegerType::get(ctx, 64));
   });
 }
 
 /// Map a std::vector<float> to a KernelBuilderType
 KernelBuilderType convertArgumentTypeToMLIR(std::vector<float> &e) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::StdvecType::get(ctx, Float32Type::get(ctx));
+    return cudaq::cc::SequenceType::get(ctx, Float32Type::get(ctx));
   });
 }
 
@@ -96,8 +96,8 @@ KernelBuilderType convertArgumentTypeToMLIR(std::vector<float> &e) {
 KernelBuilderType
 convertArgumentTypeToMLIR(std::vector<std::complex<double>> &e) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::StdvecType::get(ctx,
-                                      ComplexType::get(Float64Type::get(ctx)));
+    return cudaq::cc::SequenceType::get(
+        ctx, ComplexType::get(Float64Type::get(ctx)));
   });
 }
 
@@ -105,8 +105,8 @@ convertArgumentTypeToMLIR(std::vector<std::complex<double>> &e) {
 KernelBuilderType
 convertArgumentTypeToMLIR(std::vector<std::complex<float>> &e) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::StdvecType::get(ctx,
-                                      ComplexType::get(Float32Type::get(ctx)));
+    return cudaq::cc::SequenceType::get(
+        ctx, ComplexType::get(Float32Type::get(ctx)));
   });
 }
 
@@ -122,7 +122,7 @@ KernelBuilderType convertArgumentTypeToMLIR(cudaq::qvector<> &e) {
 
 KernelBuilderType convertArgumentTypeToMLIR(std::vector<cudaq::pauli_word> &) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::StdvecType::get(cudaq::cc::CharspanType::get(ctx));
+    return cudaq::cc::SequenceType::get(cudaq::cc::CharspanType::get(ctx));
   });
 }
 
@@ -185,8 +185,8 @@ initializeBuilder(MLIRContext *context,
 }
 void deleteBuilder(ImplicitLocOpBuilder *builder) { delete builder; }
 
-bool isArgStdVec(std::vector<QuakeValue> &args, std::size_t idx) {
-  return args[idx].isStdVec();
+bool isArgSequence(std::vector<QuakeValue> &args, std::size_t idx) {
+  return args[idx].isSequence();
 }
 
 void exp_pauli(ImplicitLocOpBuilder &builder, const QuakeValue &theta,
@@ -505,12 +505,12 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, QuakeValue &sizeOrVec) {
   auto type = value.getType();
   auto context = builder.getContext();
 
-  if (auto stdvecTy = dyn_cast<cc::StdvecType>(type)) {
+  if (auto sequenceTy = dyn_cast<cc::SequenceType>(type)) {
     // get the size
-    auto ptrTy = cc::PointerType::get(stdvecTy.getElementType());
-    Value initials = cc::StdvecDataOp::create(builder, ptrTy, value);
+    auto ptrTy = cc::PointerType::get(sequenceTy.getElementType());
+    Value initials = cc::SequenceDataOp::create(builder, ptrTy, value);
     auto i64Ty = builder.getI64Type();
-    Value size = cc::StdvecSizeOp::create(builder, i64Ty, value);
+    Value size = cc::SequenceSizeOp::create(builder, i64Ty, value);
     auto stateTy = cc::PointerType::get(cudaq::quake::StateType::get(context));
     auto state =
         cudaq::quake::CreateStateOp::create(builder, stateTy, initials, size);
@@ -797,12 +797,12 @@ QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
     strAttr = builder.getStringAttr(regName);
 
   // `mz`/`mx`/`my` produce a `!cc.measure_handle` (or
-  // `!cc.stdvec<!cc.measure_handle>` when the target is a vector).
+  // `!cc.sequence<!cc.measure_handle>` when the target is a vector).
   // Discrimination is deferred to consumer sites, matching the AST-bridge
   // behavior.
   Type measTy = cc::MeasureHandleType::get(builder.getContext());
   if (!isa<cudaq::quake::RefType>(type))
-    measTy = cc::StdvecType::get(measTy);
+    measTy = cc::SequenceType::get(measTy);
   Value handle;
   if (strAttr)
     handle =
@@ -913,7 +913,7 @@ std::string name(std::string_view kernelName) {
 bool isQubitType(Type ty) {
   if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(ty))
     return true;
-  if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))
+  if (auto vecTy = dyn_cast<cudaq::cc::SequenceType>(ty))
     return isQubitType(vecTy.getElementType());
   return false;
 }

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -325,8 +325,8 @@ void forLoop(mlir::ImplicitLocOpBuilder &builder, QuakeValue &start,
 std::string to_quake(mlir::ImplicitLocOpBuilder &builder);
 
 /// @brief Returns `true` if the argument to the `kernel_builder` is a
-/// `cc::StdvecType`. Returns `false` otherwise.
-bool isArgStdVec(std::vector<QuakeValue> &args, std::size_t idx);
+/// `cc::SequenceType`. Returns `false` otherwise.
+bool isArgSequence(std::vector<QuakeValue> &args, std::size_t idx);
 
 /// @brief The `ArgumentValidator` provides a way validate the input arguments
 /// when the kernel is invoked (via a fold expression).
@@ -347,7 +347,7 @@ struct ArgumentValidator<std::vector<T>> {
   static void validate(std::size_t &argCounter, std::vector<QuakeValue> &args,
                        std::vector<T> &input) {
     if (argCounter >= args.size())
-      throw std::runtime_error("Error validating stdvec input to "
+      throw std::runtime_error("Error validating sequence input to "
                                "kernel_builder. argCounter >= args.size()");
 
     // Get the argument, increment the counter
@@ -466,8 +466,8 @@ public:
 
   /// @brief Return `true` if the argument to the kernel is a `std::vector`,
   /// `false` otherwise.
-  bool isArgStdVec(std::size_t idx) {
-    return detail::isArgStdVec(arguments, idx);
+  bool isArgSequence(std::size_t idx) {
+    return detail::isArgSequence(arguments, idx);
   }
 
   /// @brief Return the name of this kernel
@@ -710,7 +710,7 @@ public:
 
   /// @brief `logical_observable` with an explicit `observable_index`.
   /// Takes a single `QuakeValue` handle (typically a
-  /// `!cc.stdvec<!cc.measure_handle>` from `mz` on a `qvector`, but a
+  /// `!cc.sequence<!cc.measure_handle>` from `mz` on a `qvector`, but a
   /// scalar handle is also accepted by the dialect).
   void logical_observable(QuakeValue measurements,
                           std::size_t observable_index) {

--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -230,7 +230,7 @@ inline void validateAngularEncodeSizes(std::optional<std::size_t> qSize,
 template <typename Kernel>
 void angular_encode(Kernel &&kernel, QuakeValue &q, QuakeValue &angles,
                     RotationAxis rotation = RotationAxis::Y) {
-  if (!angles.isStdVec())
+  if (!angles.isSequence())
     throw std::runtime_error(
         "cudaq.contrib.angular_encode: angles must be std::vector<double>");
 

--- a/runtime/internal/compiler/ArgumentConversion.cpp
+++ b/runtime/internal/compiler/ArgumentConversion.cpp
@@ -92,13 +92,13 @@ static Value genConstant(OpBuilder &builder, const std::string &v,
   auto cast = cudaq::cc::CastOp::create(builder, loc, i8PtrTy, strLit);
   auto size = arith::ConstantIntOp::create(builder, loc, v.size(), 64);
   auto chSpanTy = cudaq::cc::CharspanType::get(ctx);
-  return cudaq::cc::StdvecInitOp::create(builder, loc, chSpanTy, cast, size);
+  return cudaq::cc::SequenceInitOp::create(builder, loc, chSpanTy, cast, size);
 }
 
 // Forward declare aggregate type builder as they can be recursive.
-static Value genRecursiveSpan(OpBuilder &, cudaq::cc::StdvecType, void *,
+static Value genRecursiveSpan(OpBuilder &, cudaq::cc::SequenceType, void *,
                               ModuleOp, llvm::DataLayout &, bool);
-static Value genConstant(OpBuilder &, cudaq::cc::StdvecType, void *, ModuleOp,
+static Value genConstant(OpBuilder &, cudaq::cc::SequenceType, void *, ModuleOp,
                          llvm::DataLayout &, bool);
 static Value genConstant(OpBuilder &, cudaq::cc::StructType, void *, ModuleOp,
                          llvm::DataLayout &, bool);
@@ -515,7 +515,7 @@ genConstant(OpBuilder &builder, const cudaq::state *v, llvm::DataLayout &layout,
       "Invalid cudaq::state* encountered in argument synthesis.");
 }
 
-static bool isSupportedRecursiveSpan(cudaq::cc::StdvecType ty) {
+static bool isSupportedRecursiveSpan(cudaq::cc::SequenceType ty) {
   Type eleTy = ty.getElementType();
   while (auto ty = dyn_cast<cudaq::cc::SpanLikeType>(eleTy))
     eleTy = ty.getElementType();
@@ -566,7 +566,7 @@ Value dispatchSubtype(OpBuilder &builder, Type ty, void *p, ModuleOp substMod,
         return genConstant(builder, static_cast<cudaq::pauli_word *>(p)->str(),
                            substMod);
       })
-      .Case([&](cudaq::cc::StdvecType ty) {
+      .Case([&](cudaq::cc::SequenceType ty) {
         return genConstant(builder, ty, p, substMod, layout, boolVecBitPacked);
       })
       .Case([&](cudaq::cc::StructType ty) {
@@ -584,7 +584,7 @@ Value dispatchSubtype(OpBuilder &builder, Type ty, void *p, ModuleOp substMod,
 // Get the size of \p eleTy on the host side in bytes.
 static std::size_t getHostSideElementSize(Type eleTy,
                                           llvm::DataLayout &layout) {
-  if (isa<cudaq::cc::StdvecType>(eleTy))
+  if (isa<cudaq::cc::SequenceType>(eleTy))
     return sizeof(std::vector<int>);
   if (isa<cudaq::cc::CharspanType>(eleTy)) {
     // char span type is a std::string on host side.
@@ -601,7 +601,7 @@ static std::size_t getHostSideElementSize(Type eleTy,
 /// Set \p boolVecBitPacked when an `i1` vector arg is a host
 /// `std::vector<bool>` (bit-packed; not the `{begin, end, capacity}` triple).
 ArrayAttr genRecursiveConstantArray(OpBuilder &builder,
-                                    cudaq::cc::StdvecType vecTy, void *p,
+                                    cudaq::cc::SequenceType vecTy, void *p,
                                     llvm::DataLayout &layout,
                                     bool boolVecBitPacked = false) {
   auto eleTy = vecTy.getElementType();
@@ -626,7 +626,7 @@ ArrayAttr genRecursiveConstantArray(OpBuilder &builder,
     return {};
   unsigned stepBy = 0;
   std::function<Attribute(char *)> genAttr;
-  if (auto innerTy = dyn_cast<cudaq::cc::StdvecType>(eleTy)) {
+  if (auto innerTy = dyn_cast<cudaq::cc::SequenceType>(eleTy)) {
     stepBy = sizeof(VectorType);
     genAttr = [&, innerTy](char *p) -> Attribute {
       return genRecursiveConstantArray(builder, innerTy, p, layout,
@@ -694,7 +694,7 @@ ArrayAttr genRecursiveConstantArray(OpBuilder &builder,
 }
 
 static Type convertRecursiveSpanType(Type ty) {
-  if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))
+  if (auto vecTy = dyn_cast<cudaq::cc::SequenceType>(ty))
     return cudaq::cc::ArrayType::get(
         convertRecursiveSpanType(vecTy.getElementType()));
   if (auto cspanTy = dyn_cast<cudaq::cc::CharspanType>(ty))
@@ -706,7 +706,7 @@ static Type convertRecursiveSpanType(Type ty) {
 /// `cc.reify_span` operation. This higher level semantics helps facilitate
 /// constant propagation through the recursive span structure. The reify
 /// operation will be lowered to more primitive ops on an as-needed basis.
-Value genRecursiveSpan(OpBuilder &builder, cudaq::cc::StdvecType ty, void *p,
+Value genRecursiveSpan(OpBuilder &builder, cudaq::cc::SequenceType ty, void *p,
                        ModuleOp substMod, llvm::DataLayout &layout,
                        bool boolVecBitPacked = false) {
   ArrayAttr constants =
@@ -717,7 +717,7 @@ Value genRecursiveSpan(OpBuilder &builder, cudaq::cc::StdvecType ty, void *p,
     auto zero = arith::ConstantIntOp::create(builder, loc, 0, 64);
     auto ptr = cudaq::cc::CastOp::create(
         builder, loc, cudaq::cc::PointerType::get(ty.getElementType()), zero);
-    return cudaq::cc::StdvecInitOp::create(builder, loc, ty, ptr, zero);
+    return cudaq::cc::SequenceInitOp::create(builder, loc, ty, ptr, zero);
   }
   auto arrTy = convertRecursiveSpanType(ty);
   auto conArr =
@@ -725,7 +725,7 @@ Value genRecursiveSpan(OpBuilder &builder, cudaq::cc::StdvecType ty, void *p,
   return cudaq::cc::ReifySpanOp::create(builder, loc, ty, conArr);
 }
 
-Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
+Value genConstant(OpBuilder &builder, cudaq::cc::SequenceType vecTy, void *p,
                   ModuleOp substMod, llvm::DataLayout &layout,
                   bool boolVecBitPacked = false) {
   if (isSupportedRecursiveSpan(vecTy))
@@ -759,7 +759,7 @@ Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
     cursor += eleSize;
   }
   auto size = arith::ConstantIntOp::create(builder, loc, vecSize, 64);
-  return cudaq::cc::StdvecInitOp::create(builder, loc, vecTy, buffer, size);
+  return cudaq::cc::SequenceInitOp::create(builder, loc, vecTy, buffer, size);
 }
 
 Value genConstant(OpBuilder &builder, cudaq::cc::StructType strTy, void *p,
@@ -980,7 +980,7 @@ void cudaq_internal::compiler::ArgumentConverter::gen(
                                   dataLayout, kernelName, substModule, *this);
               return {};
             })
-            .Case([&](cudaq::cc::StdvecType ty) {
+            .Case([&](cudaq::cc::SequenceType ty) {
               return buildSubst(ty, argPtr, substModule, dataLayout,
                                 boolVecBitPacked);
             })

--- a/runtime/internal/compiler/LayoutInfo.cpp
+++ b/runtime/internal/compiler/LayoutInfo.cpp
@@ -140,7 +140,7 @@ cudaq_internal::compiler::getResultBufferLayout(ModuleOp mod, Type resultTy) {
       .Case([&](ComplexType) { bufferSize = 2 * sizeof(double); })
       .Case([&](Float64Type) { bufferSize = sizeof(double); })
       .Case([&](Float32Type) { bufferSize = sizeof(float); })
-      .Case([&](cudaq::cc::StdvecType) {
+      .Case([&](cudaq::cc::SequenceType) {
         struct vec {
           void *data;
           std::size_t length;

--- a/runtime/test/test_argument_conversion.cpp
+++ b/runtime/test/test_argument_conversion.cpp
@@ -333,7 +333,7 @@ void test_scalars(mlir::MLIRContext *ctx) {
 // CHECK:           %[[VAL_0:.*]] = cc.string_literal "XYZ" : !cc.ptr<!cc.array<i8 x 4>>
 // CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_init %[[VAL_1]], %[[VAL_2]] : (!cc.ptr<i8>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_3:.*]] = cc.sequence_init %[[VAL_1]], %[[VAL_2]] : (!cc.ptr<i8>, i64) -> !cc.charspan
 // CHECK:         }
   // clang-format on
 }
@@ -342,33 +342,33 @@ void test_vectors(mlir::MLIRContext *ctx) {
   {
     std::vector<std::int32_t> x;
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<i32>", v);
+    doSimpleTest(ctx, "!cc.sequence<i32>", v);
   }
   // clang-format off
 // CHECK: Source module:
-// CHECK:  func.func private @callee(!cc.stdvec<i32>)
+// CHECK:  func.func private @callee(!cc.sequence<i32>)
 // CHECK: Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = arith.constant 0 : i64
 // CHECK: %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (i64) -> !cc.ptr<i32>
-// CHECK: %[[VAL_2:.*]] = cc.stdvec_init %[[VAL_1]], %[[VAL_0]] : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
+// CHECK: %[[VAL_2:.*]] = cc.sequence_init %[[VAL_1]], %[[VAL_0]] : (!cc.ptr<i32>, i64) -> !cc.sequence<i32>
 // CHECK: }
   // clang-format on
 
   {
     std::vector<std::int32_t> x = {14581, 0xcafe, 42, 0xbeef};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<i32>", v);
+    doSimpleTest(ctx, "!cc.sequence<i32>", v);
   }
   // clang-format off
 // CHECK:       Source module:
-// CHECK:         func.func private @callee(!cc.stdvec<i32>)
+// CHECK:         func.func private @callee(!cc.sequence<i32>)
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array [14581 : i32, 51966 : i32, 42 : i32, 48879 : i32] : !cc.array<i32 x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i32 x ?>) -> !cc.stdvec<i32>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i32 x ?>) -> !cc.sequence<i32>
 // CHECK:         }
   // clang-format on
 
@@ -376,12 +376,12 @@ void test_vectors(mlir::MLIRContext *ctx) {
     std::vector<cudaq::pauli_word> x = {cudaq::pauli_word{"XX"},
                                         cudaq::pauli_word{"XY"}};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<!cc.charspan>", v);
+    doSimpleTest(ctx, "!cc.sequence<!cc.charspan>", v);
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array ["XX", "XY"] : !cc.array<!cc.array<i8 x ?> x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i8 x ?> x ?>) -> !cc.stdvec<!cc.charspan>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i8 x ?> x ?>) -> !cc.sequence<!cc.charspan>
  // CHECK:         }
   // clang-format on
 
@@ -393,12 +393,12 @@ void test_vectors(mlir::MLIRContext *ctx) {
     // template specialization.
     std::vector<char> x = {true, false};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<i1>", v);
+    doSimpleTest(ctx, "!cc.sequence<i1>", v);
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array [true, false] : !cc.array<i1 x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i1 x ?>) -> !cc.stdvec<i1>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i1 x ?>) -> !cc.sequence<i1>
  // CHECK:         }
   // clang-format on
 
@@ -408,13 +408,13 @@ void test_vectors(mlir::MLIRContext *ctx) {
     // heap; `boolVecBitPacked` selects the correct reader.
     std::vector<bool> x = {true, false, true, true};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<i1>", v, /*additionalCode=*/"",
+    doSimpleTest(ctx, "!cc.sequence<i1>", v, /*additionalCode=*/"",
                  /*boolVecBitPacked=*/true);
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array [true, false, true, true] : !cc.array<i1 x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i1 x ?>) -> !cc.stdvec<i1>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i1 x ?>) -> !cc.sequence<i1>
  // CHECK:         }
   // clang-format on
 
@@ -424,12 +424,12 @@ void test_vectors(mlir::MLIRContext *ctx) {
         {cudaq::pauli_word{"ZI"}, cudaq::pauli_word{"YY"}},
         {cudaq::pauli_word{"ZY"}, cudaq::pauli_word{"YX"}}};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<!cc.stdvec<!cc.charspan>>", v);
+    doSimpleTest(ctx, "!cc.sequence<!cc.sequence<!cc.charspan>>", v);
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array {{\[}}["XX", "XY"], ["ZI", "YY"], ["ZY", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x ?> x ?> x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<!cc.array<i8 x ?> x ?> x ?>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<!cc.array<i8 x ?> x ?> x ?>) -> !cc.sequence<!cc.sequence<!cc.charspan>>
 // CHECK:         }
   // clang-format on
 
@@ -437,12 +437,12 @@ void test_vectors(mlir::MLIRContext *ctx) {
     std::vector<std::vector<double>> x = {
         {1.0, 2.0, 3.0}, {14.0, 15.0, 16.0}, {27.1, 28.2, 29.3}};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<!cc.stdvec<f64>>", v);
+    doSimpleTest(ctx, "!cc.sequence<!cc.sequence<f64>>", v);
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array {{\[}}[1.000000e+00, 2.000000e+00, 3.000000e+00], [1.400000e+01, 1.500000e+01, 1.600000e+01], [2.710000e+01, 2.820000e+01, 2.930000e+01]] : !cc.array<!cc.array<f64 x ?> x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<f64 x ?> x ?>) -> !cc.stdvec<!cc.stdvec<f64>>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<f64 x ?> x ?>) -> !cc.sequence<!cc.sequence<f64>>
 // CHECK:         }
   // clang-format on
 
@@ -450,12 +450,12 @@ void test_vectors(mlir::MLIRContext *ctx) {
     std::vector<std::vector<std::int64_t>> x = {
         {1, 2, 3, 0}, {14, 15, 16, 13}, {127, 128, 129, 126}};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<!cc.stdvec<i64>>", v);
+    doSimpleTest(ctx, "!cc.sequence<!cc.sequence<i64>>", v);
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array {{\[}}[1, 2, 3, 0], [14, 15, 16, 13], [127, 128, 129, 126]] : !cc.array<!cc.array<i64 x ?> x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i64 x ?> x ?>) -> !cc.stdvec<!cc.stdvec<i64>>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i64 x ?> x ?>) -> !cc.sequence<!cc.sequence<i64>>
 // CHECK:         }
   // clang-format on
 
@@ -464,12 +464,12 @@ void test_vectors(mlir::MLIRContext *ctx) {
                                         {false, false, false, true},
                                         {true, false, false, true}};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<!cc.stdvec<i1>>", v);
+    doSimpleTest(ctx, "!cc.sequence<!cc.sequence<i1>>", v);
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array {{\[}}[true, true, false, true], [false, false, false, true], [true, false, false, true]] : !cc.array<!cc.array<i1 x ?> x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i1 x ?> x ?>) -> !cc.stdvec<!cc.stdvec<i1>>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i1 x ?> x ?>) -> !cc.sequence<!cc.sequence<i1>>
 // CHECK:         }
   // clang-format on
 }
@@ -520,11 +520,11 @@ void test_recursive(mlir::MLIRContext *ctx) {
     ure x2 = {90210, 782934.78923, 'C', 747};
     std::vector<ure> x = {x0, x1, x2};
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.stdvec<!cc.struct<{i32,f64,i8,i16}>>", v);
+    doSimpleTest(ctx, "!cc.sequence<!cc.struct<{i32,f64,i8,i16}>>", v);
   }
   // clang-format off
 // CHECK:       Source module:
-// CHECK:         func.func private @callee(!cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>)
+// CHECK:         func.func private @callee(!cc.sequence<!cc.struct<{i32, f64, i8, i16}>>)
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
@@ -563,7 +563,7 @@ void test_recursive(mlir::MLIRContext *ctx) {
 // CHECK:           %[[VAL_30:.*]] = cc.compute_ptr %[[VAL_0]][2] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>) -> !cc.ptr<!cc.struct<{i32, f64, i8, i16}>>
 // CHECK:           cc.store %[[VAL_29]], %[[VAL_30]] : !cc.ptr<!cc.struct<{i32, f64, i8, i16}>>
 // CHECK:           %[[VAL_31:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_32:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_31]] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>, i64) -> !cc.stdvec<!cc.struct<{i32, f64, i8, i16}>>
+// CHECK:           %[[VAL_32:.*]] = cc.sequence_init %[[VAL_0]], %[[VAL_31]] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64, i8, i16}> x 3>>, i64) -> !cc.sequence<!cc.struct<{i32, f64, i8, i16}>>
 // CHECK:         }
   // clang-format on
 }
@@ -657,19 +657,19 @@ void test_combinations(mlir::MLIRContext *ctx) {
 
     std::vector<void *> v = {static_cast<void *>(&x), static_cast<void *>(&y),
                              static_cast<void *>(&z)};
-    std::vector<std::string> t = {"!cc.stdvec<f32>", "!cc.ptr<!quake.state>",
-                                  "!cc.stdvec<!cc.charspan>"};
+    std::vector<std::string> t = {"!cc.sequence<f32>", "!cc.ptr<!quake.state>",
+                                  "!cc.sequence<!cc.charspan>"};
     doTest(ctx, t, v);
   }
 
   // clang-format off
 // CHECK:       Source module:
-// CHECK:         func.func private @callee(!cc.stdvec<f32>, !cc.ptr<!quake.state>, !cc.stdvec<!cc.charspan>)
+// CHECK:         func.func private @callee(!cc.sequence<f32>, !cc.ptr<!quake.state>, !cc.sequence<!cc.charspan>)
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array [0.000000e+00 : f32, 1.750000e+00 : f32, 4.17232506E-8 : f32, 1.775000e+00 : f32] : !cc.array<f32 x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<f32 x ?>) -> !cc.stdvec<f32>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<f32 x ?>) -> !cc.sequence<f32>
 // CHECK:         }
 // CHECK-LABEL:   cc.arg_subst[1] {
 // CHECK:           %[[VAL_1:.*]] = arith.constant {{.*}} : i64
@@ -677,7 +677,7 @@ void test_combinations(mlir::MLIRContext *ctx) {
 // CHECK:         }
 // CHECK-LABEL:   cc.arg_subst[2] {
 // CHECK: %[[VAL_0:.*]] = cc.const_array ["XX", "XY"] : !cc.array<!cc.array<i8 x ?> x ?>
-// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i8 x ?> x ?>) -> !cc.stdvec<!cc.charspan>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i8 x ?> x ?>) -> !cc.sequence<!cc.charspan>
 // CHECK:         }
   // clang-format on
 }

--- a/targettests/execution/dem_from_kernel.cpp
+++ b/targettests/execution/dem_from_kernel.cpp
@@ -348,7 +348,7 @@ int main() {
   // multi-target observable.
   runCase("MEM_EXP_2R", memoryExperimentTwoRounds{});
 
-  // Vectorized stdvec form producing the same shape as MEM_EXP_2R.
+  // Vectorized sequence form producing the same shape as MEM_EXP_2R.
   runCase("VECTORIZED", vectorizedDetectors{});
 
   // Correlated XX error: raw DEM keeps a four-detector hyperedge; decomposed

--- a/targettests/execution/state_init_mid_circuit.cpp
+++ b/targettests/execution/state_init_mid_circuit.cpp
@@ -88,29 +88,29 @@ int main() {
 // clang-format off
 // MLIR-LABEL: func.func @__nvqpp__mlirgen__function_test_single_then_state.
 // MLIR:         %[[VAL_1:.*]] = quake.alloca !quake.ref
-// MLIR:         %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0:.*]] : (!cc.stdvec<complex<f64>>) -> !cc.ptr<complex<f64>>
-// MLIR:         %[[VAL_3:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<complex<f64>>) -> i64
+// MLIR:         %[[VAL_2:.*]] = cc.sequence_data %[[VAL_0:.*]] : (!cc.sequence<complex<f64>>) -> !cc.ptr<complex<f64>>
+// MLIR:         %[[VAL_3:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<complex<f64>>) -> i64
 // MLIR:         %[[VAL_4:.*]] = quake.create_state %[[VAL_2]], %[[VAL_3]] : (!cc.ptr<complex<f64>>, i64) -> !cc.ptr<!quake.state>
 // MLIR:         %[[VAL_5:.*]] = quake.get_number_of_qubits %[[VAL_4]] : (!cc.ptr<!quake.state>) -> i64
 // MLIR:         %[[VAL_6:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_5]] : i64]
 // MLIR:         %[[VAL_7:.*]] = quake.init_state %[[VAL_6]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // MLIR:         quake.delete_state %[[VAL_4]] : !cc.ptr<!quake.state>
 // MLIR:         %[[VAL_8:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !cc.measure_handle
-// MLIR:         %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// MLIR:         %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // MLIR:         return
 // MLIR:       }
 
 // MLIR-LABEL: func.func @__nvqpp__mlirgen__function_test_multi_then_state.
 // MLIR:         %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
-// MLIR:         %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0:.*]] : (!cc.stdvec<complex<f64>>) -> !cc.ptr<complex<f64>>
-// MLIR:         %[[VAL_3:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<complex<f64>>) -> i64
+// MLIR:         %[[VAL_2:.*]] = cc.sequence_data %[[VAL_0:.*]] : (!cc.sequence<complex<f64>>) -> !cc.ptr<complex<f64>>
+// MLIR:         %[[VAL_3:.*]] = cc.sequence_size %[[VAL_0]] : (!cc.sequence<complex<f64>>) -> i64
 // MLIR:         %[[VAL_4:.*]] = quake.create_state %[[VAL_2]], %[[VAL_3]] : (!cc.ptr<complex<f64>>, i64) -> !cc.ptr<!quake.state>
 // MLIR:         %[[VAL_5:.*]] = quake.get_number_of_qubits %[[VAL_4]] : (!cc.ptr<!quake.state>) -> i64
 // MLIR:         %[[VAL_6:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_5]] : i64]
 // MLIR:         %[[VAL_7:.*]] = quake.init_state %[[VAL_6]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // MLIR:         quake.delete_state %[[VAL_4]] : !cc.ptr<!quake.state>
-// MLIR:         %[[VAL_8:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// MLIR:         %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// MLIR:         %[[VAL_8:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.sequence<!cc.measure_handle>
+// MLIR:         %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.veq<?>) -> !cc.sequence<!cc.measure_handle>
 // MLIR:         return
 // MLIR:       }
 // clang-format on

--- a/unittests/nvqpp/integration/builder_tester.cpp
+++ b/unittests/nvqpp/integration/builder_tester.cpp
@@ -719,7 +719,7 @@ CUDAQ_TEST(BuilderTester, checkSlice) {
 #endif
 
 #ifndef CUDAQ_BACKEND_STIM
-CUDAQ_TEST(BuilderTester, checkStdVecValidate) {
+CUDAQ_TEST(BuilderTester, checkSequenceValidate) {
   auto [kernel, thetas] = cudaq::make_kernel<std::vector<double>>();
   auto q = kernel.qalloc(2);
   kernel.rx(thetas[0], q[0]);
@@ -735,12 +735,12 @@ CUDAQ_TEST(BuilderTester, checkStdVecValidate) {
 }
 #endif
 
-CUDAQ_TEST(BuilderTester, checkIsArgStdVec) {
+CUDAQ_TEST(BuilderTester, checkIsArgSequence) {
   auto [kernel, one, two, thetas, four] =
       cudaq::make_kernel<double, float, std::vector<double>, int>();
 
-  EXPECT_TRUE(kernel.isArgStdVec(2));
-  EXPECT_FALSE(kernel.isArgStdVec(1));
+  EXPECT_TRUE(kernel.isArgSequence(2));
+  EXPECT_FALSE(kernel.isArgSequence(1));
 }
 
 // Stim does not currently support a controlled H gate.
@@ -1092,14 +1092,14 @@ CUDAQ_TEST(BuilderTester, checkMeasureHandleEmission) {
   }
 
   {
-    // Vector `mz` on a register produces `!cc.stdvec<!cc.measure_handle>`
+    // Vector `mz` on a register produces `!cc.sequence<!cc.measure_handle>`
     // before `expand-measurements`.
     auto kernel = cudaq::make_kernel();
     auto q = kernel.qalloc(3);
     kernel.h(q);
     kernel.mz(q, "vectorHandle");
     auto ir = kernel.to_quake();
-    EXPECT_NE(ir.find("!cc.stdvec<!cc.measure_handle>"), std::string::npos);
+    EXPECT_NE(ir.find("!cc.sequence<!cc.measure_handle>"), std::string::npos);
     EXPECT_NE(ir.find("\"vectorHandle\""), std::string::npos);
     EXPECT_EQ(ir.find("quake.discriminate"), std::string::npos);
     EXPECT_EQ(ir.find("!quake.measure"), std::string::npos);


### PR DESCRIPTION
There are no std::vector objects on the device, so the reference to the C++ type on the host side is causing confusion.
