### PR TITLE
[Python] Fix transposed closed-system propagator in cudaq.contrib

### DIFF
--- a/python/cudaq/contrib/propagator.py
+++ b/python/cudaq/contrib/propagator.py
@@ -48,7 +48,7 @@ def _state_to_matrix(state, dimension: int) -> np.ndarray:
         raise RuntimeError("Expected propagator state with size "
                            f"{expected_size}, got {data.size}.")
 
-    return data.reshape((dimension, dimension)).T
+    return data.reshape((dimension, dimension))
 
 
 def _closed_system_generator(hamiltonian):


### PR DESCRIPTION
`_state_to_matrix` rebuilt the propagator with an extra `.T`, inconsistent with the C-order flattening used to construct the initial identity state, so it returned `U^T` instead of `U`. This is invisible for symmetric propagators (the Z/X test cases) but wrong for a general non-symmetric U such as a noncommuting time-dependent Hamiltonian.

Drop the .T to keep reconstruction row-major-consistent. Fixes test_propagator_noncommuting_time_dependent_hamiltonian.

Found recently while working on the new Validation pipeline: https://github.com/NVIDIA/cuda-quantum/actions/runs/31439915220/job/93626855285#step:7:21873

```
>       np.testing.assert_allclose(computed, expected, atol=1e-4)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=0.0001
E       
E       Mismatched elements: 2 / 4 (50%)
E       Mismatch at indices:
E        [0, 1]: (-0.005951216472463002-0.06352238385117413j) (ACTUAL), (0.005951216483126702-0.06352238379971506j) (DESIRED)
E        [1, 0]: (0.005951216472463002-0.06352238385117413j) (ACTUAL), (-0.0059512164831267015-0.06352238379971505j) (DESIRED)
E       Max absolute difference among violations: 0.01190243
E       Max relative difference among violations: 0.1865569
E        ACTUAL: array([[ 0.983887-0.16702j , -0.005951-0.063522j],
E              [ 0.005951-0.063522j,  0.983887+0.16702j ]])
E        DESIRED: array([[ 0.983887-0.16702j ,  0.005951-0.063522j],
E              [-0.005951-0.063522j,  0.983887+0.16702j ]])
```