### PR TITLE
Add standalone ObservableUserData helper for external plugins

### DIFF
--- a/runtime/common/ObservableUserData.h
+++ b/runtime/common/ObservableUserData.h
@@ -1,0 +1,49 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// Helpers for attaching a full spin_op to KernelExecution::user_data when a
+/// REST / custom QPU backend evaluates observables server-side.
+///
+/// This is intentionally independent of the in-tree Fermioniq backend, which
+/// keeps its own private attach helper so Fermioniq wire-format changes do not
+/// impact external plugins (and vice versa).
+
+#pragma once
+
+#include "common/KernelExecution.h"
+#include "nlohmann/json.hpp"
+#include "cudaq/runtime/logger/cudaq_fmt.h"
+#include "cudaq/spin_op.h"
+#include <cmath>
+
+namespace cudaq {
+
+/// @brief Attach a full spin observable to a KernelExecution as
+/// `user_data["observable"]` for server-side observe backends.
+///
+/// Wire format:
+/// `[["Z0", "0.5+0.0j"], ["Z0 Z1", "0.3+0.0j"], ...]`
+inline void attachObservableUserData(KernelExecution &code,
+                                     const spin_op &spin) {
+  nlohmann::json user_data = nlohmann::json::object();
+  nlohmann::json obs = nlohmann::json::array();
+  for (const auto &term : spin) {
+    nlohmann::json terms = nlohmann::json::array();
+    terms.push_back(term.get_term_id());
+    auto coeff = term.evaluate_coefficient();
+    auto coeff_str = cudaq_fmt::format("{}{}{}j", coeff.real(),
+                                       coeff.imag() < 0.0 ? "-" : "+",
+                                       std::fabs(coeff.imag()));
+    terms.push_back(coeff_str);
+    obs.push_back(std::move(terms));
+  }
+  user_data["observable"] = std::move(obs);
+  code.user_data = cudaq_json(std::move(user_data));
+}
+
+} // namespace cudaq

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -242,6 +242,19 @@ target_link_libraries(test_exec_ctx_thread
   gtest_main)
 cudaq_gtest_discover_tests(test_exec_ctx_thread DISCOVERY_TIMEOUT 120)
 
+# Standalone server-side observe helper for external custom QPU plugins
+add_executable(test_observable_user_data
+  main.cpp
+  common/ObservableUserDataTester.cpp)
+target_include_directories(test_observable_user_data PRIVATE .)
+target_link_libraries(test_observable_user_data
+  PRIVATE
+  cudaq
+  cudaq-common
+  cudaq-operator
+  gtest_main)
+cudaq_gtest_discover_tests(test_observable_user_data DISCOVERY_TIMEOUT 120)
+
 add_executable(test_quantum_platform main.cpp common/QuantumPlatformTester.cpp)
 target_include_directories(test_quantum_platform PRIVATE .)
 target_link_libraries(test_quantum_platform

--- a/unittests/common/ObservableUserDataTester.cpp
+++ b/unittests/common/ObservableUserDataTester.cpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// Unit tests for the standalone server-side observe user_data helper used by
+/// external custom QPU plugins.
+
+#include "common/ObservableUserData.h"
+#include "cudaq/operators.h"
+#include <gtest/gtest.h>
+#include <set>
+#include <string>
+
+TEST(ObservableUserDataTester, attachesObservableUserData) {
+  cudaq::KernelExecution code;
+  auto spin =
+      0.5 * cudaq::spin::z(0) + 0.3 * cudaq::spin::z(0) * cudaq::spin::z(1);
+
+  cudaq::attachObservableUserData(code, spin);
+
+  ASSERT_TRUE(code.user_data->contains("observable"));
+  ASSERT_TRUE(code.user_data->at("observable").is_array());
+  ASSERT_EQ(code.user_data->at("observable").size(), 2u);
+
+  std::set<std::string> termIds;
+  for (const auto &entry : code.user_data->at("observable")) {
+    ASSERT_TRUE(entry.is_array());
+    ASSERT_EQ(entry.size(), 2u);
+    ASSERT_TRUE(entry[0].is_string());
+    ASSERT_TRUE(entry[1].is_string());
+    termIds.insert(entry[0].get<std::string>());
+    // Coefficient strings: "re±imj"
+    const auto coeff = entry[1].get<std::string>();
+    EXPECT_NE(coeff.find('j'), std::string::npos);
+  }
+  EXPECT_TRUE(termIds.count("Z0"));
+  EXPECT_TRUE(termIds.count("Z0Z1"));
+}


### PR DESCRIPTION
## Summary
- Add `runtime/common/ObservableUserData.h` with `attachObservableUserData()` for external / custom server-side observe plugins
- Leave the in-tree Fermioniq backend untouched (keeps its private attach helper)
- Add unit coverage via `test_observable_user_data`

Addresses review feedback on #5055: do not share Fermioniq's attach path with external plugins, so Fermioniq wire-format changes (and its separately credentialed CI) cannot silently break other backends, and vice versa.

## Test plan
- [ ] `test_observable_user_data`
- [ ] Confirm Fermioniq sources are unchanged vs `main`


Made with [Cursor](https://cursor.com)