### PR TITLE
Retry gha-tools download in wheel test Dockerfiles

### DIFF
--- a/docker/test/wheels/debian.Dockerfile
+++ b/docker/test/wheels/debian.Dockerfile
@@ -46,7 +46,13 @@ RUN if [ -n "$pip_install_flags" ]; then \
     fi
 
 # Working around issue https://github.com/pypa/pip/issues/11153.
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin && \
+# Retry download to a file (not a pipe) to survive transient/truncated fetches.
+RUN for i in 1 2 3; do \
+        wget --tries=3 --retry-connrefused --waitretry=5 --timeout=30 \
+            https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O /tmp/tools.tar.gz \
+        && gzip -t /tmp/tools.tar.gz && tar -xzf /tmp/tools.tar.gz -C /usr/local/bin && break \
+        || { echo "gha-tools download attempt $i failed; retrying..."; sleep 5; }; \
+    done && rm -f /tmp/tools.tar.gz && \
     RAPIDS_PIP_EXE="python${python_version} -m pip" \
     /usr/local/bin/rapids-pip-retry install ${pip_install_flags} /tmp/$cuda_quantum_wheel
 RUN if [ -n "$optional_dependencies" ]; then \

--- a/docker/test/wheels/fedora.Dockerfile
+++ b/docker/test/wheels/fedora.Dockerfile
@@ -34,7 +34,13 @@ COPY python/tests /tmp/tests/
 COPY python/README*.md /tmp/
 
 # Working around issue https://github.com/pypa/pip/issues/11153.
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin && \
+# Retry download to a file (not a pipe) to survive transient/truncated fetches.
+RUN for i in 1 2 3; do \
+        wget --tries=3 --retry-connrefused --waitretry=5 --timeout=30 \
+            https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O /tmp/tools.tar.gz \
+        && gzip -t /tmp/tools.tar.gz && tar -xzf /tmp/tools.tar.gz -C /usr/local/bin && break \
+        || { echo "gha-tools download attempt $i failed; retrying..."; sleep 5; }; \
+    done && rm -f /tmp/tools.tar.gz && \
     RAPIDS_PIP_EXE="python${python_version} -m pip" \
     /usr/local/bin/rapids-pip-retry install ${pip_install_flags} /tmp/$cuda_quantum_wheel
 RUN if [ -n "$optional_dependencies" ]; then \

--- a/docker/test/wheels/opensuse.Dockerfile
+++ b/docker/test/wheels/opensuse.Dockerfile
@@ -33,7 +33,13 @@ COPY python/tests /tmp/tests/
 COPY python/README*.md /tmp/
 
 # Working around issue https://github.com/pypa/pip/issues/11153.
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin && \
+# Retry download to a file (not a pipe) to survive transient/truncated fetches.
+RUN for i in 1 2 3; do \
+        wget --tries=3 --retry-connrefused --waitretry=5 --timeout=30 \
+            https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O /tmp/tools.tar.gz \
+        && gzip -t /tmp/tools.tar.gz && tar -xzf /tmp/tools.tar.gz -C /usr/local/bin && break \
+        || { echo "gha-tools download attempt $i failed; retrying..."; sleep 5; }; \
+    done && rm -f /tmp/tools.tar.gz && \
     RAPIDS_PIP_EXE="python${python_version} -m pip" \
     /usr/local/bin/rapids-pip-retry install ${pip_install_flags} /tmp/$cuda_quantum_wheel
 RUN if [ -n "$optional_dependencies" ]; then \

--- a/docker/test/wheels/redhat.Dockerfile
+++ b/docker/test/wheels/redhat.Dockerfile
@@ -32,7 +32,13 @@ COPY python/tests /tmp/tests/
 COPY python/README*.md /tmp/
 
 # Working around issue https://github.com/pypa/pip/issues/11153.
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin && \
+# Retry download to a file (not a pipe) to survive transient/truncated fetches.
+RUN for i in 1 2 3; do \
+        wget --tries=3 --retry-connrefused --waitretry=5 --timeout=30 \
+            https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O /tmp/tools.tar.gz \
+        && gzip -t /tmp/tools.tar.gz && tar -xzf /tmp/tools.tar.gz -C /usr/local/bin && break \
+        || { echo "gha-tools download attempt $i failed; retrying..."; sleep 5; }; \
+    done && rm -f /tmp/tools.tar.gz && \
     RAPIDS_PIP_EXE="python${python_version} -m pip" \
     /usr/local/bin/rapids-pip-retry install ${pip_install_flags} /tmp/$cuda_quantum_wheel
 RUN if [ -n "$optional_dependencies" ]; then \

--- a/docker/test/wheels/ubuntu.Dockerfile
+++ b/docker/test/wheels/ubuntu.Dockerfile
@@ -42,7 +42,13 @@ COPY python/README*.md /tmp/
 RUN sed -ie 's/include-system-site-packages\s*=\s*false/include-system-site-packages = true/g' "$VIRTUAL_ENV/pyvenv.cfg"
 
 # Working around issue https://github.com/pypa/pip/issues/11153.
-RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin && \
+# Retry download to a file (not a pipe) to survive transient/truncated fetches.
+RUN for i in 1 2 3; do \
+        wget --tries=3 --retry-connrefused --waitretry=5 --timeout=30 \
+            https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O /tmp/tools.tar.gz \
+        && gzip -t /tmp/tools.tar.gz && tar -xzf /tmp/tools.tar.gz -C /usr/local/bin && break \
+        || { echo "gha-tools download attempt $i failed; retrying..."; sleep 5; }; \
+    done && rm -f /tmp/tools.tar.gz && \
     RAPIDS_PIP_EXE="python${python_version} -m pip" \
     /usr/local/bin/rapids-pip-retry install ${pip_install_flags} /tmp/$cuda_quantum_wheel
 RUN if [ -n "$optional_dependencies" ]; then \


### PR DESCRIPTION
Download tools.tar.gz to a file with retries and verify it before extracting, instead of piping wget straight into tar. Guards against transient/truncated fetches that failed the wheel validation builds.

See: https://github.com/NVIDIA/cuda-quantum/actions/runs/31673087977/job/94366019533