### PR TITLE
Fix aliasing issues for quantum vectors

### DIFF
--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -398,6 +398,44 @@ struct ConcatSizePattern : public OpRewritePattern<cudaq::quake::ConcatOp> {
   }
 };
 
+// %i = quake.concat %a, %b     : (!quake.ref, !quake.ref) -> !quake.veq<2>
+// %o = quake.concat %x, %i, %y : (!quake.ref, !quake.veq<2>,
+//                                 !quake.ref) -> !quake.veq<4>
+// ─────────────────────────────────────────────────────────────────────────
+// %o = quake.concat %x, %a, %b, %y : (!quake.ref, !quake.ref, !quake.ref,
+//                                     !quake.ref) -> !quake.veq<4>
+//
+// Flattens one level of concat-of-concat. This enables downstream DCE of the
+// inner concat once it has no remaining uses.
+struct ConcatFlattenPattern : public OpRewritePattern<cudaq::quake::ConcatOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::ConcatOp concat,
+                                PatternRewriter &rewriter) const override {
+    bool anyInner = false;
+    SmallVector<Value> flatArgs;
+    for (Value arg : concat.getTargets()) {
+      auto inner = arg.getDefiningOp<cudaq::quake::ConcatOp>();
+      if (!inner) {
+        flatArgs.push_back(arg);
+        continue;
+      }
+      auto innerTy = dyn_cast<cudaq::quake::VeqType>(inner.getType());
+      if (!innerTy) {
+        flatArgs.push_back(arg);
+        continue;
+      }
+      flatArgs.append(inner.getTargets().begin(), inner.getTargets().end());
+      anyInner = true;
+    }
+    if (!anyInner)
+      return failure();
+    rewriter.replaceOpWithNewOp<cudaq::quake::ConcatOp>(
+        concat, concat.getType(), flatArgs);
+    return success();
+  }
+};
+
 // %0 = quake.alloca !quake.veq<2>
 // %1 = quake.extract_ref %0[0] : (!quake.veq<2>) -> !quake.ref
 // %2 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
@@ -774,9 +812,9 @@ static bool isDirectlyThreadedPhase(cudaq::quake::PhaseOp first,
        llvm::zip(firstTargets, secondTargets))
     if (!matchesOperand(firstTarget, secondTarget))
       return false;
