### PR TITLE
[CI] Load shipped GMP/MPFR first in license replacement checks

### DIFF
--- a/scripts/validate_license_compliance.sh
+++ b/scripts/validate_license_compliance.sh
@@ -244,12 +244,16 @@ func.func @rz() {
 }
 EOF
     synthesis_smoke_test() {
-        "$install_root/bin/cudaq-opt" --clifford-t-synthesis='epsilon=1e-3' \
+        # Load the shipped libgmp/libmpfr first so the replacement checks act on
+        # them, not a same-soname copy elsewhere on the search path.
+        LD_LIBRARY_PATH="$lib_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            "$install_root/bin/cudaq-opt" --clifford-t-synthesis='epsilon=1e-3' \
             "$smoke_dir/rz.qke" 2>/dev/null | grep -q "__cliffordt_rz_"
     }
 else
     synthesis_smoke_test() {
-        python3 -c "import cudaq; gates = cudaq.synth.gridsynth(0.7853981633974483, 1e-3); assert 'T' in gates, gates" 2>/dev/null
+        LD_LIBRARY_PATH="$lib_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            python3 -c "import cudaq; gates = cudaq.synth.gridsynth(0.7853981633974483, 1e-3); assert 'T' in gates, gates" 2>/dev/null
     }
 fi
 


### PR DESCRIPTION
The replacement checks corrupt the shipped libgmp/libmpfr and expect synthesis to break. In a conda/Python env the OS or conda ships a same-soname libgmp that the loader resolves ahead of the shipped copy (LD_LIBRARY_PATH before the wheel RUNPATH), so corrupting the unused shipped file was a no-op and the negative assertion failed.

Prepend the shipped lib dir to LD_LIBRARY_PATH in the smoke test so the shipped copies are the ones loaded, making the check valid in every environment instead of only where no competing copy exists.