### PR TITLE
[docs] Resolve llms.txt links from where the file is served

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -4,26 +4,25 @@
 
 ## Docs
 
-- [Quick Start](latest/using/quick_start.md)
+- [Quick Start](using/quick_start.md)
 
 ## API
 
-- [API Reference](latest/api/api.md)
+- [API Reference](api/api.md)
 
 ## Examples
 
-- [Basics](latest/using/basics/basics.md)
-- [Examples](latest/using/examples/examples.md)
-- [Applications](latest/using/applications.md)
-- [Backends](latest/using/backends/backends.md)
-- [Dynamics](latest/using/dynamics.md)
-- [CUDA-QX](latest/using/cudaqx/cudaqx.md)
-- [Release Notes](latest/releases.md)
+- [Basics](using/basics/basics.md)
+- [Examples](using/examples/examples.md)
+- [Applications](using/applications.md)
+- [Backends](using/backends/backends.md)
+- [Dynamics](using/dynamics.md)
+- [CUDA-QX](using/cudaqx/cudaqx.md)
+- [Release Notes](releases.md)
 
 ## Optional
 
-- [Installation](latest/using/install/install.md)
-- [Integration](latest/using/integration/integration.md)
-- [Extending](latest/using/extending/extending.md)
-- [Specifications](latest/specification/index.md)
-- [llms-full.txt](latest/llms-full.txt): Full concatenated content of this documentation
+- [Installation](using/install/install.md)
+- [Integration](using/integration/integration.md)
+- [Extending](using/extending/extending.md)
+- [Specifications](specification/index.md)


### PR DESCRIPTION
Fixes #5100.

## Problem

`scripts/build_docs.sh` copies `llms.txt` from the repository root into `DOCS_INSTALL_PREFIX`, so it is published per version:

```
https://nvidia.github.io/cuda-quantum/latest/llms.txt    200
https://nvidia.github.io/cuda-quantum/0.15.0/llms.txt    200
```

Its links are written against the site root with a `latest/` prefix, so a client that resolves them from the file's own location requests a doubled path:

```
/latest/latest/using/quick_start.md   404
/latest/using/quick_start.md          200
```

The hardcoded prefix has a second effect the issue does not mention: the copy served under `/0.15.0/` points at the `latest` docs rather than its own version, so a pinned-version agent silently reads the wrong release.

Separately, `llms-full.txt` is advertised under Optional but the docs build never generates it, and it returns 404 under every version prefix.

## Fix

Drop the `latest/` prefix so each published copy resolves against its own version directory, and drop the `llms-full.txt` entry.

## Verification

Every link in the file was fetched under both version prefixes:

| Link | `/latest/` | `/0.15.0/` |
|---|---|---|
| `using/quick_start.md` | 200 | 200 |
| `api/api.md` | 200 | 200 |
| `using/basics/basics.md` | 200 | 200 |
| `using/examples/examples.md` | 200 | 200 |
| `using/applications.md` | 200 | 200 |
| `using/backends/backends.md` | 200 | 200 |
| `using/dynamics.md` | 200 | 200 |
| `using/cudaqx/cudaqx.md` | 200 | 200 |
| `releases.md` | 200 | 200 |
| `using/install/install.md` | 200 | 200 |
| `using/integration/integration.md` | 200 | 200 |
| `using/extending/extending.md` | 200 | 200 |
| `specification/index.md` | 200 | 200 |
| `llms-full.txt` | 404 | 404 |

All thirteen remaining links resolve under both prefixes. The removed entry is the only one that does not.

## Not addressed here

The issue also asks for `llms.txt` to be served at the published site root, which is where the convention points agents. That is a change to how the docs site is published rather than to the file's contents, and it is a maintainer decision about the deployment layout, so it is left out of this change. This fix makes the links correct wherever the file is currently served, and stays correct if a root copy is added later with root-relative links.