### PR TITLE
[CI] Install CUDA-aware Open MPI for redhat installer validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -730,7 +730,8 @@ jobs:
           bash /tmp/miniconda.sh -b -u -p "$conda_prefix"
           rm -f /tmp/miniconda.sh
           eval "$($conda_prefix/bin/conda shell.bash hook)"
-          retry conda install -y -c conda-forge openmpi">=5.0.7"
+          export CONDA_OVERRIDE_CUDA="$CUDA_VERSION"
+          retry conda install -y --override-channels -c conda-forge openmpi">=5.0.7"
           chmod -R a+rX "$conda_prefix"
 
       - name: Install and run sanity checks


### PR DESCRIPTION
conda install -c conda-forge openmpi>=5.0.7 resolved openmpi from the bundled defaults channel (pkgs/main), whose build is not CUDA-aware, so all 64 nvidia fp32,mgpu/fp64,mgpu cases aborted with 'the library was not compiled with any support'. Pin the source with --override-channels and set CONDA_OVERRIDE_CUDA so the conda-forge CUDA build's __cuda constraint is satisfiable when no driver is visible at dependency-install time.