### PR TITLE
[NFC] Split out cudaq-devel build for reuse

### DIFF
--- a/.github/actions/setup-cudaq-devel-venv/action.yml
+++ b/.github/actions/setup-cudaq-devel-venv/action.yml
@@ -1,0 +1,168 @@
+name: Set up cudaq-devel environment
+description: |
+  Resolve and download the latest cudaq wheel, install the Python
+  build toolchain, build a cudaq-devel wheel, and expose wheel paths for further installation or validation.
+
+inputs:
+  cudaq-wheel-url:
+    description: |
+      Optional URL of a cudaq wheel artifact (e.g. .../actions/runs/RUN_ID/artifacts/ARTIFACT_ID).
+      Defaults to the latest artifact built from main.
+    required: false
+    default: ''
+  output-dir:
+    description: Directory where the cudaq-devel wheel is written.
+    required: false
+    default: dist
+
+outputs:
+  cudaq-version:
+    description: CUDA-Q release version used to build the devel wheel.
+    value: ${{ steps.version.outputs.cudaq_version }}
+  python-version:
+    description: Python version inferred from the runtime wheel (e.g. 3.11).
+    value: ${{ steps.runtime_wheel.outputs.python_version }}
+  python-executable:
+    description: Path to the uv-managed Python interpreter matching the runtime wheel.
+    value: ${{ steps.toolchain.outputs.python_executable }}
+  output-dir:
+    description: Directory containing the downloaded/built wheels.
+    value: ${{ inputs.output-dir }}
+  cudaq-wheel-path:
+    description: Path to the downloaded cudaq*.whl file.
+    value: ${{ steps.runtime_wheel.outputs.wheel_path }}
+  cudaq-devel-wheel-path:
+    description: Path to the built cudaq_devel*.whl file.
+    value: ${{ steps.devel_wheel.outputs.wheel_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Initialize submodules (with retry)
+      shell: bash
+      run: |
+        retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+        retry git -c submodule.tpls/llvm.update=none submodule update --init --recursive
+
+    - name: Compute CUDA-Q version
+      id: version
+      uses: ./.github/actions/compute-cudaq-version
+
+    - name: Resolve runtime wheel artifact
+      id: runtime_artifact
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        ARTIFACT_NAME: pycudaq-3-11-manylinux-amd64-cu13-0-gcc12-main
+        WHEEL_URL: ${{ inputs.cudaq-wheel-url }}
+      run: |
+        if [ -n "$WHEEL_URL" ]; then
+          run_id=$(echo "$WHEEL_URL" | sed -n 's|.*/runs/\([0-9]*\)/.*|\1|p')
+          artifact_id=$(echo "$WHEEL_URL" | sed -n 's|.*/artifacts/\([0-9]*\)$|\1|p')
+          if [ -z "$run_id" ] || [ -z "$artifact_id" ]; then
+            echo "::error::Could not parse run and artifact id from: $WHEEL_URL"
+            exit 1
+          fi
+        else
+          artifact=$(gh api "repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == "main")]
+                  | sort_by(.created_at) | last')
+          if [ -z "$artifact" ] || [ "$artifact" = "null" ]; then
+            echo "::error::No unexpired $ARTIFACT_NAME artifact built from main. Wheels are only kept for a day; pass runtime-wheel-url to use a specific artifact instead."
+            exit 1
+          fi
+          run_id=$(echo "$artifact" | jq -r '.workflow_run.id')
+          artifact_id=$(echo "$artifact" | jq -r '.id')
+        fi
+        echo "Using artifact $artifact_id from run $run_id"
+        echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+        echo "artifact_id=$artifact_id" >> "$GITHUB_OUTPUT"
+
+    - name: Download runtime wheel
+      uses: actions/download-artifact@v8
+      with:
+        run-id: ${{ steps.runtime_artifact.outputs.run_id }}
+        artifact-ids: ${{ steps.runtime_artifact.outputs.artifact_id }}
+        path: ${{ inputs.output-dir }}
+        github-token: ${{ github.token }}
+
+    - name: Resolve runtime wheel Python version
+      id: runtime_wheel
+      shell: bash
+      env:
+        RUNTIME_DIR: ${{ inputs.output-dir }}
+      run: |
+        whl=$(find "$RUNTIME_DIR" -name 'cuda_quantum_cu13*.whl' | head -1)
+        if [ -z "$whl" ]; then
+          echo "::error::No cuda_quantum_cu13*.whl found under $RUNTIME_DIR/"
+          find "$RUNTIME_DIR" -type f || true
+          exit 1
+        fi
+        py=$(basename "$whl" | sed -nE 's/.*-cp3([0-9]+)-cp3[0-9]+.*/3.\1/p')
+        if [ -z "$py" ]; then
+          echo "::error::Could not parse Python version from wheel: $whl"
+          exit 1
+        fi
+        echo "Using runtime wheel: $whl (Python $py)"
+        echo "python_version=$py" >> "$GITHUB_OUTPUT"
+        echo "wheel_path=$whl" >> "$GITHUB_OUTPUT"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+
+    - name: Set up validation toolchain
+      id: toolchain
+      shell: bash
+      env:
+        PY: ${{ steps.runtime_wheel.outputs.python_version }}
+      run: |
+        retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+        uv python install "$PY"
+        uv tool install "cmake==4.0.3"
+        uv tool install "ninja==1.13.0"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        retry sudo apt-get update
+        retry sudo apt-get install -y g++-12
+        echo "CC=gcc-12" >> "$GITHUB_ENV"
+        echo "CXX=g++-12" >> "$GITHUB_ENV"
+        echo "python_executable=$(uv python find "$PY")" >> "$GITHUB_OUTPUT"
+
+    - name: Log in to GitHub CR
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build cudaq-devel wheel
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.cudaq_version }}
+        BASE_IMAGE: ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu13.0-gcc12-main
+        DEVEL_DIR: ${{ inputs.output-dir }}
+        PYTHON_VERSION: ${{ steps.runtime_wheel.outputs.python_version }}
+      run: |
+        mkdir -p "$DEVEL_DIR"
+        DOCKER_BUILDKIT=1 docker build \
+          -f docker/release/cudaq.wheel.Dockerfile \
+          --build-arg base_image="${BASE_IMAGE}" \
+          --build-arg release_version="${RELEASE_VERSION}" \
+          --build-arg python_version="${PYTHON_VERSION}" \
+          --build-arg build_devel=1 \
+          --output "$DEVEL_DIR" .
+
+    - name: Resolve devel wheel path
+      id: devel_wheel
+      shell: bash
+      env:
+        DEVEL_DIR: ${{ inputs.output-dir }}
+      run: |
+        whl=$(find "$DEVEL_DIR" -name 'cudaq_devel*.whl' | head -1)
+        if [ -z "$whl" ]; then
+          echo "::error::No cudaq_devel*.whl found under $DEVEL_DIR/"
+          find "$DEVEL_DIR" -type f || true
+          exit 1
+        fi
+        echo "Built devel wheel: $whl"
+        echo "wheel_path=$whl" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/python_devel_wheels.yml
+++ b/.github/workflows/python_devel_wheels.yml
@@ -6,7 +6,7 @@ name: Python devel wheels
 on:
   workflow_dispatch:
     inputs:
-      runtime_wheel_url:
+      cudaq_wheel_url:
         required: false
         type: string
         description: 'Optional: URL of a cuda-quantum runtime wheel artifact (e.g. .../actions/runs/RUN_ID/artifacts/ARTIFACT_ID). Defaults to the latest CI run on main.'
@@ -26,115 +26,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Initialize submodules (with retry)
-        run: |
-          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
-          retry git -c submodule.tpls/llvm.update=none submodule update --init --recursive
-
-      - name: Compute CUDA-Q version
-        id: version
-        uses: ./.github/actions/compute-cudaq-version
-
-      - name: Resolve runtime wheel artifact
-        id: runtime_artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          ARTIFACT_NAME: pycudaq-3-11-manylinux-amd64-cu13-0-gcc12-main
-          WHEEL_URL: ${{ inputs.runtime_wheel_url }}
-        run: |
-          if [ -n "$WHEEL_URL" ]; then
-            run_id=$(echo "$WHEEL_URL" | sed -n 's|.*/runs/\([0-9]*\)/.*|\1|p')
-            artifact_id=$(echo "$WHEEL_URL" | sed -n 's|.*/artifacts/\([0-9]*\)$|\1|p')
-            if [ -z "$run_id" ] || [ -z "$artifact_id" ]; then
-              echo "::error::Could not parse run and artifact id from: $WHEEL_URL"
-              exit 1
-            fi
-          else
-            artifact=$(gh api "repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME&per_page=100" \
-              --jq '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == "main")]
-                    | sort_by(.created_at) | last')
-            if [ -z "$artifact" ] || [ "$artifact" = "null" ]; then
-              echo "::error::No unexpired $ARTIFACT_NAME artifact built from main. Wheels are only kept for a day; pass runtime_wheel_url to use a specific artifact instead."
-              exit 1
-            fi
-            run_id=$(echo "$artifact" | jq -r '.workflow_run.id')
-            artifact_id=$(echo "$artifact" | jq -r '.id')
-          fi
-          echo "Using artifact $artifact_id from run $run_id"
-          echo "run_id=$run_id" >> $GITHUB_OUTPUT
-          echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
-
-      - name: Download runtime wheel
-        uses: actions/download-artifact@v8
+      - name: Set up cudaq-devel environment
+        id: setup
+        uses: ./.github/actions/setup-cudaq-devel-venv
         with:
-          run-id: ${{ steps.runtime_artifact.outputs.run_id }}
-          artifact-ids: ${{ steps.runtime_artifact.outputs.artifact_id }}
-          path: runtime/
-          github-token: ${{ github.token }}
-
-      - name: Resolve runtime wheel Python version
-        id: runtime_wheel
-        run: |
-          whl=$(find runtime -name 'cuda_quantum_cu13*.whl' | head -1)
-          if [ -z "$whl" ]; then
-            echo "::error::No cuda_quantum_cu13*.whl found under runtime/"
-            find runtime -type f || true
-            exit 1
-          fi
-          py=$(basename "$whl" | sed -nE 's/.*-cp3([0-9]+)-cp3[0-9]+.*/3.\1/p')
-          if [ -z "$py" ]; then
-            echo "::error::Could not parse Python version from wheel: $whl"
-            exit 1
-          fi
-          echo "Using runtime wheel: $whl (Python $py)"
-          echo "python_version=$py" >> $GITHUB_OUTPUT
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Set up validation toolchain
-        run: |
-          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
-          py="${{ steps.runtime_wheel.outputs.python_version }}"
-          uv python install "$py"
-          uv tool install "cmake==4.0.3"
-          uv tool install "ninja==1.13.0"
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          retry sudo apt-get update
-          retry sudo apt-get install -y g++-12
-          echo "CC=gcc-12" >> $GITHUB_ENV
-          echo "CXX=g++-12" >> $GITHUB_ENV
-
-      - name: Log in to GitHub CR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Build cudaq-devel wheel
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.cudaq_version }}
-          BASE_IMAGE: ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu13.0-gcc12-main
-        run: |
-          mkdir -p dist
-          DOCKER_BUILDKIT=1 docker build \
-            -f docker/release/cudaq.wheel.Dockerfile \
-            --build-arg base_image="${BASE_IMAGE}" \
-            --build-arg release_version="${RELEASE_VERSION}" \
-            --build-arg python_version="${{ steps.runtime_wheel.outputs.python_version }}" \
-            --build-arg build_devel=1 \
-            --output dist .
+          cudaq-wheel-url: ${{ inputs.cudaq_wheel_url }}
 
       - name: Validate devel wheel contents
         run: |
