### PR TITLE
Add post rotation-synthesis Clifford+T benchmark target

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.h
@@ -79,7 +79,8 @@ void addDecomposition(mlir::OpPassManager &pm,
 /// idempotent on already-lowered IR, so the duplication is safe.
 ///
 /// Opt-in only. This helper is not added to default target pipelines.
-void addCliffordTSynthesis(mlir::OpPassManager &pm, double epsilon = 1e-10);
+void addCliffordTSynthesis(mlir::OpPassManager &pm, double epsilon = 1e-10,
+                           bool failOnControlledRotation = false);
 
 void registerAOTPipelines();
 void registerJITPipelines();

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -210,6 +210,12 @@ def CliffordTSynthesis : Pass<"clifford-t-synthesis", "mlir::ModuleOp"> {
     Option<"onDynamicAngle", "on-dynamic-angle", "std::string",
       /*default=*/"\"error\"",
       "Behavior on non-constant rotation angles: 'error' or 'skip'.">,
+    // TODO: Remove this option once controlled Clifford+T synthesis preserves
+    // the synthesis global phase.
+    Option<"failOnControlledRotation", "fail-on-controlled-rotation", "bool",
+      /*default=*/"false",
+      "Fail instead of preserving a controlled rotation that cannot be "
+      "synthesized without global-phase support.">,
     Option<"skipBelow", "skip-below", "double", /*default=*/"1e-12",
       "Erase (treat as identity) rotations whose |theta| is below this "
       "threshold, rather than synthesizing a Clifford+T approximation for "

--- a/cudaq/lib/Optimizer/Transforms/CliffordTSynthesis.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CliffordTSynthesis.cpp
@@ -42,6 +42,7 @@ struct RotationOptions {
   int32_t factoringTimeoutMs;
   int32_t retryCount;
   std::string onDynamicAngle;
+  bool failOnControlledRotation;
   double skipBelow;
 };
 
@@ -226,6 +227,12 @@ static PreCheck validateRotationOperands(Operation *op, Value angleVal,
                                          const RotationOptions &opts,
                                          bool *hadHardError) {
   if (!controls.empty()) {
+    if (opts.failOnControlledRotation) {
+      op->emitError("clifford-t-synthesis: controlled rotation requires "
+                    "global-phase-aware synthesis");
+      *hadHardError = true;
+      return {PreCheck::Action::LeaveInPlace, 0.0};
+    }
     op->emitRemark("clifford-t-synthesis: skipping controlled rotation; run "
                    "ApplyOpSpecialization to materialize controls before "
                    "synthesis");
@@ -370,7 +377,8 @@ public:
 
     RotationOptions opts{
         epsilon,    diophantineTimeoutMs,      factoringTimeoutMs,
-        retryCount, onDynamicAngle.getValue(), skipBelow};
+        retryCount, onDynamicAngle.getValue(), failOnControlledRotation,
+        skipBelow};
 
     MLIRContext *ctx = &getContext();
     SynthState state;

--- a/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -658,8 +658,9 @@ struct R1ToRz
       return failure();
 
     rewriter.replaceOpWithNewOp<cudaq::quake::RzOp>(
-        r1Op, r1Op.isAdj(), r1Op.getParameters(), r1Op.getControls(),
-        r1Op.getTargets());
+        r1Op, r1Op.getResultTypes(), r1Op.isAdj(), r1Op.getParameters(),
+        r1Op.getControls(), r1Op.getTargets(),
+        r1Op.getNegatedQubitControlsAttr());
     return success();
   }
 };

--- a/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
@@ -77,6 +77,10 @@ struct FaultTolerantTargetPipelineOptions
       *this, "epsilon",
       llvm::cl::desc("Approximation tolerance for Clifford+T synthesis."),
       llvm::cl::init(1e-10)};
+  PassOptions::Option<bool> failOnControlledRotation{
+      *this, "fail-on-controlled-rotation",
+      llvm::cl::desc("Reject controlled rotations left at synthesis."),
+      llvm::cl::init(false)};
 };
 } // namespace
 
