### PR TITLE
Materialize atomic quantum regions during aggressive inlining

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/AggressiveInlining.cpp
+++ b/cudaq/lib/Optimizer/Transforms/AggressiveInlining.cpp
@@ -94,10 +94,16 @@ public:
         cudaq::opt::factory::getOrAddFunc(loc, directName, funcTy, mod);
         auto directAttr = FlatSymbolRefAttr::get(ctx, directName);
         call.setCalleeFromCallable(directAttr);
+        calleeAttr = directAttr;
         LLVM_DEBUG(llvm::dbgs() << "Rewriting " << directName << '\n');
       }
 
       if (!isa<cudaq::cc::DeviceCallOp, cudaq::cc::NoInlineCallOp>(op)) {
+        auto calleeFunc = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+            call, calleeAttr);
+        const bool isAtomicQuantumRegion =
+            calleeFunc &&
+            calleeFunc->hasAttr(cudaq::cc::atomicQuantumRegionAttrName);
         // Move the call into a scope so as to preserve any live-ranges for
         // allocated resources.
         auto loc = call.getLoc();
@@ -108,6 +114,8 @@ public:
               builder.insert(clone);
               cudaq::cc::ContinueOp::create(builder, loc, clone->getResults());
             });
+        if (isAtomicQuantumRegion)
+          scope.setAtomicQuantumRegionAttr(rewriter.getUnitAttr());
         LLVM_DEBUG(llvm::dbgs() << "Call moved into scope " << scope << '\n');
         op->replaceAllUsesWith(scope);
         op->erase();
@@ -152,14 +160,16 @@ public:
 static void defaultInlinerOptPipeline(OpPassManager &pm) {}
 
 /// Run the passes in the correct order.
-/// 1) Convert calls between kernels to direct calls (on the QPU).
-/// 2) Aggressively inline all calls.
-/// 3) Detect if kernel inlining has failed and left behind calls to kernels.
+/// 1) Lower unwind control flow before creating call-site scopes.
+/// 2) Convert calls between kernels to direct calls (on the QPU).
+/// 3) Aggressively inline all calls.
+/// 4) Detect if kernel inlining has failed and left behind calls to kernels.
 /// Such a failure is most likely a sign that there is a cycle in the call
 /// graph. [This check is a bad idea: this should be deferred to final codegen
 /// when translating the final Quake IR.]
 void cudaq::opt::addAggressiveInlining(OpPassManager &pm, bool fatalChecks) {
   llvm::StringMap<OpPassManager> opPipelines;
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createUnwindLowering());
   pm.addPass(cudaq::opt::createConvertToDirectCalls());
   pm.addPass(createInlinerPass(opPipelines, defaultInlinerOptPipeline));
   if (fatalChecks)

