### PR TITLE
Adding qbraid to hw providers

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -243,6 +243,10 @@ nitpick_ignore = [
     ('py:class', 'function'),
     ('py:class', 'type'),
     ('py:class', 'numpy.ndarray[]'),
+    # numpy documents NDArray as py:data, so the py:class reference that
+    # autodoc generates for the annotation cannot resolve via intersphinx
+    ('py:class', 'NDArray'),
+    ('py:class', 'numpy.typing.NDArray'),
     # FIXME: remove these after adding proper documentation
     # (also reexamine why some of the ones above are ignored)
     ('py:class', 'cudaq::sum_op<cudaq::spin_handler>'),

--- a/docs/sphinx/using/backends/hardware.rst
+++ b/docs/sphinx/using/backends/hardware.rst
@@ -22,3 +22,5 @@ To submit to a hardware backend, you need an account with the respective provide
   - :doc:`Amazon Braket <cloud/braket>`
 
   - :doc:`Scaleway QaaS <cloud/scaleway>`
+
+  - :doc:`qBraid <cloud/qbraid>`


### PR DESCRIPTION
Adding qbraid to hw providers and fixing docs warnings.

@mmvandieren for viz.

<img width="673" height="595" alt="image" src="https://github.com/user-attachments/assets/cf5d97a2-8fe5-44a3-90f5-0fb8fa380209" />

Fixes #5117 