### PR TITLE
Publish llms.txt at site root and generate llms-full.txt (#5100)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -149,6 +149,17 @@ jobs:
           rm -rf "$target_folder"
           unzip -d "$target_folder" "${{ steps.artifacts.outputs.docs_archive }}"
 
+          # Also place llms.txt/llms-full.txt at the site root, where the
+          # convention expects them and their root-relative links resolve.
+          if [ "$target_folder" == "latest" ]; then
+            for llms_file in llms.txt llms-full.txt; do
+              if [ -f "$target_folder/$llms_file" ]; then
+                cp "$target_folder/$llms_file" "$llms_file"
+                git add "$llms_file"
+              fi
+            done
+          fi
+
           git config --global user.name "cuda-quantum-bot"
           git config --global user.email "cuda-quantum-bot@users.noreply.github.com"
 

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -275,11 +275,33 @@ if [ "$docs_exit_code" -eq "0" ]; then
         echo "Markdown files copied successfully to $DOCS_INSTALL_PREFIX."
 
         # Copy llms.txt from the repository root to the docs install prefix
-        if [ -f "$CUDAQ_REPO_ROOT/llms.txt" ]; then
-            cp "$CUDAQ_REPO_ROOT/llms.txt" "$DOCS_INSTALL_PREFIX/"
+        if [ -f "$repo_root/llms.txt" ]; then
+            cp "$repo_root/llms.txt" "$DOCS_INSTALL_PREFIX/"
             echo "Copied llms.txt to $DOCS_INSTALL_PREFIX."
         else
-            echo "Warning: llms.txt not found in $CUDAQ_REPO_ROOT, skipping copy."
+            echo "Warning: llms.txt not found in $repo_root, skipping copy."
+        fi
+
+        # Generate llms-full.txt by concatenating the markdown files llms.txt
+        # links to (its links are relative to the site root, i.e. the latest/
+        # prefix that $DOCS_INSTALL_PREFIX corresponds to).
+        if [ -f "$DOCS_INSTALL_PREFIX/llms.txt" ]; then
+            llms_full_file="$DOCS_INSTALL_PREFIX/llms-full.txt"
+            rm -f "$llms_full_file"
+            grep -oE '\]\(latest/[^)]+\.md\)' "$DOCS_INSTALL_PREFIX/llms.txt" | \
+            sed -e 's|^](latest/||' -e 's|)$||' | while read -r md_path; do
+                if [ -f "$DOCS_INSTALL_PREFIX/$md_path" ]; then
+                    printf '\n\n<!-- Source: %s -->\n\n' "$md_path" >> "$llms_full_file"
+                    cat "$DOCS_INSTALL_PREFIX/$md_path" >> "$llms_full_file"
+                else
+                    echo "Warning: $md_path is referenced in llms.txt but was not found, skipping it in llms-full.txt."
+                fi
+            done
+            if [ -f "$llms_full_file" ]; then
+                echo "Generated llms-full.txt in $DOCS_INSTALL_PREFIX."
+            else
+                echo "Warning: no markdown files were found to generate llms-full.txt."
+            fi
         fi
     else
         echo "Markdown documentation encountered issues."


### PR DESCRIPTION
The published llms.txt advertised two entry points that 404'd: the linked llms-full.txt was never generated, and llms.txt was served only under version prefixes, so its root-relative links resolved to /latest/latest/... paths.

build_docs.sh now generates llms-full.txt from the markdown mirrors llms.txt links to, and the publish workflow copies both files to the site root when updating latest. Also use $repo_root instead of the unset $CUDAQ_REPO_ROOT so the copy works outside the dev container.

Based on a branch proposed by @rogerawong.