-  return resultIndex == first.getNumResults() && 
-    llvm::all_of(first.getWires(),
-      [](Value wire) { return wire.hasOneUse(); });
+  return resultIndex == first.getNumResults() &&
+         llvm::all_of(first.getWires(),
+                      [](Value wire) { return wire.hasOneUse(); });
 }
 
 struct EraseZeroPhasePattern : public OpRewritePattern<cudaq::quake::PhaseOp> {

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -542,8 +542,8 @@ LogicalResult cudaq::quake::BorrowWireOp::verify() {
 
 void cudaq::quake::ConcatOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<ConcatSizePattern, ConcatNoOpPattern, UselessConcatOpPattern>(
-      context);
+  patterns.add<ConcatSizePattern, ConcatNoOpPattern, UselessConcatOpPattern,
+               ConcatFlattenPattern>(context);
 }
 
 LogicalResult cudaq::quake::ConcatOp::verify() {

--- a/cudaq/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
@@ -224,11 +224,11 @@ concatResultIndex(cudaq::quake::ConcatOp concat, std::size_t operandPos) {
 namespace {
 /// When individual `!quake.ref` `alloca`s are aliased into a `veq` via
 /// `quake.concat` and then also used directly by gate or measurement `ops` that
-/// appear *after* the `concat` in the same block, this pattern is deployed to
-/// replace each such post-`concat` direct use of an `alloca` `ref` with a fresh
-/// `quake.extract_ref` `op` from the `concat` result at the correct index,
-/// making every post-`concat` qubit access go through the `veq` and eliminate
-/// `use-def` chain aliasing via the `concat` `op`.
+/// appear *after* the `concat` — either in the same block or inside a nested
+/// region of an op that follows the concat — this pattern replaces each such
+/// direct use with a fresh `quake.extract_ref` from the `concat` result at the
+/// correct index, making every post-`concat` qubit access go through the `veq`
+/// and eliminating use-def chain aliasing via the `concat` op.
 class ConcatAllocaAliasPattern
     : public OpRewritePattern<cudaq::quake::ConcatOp> {
 public:
@@ -241,6 +241,27 @@ public:
     bool modified = false;
     auto refTy = cudaq::quake::RefType::get(rewriter.getContext());
 
+    // Returns true if `user` is dominated by `concat`.  This covers:
+    //   (a) same-block uses that come after the concat, and
+    //   (b) uses inside nested regions of ops that come after the concat.
+    auto dominatedByConcat = [&](Operation *user) -> bool {
+      // Walk up the parent-op chain until we reach concatBlock.
+      Block *block = user->getBlock();
+      while (block != concatBlock) {
+        Operation *parentOp = block->getParentOp();
+        if (!parentOp)
+          return false;
+        block = parentOp->getBlock();
+        if (!block)
+          return false;
+        // If we found concatBlock, check that the containing op follows concat.
+        if (block == concatBlock)
+          return concat->isBeforeInBlock(parentOp);
+      }
+      // Same block as concat — just check ordering.
+      return concat->isBeforeInBlock(user);
+    };
+
     for (auto [pos, operand] : llvm::enumerate(concat.getTargets())) {
       if (operand.getType() != refTy ||
           !operand.getDefiningOp<cudaq::quake::AllocaOp>())
@@ -251,18 +272,16 @@ public:
         continue;
       std::size_t veqIdx = *maybeIdx;
 
-      // Replace every direct use of this alloca that (a) is in the same block,
-      // (b) comes after the concat, and (c) is not the concat itself or a
-      // dealloc (deallocs manage lifetime, not qubit state).
+      // Replace every direct use of this alloca that (a) is dominated by the
+      // concat (same block after, or nested in an op after), and (b) is not the
+      // concat itself or a dealloc (deallocs manage lifetime, not qubit state).
       for (OpOperand &use : llvm::make_early_inc_range(operand.getUses())) {
         auto *user = use.getOwner();
         if (user == concat.getOperation())
           continue;
         if (isa<cudaq::quake::DeallocOp>(user))
           continue;
-        if (user->getBlock() != concatBlock)
-          continue;
-        if (!concat->isBeforeInBlock(user))
+        if (!dominatedByConcat(user))
           continue;
 
         rewriter.setInsertionPoint(user);

--- a/cudaq/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
@@ -196,6 +196,86 @@ public:
     return success();
   }
 };
+} // namespace
+
+/// Compute the index within the `concat` result at which the operand at
+/// position \p operandPos of \p concat lands. Returns `nullopt` if the index
+/// cannot be determined statically (e.g., a preceding `veq` has an unspecified
+/// size).
+static std::optional<std::size_t>
+concatResultIndex(cudaq::quake::ConcatOp concat, std::size_t operandPos) {
+  std::size_t idx = 0;
+  auto refTy = cudaq::quake::RefType::get(concat.getContext());
+  for (std::size_t i = 0; i < operandPos; ++i) {
+    auto t = concat.getTargets()[i].getType();
+    if (t == refTy) {
+      idx += 1;
+    } else if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(t)) {
+      if (!veqTy.hasSpecifiedSize())
+        return std::nullopt;
+      idx += veqTy.getSize();
+    } else {
+      return std::nullopt;
+    }
+  }
+  return idx;
+}
+
+namespace {
+/// When individual `!quake.ref` `alloca`s are aliased into a `veq` via
+/// `quake.concat` and then also used directly by gate or measurement `ops` that
+/// appear *after* the `concat` in the same block, this pattern is deployed to
+/// replace each such post-`concat` direct use of an `alloca` `ref` with a fresh
+/// `quake.extract_ref` `op` from the `concat` result at the correct index,
+/// making every post-`concat` qubit access go through the `veq` and eliminate
+/// `use-def` chain aliasing via the `concat` `op`.
+class ConcatAllocaAliasPattern
+    : public OpRewritePattern<cudaq::quake::ConcatOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::ConcatOp concat,
+                                PatternRewriter &rewriter) const override {
+    Block *concatBlock = concat->getBlock();
+    Value concatResult = concat.getResult();
+    bool modified = false;
+    auto refTy = cudaq::quake::RefType::get(rewriter.getContext());
+
+    for (auto [pos, operand] : llvm::enumerate(concat.getTargets())) {
+      if (operand.getType() != refTy ||
+          !operand.getDefiningOp<cudaq::quake::AllocaOp>())
+        continue;
+
+      auto maybeIdx = concatResultIndex(concat, pos);
+      if (!maybeIdx)
+        continue;
+      std::size_t veqIdx = *maybeIdx;
+
+      // Replace every direct use of this alloca that (a) is in the same block,
+      // (b) comes after the concat, and (c) is not the concat itself or a
+      // dealloc (deallocs manage lifetime, not qubit state).
+      for (OpOperand &use : llvm::make_early_inc_range(operand.getUses())) {
+        auto *user = use.getOwner();
+        if (user == concat.getOperation())
+          continue;
+        if (isa<cudaq::quake::DeallocOp>(user))
+          continue;
+        if (user->getBlock() != concatBlock)
+          continue;
+        if (!concat->isBeforeInBlock(user))
+          continue;
+
+        rewriter.setInsertionPoint(user);
+        auto freshRef = cudaq::quake::ExtractRefOp::create(
+            rewriter, user->getLoc(), concatResult, veqIdx);
+        use.set(freshRef.getResult());
+        modified = true;
+      }
+    }
+
+    return success(modified);
+  }
+};
 
 class DeallocPattern : public OpRewritePattern<cudaq::quake::DeallocOp> {
 public:
@@ -300,6 +380,7 @@ public:
     func::FuncOp func = getOperation();
     RewritePatternSet patterns(ctx);
     patterns.insert<AllocaPattern>(ctx);
+    patterns.insert<ConcatAllocaAliasPattern>(ctx);
     if (failed(applyPatternsGreedily(func, std::move(patterns))))
       return failure();
     return success();

--- a/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
@@ -343,22 +343,65 @@ public:
       toCancel.push_back({ref, wire});
     }
     for (auto [ref, wire] : toCancel) {
-      // Skip bindings whose wire is already consumed by the triggering op
-      // itself.
+      // Skip bindings whose wire is already consumed by the triggering op.
       if (triggeringOp && llvm::is_contained(triggeringOp->getOperands(), wire))
         continue;
 
-      // Alloca refs whose defining op is in cleanUps are being SSI-promoted.
-      // Wrapping them back is pointless. Keep the binding active.
+      // Alloca refs in cleanUps are being SSA-promoted; skip the wrap but
+      // still cancel so subsequent uses get a fresh binding.
       if (auto *defOp = ref.getDefiningOp())
-        if (cleanUps.count(defOp))
+        if (cleanUps.count(defOp)) {
+          cancelBinding(block, ref);
           continue;
+        }
 
       auto wrapOp = cudaq::quake::WrapOp::create(builder, loc, wire, ref);
-      // Add the wrap to cleanUps so the wrap is erased if its def came from a
-      // extract_ref whose underlying alloca is later cleaned up.
       cleanUps.insert(wrapOp);
-      rMap[block][ref] = SSAReg{};
+      cancelBinding(block, ref);
+    }
+  }
+
+  /// For each veq value in \p veqsToCancel, wrap any active ref bindings back
+  /// to their refs and cancel them.  When the veq is the result of a
+  /// quake.concat whose members are known statically, only the individual ref
+  /// operands of that concat are cancelled; otherwise all active bindings in
+  /// the block are cancelled via wrapAndCancelAllQuantumBindings.
+  void cancelBindings(const SmallPtrSetImpl<Value> &veqsToCancel, Block *block,
+                      SmallPtrSetImpl<Operation *> &cleanUps, Operation *op) {
+    for (Value v : veqsToCancel) {
+      OpBuilder builder(op);
+      Location loc = op->getLoc();
+      auto concat = v.getDefiningOp<cudaq::quake::ConcatOp>();
+      if (!concat) {
+        wrapAndCancelAllQuantumBindings(block, builder, loc, cleanUps, op);
+        continue;
+      }
+      bool fallback = false;
+      for (Value arg : concat.getTargets()) {
+        if (fallback)
+          break;
+        if (isa<cudaq::quake::RefType>(arg.getType())) {
+          SSAReg cur = lookupBinding(block, arg);
+          if (cur && !llvm::is_contained(op->getOperands(), cur)) {
+            bool argInCleanUps =
+                arg.getDefiningOp() && cleanUps.count(arg.getDefiningOp());
+            if (!argInCleanUps) {
+              auto wrapOp =
+                  cudaq::quake::WrapOp::create(builder, loc, cur, arg);
+              cleanUps.insert(wrapOp);
+            }
+            cancelBinding(block, arg);
+          }
+        } else if (auto veqTy =
+                       dyn_cast<cudaq::quake::VeqType>(arg.getType())) {
+          if (!veqTy.hasSpecifiedSize())
+            fallback = true;
+        } else {
+          fallback = true;
+        }
+      }
+      if (fallback)
+        wrapAndCancelAllQuantumBindings(block, builder, loc, cleanUps, op);
     }
   }
 
@@ -461,10 +504,11 @@ public:
       }
 
     LLVM_DEBUG(
-        std::for_each(result.begin() + offset, result.end(), [](MemRef mr) {
-          if (!mr)
-            llvm::dbgs() << "block argument value must be present\n";
-        }));
+        if (std::distance(result.begin(), result.end()) > offset)
+            std::for_each(result.begin() + offset, result.end(), [](MemRef mr) {
+              if (!mr)
+                llvm::dbgs() << "block argument value must be present\n";
+            }));
     return offset;
   }
 
@@ -955,6 +999,13 @@ public:
           }
         }
 
+        // True once a dynamic extract_ref from a veq defined *outside* this
+        // block's parent scope has been seen.  After that point, any
+        // outer-scope ref first imported as a live-in gets a fresh unwrap
+        // rather than being replaced by the live-in block argument (see
+        // handleUse below).
+        bool aliasForBlock = false;
+
         // Loop over all operations in the block.
         for (Operation &operRef : *block) {
           Operation *op = &operRef;
@@ -997,18 +1048,35 @@ public:
             };
 
             // Source 1: direct veq operands.
+            // Two paths:
+            //   (a) veq defined inside this scope  → precise per-concat cancel
+            //   (b) veq defined outside this scope → conservative: cancel ALL
+            //       active ref bindings and set aliasForBlock so that any
+            //       outer-scope ref first imported after this point gets a
+            //       fresh unwrap instead of the (potentially stale) live-in.
+            bool hadOuterVeq = false;
             for (Value v : op->getOperands()) {
               if (!isa<cudaq::quake::VeqType>(v.getType()))
                 continue;
               if (auto ext = dyn_cast<cudaq::quake::ExtractRefOp>(op))
                 if (ext.hasConstantIndex())
                   continue;
-              if (isFromOutsideParent(v))
+              if (isFromOutsideParent(v)) {
                 // Record in parentMap so the outer processOpWithRegions
                 // can cancel the binding at the right scope level.
                 parentMap[parent].push_back(v);
-              else
+                hadOuterVeq = true;
+              } else {
                 veqsToCancel.insert(v);
+              }
+            }
+            if (hadOuterVeq) {
+              // Conservative cancel: we don't know which refs the outer veq
+              // contains, so cancel all active bindings in this block.
+              OpBuilder builder(op);
+              dataFlow.wrapAndCancelAllQuantumBindings(
+                  block, builder, op->getLoc(), cleanUps, op);
+              aliasForBlock = true;
             }
 
             // Source 2: summary deposited into childMap by the inner