@@ -170,7 +174,8 @@ void cudaq::opt::addDecomposition(OpPassManager &pm,
   pm.addPass(cudaq::opt::createDecomposition(opts));
 }
 
-void cudaq::opt::addCliffordTSynthesis(OpPassManager &pm, double epsilon) {
+void cudaq::opt::addCliffordTSynthesis(OpPassManager &pm, double epsilon,
+                                       bool failOnControlledRotation) {
   pm.addPass(cudaq::opt::createUnitarySynthesis());
   pm.addPass(cudaq::opt::createApplySpecialization());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createConstantPropagation());
@@ -180,6 +185,7 @@ void cudaq::opt::addCliffordTSynthesis(OpPassManager &pm, double epsilon) {
   cudaq::opt::addDecomposition(pm, {"RxToRz", "RyToRz", "R1ToRz"});
   cudaq::opt::CliffordTSynthesisOptions ctsOpts;
   ctsOpts.epsilon = epsilon;
+  ctsOpts.failOnControlledRotation = failOnControlledRotation;
   pm.addPass(cudaq::opt::createCliffordTSynthesis(ctsOpts));
   cudaq::opt::DecompositionOptions decOpts;
   decOpts.basis = {"h", "s", "t", "x", "z", "x(1)"};
@@ -192,7 +198,8 @@ void cudaq::opt::registerFaultTolerantTargetPipeline() {
       "Lower rotations to the {H, S, T, X, Z, CNOT} basis via Clifford+T "
       "synthesis.",
       [](OpPassManager &pm, const FaultTolerantTargetPipelineOptions &options) {
-        cudaq::opt::addCliffordTSynthesis(pm, options.epsilon);
+        cudaq::opt::addCliffordTSynthesis(pm, options.epsilon,
+                                          options.failOnControlledRotation);
       });
 }
 

--- a/cudaq/lib/Optimizer/Transforms/ResourceCountPreprocess.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ResourceCountPreprocess.cpp
@@ -74,13 +74,38 @@ struct ResourceCountPreprocessPass
     if (!isQuakeOperation(op))
       return false;
 
+    if (auto measurement = dyn_cast<cudaq::quake::MeasurementInterface>(op);
+        isa<cudaq::quake::MxOp, cudaq::quake::MyOp>(op)) {
+      // An unused measurement cannot affect resource-count control flow. Count
+      // it from Quake IR before code generation lowers its axis to an execution
+      // manager Z measurement, then remove it with the other pre-counted ops.
+      for (Value result : op->getResults())
+        if (!result.use_empty())
+          return false;
+
+      std::vector<std::size_t> targetIndices;
+      bool allResolved = true;
+      for (Value target : measurement.getTargets()) {
+        if (auto idx = resolveQubitIndex(target))
+          targetIndices.push_back(*idx);
+        else
+          allResolved = false;
+      }
+      if (!allResolved)
+        targetIndices.clear();
+
+      auto name = op->getName().stripDialect();
+      if (dumpPreprocessed)
+        llvm::outs() << "Preprocessing " << name << "(0) for " << to_add
+                     << " counts\n";
+      countGate(name.str(), {}, targetIndices, to_add);
+      to_erase.insert(op);
+      return true;
+    }
+
     auto opi = dyn_cast<cudaq::quake::OperatorInterface>(op);
 
     if (!opi)
-      return false;
-
-    // Measures may affect control flow, don't remove for now
-    if (isa<cudaq::quake::MeasurementInterface>(op))
       return false;
 
     auto name = op->getName().stripDialect();

--- a/cudaq/test/Transforms/CliffordTSynthesis/controls_error.qke
+++ b/cudaq/test/Transforms/CliffordTSynthesis/controls_error.qke
@@ -1,0 +1,23 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --clifford-t-synthesis='epsilon=1e-3 fail-on-controlled-rotation=true' -verify-diagnostics %s
+// RUN: cudaq-opt --cudaq-fault-tolerant-target='epsilon=1e-3 fail-on-controlled-rotation=true' -verify-diagnostics %s
+
+// A resource boundary must reject a controlled rotation rather than silently
+// preserving an operation the resource counter cannot represent. Global-phase
+// aware synthesis is required before this case can be lowered directly.
+
+func.func @ctrl() {
+  %q = quake.alloca !quake.ref
+  %c = quake.alloca !quake.ref
+  %a = arith.constant 0.7853981633974483 : f64
+  // expected-error @+1 {{controlled rotation requires global-phase-aware synthesis}}
+  quake.rz (%a) [%c] %q : (f64, !quake.ref, !quake.ref) -> ()
+  return
+}

--- a/cudaq/test/Transforms/CliffordTSynthesis/fault_tolerant_target_pipeline.qke
+++ b/cudaq/test/Transforms/CliffordTSynthesis/fault_tolerant_target_pipeline.qke
@@ -9,6 +9,11 @@
 
 // RUN: cudaq-opt --cudaq-fault-tolerant-target='epsilon=1e-3' %s | \
 // RUN:   FileCheck %s --implicit-check-not='quake.r{{[xyz1]}}'
+// RUN: cudaq-opt --pass-pipeline='builtin.module(cudaq-fault-tolerant-target{epsilon=1e-3 fail-on-controlled-rotation=true},inline,func.func(memtoreg,quake-simplify,canonicalize,dqe,regtomem),symbol-dce)' %s | \
+// RUN:   FileCheck %s --check-prefix=FLAT \
+// RUN:   --implicit-check-not='func.call' \
+// RUN:   --implicit-check-not='func.func private @__cliffordt_' \
+// RUN:   --implicit-check-not='quake.r{{[xyz1]}}'
 
 // End-to-end test of the registered `cudaq-fault-tolerant-target` pipeline
 // (UnitarySynthesis -> ApplyOpSpecialization -> ConstantPropagation ->
@@ -17,12 +22,13 @@
 // the fault-tolerant basis. gridsynth output is stochastic, so we assert only
 // structural invariants.
 
-func.func @kernel() {
+func.func @kernel() -> !quake.measure {
   %q = quake.alloca !quake.ref
   %a = arith.constant 0.7853981633974483 : f64
   quake.rz (%a) %q : (f64, !quake.ref) -> ()
   quake.h %q : (!quake.ref) -> ()
-  return
+  %m = quake.mz %q : (!quake.ref) -> !quake.measure
+  return %m : !quake.measure
 }
 
 // The constant rotation is synthesized into a Clifford+T helper (dozens of T
@@ -39,14 +45,24 @@ func.func @kernel() {
 // rotation ops. The kernel is marked as an entry point so the decomposition
 // pass processes it (it only decomposes entry points or functions taking
 // qubit arguments).
-func.func @kernel_rx_ry() attributes {"cudaq-entrypoint"} {
+func.func @kernel_rx_ry() -> !quake.measure attributes {"cudaq-entrypoint"} {
   %q = quake.alloca !quake.ref
   %a = arith.constant 0.7853981633974483 : f64
   quake.rx (%a) %q : (f64, !quake.ref) -> ()
   quake.ry (%a) %q : (f64, !quake.ref) -> ()
-  return
+  %m = quake.mz %q : (!quake.ref) -> !quake.measure
+  return %m : !quake.measure
 }
 
 // CHECK-LABEL: func.func @kernel_rx_ry
 // CHECK:         quake.alloca
 // CHECK:         call @__cliffordt_rz_
+
+// The benchmark boundary inlines the shared angle helper at every call site
+// and deletes the helper symbol before resource counting.
+// FLAT-LABEL: func.func @kernel
+// FLAT:         quake.t
+// FLAT:         quake.mz
+// FLAT-LABEL: func.func @kernel_rx_ry
+// FLAT:         quake.t
+// FLAT:         quake.mz

--- a/cudaq/test/Transforms/CliffordTSynthesis/invalid_options.qke
+++ b/cudaq/test/Transforms/CliffordTSynthesis/invalid_options.qke
@@ -1,0 +1,19 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --clifford-t-synthesis='epsilon=0' -verify-diagnostics %s
+
+// expected-error @+1 {{clifford-t-synthesis: invalid options; require epsilon > 0}}
+module {
+  func.func @rotation() {
+    %q = quake.alloca !quake.ref
+    %a = arith.constant 0.125 : f64
+    quake.rz (%a) %q : (f64, !quake.ref) -> ()
+    return
+  }
+}

--- a/cudaq/test/Transforms/DecompositionPatterns/R1ToRz.qke
+++ b/cudaq/test/Transforms/DecompositionPatterns/R1ToRz.qke
@@ -1,0 +1,29 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=R1ToRz})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=R1ToRz})' %s | CircuitCheck %s --up-to-global-phase
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=R1ToRz})' %s | FileCheck %s --check-prefix=VALUE
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=R1ToRz})' %s | CircuitCheck %s --up-to-global-phase
+
+// R1 and Rz differ only by global phase. The value-semantics run ensures the
+// replacement preserves the wire result introduced by memtoreg.
+
+// CHECK-LABEL: func.func @test
+func.func @test(%qubit: !quake.ref) {
+  %0 = arith.constant 1.57079632679489660 : f64
+  // CHECK: quake.rz
+  // CHECK-NOT: quake.r1
+  quake.r1 (%0) %qubit : (f64, !quake.ref) -> ()
+  return
+}
+
+// VALUE-LABEL: func.func @test
+// VALUE: quake.rz
+// VALUE-SAME: -> !quake.wire
+// VALUE-NOT: quake.r1

