### PR TITLE
Fixing transposed closed-system propagator in cudaq.contrib

### DIFF
--- a/python/cudaq/contrib/propagator.py
+++ b/python/cudaq/contrib/propagator.py
@@ -48,7 +48,7 @@ def _state_to_matrix(state, dimension: int) -> np.ndarray:
         raise RuntimeError("Expected propagator state with size "
                            f"{expected_size}, got {data.size}.")
 
-    return data.reshape((dimension, dimension)).T
+    return data.reshape((dimension, dimension))
 
 
 def _closed_system_generator(hamiltonian):

--- a/python/cudaq/contrib/propagator.py
+++ b/python/cudaq/contrib/propagator.py
@@ -44,7 +44,7 @@ def _state_to_matrix(state,
                      column_major: bool = False) -> np.ndarray:
     """Convert a `vectorized` propagated identity state back to a matrix.
 
-    The dynamics backend vectorizes super-operator states in row-major order
+    The dynamics backend `vectorizes` super-operator states in row-major order
     for a single system but in column-major order for a batch, so the batched
     path must transpose to recover the same propagator.
     """

--- a/python/cudaq/contrib/propagator.py
+++ b/python/cudaq/contrib/propagator.py
@@ -39,8 +39,15 @@ def _basis_states(dimension: int):
     return states
 
 
-def _state_to_matrix(state, dimension: int) -> np.ndarray:
-    """Convert a `vectorized` propagated identity state back to a matrix."""
+def _state_to_matrix(state,
+                     dimension: int,
+                     column_major: bool = False) -> np.ndarray:
+    """Convert a `vectorized` propagated identity state back to a matrix.
+
+    The dynamics backend vectorizes super-operator states in row-major order
+    for a single system but in column-major order for a batch, so the batched
+    path must transpose to recover the same propagator.
+    """
     data = np.array(state).reshape(-1)
     expected_size = dimension * dimension
 
@@ -48,7 +55,8 @@ def _state_to_matrix(state, dimension: int) -> np.ndarray:
         raise RuntimeError("Expected propagator state with size "
                            f"{expected_size}, got {data.size}.")
 
-    return data.reshape((dimension, dimension))
+    matrix = data.reshape((dimension, dimension))
+    return matrix.T if column_major else matrix
 
 
 def _closed_system_generator(hamiltonian):
@@ -58,16 +66,18 @@ def _closed_system_generator(hamiltonian):
     return generator
 
 
-def _extract_propagator(result, dimension: int,
-                        store_intermediate_results: bool):
+def _extract_propagator(result,
+                        dimension: int,
+                        store_intermediate_results: bool,
+                        column_major: bool = False):
     """Extract closed-system propagators from a CUDA-Q evolve result."""
     if store_intermediate_results:
         return [
-            _state_to_matrix(state, dimension)
+            _state_to_matrix(state, dimension, column_major)
             for state in result.intermediate_states()
         ]
 
-    return _state_to_matrix(result.final_state(), dimension)
+    return _state_to_matrix(result.final_state(), dimension, column_major)
 
 
 def _extract_batched_basis_propagator(results,
@@ -237,9 +247,10 @@ def propagator(
 
     if is_batched:
         return [
-            _extract_propagator(single_result, propagator_dimension,
-                                store_intermediate_results)
-            for single_result in result
+            _extract_propagator(single_result,
+                                propagator_dimension,
+                                store_intermediate_results,
+                                column_major=True) for single_result in result
         ]
 
     return _extract_propagator(result, propagator_dimension,

--- a/python/tests/contrib/test_propagator.py
+++ b/python/tests/contrib/test_propagator.py
@@ -32,7 +32,7 @@ _X = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.complex128)
 _Z = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=np.complex128)
 
 
-def _solve_propagator_reference(hamiltonian_matrix, t_final):
+def _solve_propagator_reference(hamiltonian_matrix, t_final, times=None):
     dimension = hamiltonian_matrix(0.0).shape[0]
 
     def rhs(t, flattened_u):
@@ -47,10 +47,30 @@ def _solve_propagator_reference(hamiltonian_matrix, t_final):
         initial,
         rtol=1e-10,
         atol=1e-12,
+        t_eval=times,
     )
 
     assert solution.success
-    return solution.y[:, -1].reshape((dimension, dimension))
+
+    if times is None:
+        return solution.y[:, -1].reshape((dimension, dimension))
+
+    return [
+        solution.y[:, index].reshape((dimension, dimension))
+        for index in range(solution.y.shape[1])
+    ]
+
+
+_ASYMMETRIC_PARAMETERS = [(0.2, 0.35), (0.45, 0.15)]
+
+
+def _asymmetric_hamiltonian(ax, bz):
+    return (ax * ScalarOperator(lambda t: t) * spin.x(0) +
+            bz * ScalarOperator(lambda t: 1.0 - t) * spin.z(0))
+
+
+def _asymmetric_hamiltonian_matrix(ax, bz):
+    return lambda t: ax * t * _X + bz * (1.0 - t) * _Z
 
 
 def test_propagator_constant_z_hamiltonian():