@@ -1025,48 +1093,8 @@ public:
               childMap.erase(it);
             }
 
-            // Apply binding cancellations for all collected veqs.
-            for (Value v : veqsToCancel) {
-              OpBuilder builder(op);
-              Location loc = op->getLoc();
-              auto concat = v.getDefiningOp<cudaq::quake::ConcatOp>();
-              if (!concat) {
-                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc,
-                                                         cleanUps, op);
-                continue;
-              }
-              bool fallback = false;
-              for (Value arg : concat.getTargets()) {
-                if (fallback)
-                  break;
-                if (isa<cudaq::quake::RefType>(arg.getType())) {
-                  if (auto wire = dataFlow.lookupBinding(block, arg)) {
-                    if (!llvm::is_contained(op->getOperands(), wire)) {
-                      // Skip alloca refs being SSA-promoted (same logic as
-                      // wrapAndCancelAllQuantumBindings).
-                      bool allocaInCleanUps =
-                          arg.getDefiningOp() &&
-                          cleanUps.count(arg.getDefiningOp());
-                      if (!allocaInCleanUps) {
-                        auto wrapOp = cudaq::quake::WrapOp::create(builder, loc,
-                                                                   wire, arg);
-                        cleanUps.insert(wrapOp);
-                        dataFlow.cancelBinding(block, arg);
-                      }
-                    }
-                  }
-                } else if (auto veqTy =
-                               dyn_cast<cudaq::quake::VeqType>(arg.getType())) {
-                  if (!veqTy.hasSpecifiedSize())
-                    fallback = true;
-                } else {
-                  fallback = true;
-                }
-              }
-              if (fallback)
-                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc,
-                                                         cleanUps, op);
-            }
+            // Apply binding cancellations for inner-scope veqs.
+            dataFlow.cancelBindings(veqsToCancel, block, cleanUps, op);
           }
 
           // For any operation that creates a value of quantum reference type,
@@ -1173,7 +1201,25 @@ public:
             // Parent is not a function.
             if (!isDescendantOf(parent, memuse)) {
               // `block` is using a value from another scope.
-              // Create a promoted value that dominates parent.
+              if (aliasForBlock) {
+                // A dynamic veq-aliasing event already occurred in this block:
+                // a non-constant extract_ref from a veq defined outside this
+                // scope acts as a barrier — all wire chains must be wrapped
+                // back to their refs, and subsequent uses get a fresh unwrap.
+                // We still create a promoted value (so it lands in liveInArgs
+                // and the outer scope threads the pre-aliasing state into this
+                // block) and a live-in block arg (so getLiveInToBlock can find
+                // it). The binding is set to the fresh useop (unwrap), NOT to
+                // the live-in arg — the gate sees the current ref state, not
+                // the pre-aliasing state.
+                dataFlow.createPromotedValue(parent, memuse);
+                dataFlow.addLiveInToBlock(block, memuse); // creates block arg
+                dataFlow.addBinding(block, memuse, useop);
+                // useop stays in the IR (not replaced, not in cleanUps).
+                return;
+              }
+              // Normal path: create a promoted value that dominates parent and
+              // thread it in as a live-in block argument.
               auto newUseopVal = dataFlow.createPromotedValue(parent, memuse);
               dataFlow.addBinding(block, memuse, newUseopVal);
               dataFlow.addLiveInToBlock(block, memuse, newUseopVal);

--- a/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
@@ -320,6 +320,27 @@ public:
     addBinding(block, mr, SSAReg{});
   }
 