--- a/cudaq/test/Transforms/resource_count_preprocess.qke
+++ b/cudaq/test/Transforms/resource_count_preprocess.qke
@@ -190,3 +190,62 @@ func.func @kernel_veq_ctrl() {
   quake.x [%ctrl] %3 : (!quake.veq<2>, !quake.ref) -> ()
   return
 }
+
+// -----
+
+// CHECK: Preprocessing mx(0) for 1 counts
+// CHECK: Preprocessing my(0) for 1 counts
+// CHECK-LABEL: func.func @kernel_axis_measurements() {
+// CHECK:   %0 = quake.alloca !quake.ref
+// CHECK:   %1 = quake.alloca !quake.ref
+// CHECK-NOT: quake.m{{[xyz]}}
+// CHECK:   return
+// CHECK: }
+
+// Unused axis measurements are invariant for resource counting. Count them
+// before execution-manager lowering would normalize their axes to Z.
+func.func @kernel_axis_measurements() {
+  %0 = quake.alloca !quake.ref
+  %1 = quake.alloca !quake.ref
+  %mx = quake.mx %0 : (!quake.ref) -> !quake.measure
+  %my = quake.my %1 : (!quake.ref) -> !quake.measure
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_used_axis_measurement() {
+// CHECK:   %measOut = quake.mx %0 : (!quake.ref) -> !quake.measure
+// CHECK:   %{{.*}} = quake.discriminate %measOut : (!quake.measure) -> i1
+// CHECK:   cc.if
+// CHECK:     quake.x %1 : (!quake.ref) -> ()
+// CHECK:   return
+// CHECK: }
+
+// Retain a measurement whose result may influence control flow.
+func.func @kernel_used_axis_measurement() {
+  %0 = quake.alloca !quake.ref
+  %1 = quake.alloca !quake.ref
+  %measOut = quake.mx %0 : (!quake.ref) -> !quake.measure
+  %2 = quake.discriminate %measOut : (!quake.measure) -> i1
+  cc.if(%2) {
+    quake.x %1 : (!quake.ref) -> ()
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @kernel_used_axis_wire(
+// CHECK:   quake.my
+// CHECK:   quake.sink
+// CHECK:   return
+// CHECK: }
+
+// The linear-value result is also a live measurement result and must retain
+// the operation for subsequent lowering.
+func.func @kernel_used_axis_wire(%q: !quake.wire) {
+  %0:2 = quake.my %q : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.sink %0#1 : !quake.wire
+  return
+}

--- a/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
+++ b/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
@@ -1,0 +1,82 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import math
+
+import cudaq
+import pytest
+
+FTQC_CLIFFORD_T_TARGET = 'compiler-bench-ftqc-clifford-t'
+
+ALLOWED_CLIFFORD_T_OPS = {
+    'h', 's', 'sdg', 't', 'tdg', 'x', 'y', 'z', 'cx', 'cy', 'cz', 'swap', 'mz'
+}
+
+
+@pytest.fixture(autouse=True)
+def reset():
+    cudaq.reset_target()
+    yield
+    cudaq.reset_target()
+
+
+def test_compiles_full_pipeline_to_flat_clifford_t_boundary():
+    cudaq.set_target(FTQC_CLIFFORD_T_TARGET, epsilon='0.001')
+
+    candidate = cudaq.make_kernel()
+    q = candidate.qalloc(20)
+    candidate.rz(math.pi / 8, q[0])
+    candidate.rz(math.pi / 8, q[0])
+    candidate.rz(0.0005, q[1])
+    candidate.ry(0.25, q[2])
+    candidate.crz(0.125, q[3], q[4])
+    candidate.y(q[5])
+    candidate.cy(q[6], q[7])
+    candidate.cz(q[8], q[9])
+    candidate.swap(q[10], q[11])
+    candidate.mx(q[12])
+    candidate.my(q[13])
+    candidate.cx([q[14], q[15]], q[16])
+    candidate.cz([q[17], q[18]], q[19])
+    for i in range(12):
+        candidate.mz(q[i])
+
+    reference = cudaq.make_kernel()
+    q = reference.qalloc(20)
+    reference.rz(math.pi / 4, q[0])
+    reference.ry(0.25, q[2])
+    reference.crz(0.125, q[3], q[4])
+    reference.y(q[5])
+    reference.cy(q[6], q[7])
+    reference.cz(q[8], q[9])
+    reference.swap(q[10], q[11])
+    reference.mx(q[12])
+    reference.my(q[13])
+    reference.cx([q[14], q[15]], q[16])
+    reference.cz([q[17], q[18]], q[19])
+    for i in range(12):
+        reference.mz(q[i])
+
+    candidate_resources = cudaq.estimate_resources(candidate)
+    reference_resources = cudaq.estimate_resources(reference)
+    operations = candidate_resources.to_dict()
+    reference_operations = reference_resources.to_dict()
+    t_count = operations.get('t', 0) + operations.get('tdg', 0)
+    reference_t_count = (reference_operations.get('t', 0) +
+                         reference_operations.get('tdg', 0))
+
+    assert set(operations).issubset(ALLOWED_CLIFFORD_T_OPS)
+    assert operations.get('cx', 0) >= 2
+    assert operations.get('y', 0) == 1
+    assert operations.get('cy', 0) == 1
+    assert operations.get('cz', 0) == 1
+    assert operations.get('swap', 0) == 1
+    assert operations.get('mz', 0) == 14
+    assert t_count == reference_t_count
+    assert t_count > 0
+    assert candidate_resources.depth > 0

--- a/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
+++ b/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
@@ -81,7 +81,7 @@ def test_compiles_full_pipeline_to_flat_clifford_t_boundary():
     assert t_count > 0
     assert candidate_resources.depth > 0
 
-    # Synthesis epsilon owns approximate pruning at the target boundary.
+    # The target epsilon preserves rotations above its pruning boundary.
     cudaq.reset_target()
     cudaq.set_target(FTQC_CLIFFORD_T_TARGET, epsilon='1e-13')
     precision_boundary = cudaq.make_kernel()

--- a/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
+++ b/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
@@ -80,3 +80,14 @@ def test_compiles_full_pipeline_to_flat_clifford_t_boundary():
     assert t_count == reference_t_count
     assert t_count > 0
     assert candidate_resources.depth > 0
+
+    # Synthesis epsilon owns approximate pruning at the target boundary.
+    cudaq.reset_target()
+    cudaq.set_target(FTQC_CLIFFORD_T_TARGET, epsilon='1e-13')
+    precision_boundary = cudaq.make_kernel()
+    q = precision_boundary.qalloc()
+    precision_boundary.rz(5e-13, q)
+    boundary_operations = cudaq.estimate_resources(precision_boundary).to_dict()
+    boundary_t_count = (boundary_operations.get('t', 0) +
+                        boundary_operations.get('tdg', 0))
+    assert boundary_t_count > 0

--- a/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
+++ b/python/tests/backends/test_compiler_bench_ftqc_clifford_t.py
@@ -14,7 +14,8 @@ import pytest
 FTQC_CLIFFORD_T_TARGET = 'compiler-bench-ftqc-clifford-t'
 
 ALLOWED_CLIFFORD_T_OPS = {
-    'h', 's', 'sdg', 't', 'tdg', 'x', 'y', 'z', 'cx', 'cy', 'cz', 'swap', 'mz'
+    'h', 's', 'sdg', 't', 'tdg', 'x', 'y', 'z', 'cx', 'cy', 'cz', 'swap', 'mx',
+    'my', 'mz'
 }
 
 
@@ -76,7 +77,9 @@ def test_compiles_full_pipeline_to_flat_clifford_t_boundary():
     assert operations.get('cy', 0) == 1
     assert operations.get('cz', 0) == 1
     assert operations.get('swap', 0) == 1
-    assert operations.get('mz', 0) == 14
+    assert operations.get('mx', 0) == 1
+    assert operations.get('my', 0) == 1
+    assert operations.get('mz', 0) == 12
     assert t_count == reference_t_count
     assert t_count > 0
     assert candidate_resources.depth > 0

--- a/python/tests/backends/test_compiler_bench_ftqc_logical.py
+++ b/python/tests/backends/test_compiler_bench_ftqc_logical.py
@@ -15,8 +15,8 @@ import pytest
 FTQC_LOGICAL_TARGET = 'compiler-bench-ftqc-logical'
 
 ALLOWED_LOGICAL_OPS = {
-    'h', 's', 'sdg', 't', 'tdg', 'rx', 'ry', 'rz', 'x', 'y', 'z', 'cx', 'cy',
-    'cz', 'ccx', 'ccz', 'mz'
+    'h', 's', 'sdg', 't', 'tdg', 'rx', 'ry', 'rz', 'x', 'y', 'z', 'swap', 'cx',
+    'cy', 'cz', 'ccx', 'ccz', 'mz'
 }
 
 
@@ -62,16 +62,18 @@ def test_preserves_structured_logical_operations():
     cudaq.set_target(FTQC_LOGICAL_TARGET)
 
     kernel = cudaq.make_kernel()
-    q = kernel.qalloc(3)
+    q = kernel.qalloc(5)
     kernel.cz(q[0], q[1])
     kernel.cx([q[0], q[1]], q[2])
     kernel.cz([q[0], q[1]], q[2])
+    kernel.swap(q[3], q[4])
 
     ops = cudaq.estimate_resources(kernel).to_dict()
     assert_logical_basis_only(ops)
     assert ops.get('cz', 0) == 1
     assert ops.get('ccx', 0) == 1
     assert ops.get('ccz', 0) == 1
+    assert ops.get('swap', 0) == 1
 
 
 def test_preserves_native_cy_as_structured_logical_operation():
@@ -110,13 +112,11 @@ def test_composite_operations_lower_to_logical_basis():
     q = kernel.qalloc(3)
     kernel.r1(0.75, q[0])
     kernel.cr1(0.375, q[1], q[2])
-    kernel.swap(q[0], q[2])
 
     ops = cudaq.estimate_resources(kernel).to_dict()
     assert_logical_basis_only(ops)
     assert 'r1' not in ops, f"R1 did not lower to RZ: {ops}"
     assert 'cr1' not in ops, f"CR1 did not lower to CX/RZ basis: {ops}"
-    assert 'swap' not in ops, f"SWAP did not lower to CX basis: {ops}"
     assert ops.get('rz', 0) >= 2
     assert ops.get('cx', 0) >= 1
 

--- a/python/tests/backends/test_compiler_bench_ftqc_logical.py
+++ b/python/tests/backends/test_compiler_bench_ftqc_logical.py
@@ -16,7 +16,7 @@ FTQC_LOGICAL_TARGET = 'compiler-bench-ftqc-logical'
 
 ALLOWED_LOGICAL_OPS = {
     'h', 's', 'sdg', 't', 'tdg', 'rx', 'ry', 'rz', 'x', 'y', 'z', 'swap', 'cx',
-    'cy', 'cz', 'ccx', 'ccz', 'mz'
+    'cy', 'cz', 'ccx', 'ccz', 'mx', 'my', 'mz'
 }
 
 
@@ -102,7 +102,9 @@ def test_axis_measurements_count_as_measurements():
 
     ops = cudaq.estimate_resources(kernel).to_dict()
     assert_logical_basis_only(ops)
-    assert ops.get('mz', 0) == 3
+    assert ops.get('mx', 0) == 1
+    assert ops.get('my', 0) == 1
+    assert ops.get('mz', 0) == 1
 
 
 def test_composite_operations_lower_to_logical_basis():

--- a/runtime/cudaq/platform/default/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/CMakeLists.txt
@@ -68,6 +68,7 @@ endif()
 add_target_config(opt-test)
 add_target_config(compiler-bench-nisq)
 add_target_config(compiler-bench-ftqc-logical)
+add_target_config(compiler-bench-ftqc-clifford-t)
 
 if (cuStateVec_FOUND)
   add_target_config(nvidia)

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
@@ -28,4 +28,4 @@ config:
   #
   # TODO: Remove fail-on-controlled-rotation after controlled Clifford+T
   # synthesis preserves the synthesis global phase.
-  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,swap,x(1),y(1),z(1),x(2),z(2)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe,memtoreg,quake-simplify,canonicalize,dqe),unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=%EPSILON:1e-10% fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"
+  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe,memtoreg),unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},func.func(quake-simplify{threshold=0},canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=%EPSILON:1e-10% fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
@@ -1,0 +1,31 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+name: compiler-bench-ftqc-clifford-t
+description: "Post-rotation-synthesis Clifford+T benchmark target for resource counting"
+
+target-arguments:
+  - key: epsilon
+    required: false
+    type: string
+    help-string: "Per-rotation approximation tolerance. Defaults to 1e-10."
+
+config:
+  nvqir-simulation-backend: qpp
+  # Preserve named Clifford operations while reducing rotations and
+  # non-Clifford controlled gates before synthesis. Keep the circuit in value
+  # semantics through post-synthesis simplification.
+  # TODO: Standardize this with compiler-bench-ftqc-logical.yml once we know
+  # what the common pipeline should be.
+  #
+  # Clifford+T synthesis outlines one private helper for each distinct angle.
+  # Inline those helpers and simplify before the resource-counting boundary.
+  #
+  # TODO: Remove fail-on-controlled-rotation after controlled Clifford+T
+  # synthesis preserves the synthesis global phase.
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,swap,x(1),y(1),z(1),x(2),z(2)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe,memtoreg,quake-simplify,canonicalize,dqe),unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=%EPSILON:1e-10% fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
@@ -20,12 +20,12 @@ config:
   # Preserve named Clifford operations while reducing rotations and
   # non-Clifford controlled gates before synthesis. Keep the circuit in value
   # semantics through post-synthesis simplification.
-  # TODO: Standardize this with compiler-bench-ftqc-logical.yml once we know
-  # what the common pipeline should be.
+  # Use the shared conversion pipeline with compiler-bench-ftqc-logical.yml
+  # so both FTQC targets enter explicit linear value semantics consistently.
   #
   # Clifford+T synthesis outlines one private helper for each distinct angle.
   # Inline those helpers and simplify before the resource-counting boundary.
   #
   # TODO: Remove fail-on-controlled-rotation after controlled Clifford+T
   # synthesis preserves the synthesis global phase.
-  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe,memtoreg),unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},func.func(quake-simplify{threshold=0},canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=%EPSILON:1e-10% fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"
+  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},func.func(quake-simplify{threshold=0},canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=%EPSILON:1e-10% fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
@@ -28,4 +28,4 @@ config:
   #
   # TODO: Remove fail-on-controlled-rotation after controlled Clifford+T
   # synthesis preserves the synthesis global phase.
-  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},func.func(quake-simplify{threshold=0},canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=%EPSILON:1e-10% fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"
+  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},func.func(quake-simplify{threshold=%EPSILON:1e-10%},canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=0 fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
@@ -28,4 +28,4 @@ config:
   #
   # TODO: Remove fail-on-controlled-rotation after controlled Clifford+T
   # synthesis preserves the synthesis global phase.
-  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,x(1),y(1),z(1)},func.func(quake-simplify{threshold=%EPSILON:1e-10%},canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=0 fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"
+  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1)},func.func(quake-simplify{threshold=%EPSILON:1e-10%},canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=0 fail-on-controlled-rotation=true},inline,func.func(quake-simplify,canonicalize,dqe,regtomem),symbol-dce"

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
@@ -15,5 +15,5 @@ config:
   # memory semantics, then enter value semantics once for local gate
   # simplification. The basis preserves T-family gates and unresolved
   # single-qubit rotations for layer-one FTQC metrics.
