### PR TITLE
Preserving state layout metadata when splitting a batched state

### DIFF
--- a/python/cudaq/contrib/propagator.py
+++ b/python/cudaq/contrib/propagator.py
@@ -78,7 +78,7 @@ def _extract_propagator(result, dimension: int,
 def _vectorize_state(state) -> np.ndarray:
     """Flatten an evolved basis state in the column-major `Liouville` order.
 
-    The evolved states are reported as matrices, so they must be re-vectorized
+    The evolved states are reported as matrices, so they must be `re-vectorized`
     in the same column-major order used to build the input basis states.
     """
     return np.array(state).reshape(-1, order="F")

--- a/python/cudaq/contrib/propagator.py
+++ b/python/cudaq/contrib/propagator.py
@@ -39,14 +39,12 @@ def _basis_states(dimension: int):
     return states
 
 
-def _state_to_matrix(state,
-                     dimension: int,
-                     column_major: bool = False) -> np.ndarray:
+def _state_to_matrix(state, dimension: int) -> np.ndarray:
     """Convert a `vectorized` propagated identity state back to a matrix.
 
-    The dynamics backend `vectorizes` super-operator states in row-major order
-    for a single system but in column-major order for a batch, so the batched
-    path must transpose to recover the same propagator.
+    The dynamics backend stores super-operator states in column-major order and
+    reports that layout on the returned state, so `np.array` already hands back
+    the matrix in the conventional orientation.
     """
     data = np.array(state).reshape(-1)
     expected_size = dimension * dimension
@@ -55,8 +53,7 @@ def _state_to_matrix(state,
         raise RuntimeError("Expected propagator state with size "
                            f"{expected_size}, got {data.size}.")
 
-    matrix = data.reshape((dimension, dimension))
-    return matrix.T if column_major else matrix
+    return data.reshape((dimension, dimension))
 
 
 def _closed_system_generator(hamiltonian):
@@ -66,18 +63,25 @@ def _closed_system_generator(hamiltonian):
     return generator
 
 
-def _extract_propagator(result,
-                        dimension: int,
-                        store_intermediate_results: bool,
-                        column_major: bool = False):
+def _extract_propagator(result, dimension: int,
+                        store_intermediate_results: bool):
     """Extract closed-system propagators from a CUDA-Q evolve result."""
     if store_intermediate_results:
         return [
-            _state_to_matrix(state, dimension, column_major)
+            _state_to_matrix(state, dimension)
             for state in result.intermediate_states()
         ]
 
-    return _state_to_matrix(result.final_state(), dimension, column_major)
+    return _state_to_matrix(result.final_state(), dimension)
+
+
+def _vectorize_state(state) -> np.ndarray:
+    """Flatten an evolved basis state in the column-major `Liouville` order.
+
+    The evolved states are reported as matrices, so they must be re-vectorized
+    in the same column-major order used to build the input basis states.
+    """
+    return np.array(state).reshape(-1, order="F")
 
 
 def _extract_batched_basis_propagator(results,
@@ -90,14 +94,14 @@ def _extract_batched_basis_propagator(results,
         ]
         return [
             np.column_stack([
-                np.array(states[time_index]).reshape(-1)
+                _vectorize_state(states[time_index])
                 for states in intermediate_states
             ])
             for time_index in range(len(intermediate_states[0]))
         ]
 
     columns = [
-        np.array(single_result.final_state()).reshape(-1)
+        _vectorize_state(single_result.final_state())
         for single_result in results
     ]
     return np.column_stack(columns)
@@ -247,10 +251,9 @@ def propagator(
 
     if is_batched:
         return [
-            _extract_propagator(single_result,
-                                propagator_dimension,
-                                store_intermediate_results,
-                                column_major=True) for single_result in result
+            _extract_propagator(single_result, propagator_dimension,
+                                store_intermediate_results)
+            for single_result in result
         ]
 
     return _extract_propagator(result, propagator_dimension,

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -478,6 +478,50 @@ def test_evolve_from_data_random_density_matrix_preserved_cudm():
         err_msg="final state should match initial density matrix")
 
 
+def test_batched_density_matrix_layout_matches_single_cudm():
+    """A state split out of a batch must look like a non-batched state.
+
+    Batching should change execution and storage aggregation only, not the
+    shape or storage order reported for each returned state.
+    """
+    np.random.seed(7)
+    N = 4
+    A = np.random.rand(N, N) + 1j * np.random.rand(N, N)
+    rho = A @ A.conj().T
+    rho /= np.trace(rho)
+
+    hamiltonian = 2 * np.pi * 0.1 * boson.number(0)
+    dimensions = {0: N}
+    schedule = Schedule(np.linspace(0.0, 1.0, 11), ["t"])
+    collapse_operators = [0.05 * boson.annihilate(0)]
+
+    def evolve(hamiltonians, initial_states, collapse):
+        return cudaq.evolve(
+            hamiltonians,
+            dimensions,
+            schedule,
+            initial_states,
+            observables=[],
+            collapse_operators=collapse,
+            store_intermediate_results=cudaq.IntermediateResultSave.NONE,
+        )
+
+    single = evolve(hamiltonian, cudaq.State.from_data(rho), collapse_operators)
+    batched = evolve([hamiltonian, hamiltonian],
+                     [cudaq.State.from_data(rho),
+                      cudaq.State.from_data(rho)],
+                     [collapse_operators, collapse_operators])
+
+    single_state = single.final_state()
+    single_arr = np.array(single_state)
+    assert single_arr.shape == (N, N)
+
+    for result in batched:
+        batched_arr = np.array(result.final_state())
+        assert batched_arr.shape == single_arr.shape
+        np.testing.assert_allclose(batched_arr, single_arr, atol=1e-6)
+
+
 def test_user_provided_stepper_scipy():
     """Verify that ScipyZvodeIntegrator uses a user-provided stepper."""
     from cudaq.dynamics.integrators.builtin_integrators import cuDensityMatTimeStepper

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -692,7 +692,7 @@ CuDensityMatState::~CuDensityMatState() { destroyState(); }
 bool CuDensityMatState::is_initialized() const { return cudmState != nullptr; }
 
 bool cudaq::CuDensityMatState::is_density_matrix() const {
-  if (!is_initialized())
+  if (!is_initialized() && hilbertSpaceDims.empty())
     return false;
 
   return isDensityMatrix;
@@ -1146,8 +1146,11 @@ CuDensityMatState::splitBatchedState(CuDensityMatState &batchedState) {
     HANDLE_CUDA_ERROR(cudaMemcpy(splitStateMemPtr, ptr + i * stateSize,
                                  stateSize * sizeof(std::complex<double>),
                                  cudaMemcpyDefault));
-    splitStates.emplace_back(
-        new CuDensityMatState(stateSize, splitStateMemPtr));
+    auto *splitState = new CuDensityMatState(stateSize, splitStateMemPtr);
+    splitState->isDensityMatrix = batchedState.isDensityMatrix;
+    splitState->hilbertSpaceDims = batchedState.hilbertSpaceDims;
+    splitState->singleStateDimension = stateSize;
+    splitStates.emplace_back(splitState);
   }
   return splitStates;
 }

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -692,7 +692,11 @@ CuDensityMatState::~CuDensityMatState() { destroyState(); }
 bool CuDensityMatState::is_initialized() const { return cudmState != nullptr; }
 
 bool cudaq::CuDensityMatState::is_density_matrix() const {
-  if (!is_initialized() && hilbertSpaceDims.empty())
+  // States split out of a batch keep the shape metadata of the batch but are
+  // left uninitialized until they are evolved again, so the flag is meaningful
+  // for them even though there is no `cudensitymat` state yet.
+  const bool hasHilbertSpaceMetadata = !hilbertSpaceDims.empty();
+  if (!is_initialized() && !hasHilbertSpaceMetadata)
     return false;
 
   return isDensityMatrix;

--- a/unittests/dynamics/test_CuDensityMatState.cpp
+++ b/unittests/dynamics/test_CuDensityMatState.cpp
@@ -416,3 +416,29 @@ TEST_F(CuDensityMatStateTest, CreateFromDataDensityMatrixLayout) {
   EXPECT_NEAR(hostOffCol(1, 0).real(), 3.0, 1e-12);
   EXPECT_NEAR(hostOffCol(1, 1).real(), 4.0, 1e-12);
 }
+
+TEST_F(CuDensityMatStateTest, SplitBatchedStatePreservesLayoutMetadata) {
+  const std::vector<int64_t> dims{2};
+  const std::vector<std::complex<double>> dm = {
+      {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}};
+
+  CuDensityMatState state1(dm.size(), cudaq::dynamics::createArrayGpu(dm));
+  state1.initialize_cudm(handle, dims, /*batchSize=*/1);
+  CuDensityMatState state2(dm.size(), cudaq::dynamics::createArrayGpu(dm));
+  state2.initialize_cudm(handle, dims, /*batchSize=*/1);
+  ASSERT_TRUE(state1.is_density_matrix());
+
+  auto batchedState = CuDensityMatState::createBatchedState(
+      handle, {&state1, &state2}, dims, /*createDensityState=*/true);
+  auto splitStates = CuDensityMatState::splitBatchedState(*batchedState);
+  ASSERT_EQ(splitStates.size(), 2);
+
+  const auto referenceTensor = state1.getTensor();
+  for (auto *splitState : splitStates) {
+    EXPECT_TRUE(splitState->is_density_matrix());
+    const auto tensor = splitState->getTensor();
+    EXPECT_EQ(tensor.extents, referenceTensor.extents);
+    EXPECT_EQ(tensor.order, referenceTensor.order);
+    delete splitState;
+  }
+}


### PR DESCRIPTION
When we run a batched `cudaq.evolve`, the backend splits the batch back into individual states at the end. That split was losing information. Each piece was created with just a size and a pointer, so it no longer knew it was a density matrix or what the sub-system dimensions were.

Because of that, a state from a batched run came back as a flat 1D array, while the exact same state from a single run came back as a proper 2D matrix. So batching was changing how each result looked, which it should not do.

The fix copies that information onto each split state. With it, the `column_major` workaround added in #[5093](https://github.com/NVIDIA/cuda-quantum/pull/5093) is no longer needed. It was correcting for the missing description, not for a real difference in how states are stored. The open-system path in `cudaq.contrib.propagator` now flattens in Fortran order, because those states now arrive as matrices instead of raw vectors.

`is_density_matrix()` also had to be relaxed slightly. It used to require a fully initialized state, but split states are intentionally left uninitialized until they are used again.

Fixes #5114 