+  /// Wrap all active quantum-ref bindings back into their refs and cancel them.
+  /// Used when an operation may alias any qubit through a veq whose membership
+  /// cannot be precisely determined.
+  void wrapAndCancelAllQuantumBindings(Block *block, OpBuilder &builder,
+                                       Location loc) {
+    if (!rMap.count(block))
+      return;
+    SmallVector<std::pair<MemRef, SSAReg>> toCancel;
+    for (auto &[ref, wire] : rMap[block]) {
+      if (!wire)
+        continue;
+      if (!isa<cudaq::quake::RefType>(ref.getType()))
+        continue;
+      toCancel.push_back({ref, wire});
+    }
+    for (auto [ref, wire] : toCancel) {
+      cudaq::quake::WrapOp::create(builder, loc, wire, ref);
+      rMap[block][ref] = SSAReg{};
+    }
+  }
+
   bool hasBinding(Block *block, MemRef mr) const {
     assert(block && rMap.count(block));
     return rMap.find(block)->second.count(mr);
@@ -781,6 +802,7 @@ class MemToRegPass : public cudaq::opt::impl::MemToRegBase<MemToRegPass> {
 public:
   using MemToRegBase::MemToRegBase;
   using DefnMap = DenseMap<Value, Value>;
+  using VeqAccessMap = DenseMap<Operation *, SmallVector<Value, 4>>;
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
@@ -805,7 +827,8 @@ public:
     MemoryAnalysis memAnalysis(func);
     SmallPtrSet<Operation *, 4> cleanUps;
     std::optional<DominanceInfo> domOpt;
-    processOpWithRegions(func, memAnalysis, cleanUps, domOpt);
+    VeqAccessMap unusedMap;
+    processOpWithRegions(func, memAnalysis, cleanUps, domOpt, unusedMap);
 
     // 3) Cleanup the dead ops. Make sure to delay erasing wrap ops since they
     // may still have uses.
@@ -839,12 +862,13 @@ public:
 
   void handleSubRegions(Operation *parent, const MemoryAnalysis &memAnalysis,
                         SmallPtrSetImpl<Operation *> &cleanUps,
-                        std::optional<DominanceInfo> &domOpt) {
+                        std::optional<DominanceInfo> &domOpt,
+                        VeqAccessMap &childMap) {
     for (auto &region : parent->getRegions())
       for (auto &block : region)
         for (auto &op : block)
           if (op.getNumRegions())
-            processOpWithRegions(&op, memAnalysis, cleanUps, domOpt);
+            processOpWithRegions(&op, memAnalysis, cleanUps, domOpt, childMap);
   }
 
   /// Process the operation \p parent, which must contain regions, and derive
@@ -858,7 +882,8 @@ public:
   void processOpWithRegions(Operation *parent,
                             const MemoryAnalysis &memAnalysis,
                             SmallPtrSetImpl<Operation *> &cleanUps,
-                            std::optional<DominanceInfo> &domOpt) {
+                            std::optional<DominanceInfo> &domOpt,
+                            VeqAccessMap &parentMap) {
     ++numProcessOpWithRegionsCalls;
     auto *ctx = &getContext();
     auto wireTy = cudaq::quake::WireType::get(ctx);
@@ -879,7 +904,10 @@ public:
     // 1. If any operations held by the blocks of \p parent contain regions,
     // recursively process those operations. This establishes the value
     // semantics interface for these macro ops.
-    handleSubRegions(parent, memAnalysis, cleanUps, domOpt);
+    // childMap accumulates veq-access summaries from the recursive calls so
+    // the block loop below can apply binding cancellations at the right scope.
+    VeqAccessMap childMap;
+    handleSubRegions(parent, memAnalysis, cleanUps, domOpt, childMap);
 
     // 2. Traverse each basic block threading the defs to their uses. This will
     // construct the liveIn and liveOut maps for each block. If parent is not a
@@ -909,6 +937,103 @@ public:
         // Loop over all operations in the block.
         for (Operation &operRef : *block) {
           Operation *op = &operRef;
+
+          // Veq aliasing: an op that reads from or passes a veq (dynamic
+          // extract_ref, mz, subveq, func.call, etc.) may access any qubit
+          // inside that veq, potentially modifying qubits we are tracking via
+          // individual ref bindings.  Wrap and cancel all affected bindings so
+          // that subsequent uses re-load the up-to-date qubit state.
+          //
+          // This check must run FIRST — before any handler that issues a
+          // `continue` — so it fires even for ops like extract_ref that both
+          // use a veq operand and produce a !quake.ref result.
+          //
+          // Excluded: quake.concat (assembles refs into a veq without reading
+          // through it) and quake.dealloc (handled separately).
+          if (quantumValues &&
+              !isa<cudaq::quake::ConcatOp, cudaq::quake::DeallocOp>(op)) {
+            // Collect veqs whose ref-bindings need to be cancelled.
+            // Two sources feed into this set:
+            //
+            //  1. Direct veq operands of this op that represent a
+            //     non-conservative access (dynamic-index extract_ref, mz, …).
+            //     If the veq's defining op is *outside* the current `parent`
+            //     scope we cannot cancel here — record it for the outer scope.
+            //
+            //  2. Summary entries deposited by the inner processOpWithRegions
+            //     call for this op (via externalVeqAccesses).  If any of those
+            //     veqs are *also* from outside the current `parent`, propagate
+            //     them one level further up; otherwise cancel now.
+            SmallPtrSet<Value, 4> veqsToCancel;
+
+            // Helper: is `v` defined outside of `parent`'s regions?
+            auto isFromOutsideParent = [&](Value v) -> bool {
+              if (auto *defOp = v.getDefiningOp())
+                return !parent->isAncestor(defOp);
+              if (auto ba = dyn_cast<BlockArgument>(v))
+                return !parent->isAncestor(ba.getOwner()->getParentOp());
+              return false;
+            };
+
+            // Source 1: direct veq operands.
+            for (Value v : op->getOperands()) {
+              if (!isa<cudaq::quake::VeqType>(v.getType()))
+                continue;
+              if (auto ext = dyn_cast<cudaq::quake::ExtractRefOp>(op))
+                if (ext.hasConstantIndex())
+                  continue;
+              if (isFromOutsideParent(v))
+                // Record in parentMap so the outer processOpWithRegions
+                // can cancel the binding at the right scope level.
+                parentMap[parent].push_back(v);
+              else
+                veqsToCancel.insert(v);
+            }
+
+            // Source 2: summary deposited into childMap by the inner
+            // processOpWithRegions call for this op-with-regions.
+            auto it = childMap.find(op);
+            if (it != childMap.end()) {
+              for (Value v : it->second) {
+                if (isFromOutsideParent(v))
+                  // Still from above — propagate one more level up.
+                  parentMap[parent].push_back(v);
+                else
+                  veqsToCancel.insert(v);
+              }
+              childMap.erase(it);
+            }
+
+            // Apply binding cancellations for all collected veqs.
+            for (Value v : veqsToCancel) {
+              OpBuilder builder(op);
+              Location loc = op->getLoc();
+              auto concat = v.getDefiningOp<cudaq::quake::ConcatOp>();
+              if (!concat) {
+                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc);
+                continue;
+              }
+              bool fallback = false;
+              for (Value arg : concat.getTargets()) {
+                if (fallback)
+                  break;
+                if (isa<cudaq::quake::RefType>(arg.getType())) {
+                  if (auto wire = dataFlow.lookupBinding(block, arg)) {
+                    cudaq::quake::WrapOp::create(builder, loc, wire, arg);
+                    dataFlow.cancelBinding(block, arg);
+                  }
+                } else if (auto veqTy =
+                               dyn_cast<cudaq::quake::VeqType>(arg.getType())) {
+                  if (!veqTy.hasSpecifiedSize())
+                    fallback = true;
+                } else {
+                  fallback = true;
+                }
+              }
+              if (fallback)
+                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc);
+            }
+          }
 
           // For any operation that creates a value of quantum reference type,
           // replace it with a null wire (if it is an AllocaOp) or unwrap the

--- a/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
@@ -323,8 +323,15 @@ public:
   /// Wrap all active quantum-ref bindings back into their refs and cancel them.
   /// Used when an operation may alias any qubit through a veq whose membership
   /// cannot be precisely determined.
+  ///
+  /// If \p triggeringOp is non-null, any binding whose current wire value is
+  /// already a direct operand of \p triggeringOp is skipped.  Wrapping such a
+  /// wire would give it two uses (the wrap and the op), violating wire
+  /// linearity — the op itself is about to "consume" that wire.
   void wrapAndCancelAllQuantumBindings(Block *block, OpBuilder &builder,
-                                       Location loc) {
+                                       Location loc,
+                                       SmallPtrSetImpl<Operation *> &cleanUps,
+                                       Operation *triggeringOp = nullptr) {
     if (!rMap.count(block))
       return;
     SmallVector<std::pair<MemRef, SSAReg>> toCancel;
@@ -336,7 +343,21 @@ public:
       toCancel.push_back({ref, wire});
     }
     for (auto [ref, wire] : toCancel) {
-      cudaq::quake::WrapOp::create(builder, loc, wire, ref);
+      // Skip bindings whose wire is already consumed by the triggering op
+      // itself.
+      if (triggeringOp && llvm::is_contained(triggeringOp->getOperands(), wire))
+        continue;
+
+      // Alloca refs whose defining op is in cleanUps are being SSI-promoted.
+      // Wrapping them back is pointless. Keep the binding active.
+      if (auto *defOp = ref.getDefiningOp())
+        if (cleanUps.count(defOp))
+          continue;
+
+      auto wrapOp = cudaq::quake::WrapOp::create(builder, loc, wire, ref);
+      // Add the wrap to cleanUps so the wrap is erased if its def came from a
+      // extract_ref whose underlying alloca is later cleaned up.
+      cleanUps.insert(wrapOp);
       rMap[block][ref] = SSAReg{};
     }
   }
@@ -1010,7 +1031,8 @@ public:
               Location loc = op->getLoc();
               auto concat = v.getDefiningOp<cudaq::quake::ConcatOp>();
               if (!concat) {
-                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc);
+                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc,
+                                                         cleanUps, op);
                 continue;
               }
               bool fallback = false;
@@ -1019,8 +1041,19 @@ public:
                   break;
                 if (isa<cudaq::quake::RefType>(arg.getType())) {
                   if (auto wire = dataFlow.lookupBinding(block, arg)) {
-                    cudaq::quake::WrapOp::create(builder, loc, wire, arg);
-                    dataFlow.cancelBinding(block, arg);
+                    if (!llvm::is_contained(op->getOperands(), wire)) {
+                      // Skip alloca refs being SSA-promoted (same logic as
+                      // wrapAndCancelAllQuantumBindings).
+                      bool allocaInCleanUps =
+                          arg.getDefiningOp() &&
+                          cleanUps.count(arg.getDefiningOp());
+                      if (!allocaInCleanUps) {
+                        auto wrapOp = cudaq::quake::WrapOp::create(builder, loc,
+                                                                   wire, arg);
+                        cleanUps.insert(wrapOp);
+                        dataFlow.cancelBinding(block, arg);
+                      }
+                    }
                   }
                 } else if (auto veqTy =
                                dyn_cast<cudaq::quake::VeqType>(arg.getType())) {
@@ -1031,7 +1064,8 @@ public:
                 }
               }
               if (fallback)
