### PR TITLE
Add atomic quantum region marker plumbing

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.h
+++ b/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.h
@@ -22,6 +22,8 @@
 #include "mlir/Interfaces/LoopLikeInterface.h"
 
 namespace cudaq::cc {
+inline constexpr char atomicQuantumRegionAttrName[] = "atomic_quantum_region";
+
 constexpr int kInterleavedArgumentConstantBitWidth = 29;
 using InterleavedArgumentConstantIndex =
     llvm::PointerEmbeddedInt<std::int32_t,

--- a/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -60,8 +60,11 @@ def cc_ScopeOp : CCOp<"scope",
     its region must be deallocated. It can also delimit automatically generated
     adjoint code.
 
-    A ScopeOp that contains no allocations has no semantics and can be inlined
-    into the parent Region. This transformation is done in canonicalization.
+    A ScopeOp that contains no allocations has no allocation-lifetime
+    semantics and can normally be inlined into the parent Region. This
+    transformation is done in canonicalization. A scope carrying the
+    `atomic_quantum_region` attribute is retained, however, so later
+    transformations can identify it as an atomic quantum region.
 
     A ScopeOp may contain a single-entry, multiple-exit CFG with multiple
     basic blocks in its region. A ContinueOp is the terminator that exits a
@@ -78,6 +81,7 @@ def cc_ScopeOp : CCOp<"scope",
     ```
   }];
 
+  let arguments = (ins OptionalAttr<UnitAttr>:$atomic_quantum_region);
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region AnyRegion:$initRegion);
   

--- a/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -2081,6 +2081,9 @@ struct EraseScopeWhenNotNeeded : public OpRewritePattern<cudaq::cc::ScopeOp> {
 
   LogicalResult matchAndRewrite(cudaq::cc::ScopeOp scope,
                                 PatternRewriter &rewriter) const override {
+    if (scope.getAtomicQuantumRegionAttr())
+      return failure();
+
     if (scope.hasAllocation())
       return failure();
 

--- a/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -488,6 +488,9 @@ public:
     auto newFunc = cudaq::opt::factory::createFunction(
         funcName, funcTy.getResults(), inTys, module);
     newFunc.setPrivate();
+    if (auto atomicRegion =
+            func->getAttr(cudaq::cc::atomicQuantumRegionAttrName))
+      newFunc->setAttr(cudaq::cc::atomicQuantumRegionAttrName, atomicRegion);
     IRMapping mapping;
     func.getBody().cloneInto(&newFunc.getBody(), mapping);
     auto controlNotNeeded = computeActionAnalysis(newFunc);
@@ -608,6 +611,9 @@ public:
     auto newFunc = cudaq::opt::factory::createFunction(
         funcName, funcTy.getResults(), funcTy.getInputs(), module);
     newFunc.setPrivate();
+    if (auto atomicRegion =
+            func->getAttr(cudaq::cc::atomicQuantumRegionAttrName))
+      newFunc->setAttr(cudaq::cc::atomicQuantumRegionAttrName, atomicRegion);
     IRMapping mapping;
     funcBody.cloneInto(&newFunc.getBody(), mapping);
     reverseTheOpsInTheBlock(loc, newFunc.getBody().front().getTerminator(),

--- a/cudaq/test/Transforms/atomic_quantum_region_scope.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_scope.qke
@@ -1,0 +1,45 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --canonicalize %s | FileCheck %s
+// RUN: cudaq-opt --verify-each --canonicalize %s | FileCheck --check-prefix=COUNT %s
+
+func.func @marked_scope(%arg: i64) -> i64 {
+  %result = cc.scope -> (i64) {
+    %zero = arith.constant 0 : i64
+    %sum = arith.addi %arg, %zero : i64
+    cc.continue %sum : i64
+  } {atomic_quantum_region}
+  return %result : i64
+}
+
+func.func @ordinary_scope(%arg: i64) -> i64 {
+  %result = cc.scope -> (i64) {
+    %zero = arith.constant 0 : i64
+    %sum = arith.addi %arg, %zero : i64
+    cc.continue %sum : i64
+  }
+  return %result : i64
+}
+
+// CHECK-LABEL:   func.func @marked_scope(
+// CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (i64) {
+// CHECK:             cc.continue %[[ARG0]] : i64
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]] : i64
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @ordinary_scope(
+// CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
+// CHECK-NOT:       cc.scope
+// CHECK:           return %[[ARG0]] : i64
+// CHECK:         }
+
+// COUNT-COUNT-1: atomic_quantum_region
+// COUNT-NOT: atomic_quantum_region

--- a/cudaq/test/Transforms/atomic_quantum_region_specialization.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_specialization.qke
@@ -1,0 +1,81 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --apply-op-specialization %s | FileCheck %s
+// RUN: cudaq-opt --verify-each --apply-op-specialization %s | FileCheck --check-prefix=COUNT %s
+
+func.func private @marked(%target: !quake.ref) attributes {atomic_quantum_region} {
+  quake.t %target : (!quake.ref) -> ()
+  return
+}
+
+func.func private @ordinary(%target: !quake.ref) {
+  quake.t %target : (!quake.ref) -> ()
+  return
+}
+
+func.func @caller(%control: !quake.ref, %target: !quake.ref) {
+  quake.apply<adj> @marked %target : (!quake.ref) -> ()
+  quake.apply @marked [%control] %target : (!quake.ref, !quake.ref) -> ()
+  quake.apply<adj> @marked [%control] %target : (!quake.ref, !quake.ref) -> ()
+  quake.apply<adj> @ordinary %target : (!quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func private @ordinary.adj(
+// CHECK-SAME:      %[[ARG0:.*]]: !quake.ref) {
+// CHECK:           quake.t<adj> %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @marked.adj.ctrl(
+// CHECK-SAME:      %[[ARG0:.*]]: !quake.veq<?>,
+// CHECK-SAME:      %[[ARG1:.*]]: !quake.ref) attributes {atomic_quantum_region} {
+// CHECK:           quake.t<adj> {{\[}}%[[ARG0]]] %[[ARG1]] : (!quake.veq<?>, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @marked.adj(
+// CHECK-SAME:      %[[ARG0:.*]]: !quake.ref) attributes {atomic_quantum_region} {
+// CHECK:           quake.t<adj> %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @marked.ctrl(
+// CHECK-SAME:      %[[ARG0:.*]]: !quake.veq<?>,
+// CHECK-SAME:      %[[ARG1:.*]]: !quake.ref) attributes {atomic_quantum_region} {
+// CHECK:           quake.t {{\[}}%[[ARG0]]] %[[ARG1]] : (!quake.veq<?>, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @marked(
+// CHECK-SAME:      %[[ARG0:.*]]: !quake.ref) attributes {atomic_quantum_region} {
+// CHECK:           quake.t %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @ordinary(
+// CHECK-SAME:      %[[ARG0:.*]]: !quake.ref) {
+// CHECK:           quake.t %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @caller(
+// CHECK-SAME:                      %[[ARG0:.*]]: !quake.ref,
+// CHECK-SAME:                      %[[ARG1:.*]]: !quake.ref) {
+// CHECK:           call @marked.adj(%[[ARG1]]) : (!quake.ref) -> ()
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %[[ARG0]] : (!quake.ref) -> !quake.veq<?>
+// CHECK:           call @marked.ctrl(%[[CONCAT_0]], %[[ARG1]]) : (!quake.veq<?>, !quake.ref) -> ()
+// CHECK:           %[[CONCAT_1:.*]] = quake.concat %[[ARG0]] : (!quake.ref) -> !quake.veq<?>
+// CHECK:           call @marked.adj.ctrl(%[[CONCAT_1]], %[[ARG1]]) : (!quake.veq<?>, !quake.ref) -> ()
+// CHECK:           call @ordinary.adj(%[[ARG1]]) : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// COUNT-COUNT-4: atomic_quantum_region
+// COUNT-NOT: atomic_quantum_region

--- a/docs/sphinx/using/extending/compiler/mlir_pass.rst
+++ b/docs/sphinx/using/extending/compiler/mlir_pass.rst
@@ -124,14 +124,21 @@ path. Treat calls as boundaries unless they have been inlined or the pass
 explicitly supports optimization across calls.
 
 Ordinary ``cc.scope`` operations are the common exception. Frontend lowering
-and inlining introduce them frequently, so circuit optimizations should work
+and inlining introduce them frequently, so quantum optimizations should work
 within and across scopes when wire threading is unambiguous. This does not
 require general control-flow support. Rewrites may cross the scope boundary
 only when they do not move scoped allocations or their uses, or bypass cleanup
 performed when the scope exits.
 
+A ``cc.scope`` carrying the ``atomic_quantum_region`` unit attribute, is not
+transparent in this way. Canonicalization retains a marked scope even when it
+holds no allocations, so the marker reaches later passes. An optimization may
+rewrite quantum operations wholly inside or wholly outside a marked scope, but
+must not combine, cancel, or move operations across its boundary.
+
 Tests should cover optimization within a block, across an ordinary scope, and
-conservative behavior at an unsupported control-flow boundary.
+conservative behavior at both a marked scope and an unsupported control-flow
+boundary.
 
 Pipeline integration should keep related quantum optimizations together in a
 value-form portion of the pipeline. A quantum optimization should not require


### PR DESCRIPTION
### Summary

This is the first PR in the atomic quantum region feature stack. It adds the internal marker plumbing needed before inlining can materialize atomic regions at call sites.

  - Add the optional `atomic_quantum_region` unit attribute to `cc.scope`.
  - Preserve existing behavior for ordinary scopes and unmarked functions.

  The next stacked PR will copy the marker from these functions onto the call-site scopes created by aggressive inlining.

  _Note: This PR does not add public Python or C++ syntax, change optimization pipelines, or alter quantum optimization behavior._