### PR TITLE
Retrying ORAS download to fix transient curl failures

### DIFF
--- a/.github/actions/ccache-setup/action.yml
+++ b/.github/actions/ccache-setup/action.yml
@@ -24,7 +24,9 @@ runs:
         oras_version="1.2.2"
         os=$(uname -s | tr '[:upper:]' '[:lower:]')
         arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-        curl -sLO "https://github.com/oras-project/oras/releases/download/v${oras_version}/oras_${oras_version}_${os}_${arch}.tar.gz"
+        curl -fsSLO --retry 5 --retry-all-errors --retry-delay 2 \
+          --connect-timeout 10 --max-time 120 \
+          "https://github.com/oras-project/oras/releases/download/v${oras_version}/oras_${oras_version}_${os}_${arch}.tar.gz"
         sudo tar -xzf oras_*.tar.gz -C /usr/local/bin/ oras
         rm -f oras_*.tar.gz
 


### PR DESCRIPTION
Retrying ORAS download to fix transient curl failures

Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/31638067093/job/94264595639#step:6:21