### PR TITLE
Fix release image notebook validation (CuPy headers, mpi4py)

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -193,11 +193,12 @@ jobs:
         with:
           context: .
           file: ./docker/build/devcontainer.Dockerfile
+          # cuda-cudart-dev ships the CUDA headers CuPy JITs against at runtime.
           build-args: |
             ompidev_image=${{ inputs.ompidev_image }}
             base_image=nvcr.io/nvidia/cuda:${{ inputs.cuda_version }}.0-runtime-ubuntu24.04
             cuda_version=${{ inputs.cuda_version }}
-            cuda_packages=
+            cuda_packages=cuda-cudart-dev
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: ${{ inputs.platforms }}

--- a/scripts/validate_installation.sh
+++ b/scripts/validate_installation.sh
@@ -576,7 +576,14 @@ if [ -n "$(find examples/ applications/ -name '*.ipynb')" ]; then
     else
         pip install jupyter ipykernel notebook -q
     fi
-    
+
+    # skqd.ipynb imports mpi4py, which is not shipped in the image.
+    if [ -n "$MPI_ROOT" ] && ! python3 -c "import mpi4py" 2>/dev/null; then
+        echo "Installing mpi4py for notebooks that require it..."
+        pip install "mpi4py~=4.1" -q \
+            || echo "Warning: could not install mpi4py; notebooks importing it will fail."
+    fi
+
     # Register the venv as a Jupyter kernel
     # Notebooks will execute in this environment and can install their own packages
     JUPYTER_KERNEL_NAME="cudaq_nb_validation_container"


### PR DESCRIPTION
CuPy JIT-compiles kernels at runtime and resolves their includes from CUDA_PATH, but the release image base ships only the cudart runtime, so vector_types.h and cuda_fp16.h are absent. The dynamics notebooks and snippets/using/backends/dynamics.py fail as a result. Add cuda-cudart-dev to the cuda_packages build arg of the image that installs CuPy.

#5111 added the package to docker/release/cudaq.ext.Dockerfile, which no workflow builds; the validated image comes from cudaq.Dockerfile on top of this base instead.

skqd.ipynb also imports mpi4py, which is not shipped in the image. Install it into the notebook validation venv rather than adding it to the image.

Verified against the failing cu12 and cu13 images on amd64 and arm64. entanglement_acc_hamiltonian_simulation.ipynb still fails for an unrelated reason: dqe removes qubit allocations that no operation uses.