### PR TITLE
[python] Add bindings for CompileTarget

### DIFF
--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -61,6 +61,8 @@ struct CompileTarget {
       return overridePassPipeline.empty() && highLevelPipeline.empty() &&
              midLevelPipeline.empty() && lowLevelPipeline.empty();
     }
+
+    bool operator==(const PipelineConfig &other) const = default;
   };
 
   /// Pipeline configuration, populated by the constructor.
@@ -97,6 +99,8 @@ struct CompileTarget {
                 std::map<std::string, std::string> pipelineSubstitutions = {});
 
   CompileTarget() = default;
+
+  bool operator==(const CompileTarget &other) const = default;
 };
 
 } // namespace cudaq
@@ -104,4 +108,9 @@ struct CompileTarget {
 template <>
 struct std::hash<cudaq::CompileTarget> {
   std::size_t operator()(const cudaq::CompileTarget &t) const noexcept;
+};
+template <>
+struct std::hash<cudaq::CompileTarget::PipelineConfig> {
+  std::size_t
+  operator()(const cudaq::CompileTarget::PipelineConfig &pc) const noexcept;
 };

--- a/cudaq/lib/Target/CompileTarget.cpp
+++ b/cudaq/lib/Target/CompileTarget.cpp
@@ -110,19 +110,20 @@ cudaq::CompileTarget::CompileTarget(
 
 std::size_t std::hash<cudaq::CompileTarget>::operator()(
     const cudaq::CompileTarget &t) const noexcept {
-  std::size_t seed = cudaq::detail::hashVal(
-      t.pipelineConfig.overridePassPipeline, t.pipelineConfig.highLevelPipeline,
-      t.pipelineConfig.midLevelPipeline, t.pipelineConfig.lowLevelPipeline,
-      t.pipelineConfig.codegenTranslation, t.pipelineConfig.postCodeGenPasses,
-      t.pipelineConfig.disableQubitMapping,
-      t.pipelineConfig.replaceStateWithKernel, t.pipelineConfig.addMeasurements,
-      t.overrideAOTCompilation, t.emulate,
-      t.supportConditionalsOnMeasureResults, t.supportDeviceCalls,
-      t.fullySpecialize, t.isLocalSimulator, t.argumentSynthChangeSemantics);
-
   // Optional spin observable: include its string representation when present.
-  if (t.pauliTermSplitObservable)
-    cudaq::detail::hashCombine(seed, t.pauliTermSplitObservable->to_string());
+  auto pauliStr =
+      t.pauliTermSplitObservable ? t.pauliTermSplitObservable->to_string() : "";
+  return cudaq::detail::hashVal(
+      t.pipelineConfig, t.overrideAOTCompilation, t.emulate,
+      t.supportConditionalsOnMeasureResults, t.supportDeviceCalls,
+      t.fullySpecialize, t.isLocalSimulator, t.argumentSynthChangeSemantics,
+      pauliStr);
+}
 
-  return seed;
+std::size_t std::hash<cudaq::CompileTarget::PipelineConfig>::operator()(
+    const cudaq::CompileTarget::PipelineConfig &pc) const noexcept {
+  return cudaq::detail::hashVal(
+      pc.overridePassPipeline, pc.highLevelPipeline, pc.midLevelPipeline,
+      pc.lowLevelPipeline, pc.codegenTranslation, pc.postCodeGenPasses,
+      pc.disableQubitMapping, pc.replaceStateWithKernel, pc.addMeasurements);
 }

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,1 +1,2 @@
-README.md
+# generated from /README.md.in
+/README.md

--- a/python/cudaq/_experimental/README.md
+++ b/python/cudaq/_experimental/README.md
@@ -1,0 +1,36 @@
+# Experimental features
+
+This folder contains non-documented APIs that are experimental and may change or
+get dropped at any moment without notice.
+
+## Defining custom compile targets and runtime endpoints
+
+CUDA-Q distinguishes between compile targets (the machine model that the user is
+targeting when authoring kernels) and runtime endpoints (the final backend on
+which compiled kernels should run or be simulated).
+
+The two halves are set independently, and both are dropped again by the next
+`cudaq.set_target(...)` or `cudaq.reset_target()`.
+
+WARNING: There are currently no checks in place to ensure that the compile target
+and runtime endpoint are compatible. If mis-configured, the behavior is undefined
+and the user will most likely run into confusing runtime errors.
+
+### Compile targets
+
+A compile target owns the MLIR pass pipelines, the code generation settings and
+the capabilities that kernels are compiled against. Build one with
+`cudaq._experimental.CompileTarget` and install it with
+`cudaq._experimental.set_compile_target`. It then takes precedence over the
+compile target that the active target's QPU would provide.
+
+### Runtime endpoints
+
+A runtime endpoint receives an already compiled kernel and executes it. Any
+Python object implementing one or more of the protocols in
+`cudaq._experimental.runtime_endpoint` can serve as one; register it with
+`cudaq._experimental.set_runtime_endpoint`.
+
+Registering a Python endpoint replaces the launch half only: compilation stays
+with the active compile target. If no compile target has been set explicitly,
+the default local-simulator one is installed and a warning is issued.

--- a/python/cudaq/_experimental/__init__.py
+++ b/python/cudaq/_experimental/__init__.py
@@ -12,7 +12,11 @@ may involve undocumented foot guns.
 """
 
 from .runtime_endpoint import set_runtime_endpoint
+from .compile_target import CompileTarget, PipelineConfig, set_compile_target
 
 __all__ = [
+    "CompileTarget",
+    "PipelineConfig",
+    "set_compile_target",
     "set_runtime_endpoint",
 ]

--- a/python/cudaq/_experimental/compile_target.py
+++ b/python/cudaq/_experimental/compile_target.py
@@ -1,0 +1,69 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Define a CUDA-Q compile target in Python.
+
+A compile target is the *compilation* half of a backend: it fixes the MLIR pass
+pipelines, the code generation and the capabilities that kernels are compiled
+against. It says nothing about where the compiled kernel runs -- that is the
+active target's QPU, or a :func:`set_runtime_endpoint` endpoint.
+
+Build one and register it with :func:`set_compile_target`:
+
+```python
+import cudaq
+from cudaq._experimental import CompileTarget, set_compile_target
+
+target = CompileTarget()
+target.pipeline_config.override_pass_pipeline = (
+    "canonicalize,decomposition{enable-patterns=SwapToCX},canonicalize")
+
+set_compile_target(target)
+cudaq.sample(my_kernel)      # compiled with that pipeline
+```
+
+Setting a compile target manually overrides the QPU-provided compile target that
+would have been used otherwise. To revert to a QPU-provided compile target, call
+``cudaq.set_target('target-name')`` or ``cudaq.reset_target()``.
+
+.. warning::
+
+   This API is experimental. Nothing checks that the pipeline you configure
+   produces IR that the backend understands; mismatches surface as hard to
+   diagnose compilation or execution errors.
+"""
+
+from cudaq.mlir._mlir_libs._quakeDialects.cudaq_runtime import (
+    CompileTarget,
+    CompiledModule,
+    PipelineConfig,
+)
+import cudaq.mlir._mlir_libs._quakeDialects.cudaq_runtime as _cudaq_runtime
+
+__all__ = [
+    "CompileTarget",
+    "CompiledModule",
+    "PipelineConfig",
+    "set_compile_target",
+]
+
+
+def set_compile_target(target: CompileTarget) -> None:
+    """Compile kernels with `target` instead of the active target's own.
+
+    Args:
+      target: The :class:`CompileTarget` to compile subsequent kernel launches
+        with.
+
+    Raises:
+      TypeError: If `target` is not a :class:`CompileTarget`.
+    """
+    if not isinstance(target, CompileTarget):
+        raise TypeError(
+            f"{type(target).__name__} is not a compile target: expected a "
+            f"cudaq._experimental.CompileTarget.")
+    _cudaq_runtime.set_compile_target(target)

--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -110,6 +110,7 @@ declare_mlir_python_extension(CUDAQuantumPythonSources.Extension
     ../runtime/cudaq/operators/py_matrix_op.cpp
     ../runtime/cudaq/operators/py_super_op.cpp
     ../runtime/cudaq/operators/py_handlers.cpp
+    ../runtime/cudaq/target/py_compile_target.cpp
     ../runtime/cudaq/target/py_runtime_target.cpp
     ../runtime/cudaq/target/py_testing_utils.cpp
     ../runtime/cudaq/trace/py_trace.cpp

--- a/python/extension/CUDAQuantumExtension.cpp
+++ b/python/extension/CUDAQuantumExtension.cpp
@@ -43,6 +43,7 @@
 #include "runtime/cudaq/platform/py_alt_launch_kernel.h"
 #include "runtime/cudaq/qis/py_execution_manager.h"
 #include "runtime/cudaq/qis/py_pauli_word.h"
+#include "runtime/cudaq/target/py_compile_target.h"
 #include "runtime/cudaq/target/py_runtime_target.h"
 #include "runtime/cudaq/target/py_testing_utils.h"
 #include "runtime/cudaq/trace/py_trace.h"
@@ -112,6 +113,7 @@ NB_MODULE(_quakeDialects, m) {
       nanobind::arg("target") = nanobind::none(),
       "Initialize the CUDA-Q environment.");
 
+  bindCompileTarget(cudaqRuntime);
   bindRuntimeTarget(cudaqRuntime, *holder.get());
   bindMeasureCounts(cudaqRuntime);
   bindResources(cudaqRuntime);

--- a/python/runtime/cudaq/target/py_compile_target.cpp
+++ b/python/runtime/cudaq/target/py_compile_target.cpp
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "py_compile_target.h"
+#include "cudaq/Target/CompileTarget.h"
+#include "cudaq/platform.h"
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
+#include <nanobind/stl/string.h>
+#include <sstream>
+
+using namespace nanobind::literals;
+
+static std::string reprStr(const std::string &s) { return "'" + s + "'"; }
+
+static std::string
+pipelineConfigRepr(const cudaq::CompileTarget::PipelineConfig &pc) {
+  std::ostringstream os;
+  os << "PipelineConfig(";
+  if (!pc.overridePassPipeline.empty())
+    os << "override_pass_pipeline=" << reprStr(pc.overridePassPipeline);
+  else {
+    os << "high_level_pipeline=" << reprStr(pc.highLevelPipeline)
+       << ", mid_level_pipeline=" << reprStr(pc.midLevelPipeline)
+       << ", low_level_pipeline=" << reprStr(pc.lowLevelPipeline)
+       << ", codegen_translation=" << reprStr(pc.codegenTranslation)
+       << ", post_code_gen_passes=" << reprStr(pc.postCodeGenPasses);
+  }
+  os << ")";
+  return os.str();
+}
+
+static std::string compileTargetRepr(const cudaq::CompileTarget &ct) {
+  return "CompileTarget(pipeline_config=" +
+         pipelineConfigRepr(ct.pipelineConfig) + ")";
+}
+
+void cudaq::bindCompileTarget(nanobind::module_ &mod) {
+  using PipelineConfig = cudaq::CompileTarget::PipelineConfig;
+
+  nanobind::class_<PipelineConfig>(
+      mod, "PipelineConfig",
+      "The MLIR pass pipelines and code generation settings that a "
+      "`CompileTarget` compiles kernels with.")
+      .def(nanobind::init<>())
+      .def_rw("override_pass_pipeline", &PipelineConfig::overridePassPipeline)
+      .def_rw("high_level_pipeline", &PipelineConfig::highLevelPipeline)
+      .def_rw("mid_level_pipeline", &PipelineConfig::midLevelPipeline)
+      .def_rw("low_level_pipeline", &PipelineConfig::lowLevelPipeline)
+      .def_rw("codegen_translation", &PipelineConfig::codegenTranslation)
+      .def_rw("post_code_gen_passes", &PipelineConfig::postCodeGenPasses)
+      .def_rw("disable_qubit_mapping", &PipelineConfig::disableQubitMapping)
+      .def(nanobind::self == nanobind::self)
+      .def("__hash__", std::hash<PipelineConfig>())
+      .def("__repr__", pipelineConfigRepr);
+
+  nanobind::class_<CompileTarget>(
+      mod, "CompileTarget",
+      "A machine model that determines how CUDA-Q compiles kernels. Includes "
+      "device capabilities, supported operations, codegen format and may even "
+      "specify MLIR pass pipelines explicitly.")
+      .def(
+          "__init__",
+          [](CompileTarget *target, PipelineConfig *pipelineConfig) {
+            new (target) CompileTarget();
+
+            if (pipelineConfig) {
+              target->pipelineConfig = *pipelineConfig;
+            }
+
+            // Some good defaults for Python simulators.
+            // TODO: refine this and unify with `createDefaultCompileTarget`.
+            target->fullySpecialize = false;
+            target->isLocalSimulator = true;
+            target->argumentSynthChangeSemantics = false;
+            if (target->pipelineConfig.codegenTranslation.empty()) {
+              target->pipelineConfig.codegenTranslation = "qir:";
+            }
+          },
+          "pipeline_config"_a = nanobind::none())
+      .def_rw("pipeline_config", &CompileTarget::pipelineConfig)
+      .def_rw("support_conditionals_on_measure_results",
+              &CompileTarget::supportConditionalsOnMeasureResults)
+      .def_rw("support_device_calls", &CompileTarget::supportDeviceCalls)
+      .def_rw("fully_specialize", &CompileTarget::fullySpecialize)
+      .def_rw("is_local_simulator", &CompileTarget::isLocalSimulator)
+      .def(nanobind::self == nanobind::self)
+      .def("__hash__", std::hash<CompileTarget>())
+      .def("__repr__", compileTargetRepr);
+
+  mod.def(
+      "set_compile_target",
+      [](CompileTarget target) {
+        get_platform().setCompileTarget(std::move(target));
+      },
+      nanobind::arg("target"),
+      "Compile kernels with the given `CompileTarget` instead of the one the "
+      "active target's QPU provides.");
+}

--- a/python/runtime/cudaq/target/py_compile_target.h
+++ b/python/runtime/cudaq/target/py_compile_target.h
@@ -1,0 +1,17 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace cudaq {
+
+void bindCompileTarget(nanobind::module_ &mod);
+
+} // namespace cudaq

--- a/python/tests/backends/test_experimental_compile_target.py
+++ b/python/tests/backends/test_experimental_compile_target.py
@@ -1,0 +1,238 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Tests for the experimental `CompileTarget` bindings.
+#
+# A compile target owns the compilation half of a backend: the pass pipelines,
+# the code generation and the capabilities kernels are compiled against.
+# Registering one with `set_compile_target` overrides what the active target's
+# QPU would otherwise provide, while the launch stays where it was.
+
+import os
+
+import pytest
+
+import cudaq
+from cudaq._experimental import (
+    CompileTarget,
+    PipelineConfig,
+    set_compile_target,
+    set_runtime_endpoint,
+)
+from cudaq.mlir.ir import WalkResult
+
+# Decompose swaps into CNOTs instead of running the default pipeline.
+SWAP_TO_CX_PIPELINE = (
+    "canonicalize,decomposition{enable-patterns=SwapToCX},canonicalize")
+
+
+@pytest.fixture(autouse=True)
+def reset_target():
+    """Ensure every test starts and ends from a well-defined target."""
+    cudaq.set_target("qpp-cpu")
+    yield
+    cudaq.reset_target()
+
+
+def make_swap_kernel():
+    # Build a fresh kernel per call so each has its own compiled-module cache
+    # slot and cannot reuse a previously compiled artifact.
+
+    @cudaq.kernel
+    def swap_kernel():
+        q = cudaq.qvector(2)
+        x(q[0])
+        swap(q[0], q[1])
+        mz(q)
+
+    return swap_kernel
+
+
+def swap_pipeline_target():
+    ct = CompileTarget()
+    ct.pipeline_config.override_pass_pipeline = SWAP_TO_CX_PIPELINE
+    return ct
+
+
+class CapturingEndpoint:
+    """A runtime endpoint that keeps the MLIR it was handed."""
+
+    def __init__(self):
+        self.mlir_module = None
+
+    def sample(self, module, args, **kwargs):
+        self.mlir_module = module.mlir_module
+        return cudaq.SampleResult()
+
+
+def compiled_quake_ops(kernel):
+    """Launch `kernel` through a capturing endpoint and return its quake ops.
+
+    Registering the endpoint keeps the compile target that is already
+    installed, so this observes the IR that the current target compiles to.
+    """
+    endpoint = CapturingEndpoint()
+    set_runtime_endpoint(endpoint)
+    cudaq.sample(kernel, shots_count=1)
+
+    module = endpoint.mlir_module
+    assert module is not None, "the endpoint was not handed a compiled module"
+
+    ops = []
+
+    def visit(op):
+        if op.name.startswith("quake."):
+            ops.append((op.name, len(op.operands)))
+        return WalkResult.ADVANCE
+
+    module.operation.walk(visit)
+    return ops
+
+
+# ---------------------------------------------------------------------------- #
+# Use with set_compile_target
+# ---------------------------------------------------------------------------- #
+
+
+def test_set_compile_target_rejects_non_target():
+    with pytest.raises(TypeError, match="not a compile target"):
+        set_compile_target("qpp-cpu")
+
+
+def test_kernel_runs_with_a_custom_compile_target():
+    set_compile_target(CompileTarget())
+
+    @cudaq.kernel
+    def bell():
+        q = cudaq.qvector(2)
+        h(q[0])
+        x.ctrl(q[0], q[1])
+        mz(q)
+
+    counts = cudaq.sample(bell, shots_count=10)
+    # Bell state: only correlated outcomes should appear.
+    assert set(counts) <= {"00", "11"}
+    assert sum(counts.values()) == 10
+
+
+def test_pipeline_config_controls_compiled_ir():
+    # Baseline: the default qpp-cpu pipeline keeps the swap intact.
+    set_compile_target(CompileTarget())
+    default_ops = compiled_quake_ops(make_swap_kernel())
+    assert any(name == "quake.swap" for name, _ in default_ops)
+
+    # Custom pipeline: decompose swap into CNOTs.
+    cudaq.set_target("qpp-cpu")
+    set_compile_target(swap_pipeline_target())
+    decomposed_ops = compiled_quake_ops(make_swap_kernel())
+
+    # The swap has been decomposed away into three controlled-x (CNOT) ops.
+    assert all(name != "quake.swap" for name, _ in decomposed_ops)
+    controlled_x = [
+        name for name, num_operands in decomposed_ops
+        if name == "quake.x" and num_operands > 1
+    ]
+    assert len(controlled_x) == 3
+
+
+def test_pipeline_config_preserves_kernel_semantics():
+    # Decomposition must not change the observable behaviour of the kernel.
+    set_compile_target(CompileTarget())
+    default_counts = cudaq.sample(make_swap_kernel(), shots_count=10)
+
+    set_compile_target(swap_pipeline_target())
+    decomposed_counts = cudaq.sample(make_swap_kernel(), shots_count=10)
+
+    assert dict(decomposed_counts.items()) == dict(default_counts.items())
+
+
+def test_compile_target_does_not_leak_after_switch():
+    """A compile target must not survive a target change.
+
+    Changing the target replaces the platform's QPUs, which drops the compile
+    target with them. Otherwise a custom pipeline would leak into unrelated
+    kernels (e.g. `cudaq.draw`).
+    """
+
+    def op_names(kernel):
+        return [name for name, _ in compiled_quake_ops(kernel)]
+
+    # Install a compile target that decomposes swaps into CNOTs.
+    set_compile_target(swap_pipeline_target())
+    assert "quake.swap" not in op_names(make_swap_kernel())
+
+    # Switching targets must restore default behaviour.
+    cudaq.set_target("qpp-cpu")
+    assert "quake.swap" in op_names(make_swap_kernel())
+
+    # Same expectation after a reset.
+    set_compile_target(swap_pipeline_target())
+    cudaq.reset_target()
+    assert "quake.swap" in op_names(make_swap_kernel())
+
+
+def test_support_conditionals_on_measure_results():
+    ct = CompileTarget()
+    ct.support_conditionals_on_measure_results = True
+    set_compile_target(ct)
+
+    @cudaq.kernel
+    def kernel() -> bool:
+        q = cudaq.qvector(2)
+        h(q[0])
+        b = mz(q[0])
+        if b:
+            x(q[1])
+        return b == mz(q[1])
+
+    # it runs fine
+    assert kernel()
+
+    ct.support_conditionals_on_measure_results = False
+    set_compile_target(ct)
+
+    # now it throws a runtime error
+    with pytest.raises(RuntimeError):
+        kernel()
+
+
+# ---------------------------------------------------------------------------- #
+# Equality / hashing / repr
+# ---------------------------------------------------------------------------- #
+
+
+def test_pipeline_config_equality_and_hash():
+    a = PipelineConfig()
+    b = PipelineConfig()
+    assert a == b
+    assert hash(a) == hash(b)
+
+    b.disable_qubit_mapping = True
+    assert a != b
+
+
+def test_compile_target_equality_and_hash():
+    a = CompileTarget()
+    b = CompileTarget()
+    assert a == b
+    assert hash(a) == hash(b)
+
+    b.pipeline_config.override_pass_pipeline = SWAP_TO_CX_PIPELINE
+    assert a != b
+    assert hash(a) != hash(b)
+
+
+def test_repr_is_informative():
+    assert "PipelineConfig(" in repr(PipelineConfig())
+    assert "CompileTarget(" in repr(CompileTarget())
+    assert SWAP_TO_CX_PIPELINE in repr(swap_pipeline_target())
+
+
+if __name__ == "__main__":
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-rP"])

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -145,6 +145,13 @@ public:
 
   /// Set the runtime endpoint for the QPU with ID @p qpuId.
   void setRuntimeEndpoint(RuntimeEndpoint endpoint, std::size_t qpuId = 0);
+
+  /// Set the compile target for the platform.
+  ///
+  /// Takes precedence over the compile target the QPUs would provide. It is
+  /// dropped again whenever the platform's QPUs are replaced, i.e. on the next
+  /// target change.
+  void setCompileTarget(std::optional<CompileTarget> target);
   /// \endcond
 
   /// Return whether this platform is a simulator.
@@ -262,9 +269,6 @@ protected:
   /// override
   /// @param name
   virtual void setTargetBackend(const std::string &name) {}
-
-  /// Set the compile target for the platform.
-  void setCompileTarget(std::optional<CompileTarget> target);
 
   /// Append @p qpu to the platform's QPUs.
   QPU &addQPU(std::unique_ptr<QPU> qpu);


### PR DESCRIPTION
This mirrors the Python API introduced in #5040, but for CompileTarget. In other words, it introduces `cudaq._experimental.compile_target`, which makes it possible to define the compilation target to compile to in Python:

```python
import cudaq
from cudaq._experimental import CompileTarget, set_compile_target

target = CompileTarget()
target.pipeline_config.override_pass_pipeline = (
    "canonicalize,decomposition{enable-patterns=SwapToCX},canonicalize")

set_compile_target(target)
cudaq.sample(my_kernel)      # compiled with that pipeline
```

Just like `set_runtime_endpoint`, this is kept intentionally hidden under the `_experimental` module for now. Post-release, the goal will be to migrate `cudaq.set_target` to use these newer, more fine grained APIs under the hood.