-          py="${{ steps.runtime_wheel.outputs.python_version }}"
-          PYTHON="$(uv python find "$py")" bash scripts/validate_devel_wheel.sh -i dist -r runtime
+          PYTHON="${{ steps.setup.outputs.python-executable }}" \
+            bash scripts/validate_devel_wheel.sh \
+              -i "${{ steps.setup.outputs.output-dir }}" \
+              -r "${{ steps.setup.outputs.output-dir }}"
 
       - name: Upload devel wheel artifact
         uses: actions/upload-artifact@v7
         with:
-          path: dist/cudaq_devel*.whl
+          path: ${{ steps.setup.outputs.cudaq-devel-wheel-path }}
           archive: false
           if-no-files-found: error


### PR DESCRIPTION
This PR just moves out the logic to retrieve the `cudaq` and `cudaq-devel` wheels. This is so that this logic can be reused for the CI workflows of research previews.

For now, the `cudaq` wheel is obtained from the latest publishing run on `main`, whereas the `cudaq-devel` is built from source. There is thus a risk that they mismatch. This will be fixed in a future PR, when both wheels will be built together within the publishing pipeline.

A test of the modified workflow (should be an NFC) is running here: https://github.com/NVIDIA/cuda-quantum/actions/runs/31607277865/job/94149367358?pr=5088