--- a/cudaq/test/Transforms/atomic_quantum_region_feedback.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_feedback.qke
@@ -1,0 +1,77 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --apply-op-specialization --split-input-file %s | \
+// RUN:   FileCheck --implicit-check-not="@marked_feedback.adj" \
+// RUN:   --implicit-check-not="@ordinary_feedback.adj" %s
+
+// Measurement feedback prevents adjoint specialization. Check the marked and
+// ordinary cases independently to prove the marker does not change that
+// existing behavior and neither case gains an `.adj` function.
+
+func.func private @marked_feedback(%q: !quake.ref) attributes {atomic_quantum_region} {
+  %measurement = quake.mz %q : (!quake.ref) -> !quake.measure
+  %bit = quake.discriminate %measurement : (!quake.measure) -> i1
+  cc.if(%bit) {
+    quake.z %q : (!quake.ref) -> ()
+  }
+  return
+}
+
+func.func @marked_caller(%q: !quake.ref) {
+  quake.apply<adj> @marked_feedback %q : (!quake.ref) -> ()
+  return
+}
+
+// -----
+
+func.func private @ordinary_feedback(%q: !quake.ref) {
+  %measurement = quake.mz %q : (!quake.ref) -> !quake.measure
+  %bit = quake.discriminate %measurement : (!quake.measure) -> i1
+  cc.if(%bit) {
+    quake.z %q : (!quake.ref) -> ()
+  }
+  return
+}
+
+func.func @ordinary_caller(%q: !quake.ref) {
+  quake.apply<adj> @ordinary_feedback %q : (!quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func private @marked_feedback(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.ref) attributes {atomic_quantum_region} {
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ARG0]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[MZ_0]] : (!quake.measure) -> i1
+// CHECK:           cc.if(%[[DISCRIMINATE_0]]) {
+// CHECK:             quake.z %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @marked_caller(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.ref) {
+// CHECK:           quake.apply<adj> @marked_feedback %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @ordinary_feedback(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.ref) {
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ARG0]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[MZ_0]] : (!quake.measure) -> i1
+// CHECK:           cc.if(%[[DISCRIMINATE_0]]) {
+// CHECK:             quake.z %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @ordinary_caller(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.ref) {
+// CHECK:           quake.apply<adj> @ordinary_feedback %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/Transforms/atomic_quantum_region_inlining.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_inlining.qke
@@ -1,0 +1,91 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --aggressive-inlining %s | FileCheck --implicit-check-not="call @" %s
+// RUN: cudaq-opt --verify-each --aggressive-inlining %s | FileCheck --check-prefix=COUNT %s
+
+module attributes {quake.mangled_name_map = {marked = "indirect_marked"}} {
+  func.func private @marked(%q: !quake.ref) attributes {atomic_quantum_region} {
+    quake.h %q : (!quake.ref) -> ()
+    return
+  }
+
+  func.func private @ordinary(%q: !quake.ref) {
+    quake.x %q : (!quake.ref) -> ()
+    return
+  }
+
+  func.func private @nested(%q: !quake.ref) attributes {atomic_quantum_region} {
+    func.call @marked(%q) : (!quake.ref) -> ()
+    quake.y %q : (!quake.ref) -> ()
+    return
+  }
+
+  func.func private @marked_feedback(%q: !quake.ref) attributes {atomic_quantum_region} {
+    %measurement = quake.mz %q : (!quake.ref) -> !quake.measure
+    %bit = quake.discriminate %measurement : (!quake.measure) -> i1
+    cc.if(%bit) {
+      quake.z %q : (!quake.ref) -> ()
+    }
+    return
+  }
+
+  func.func private @ordinary_feedback(%q: !quake.ref) {
+    %measurement = quake.mz %q : (!quake.ref) -> !quake.measure
+    %bit = quake.discriminate %measurement : (!quake.measure) -> i1
+    cc.if(%bit) {
+      quake.z %q : (!quake.ref) -> ()
+    }
+    return
+  }
+
+  func.func private @indirect_marked(!quake.ref)
+
+  func.func @caller(%q: !quake.ref) {
+    func.call @marked(%q) : (!quake.ref) -> ()
+    func.call @ordinary(%q) : (!quake.ref) -> ()
+    func.call @nested(%q) : (!quake.ref) -> ()
+    func.call @marked_feedback(%q) : (!quake.ref) -> ()
+    func.call @ordinary_feedback(%q) : (!quake.ref) -> ()
+    func.call @indirect_marked(%q) : (!quake.ref) -> ()
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @caller(
+// CHECK-SAME:                      %[[ARG0:.*]]: !quake.ref) {
+// CHECK:           cc.scope {
+// CHECK:             quake.h %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           } {atomic_quantum_region}
+// CHECK-NEXT:      quake.x %[[ARG0]] : (!quake.ref) -> ()
+// CHECK-NEXT:      cc.scope {
+// CHECK-NEXT:        cc.scope {
+// CHECK-NEXT:          quake.h %[[ARG0]] : (!quake.ref) -> ()
+// CHECK-NEXT:        } {atomic_quantum_region}
+// CHECK-NEXT:        quake.y %[[ARG0]] : (!quake.ref) -> ()
+// CHECK-NEXT:      } {atomic_quantum_region}
+// CHECK-NEXT:      cc.scope {
+// CHECK-NEXT:        %[[MZ_0:.*]] = quake.mz %[[ARG0]] : (!quake.ref) -> !quake.measure
+// CHECK-NEXT:        %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[MZ_0]] : (!quake.measure) -> i1
+// CHECK-NEXT:        cc.if(%[[DISCRIMINATE_0]]) {
+// CHECK-NEXT:          quake.z %[[ARG0]] : (!quake.ref) -> ()
+// CHECK-NEXT:        }
+// CHECK-NEXT:      } {atomic_quantum_region}
+// CHECK-NEXT:      %[[MZ_1:.*]] = quake.mz %[[ARG0]] : (!quake.ref) -> !quake.measure
+// CHECK-NEXT:      %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[MZ_1]] : (!quake.measure) -> i1
+// CHECK-NEXT:      cc.if(%[[DISCRIMINATE_1]]) {
+// CHECK-NEXT:        quake.z %[[ARG0]] : (!quake.ref) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:      cc.scope {
+// CHECK-NEXT:        quake.h %[[ARG0]] : (!quake.ref) -> ()
+// CHECK-NEXT:      } {atomic_quantum_region}
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// COUNT-COUNT-5: atomic_quantum_region
+// COUNT-NOT: atomic_quantum_region

--- a/cudaq/test/Transforms/atomic_quantum_region_specialization.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_specialization.qke
@@ -8,6 +8,8 @@
 
 // RUN: cudaq-opt --verify-each --apply-op-specialization %s | FileCheck %s
 // RUN: cudaq-opt --verify-each --apply-op-specialization %s | FileCheck --check-prefix=COUNT %s
+// RUN: cudaq-opt --verify-each --apply-op-specialization --aggressive-inlining %s | \
+// RUN:   FileCheck --check-prefix=INLINE --implicit-check-not="call @" %s
 
 func.func private @marked(%target: !quake.ref) attributes {atomic_quantum_region} {
   quake.t %target : (!quake.ref) -> ()
@@ -79,3 +81,21 @@ func.func @caller(%control: !quake.ref, %target: !quake.ref) {
 
 // COUNT-COUNT-4: atomic_quantum_region
 // COUNT-NOT: atomic_quantum_region
+
+// INLINE-LABEL:   func.func @caller(
+// INLINE-SAME:                      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.ref,
+// INLINE-SAME:                      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.ref) {
+// INLINE-NEXT:      cc.scope {
+// INLINE-NEXT:        quake.t<adj> %[[ARG1]] : (!quake.ref) -> ()
+// INLINE-NEXT:      } {atomic_quantum_region}
+// INLINE-NEXT:      %[[CONCAT_0:.*]] = quake.concat %[[ARG0]] : (!quake.ref) -> !quake.veq<1>
+// INLINE-NEXT:      cc.scope {
+// INLINE-NEXT:        quake.t {{\[}}%[[CONCAT_0]]] %[[ARG1]] : (!quake.veq<1>, !quake.ref) -> ()
+// INLINE-NEXT:      } {atomic_quantum_region}
+// INLINE-NEXT:      %[[CONCAT_1:.*]] = quake.concat %[[ARG0]] : (!quake.ref) -> !quake.veq<1>
+// INLINE-NEXT:      cc.scope {
+// INLINE-NEXT:        quake.t<adj> {{\[}}%[[CONCAT_1]]] %[[ARG1]] : (!quake.veq<1>, !quake.ref) -> ()
+// INLINE-NEXT:      } {atomic_quantum_region}
+// INLINE-NEXT:      quake.t<adj> %[[ARG1]] : (!quake.ref) -> ()
+// INLINE-NEXT:      return
+// INLINE-NEXT:    }

--- a/cudaq/test/Transforms/atomic_quantum_region_unwind.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_unwind.qke
@@ -1,0 +1,46 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --aggressive-inlining %s | FileCheck --implicit-check-not=cc.unwind %s
+// RUN: cudaq-opt --verify-each --aggressive-inlining %s | FileCheck --check-prefix=COUNT %s
+
+func.func private @marked(%q: !quake.ref, %condition: i1) attributes {atomic_quantum_region} {
+  cc.if(%condition) {
+    quake.h %q : (!quake.ref) -> ()
+    cc.unwind_return
+  }
+  quake.x %q : (!quake.ref) -> ()
+  return
+}
+
+func.func @caller(%q: !quake.ref, %condition: i1) {
+  func.call @marked(%q, %condition) : (!quake.ref, i1) -> ()
+  quake.y %q : (!quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @caller(
+// CHECK-SAME:                      %[[ARG0:.*]]: !quake.ref,
+// CHECK-SAME:                      %[[ARG1:.*]]: i1) {
+// CHECK:           cc.scope {
+// CHECK:             cf.cond_br %[[ARG1]], ^bb1, ^bb2
+// CHECK:           ^bb1:
+// CHECK:             quake.h %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:             cf.br ^bb3
+// CHECK:           ^bb2:
+// CHECK:             quake.x %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:             cf.br ^bb3
+// CHECK:           ^bb3:
+// CHECK:             cc.continue
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           quake.y %[[ARG0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// COUNT-COUNT-1: atomic_quantum_region
+// COUNT-NOT: atomic_quantum_region


### PR DESCRIPTION
### Summary

  - Propagate `atomic_quantum_region` from marked callees to the existing call-site `cc.scope` created by aggressive inlining.
  - Handle direct calls, converted indirect calls, nested marked calls, and adjoint/control specializations.
  - Do not mark scopes created for ordinary callees.
  - Normalize `cc.unwind_*` control flow before inlining so callee-local exits remain local and later unwind lowering cannot flatten a marked call-site scope.

