### PR TITLE
Ship CUDA headers in the ext image for CuPy JIT

### DIFF
--- a/docker/release/cudaq.ext.Dockerfile
+++ b/docker/release/cudaq.ext.Dockerfile
@@ -22,9 +22,10 @@ RUN if [ "$include_documentation" = "true" ]; then \
     fi && \
     rm -rf "$CUDA_QUANTUM_PATH/publishing-documentation"
 
-# Install additional runtime dependencies.
+# Install additional runtime dependencies. cuda-cudart-dev adds the CUDA headers
+# (vector_types.h etc.) CuPy needs to JIT dynamics-target kernels at runtime.
 RUN cuda_version_suffix=$(echo ${CUDA_VERSION} | tr . -) && \
-    for cudart_dependency in libcusolver libcusparse libcublas libcurand cuda-cudart cuda-nvrtc; do \
+    for cudart_dependency in libcusolver libcusparse libcublas libcurand cuda-cudart cuda-cudart-dev cuda-nvrtc; do \
         if [ -z "$(apt list --installed | grep -o ${cudart_dependency}-${cuda_version_suffix})" ]; then \
             apt-get install -y --no-install-recommends \
                 ${cudart_dependency}-${cuda_version_suffix}; \


### PR DESCRIPTION
The dynamics notebooks fail in the release image because CuPy cannot find vector_types.h when it JIT-compiles kernels: the ext image installs the cuda-cudart runtime but not its headers. Add cuda-cudart-dev, which provides vector_types.h and the rest of cuda_fp16.h's include chain, so CuPy resolves them from /usr/local/cuda as it does when a toolkit is present.