@@ -101,6 +121,60 @@ def test_propagator_batched_hamiltonians():
     for propagator, omega in zip(computed, omegas):
         expected = scipy_linalg.expm(-1j * 0.5 * omega * _Z * t_final)
         np.testing.assert_allclose(propagator, expected, atol=1e-4)
+
+
+def test_propagator_batched_asymmetric_hamiltonians():
+    t_final = 0.8
+
+    hamiltonians = [
+        _asymmetric_hamiltonian(ax, bz) for ax, bz in _ASYMMETRIC_PARAMETERS
+    ]
+    schedule = Schedule(np.linspace(0.0, t_final, 41), ["t"])
+
+    computed = cudaq.contrib.propagator(
+        hamiltonians,
+        {0: 2},
+        schedule,
+        max_batch_size=2,
+    )
+
+    assert len(computed) == len(_ASYMMETRIC_PARAMETERS)
+
+    for propagator, (ax, bz) in zip(computed, _ASYMMETRIC_PARAMETERS):
+        expected = _solve_propagator_reference(
+            _asymmetric_hamiltonian_matrix(ax, bz), t_final)
+        assert np.abs(expected - expected.T).max() > 1e-3
+        np.testing.assert_allclose(propagator, expected, atol=1e-4)
+
+
+def test_propagator_batched_asymmetric_intermediate_results():
+    t_final = 0.8
+    steps = np.linspace(0.0, t_final, 5)
+
+    hamiltonians = [
+        _asymmetric_hamiltonian(ax, bz) for ax, bz in _ASYMMETRIC_PARAMETERS
+    ]
+    schedule = Schedule(steps, ["t"])
+
+    computed = cudaq.contrib.propagator(
+        hamiltonians,
+        {0: 2},
+        schedule,
+        store_intermediate_results=True,
+        max_batch_size=2,
+    )
+
+    assert len(computed) == len(_ASYMMETRIC_PARAMETERS)
+
+    for propagators, (ax, bz) in zip(computed, _ASYMMETRIC_PARAMETERS):
+        expected = _solve_propagator_reference(_asymmetric_hamiltonian_matrix(
+            ax, bz),
+                                               t_final,
+                                               times=steps)
+        assert len(propagators) == len(steps)
+        assert np.abs(expected[-1] - expected[-1].T).max() > 1e-3
+        for actual, single_expected in zip(propagators, expected):
+            np.testing.assert_allclose(actual, single_expected, atol=1e-4)
 
 
 def test_propagator_intermediate_results():


### PR DESCRIPTION
`cudaq.contrib.propagator` returned the transpose of the closed-system propagator `U`. `_state_to_matrix` applied a `.T` when reshaping the evolved state, assuming the dynamics backend vectorizes the operator in column-major order. It's actually row-major, so the flat state reshapes directly into `U`.

# Tests

```
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /workspaces/cuda-quantum
configfile: pyproject.toml
plugins: xdist-3.8.0, anyio-4.14.2
collected 14 items                                                                                                                                                            

python/tests/contrib/test_propagator.py::test_propagator_constant_z_hamiltonian PASSED                                                                                  [  7%]
python/tests/contrib/test_propagator.py::test_propagator_constant_x_hamiltonian PASSED                                                                                  [ 14%]
python/tests/contrib/test_propagator.py::test_propagator_batched_hamiltonians PASSED                                                                                    [ 21%]
python/tests/contrib/test_propagator.py::test_propagator_intermediate_results PASSED                                                                                    [ 28%]
python/tests/contrib/test_propagator.py::test_propagator_commuting_time_dependent_hamiltonian PASSED                                                                    [ 35%]
python/tests/contrib/test_propagator.py::test_propagator_noncommuting_time_dependent_hamiltonian PASSED                                                                 [ 42%]
python/tests/contrib/test_propagator.py::test_open_system_propagator_amplitude_damping PASSED                                                                           [ 50%]
python/tests/contrib/test_propagator.py::test_open_system_propagator_shape PASSED                                                                                       [ 57%]
python/tests/contrib/test_propagator.py::test_propagator_multi_degree_of_freedom PASSED                                                                                 [ 64%]
python/tests/contrib/test_propagator.py::test_open_system_propagator_schedule_parameter_name PASSED                                                                     [ 71%]
python/tests/contrib/test_propagator.py::test_open_system_propagator_nonzero_hamiltonian PASSED                                                                         [ 78%]
python/tests/contrib/test_propagator.py::test_open_system_propagator_batched_shared_collapse_operators PASSED                                                           [ 85%]
python/tests/contrib/test_propagator.py::test_open_system_propagator_batched_collapse_operator_lists PASSED                                                             [ 92%]
python/tests/contrib/test_propagator.py::test_open_system_propagator_intermediate_results PASSED                                                                        [100%]
```