-                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc);
+                dataFlow.wrapAndCancelAllQuantumBindings(block, builder, loc,
+                                                         cleanUps, op);
             }
           }
 

--- a/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
@@ -371,6 +371,13 @@ public:
     for (Value v : veqsToCancel) {
       OpBuilder builder(op);
       Location loc = op->getLoc();
+      // A veq defined by a standalone alloca or by an init_state (which
+      // initializes a separate alloca) occupies an independent qubit range
+      // with no overlap with individually tracked ref allocas.  No binding
+      // cancellation is needed for those cases.
+      if (auto *defOp = v.getDefiningOp())
+        if (isa<cudaq::quake::AllocaOp, cudaq::quake::InitializeStateOp>(defOp))
+          continue;
       auto concat = v.getDefiningOp<cudaq::quake::ConcatOp>();
       if (!concat) {
         wrapAndCancelAllQuantumBindings(block, builder, loc, cleanUps, op);

--- a/cudaq/test/Transforms/alias.qke
+++ b/cudaq/test/Transforms/alias.qke
@@ -1,0 +1,121 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --factor-quantum-alloc --canonicalize --memtoreg \
+// RUN:   --canonicalize %s | FileCheck %s
+
+func.func @test0(%arg0: i32) {
+  %0 = cc.alloca i32
+  cc.store %arg0, %0 : !cc.ptr<i32>
+  %1 = quake.alloca !quake.veq<5>
+  %2 = quake.extract_ref %1[0] : (!quake.veq<5>) -> !quake.ref
+  quake.x %2 : (!quake.ref) -> ()
+  %3 = cc.load %0 : !cc.ptr<i32>
+  %4 = cc.cast signed %3 : (i32) -> i64
+  %5 = quake.extract_ref %1[%4] : (!quake.veq<5>, i64) -> !quake.ref
+  quake.h %5 : (!quake.ref) -> ()
+  %6 = quake.extract_ref %1[0] : (!quake.veq<5>) -> !quake.ref
+  quake.x %6 : (!quake.ref) -> ()
+  %measOut = quake.mz %1 : (!quake.veq<5>) -> !cc.sequence<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @test0(
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %{{.*}} : (!quake.ref, !quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<5>
+// CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %{{.*}} : (!quake.ref) -> !quake.wire
+// CHECK:           %[[X_0:.*]] = quake.x %[[UNWRAP_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[X_0]] to %{{.*}} : !quake.wire, !quake.ref
+// CHECK:           %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[CONCAT_0]]{{\[}}%{{.*}} : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[UNWRAP_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[H_0]] to %[[EXTRACT_REF_0]] : !quake.wire, !quake.ref
+// CHECK:           %[[UNWRAP_2:.*]] = quake.unwrap %{{.*}} : (!quake.ref) -> !quake.wire
+// CHECK:           %[[X_1:.*]] = quake.x %[[UNWRAP_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[X_1]] to %{{.*}} : !quake.wire, !quake.ref
+
+func.func @test1(%arg0: i32) {
+  %c1_i32 = arith.constant 1 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c5_i32 = arith.constant 5 : i32
+  %0 = cc.alloca i32
+  cc.store %arg0, %0 : !cc.ptr<i32>
+  %1 = quake.alloca !quake.veq<5>
+  %2 = quake.extract_ref %1[0] : (!quake.veq<5>) -> !quake.ref
+  quake.x %2 : (!quake.ref) -> ()
+  cc.scope {
+    %4 = cc.alloca i32
+    cc.store %c0_i32, %4 : !cc.ptr<i32>
+    cc.loop while {
+      %5 = cc.load %4 : !cc.ptr<i32>
+      %6 = arith.cmpi ult, %5, %c5_i32 : i32
+      cc.condition %6
+    } do {
+      %5 = cc.load %4 : !cc.ptr<i32>
+      %6 = cc.cast unsigned %5 : (i32) -> i64
+      %7 = quake.extract_ref %1[%6] : (!quake.veq<5>, i64) -> !quake.ref
+      quake.h %7 : (!quake.ref) -> ()
+      cc.continue
+    } step {
+      %5 = cc.load %4 : !cc.ptr<i32>
+      %6 = arith.addi %5, %c1_i32 : i32
+      cc.store %6, %4 : !cc.ptr<i32>
+    }
+  }
+  %3 = quake.extract_ref %1[0] : (!quake.veq<5>) -> !quake.ref
+  quake.x %3 : (!quake.ref) -> ()
+  %measOut = quake.mz %1 : (!quake.veq<5>) -> !cc.sequence<!cc.measure_handle>
+  return
+}
+
+
+// CHECK-LABEL:   func.func @test1(
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %{{.*}} : (!quake.ref, !quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<5>
+// CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %{{.*}} : (!quake.ref) -> !quake.wire
+// CHECK:           %[[X_0:.*]] = quake.x %[[UNWRAP_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[X_0]] to %{{.*}} : !quake.wire, !quake.ref
+// CHECK:           cc.loop while
+// CHECK:           } do {
+// CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[CONCAT_0]]{{\[}}%{{.*}} : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK:             %[[UNWRAP_1:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
+// CHECK:             %[[H_0:.*]] = quake.h %[[UNWRAP_1]] : (!quake.wire) -> !quake.wire
+// CHECK:             quake.wrap %[[H_0]] to %[[EXTRACT_REF_0]] : !quake.wire, !quake.ref
+// CHECK:           } step {
+// CHECK:           }
+// CHECK:           %[[UNWRAP_2:.*]] = quake.unwrap %{{.*}} : (!quake.ref) -> !quake.wire
+// CHECK:           %[[X_1:.*]] = quake.x %[[UNWRAP_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[X_1]] to %{{.*}} : !quake.wire, !quake.ref
+
+func.func @test2(%arg0: i32) {
+  %0 = cc.alloca i32
+  cc.store %arg0, %0 : !cc.ptr<i32>
+  %1 = quake.alloca !quake.veq<5>
+  %2 = quake.extract_ref %1[0] : (!quake.veq<5>) -> !quake.ref
+  quake.x %2 : (!quake.ref) -> ()
+  %3 = cc.load %0 : !cc.ptr<i32>
+  %4 = cc.cast signed %3 : (i32) -> i64
+  %5 = quake.extract_ref %1[%4] : (!quake.veq<5>, i64) -> !quake.ref
+  quake.h %5 : (!quake.ref) -> ()
+  quake.x %2 : (!quake.ref) -> ()
+  quake.y %2 : (!quake.ref) -> ()
+  %measOut = quake.mz %1 : (!quake.veq<5>) -> !cc.sequence<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @test2(
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (!quake.ref, !quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<5>
+// CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %{{.*}} : (!quake.ref) -> !quake.wire
+// CHECK:           %[[X_0:.*]] = quake.x %[[UNWRAP_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[X_0]] to %{{.*}} : !quake.wire, !quake.ref
+// CHECK:           %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[CONCAT_0]]{{\[}}%{{.*}} : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[UNWRAP_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[H_0]] to %[[EXTRACT_REF_0]] : !quake.wire, !quake.ref
+// CHECK:           %[[UNWRAP_2:.*]] = quake.unwrap %{{.*}} : (!quake.ref) -> !quake.wire
+// CHECK:           %[[X_1:.*]] = quake.x %[[UNWRAP_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[Y_0:.*]] = quake.y %[[X_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[Y_0]] to %{{.*}} : !quake.wire, !quake.ref

--- a/cudaq/test/Transforms/concat.qke
+++ b/cudaq/test/Transforms/concat.qke
@@ -1,0 +1,79 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --canonicalize %s | FileCheck %s
+
+// Flatten a concat whose single operand is itself a concat: the outer concat
+// should dissolve and its inner concat's args are promoted up.
+
+func.func @flatten_simple(%a : !quake.ref, %b : !quake.ref,
+                          %c : !quake.ref) -> !quake.veq<3> {
+  %inner = quake.concat %a, %b : (!quake.ref, !quake.ref) -> !quake.veq<2>
+  %outer = quake.concat %inner, %c : (!quake.veq<2>, !quake.ref) -> !quake.veq<3>
+  return %outer : !quake.veq<3>
+}
+
+// CHECK-LABEL: func.func @flatten_simple(
+// CHECK-SAME:      %[[A:.*]]: !quake.ref, %[[B:.*]]: !quake.ref, %[[C:.*]]: !quake.ref)
+// CHECK:         %[[R:.*]] = quake.concat %[[A]], %[[B]], %[[C]]
+// CHECK-SAME:        (!quake.ref, !quake.ref, !quake.ref) -> !quake.veq<3>
+// CHECK-NOT:     quake.concat
+// CHECK:         return %[[R]]
+
+// ---------------------------------------------------------------------------
+// Flatten where the inner concat is in the middle.
+
+func.func @flatten_middle(%x : !quake.ref, %a : !quake.ref, %b : !quake.ref,
+                          %y : !quake.ref) -> !quake.veq<4> {
+  %inner = quake.concat %a, %b : (!quake.ref, !quake.ref) -> !quake.veq<2>
+  %outer = quake.concat %x, %inner, %y : (!quake.ref, !quake.veq<2>, !quake.ref) -> !quake.veq<4>
+  return %outer : !quake.veq<4>
+}
+
+// CHECK-LABEL: func.func @flatten_middle(
+// CHECK-SAME:    %[[X:.*]]: !quake.ref, %[[A:.*]]: !quake.ref, %[[B:.*]]: !quake.ref, %[[Y:.*]]: !quake.ref)
+// CHECK:         %[[R:.*]] = quake.concat %[[X]], %[[A]], %[[B]], %[[Y]]
+// CHECK-SAME:      (!quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<4>
+// CHECK-NOT:     quake.concat
+// CHECK:         return %[[R]]
+
+// ---------------------------------------------------------------------------
+// Multi-level tree: two inner concats both get flattened.
+
+func.func @flatten_multi(%a : !quake.ref, %b : !quake.ref,
+                         %c : !quake.ref, %d : !quake.ref) -> !quake.veq<4> {
+  %left  = quake.concat %a, %b : (!quake.ref, !quake.ref) -> !quake.veq<2>
+  %right = quake.concat %c, %d : (!quake.ref, !quake.ref) -> !quake.veq<2>
+  %outer = quake.concat %left, %right : (!quake.veq<2>, !quake.veq<2>) -> !quake.veq<4>
+  return %outer : !quake.veq<4>
+}
+
+// CHECK-LABEL: func.func @flatten_multi(
+// CHECK-SAME:      %[[A:.*]]: !quake.ref, %[[B:.*]]: !quake.ref, %[[C:.*]]: !quake.ref, %[[D:.*]]: !quake.ref)
+// CHECK:         %[[R:.*]] = quake.concat %[[A]], %[[B]], %[[C]], %[[D]]
+// CHECK-SAME:        (!quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<4>
+// CHECK-NOT:     quake.concat
+// CHECK:         return %[[R]]
+
+// ---------------------------------------------------------------------------
+// Inner concat with unknown size: the outer concat still absorbs the inner
+// concat's args (ref and unknown-size veq), producing a single flat concat.
+
+func.func @flatten_unknown_inner(%a : !quake.ref, %v : !quake.veq<?>,
+                                  %b : !quake.ref) -> !quake.veq<?> {
+  %inner = quake.concat %a, %v : (!quake.ref, !quake.veq<?>) -> !quake.veq<?>
+  %outer = quake.concat %inner, %b : (!quake.veq<?>, !quake.ref) -> !quake.veq<?>
+  return %outer : !quake.veq<?>
+}
+
+// CHECK-LABEL: func.func @flatten_unknown_inner(
+// CHECK-SAME:    %[[A:.*]]: !quake.ref, %[[V:.*]]: !quake.veq<?>, %[[B:.*]]: !quake.ref)
+// CHECK:         %[[R:.*]] = quake.concat %[[A]], %[[V]], %[[B]]
+// CHECK-SAME:        (!quake.ref, !quake.veq<?>, !quake.ref) -> !quake.veq<?>
+// CHECK-NOT:     quake.concat
+// CHECK:         return %[[R]]

--- a/cudaq/test/Transforms/memtoreg-2.qke
+++ b/cudaq/test/Transforms/memtoreg-2.qke
@@ -697,32 +697,24 @@ func.func @apply_parametrized_one_target_operators() {
 // CHECK:         }
 
 func.func @qextract_and_apply_controlled_two_targets_operator() {
-  %c_0 = arith.constant 0 : i32
-  %c_1 = arith.constant 1 : i32
-  %c_2 = arith.constant 2 : i32
   %0 = quake.alloca !quake.veq<3>
-  %q0 = quake.extract_ref %0 [%c_0] : (!quake.veq<3>,i32) -> !quake.ref
-  %q1 = quake.extract_ref %0 [%c_1] : (!quake.veq<3>,i32) -> !quake.ref
-  %q2 = quake.extract_ref %0 [%c_2] : (!quake.veq<3>,i32) -> !quake.ref
+  %q0 = quake.extract_ref %0 [0] : (!quake.veq<3>) -> !quake.ref
+  %q1 = quake.extract_ref %0 [1] : (!quake.veq<3>) -> !quake.ref
+  %q2 = quake.extract_ref %0 [2] : (!quake.veq<3>) -> !quake.ref
   quake.swap [%q2] %q0, %q1 : (!quake.ref,!quake.ref,!quake.ref) -> ()
   quake.dealloc %0 : !quake.veq<3>
   return
 }
 
 // CHECK-LABEL:   func.func @qextract_and_apply_controlled_two_targets_operator() {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.veq<3>, i32) -> !quake.ref
-// CHECK:           %[[VAL_5:.*]] = quake.unwrap %[[VAL_4]] : (!quake.ref) -> !quake.wire
-// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<3>, i32) -> !quake.ref
-// CHECK:           %[[VAL_7:.*]] = quake.unwrap %[[VAL_6]] : (!quake.ref) -> !quake.wire
-// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.veq<3>, i32) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<3>) -> !quake.ref
+// CHECK-DAG:       %[[VAL_5:.*]] = quake.unwrap %[[VAL_4]] : (!quake.ref) -> !quake.wire
+// CHECK-DAG:       %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<3>) -> !quake.ref
+// CHECK-DAG:       %[[VAL_7:.*]] = quake.unwrap %[[VAL_6]] : (!quake.ref) -> !quake.wire
+// CHECK-DAG:       %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]][2] : (!quake.veq<3>) -> !quake.ref
 // CHECK:           %[[VAL_9:.*]] = quake.unwrap %[[VAL_8]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_10:.*]]:3 = quake.swap [%[[VAL_9]]] %[[VAL_5]], %[[VAL_7]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
-// CHECK:           return
-// CHECK:         }
 
 func.func @mz_and_reset_veq_with_extracted_refs() {
   %c_0 = arith.constant 0 : i32

--- a/cudaq/test/Transforms/memtoreg-4.qke
+++ b/cudaq/test/Transforms/memtoreg-4.qke
@@ -182,4 +182,3 @@ func.func @t3(%arg0: !quake.veq<?>) {
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }
-

--- a/cudaq/test/Transforms/memtoreg-8.qke
+++ b/cudaq/test/Transforms/memtoreg-8.qke
@@ -94,3 +94,92 @@ func.func @ai_failure_scenario_2(%arg0 : i64, %arg1 : i1) {
 // CHECK:           quake.sink %[[UNWRAP_7]] : !quake.wire
 // CHECK:           %[[UNWRAP_8:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
 // CHECK:           quake.sink %[[UNWRAP_8]] : !quake.wire
+
+func.func @init_state(%ar0: !cc.ptr<!quake.state>) {
+    %c5_i64 = arith.constant 5 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %a = quake.alloca !quake.veq<5>
+    %0 = quake.init_state %a, %ar0 : (!quake.veq<5>, !cc.ptr<!quake.state>) -> !quake.veq<5>
+    %1 = cc.loop while ((%arg0 = %c0_i64) -> (i64)) {
+      %7 = arith.cmpi slt, %arg0, %c5_i64 : i64
+      cc.condition %7(%arg0 : i64)
+    } do {
+    ^bb0(%arg0: i64):
+      %7 = quake.extract_ref %0[%arg0] : (!quake.veq<5>, i64) -> !quake.ref
+      quake.x %7 : (!quake.ref) -> ()
+      cc.continue %arg0 : i64
+    } step {
+    ^bb0(%arg0: i64):
+      %7 = arith.addi %arg0, %c1_i64 : i64
+      cc.continue %7 : i64
+    } {invariant}
+    %g3 = quake.extract_ref %0[0] : (!quake.veq<5>) -> !quake.ref
+    quake.y %g3 : (!quake.ref) -> ()
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = quake.veq_size %0 : (!quake.veq<5>) -> i64
+    %3 = arith.addi %c0_i64_0, %2 : i64
+    %c0_i64_1 = arith.constant 0 : i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %4 = quake.veq_size %0 : (!quake.veq<5>) -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %c1_i64_4 = arith.constant 1 : i64
+    %5 = cc.loop while ((%arg0 = %c0_i64_3) -> (i64)) {
+      %7 = arith.cmpi slt, %arg0, %4 : i64
+      cc.condition %7(%arg0 : i64)
+    } do {
+    ^bb0(%arg0: i64):
+      %7 = quake.extract_ref %0[%arg0] : (!quake.veq<5>, i64) -> !quake.ref
+      %measOut = quake.mz %7 : (!quake.ref) -> !cc.measure_handle
+      %8 = arith.addi %arg0, %c0_i64_1 : i64
+      cc.continue %arg0 : i64
+    } step {
+    ^bb0(%arg0: i64):
+      %7 = arith.addi %arg0, %c1_i64_4 : i64
+      cc.continue %7 : i64
+    } {invariant}
+    %6 = arith.addi %c0_i64_1, %4 : i64
+    return
+}
+
+// CHECK-LABEL:   func.func @init_state(
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.ptr<!quake.state>) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 5 : i64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : i64
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<5>
+// CHECK:           %[[INIT_STATE_0:.*]] = quake.init_state %[[ALLOCA_0]], %[[ARG0]] : (!quake.veq<5>, !cc.ptr<!quake.state>) -> !quake.veq<5>
+// CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_2]]) -> (i64)) {
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[CONSTANT_0]] : i64
+// CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]] : i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_1:.*]]: i64):
+// CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[INIT_STATE_0]]{{\[}}%[[VAL_1]]] : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK:             %[[UNWRAP_0:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
+// CHECK:             %[[X_0:.*]] = quake.x %[[UNWRAP_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             quake.wrap %[[X_0]] to %[[EXTRACT_REF_0]] : !quake.wire, !quake.ref
+// CHECK:             cc.continue %[[VAL_1]] : i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_2:.*]]: i64):
+// CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_2]], %[[CONSTANT_1]] : i64
+// CHECK:             cc.continue %[[ADDI_0]] : i64
+// CHECK:           } {invariant}
+// CHECK:           %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[INIT_STATE_0]][0] : (!quake.veq<5>) -> !quake.ref
+// CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[EXTRACT_REF_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[Y_0:.*]] = quake.y %[[UNWRAP_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[Y_0]] to %[[EXTRACT_REF_1]] : !quake.wire, !quake.ref
+// CHECK:           %[[LOOP_1:.*]] = cc.loop while ((%[[VAL_3:.*]] = %[[CONSTANT_2]]) -> (i64)) {
+// CHECK:             %[[CMPI_1:.*]] = arith.cmpi slt, %[[VAL_3]], %[[CONSTANT_0]] : i64
+// CHECK:             cc.condition %[[CMPI_1]](%[[VAL_3]] : i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: i64):
+// CHECK:             %[[EXTRACT_REF_2:.*]] = quake.extract_ref %[[INIT_STATE_0]]{{\[}}%[[VAL_4]]] : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK:             %[[UNWRAP_2:.*]] = quake.unwrap %[[EXTRACT_REF_2]] : (!quake.ref) -> !quake.wire
+// CHECK:             %[[VAL_5:.*]], %[[MZ_0:.*]] = quake.mz %[[UNWRAP_2]] : (!quake.wire) -> (!cc.measure_handle, !quake.wire)
+// CHECK:             quake.wrap %[[MZ_0]] to %[[EXTRACT_REF_2]] : !quake.wire, !quake.ref
+// CHECK:             cc.continue %[[VAL_4]] : i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_6:.*]]: i64):
+// CHECK:             %[[ADDI_1:.*]] = arith.addi %[[VAL_6]], %[[CONSTANT_1]] : i64
+// CHECK:             cc.continue %[[ADDI_1]] : i64
+// CHECK:           } {invariant}

--- a/cudaq/test/Transforms/memtoreg-8.qke
+++ b/cudaq/test/Transforms/memtoreg-8.qke
@@ -1,0 +1,96 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --canonicalize --memtoreg %s | FileCheck %s
+
+func.func @nested_concat_dynamic_alias(%index: i64) {
+  %r0 = quake.alloca !quake.ref
+  %r1 = quake.alloca !quake.ref
+  %r2 = quake.alloca !quake.ref
+  %inner = quake.concat %r0, %r1 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+  %outer = quake.concat %inner, %r2 : (!quake.veq<2>, !quake.ref) -> !quake.veq<3>
+
+  // %index may be 0, so this operation may act on the qubit in %r0.
+  %selected = quake.extract_ref %outer[%index] : (!quake.veq<3>, i64) -> !quake.ref
+  quake.h %selected : (!quake.ref) -> ()
+
+  // A correct memtoreg lowering must not reuse a wire for %r0 that predates
+  // the dynamic access above.
+  quake.x %r0 : (!quake.ref) -> ()
+  quake.dealloc %r2 : !quake.ref
+  quake.dealloc %r1 : !quake.ref
+  quake.dealloc %r0 : !quake.ref
+  return
+}
+
+// CHECK-LABEL:   func.func @nested_concat_dynamic_alias(
+// CHECK-SAME:      %[[ARG0:.*]]: i64) {
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[ALLOCA_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %[[ALLOCA_0]], %[[ALLOCA_1]], %[[ALLOCA_2]] : (!quake.ref, !quake.ref, !quake.ref) -> !quake.veq<3>
+// CHECK:           %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[CONCAT_0]]{{\[}}%[[ARG0]]] : (!quake.veq<3>, i64) -> !quake.ref
+// CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[UNWRAP_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[H_0]] to %[[EXTRACT_REF_0]] : !quake.wire, !quake.ref
+// CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[X_0:.*]] = quake.x %[[UNWRAP_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[UNWRAP_2:.*]] = quake.unwrap %[[ALLOCA_2]] : (!quake.ref) -> !quake.wire
+// CHECK:           quake.sink %[[UNWRAP_2]] : !quake.wire
+// CHECK:           %[[UNWRAP_3:.*]] = quake.unwrap %[[ALLOCA_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           quake.sink %[[UNWRAP_3]] : !quake.wire
+// CHECK:           quake.sink %[[X_0]] : !quake.wire
+
+func.func @ai_failure_scenario_2(%arg0 : i64, %arg1 : i1) {
+  %0 = quake.alloca !quake.ref
+  %1 = quake.alloca !quake.ref
+  %2 = quake.alloca !quake.ref
+  %3 = quake.concat %0, %1 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+  %4 = quake.concat %3, %2 : (!quake.veq<2>, !quake.ref) -> !quake.veq<3>
+  cc.if(%arg1) {
+    %5 = quake.extract_ref %4[%arg0] : (!quake.veq<3>, i64) -> !quake.ref
+    quake.h %5 : (!quake.ref) -> ()
+    quake.x %0 : (!quake.ref) -> ()
+  }
+  quake.dealloc %2 : !quake.ref
+  quake.dealloc %1 : !quake.ref
+  quake.dealloc %0 : !quake.ref
+  return
+}
+
+// CHECK-LABEL:   func.func @ai_failure_scenario_2(
+// CHECK-SAME:      %[[ARG0:.*]]: i64, %[[ARG1:.*]]: i1) {
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[ALLOCA_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[ALLOCA_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[UNWRAP_2:.*]] = quake.unwrap %[[ALLOCA_2]] : (!quake.ref) -> !quake.wire
+// CHECK:           quake.wrap %[[UNWRAP_0]] to %[[ALLOCA_0]] : !quake.wire, !quake.ref
+// CHECK:           quake.wrap %[[UNWRAP_1]] to %[[ALLOCA_1]] : !quake.wire, !quake.ref
+// CHECK:           quake.wrap %[[UNWRAP_2]] to %[[ALLOCA_2]] : !quake.wire, !quake.ref
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %[[ALLOCA_0]], %[[ALLOCA_1]], %[[ALLOCA_2]] : (!quake.ref, !quake.ref, !quake.ref) -> !quake.veq<3>
+// CHECK:           %[[UNWRAP_3:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[IF_0:.*]] = cc.if(%[[ARG1]]) ((%[[VAL_0:.*]] = %[[UNWRAP_3]])) -> !quake.wire {
+// CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[CONCAT_0]]{{\[}}%[[ARG0]]] : (!quake.veq<3>, i64) -> !quake.ref
+// CHECK:             %[[UNWRAP_4:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
+// CHECK:             %[[H_0:.*]] = quake.h %[[UNWRAP_4]] : (!quake.wire) -> !quake.wire
+// CHECK:             quake.wrap %[[H_0]] to %[[EXTRACT_REF_0]] : !quake.wire, !quake.ref
+// CHECK:             %[[UNWRAP_5:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
+// CHECK:             %[[X_0:.*]] = quake.x %[[UNWRAP_5]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[X_0]] : !quake.wire
+// CHECK:           } else {
+// CHECK:             cc.continue %[[VAL_1:.*]] : !quake.wire
+// CHECK:           }
+// CHECK:           quake.wrap %[[IF_0]] to %[[ALLOCA_0]] : !quake.wire, !quake.ref
+// CHECK:           %[[UNWRAP_6:.*]] = quake.unwrap %[[ALLOCA_2]] : (!quake.ref) -> !quake.wire
+// CHECK:           quake.sink %[[UNWRAP_6]] : !quake.wire
+// CHECK:           %[[UNWRAP_7:.*]] = quake.unwrap %[[ALLOCA_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           quake.sink %[[UNWRAP_7]] : !quake.wire
+// CHECK:           %[[UNWRAP_8:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           quake.sink %[[UNWRAP_8]] : !quake.wire

--- a/python/tests/mlir/exp_pauli.py
+++ b/python/tests/mlir/exp_pauli.py
@@ -86,8 +86,8 @@ def test_exp_pauli():
 # CHECK:         %[[VAL_7:.*]] = call ptr @__quantum__rt__qubit_allocate_array(i64 3)
 # CHECK:         br label %[[VAL_8:.*]]
 # CHECK:                                                    ; preds = %[[VAL_9:.*]], %[[VAL_10:.*]]
-# CHECK:         %[[VAL_11:.*]] = phi i64 [ %[[VAL_12:.*]], %[[VAL_9]] ], [ 0, %[[VAL_10]] ]
-# CHECK:         %[[VAL_13:.*]] = phi ptr [ %[[VAL_13]], %[[VAL_9]] ], [ %[[VAL_6]], %[[VAL_10]] ]
+# CHECK-DAG:     %[[VAL_11:.*]] = phi i64 [ %[[VAL_12:.*]], %[[VAL_9]] ], [ 0, %[[VAL_10]] ]
+# CHECK-DAG:     %[[VAL_13:.*]] = phi ptr [ %[[VAL_13]], %[[VAL_9]] ], [ %[[VAL_6]], %[[VAL_10]] ]
 # CHECK:         %[[VAL_14:.*]] = icmp slt i64 %[[VAL_11]], 3
 # CHECK:         br i1 %[[VAL_14]], label %[[VAL_9]], label %[[VAL_15:.*]]
 # CHECK:                                                    ; preds = %[[VAL_8]]
@@ -181,9 +181,6 @@ def test_exp_pauli_loop_controlled():
 # CHECK:         br label %[[VAL_22:.*]]
 # CHECK:                              ; preds = %[[VAL_23:.*]], %[[VAL_24:.*]]
 # CHECK:         %[[VAL_25:.*]] = phi i64 [ %[[VAL_26:.*]], %[[VAL_23]] ], [ 0, %[[VAL_24]] ]
-# CHECK:         %[[VAL_27:.*]] = phi ptr [ %[[VAL_27]], %[[VAL_23]] ], [ %[[VAL_4]], %[[VAL_24]] ]
-# CHECK:         %[[VAL_28:.*]] = phi ptr [ %[[VAL_28]], %[[VAL_23]] ], [ %[[VAL_5]], %[[VAL_24]] ]
-# CHECK:         %[[VAL_29:.*]] = phi ptr [ %[[VAL_29]], %[[VAL_23]] ], [ %[[VAL_6]], %[[VAL_24]] ]
 # CHECK:         %[[VAL_30:.*]] = icmp slt i64 %[[VAL_25]], 2
 # CHECK:         br i1 %[[VAL_30]], label %[[VAL_23]], label %[[VAL_31:.*]]
 # CHECK:                          ; preds = %[[VAL_22]]
@@ -195,9 +192,6 @@ def test_exp_pauli_loop_controlled():
 # CHECK:         call void @__quantum__qis__exp_pauli__ctl(double %[[VAL_33]], ptr %[[VAL_20]], ptr %[[VAL_19]], ptr %[[VAL_3]])
 # CHECK:         %[[VAL_26]] = add i64 %[[VAL_25]], 1
 # CHECK:         br label %[[VAL_22]]
-# CHECK:                                    ; preds = %[[VAL_22]]
-# CHECK:         call void @__quantum__rt__qubit_release(ptr %[[VAL_27]])
-# CHECK:         call void @__quantum__rt__qubit_release(ptr %[[VAL_28]])
-# CHECK:         call void @__quantum__rt__qubit_release(ptr %[[VAL_29]])
-# CHECK:         ret void
-# CHECK:       }
+# CHECK:         call void @__quantum__rt__qubit_release(ptr %
+# CHECK:         call void @__quantum__rt__qubit_release(ptr %
+# CHECK:         call void @__quantum__rt__qubit_release(ptr %


### PR DESCRIPTION
Modify factor-quantum-alloc to insert extract_ref operations when needed for aliasing issues. Modify memtoreg to track binding canceling uses of a veq via an extract_ref with a non-constant index.