-  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1),y(1),z(1),x(2),z(2)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,func.func(quake-simplify,canonicalize,dqe,regtomem)"
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,swap,x(1),y(1),z(1),x(2),z(2)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,func.func(quake-simplify,canonicalize,dqe,regtomem)"
   

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
@@ -15,5 +15,5 @@ config:
   # memory semantics, then enter value semantics once for local gate
   # simplification. The basis preserves T-family gates and unresolved
   # single-qubit rotations for layer-one FTQC metrics.
-  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,swap,x(1),y(1),z(1),x(2),z(2)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,func.func(quake-simplify,canonicalize,dqe,regtomem)"
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1),x(2),z(2)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,func.func(quake-simplify,canonicalize,dqe,regtomem)"
   

--- a/scripts/validate_installation.sh
+++ b/scripts/validate_installation.sh
@@ -124,6 +124,7 @@ should_skip_install_validation_target() {
     "opt-test.yml"
     "compiler-bench-nisq.yml"
     "compiler-bench-ftqc-logical.yml"
+    "compiler-bench-ftqc-clifford-t.yml"
   )
 
   for skipped_target_config in "${skipped_target_configs[@]}"; do


### PR DESCRIPTION
Expose an epsilon-configurable compiler-bench target that repeats the complete FTQC logical benchmark pipeline before explicit Clifford+T synthesis and post-synthesis cleanup. Keep the logical stages expanded and manually aligned for now, with a TODO to standardize their shared contract in a follow-up. The PR also corrects an issue in our targets in our targets where we weren't previously lowering to the contract gatesets for the stages due to incomplete support (which has since been resolved) and extends the supported gates to clifford+T+rotations+mx/my/mz for the logical target.

Fail explicitly if controlled rotations remain because an omitted synthesis global phase would become observable under control requires #4976. This should be removed after merger.