### PR TITLE
Adding --installpath option to the realtime installer

### DIFF
--- a/docs/sphinx/using/realtime/installation.rst
+++ b/docs/sphinx/using/realtime/installation.rst
@@ -56,6 +56,13 @@ Setup
 
         ./install_cuda_quantum_realtime_cu13.arm64  --accept
 
+    The default installation location is ``/opt/nvidia/cudaq/realtime``, which usually requires ``sudo``.
+    To install somewhere else, pass ``--installpath`` to the installer. For example,
+
+    .. code-block:: console
+
+        ./install_cuda_quantum_realtime_cu13.arm64 --accept -- --installpath $HOME/.cudaq_realtime
+
   - Follow the instructions given by the installer for post-installation steps to set environment variables.
 
   - Program the FPGA with HSB.

--- a/realtime/docs/user_guide.md
+++ b/realtime/docs/user_guide.md
@@ -52,6 +52,17 @@ Please refer to this [section](#using-docker) for instructions.
 
     <!--- -->
 
+    > **_NOTE:_** To install to a different location (which does not require
+    > `sudo`), pass `--installpath` to the installer, e.g.,
+    >
+    > ```bash
+    > ./install_cuda_quantum_realtime_cu13.arm64 --accept -- --installpath $HOME/.cudaq_realtime
+    > ```
+    >
+    > The paths used in the remaining steps then need to be adjusted accordingly.
+
+    <!--- -->
+
     > **_NOTE:_** After the installation, please follow the instructed
     > post-installation step to set the environment variable, e.g.,
     >

--- a/realtime/scripts/build_installer.sh
+++ b/realtime/scripts/build_installer.sh
@@ -165,4 +165,8 @@ makeself "${makeself_args[@]}" \
 
 echo ""
 echo "Done! Installer created: $output_dir/$installer_name"
-echo "To install: bash $output_dir/$installer_name --accept"
+echo "To install (default: $default_target):"
+echo "  sudo bash $output_dir/$installer_name --accept"
+echo ""
+echo "To install to a custom location (no sudo required):"
+echo "  bash $output_dir/$installer_name --accept -- --installpath \$HOME/.cudaq_realtime"

--- a/realtime/scripts/migrate_assets.sh
+++ b/realtime/scripts/migrate_assets.sh
@@ -15,6 +15,23 @@ target=/opt/nvidia/cudaq/realtime
 
 
 # Process command line arguments
+# Pre-process long options (getopts only handles short options).
+# The installer invokes this script with the default target already set via -t,
+# so a user-provided --installpath must come later on the command line to win.
+args=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --installpath)
+            if [ -z "${2:-}" ]; then
+                echo "Missing argument for --installpath" >&2
+                (return 0 2>/dev/null) && return 1 || exit 1
+            fi
+            args+=(-t "$2"); shift 2 ;;
+        *) args+=("$1"); shift ;;
+    esac
+done
+set -- "${args[@]}"
+
 __optind__=$OPTIND
 OPTIND=1
 while getopts ":t:" opt; do

--- a/realtime/scripts/validate_installer.sh
+++ b/realtime/scripts/validate_installer.sh
@@ -8,8 +8,9 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# Default installation location: /opt/nvidia/cudaq/realtime
-install_dir=/opt/nvidia/cudaq/realtime
+# Installation location: the directory this script was installed into, which is
+# /opt/nvidia/cudaq/realtime unless the installer was given --installpath.
+install_dir="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
 
 # Check LD_LIBRARY_PATH contains the install_dir/lib path
 if [[ ":$LD_LIBRARY_PATH:" != *":$install_dir/lib:"* ]]; then


### PR DESCRIPTION
As I am testing different installers for QM, I would like the ability to not override the one that is currently installed and working. 