### PR TITLE
[core] Don't let DQE eliminate an entry point's last allocation

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/DeadQuantumElimination.cpp
+++ b/cudaq/lib/Optimizer/Transforms/DeadQuantumElimination.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Frontend/nvqpp/AttributeNames.h"
 #include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
@@ -27,6 +28,31 @@ using namespace mlir;
 // partially eliminate those quantum allocations. For example, a
 // `quake.extract_ref` might be a use, but itself have no users.
 
+// An entry point's whole register is observable: sample() implicitly measures
+// every allocated qubit and get_state() returns the full register. Eliminating
+// the last allocation leaves a kernel with no qubits, which yields empty sample
+// counts and a null state, so keep it.
+static bool isSoleAllocationOfEntryPoint(Operation *alloc) {
+  Operation *entry = nullptr;
+  for (Operation *p = alloc->getParentOp(); p; p = p->getParentOp())
+    if (p->hasAttr(cudaq::entryPointAttrName)) {
+      entry = p;
+      break;
+    }
+  if (!entry)
+    return false;
+  bool foundOther = false;
+  entry->walk([&](Operation *op) {
+    if (op != alloc && isa<cudaq::quake::AllocaOp, cudaq::quake::NullWireOp,
+                           cudaq::quake::BorrowWireOp>(op)) {
+      foundOther = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return !foundOther;
+}
+
 namespace {
 class RefPattern : public OpRewritePattern<cudaq::quake::AllocaOp> {
 public:
@@ -36,6 +62,8 @@ public:
   LogicalResult matchAndRewrite(cudaq::quake::AllocaOp alloc,
                                 PatternRewriter &rewriter) const override {
     if (std::distance(alloc->getUsers().begin(), alloc->getUsers().end()) > 1)
+      return failure();
+    if (isSoleAllocationOfEntryPoint(alloc))
       return failure();
     if (alloc->use_empty()) {
       rewriter.eraseOp(alloc);
@@ -67,6 +95,8 @@ public:
     // FIXME: safety check as MLIR breaks linear type constraints underneath us.
     if (std::distance(nullWire->getUsers().begin(),
                       nullWire->getUsers().end()) != 1)
+      return failure();
+    if (isSoleAllocationOfEntryPoint(nullWire))
       return failure();
     // Wires are linear types. There must be exactly 1 use.
     auto sink = dyn_cast<cudaq::quake::SinkOp>(*nullWire->getUsers().begin());

--- a/cudaq/test/Transforms/dqe-1.qke
+++ b/cudaq/test/Transforms/dqe-1.qke
@@ -1,0 +1,28 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --add-dealloc --dqe %s | FileCheck %s
+
+// An entry point's register is observable even when no operation uses it:
+// sample() implicitly measures it and get_state() returns it. Keep it.
+func.func @unused_register() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %0 = quake.alloca !quake.veq<3>
+  return
+}
+
+// CHECK-LABEL:   func.func @unused_register()
+// CHECK:           quake.alloca !quake.veq<3>
+
+// Nothing observes a non-entry-point register, so it is still eliminated.
+func.func @unused_register_helper() {
+  %0 = quake.alloca !quake.veq<3>
+  return
+}
+
+// CHECK-LABEL:   func.func @unused_register_helper()
+// CHECK-NOT:       quake.alloca

--- a/python/tests/kernel/test_state_kernel.py
+++ b/python/tests/kernel/test_state_kernel.py
@@ -213,3 +213,19 @@ def test_state_vector_async():
     with pytest.raises(Exception) as error:
         # Invalid qpu_id type.
         result = cudaq.get_state_async(kernel, 0.0, 0.0, qpu_id=12)
+
+
+def test_state_of_untouched_register():
+    # A register that no operation touches is still observable: sample()
+    # implicitly measures it and get_state() returns the whole register.
+
+    @cudaq.kernel
+    def allocate_only(n: int):
+        q = cudaq.qvector(n)
+
+    counts = cudaq.sample(allocate_only, 3)
+    assert counts["000"] == 1000
+
+    state = np.array(cudaq.get_state(allocate_only, 3))
+    assert state.shape == (8,)
+    assert np.isclose(state[0], 1.0)


### PR DESCRIPTION
A kernel that allocates qubits but applies no operation to them loses its register entirely. sample() returns no counts at all and get_state() segfaults dereferencing a null SimulationState:

    @cudaq.kernel
    def allocate_only(n: int):
        q = cudaq.qvector(n)

    cudaq.sample(allocate_only, 3)     # {} instead of { 000:1000 }
    cudaq.get_state(allocate_only, 3)  # SIGSEGV

DQE erases an alloca whose only use is a dealloc, and a null_wire whose only use is a sink. That is sound when nothing observes the register, but an entry point's register is observable: sample() implicitly measures every allocated qubit and get_state() returns the whole register. Since #4993 enabled value semantics for local simulators as well, such a kernel now reaches the runtime with no qubits at all.

Keep the allocation when it is the last one in a cudaq-entrypoint function. Partially used registers are unaffected, and dead qubits in non-entry-point functions are still eliminated.

Adds a FileCheck test for both halves of that rule and an execution test asserting the observable contract. Both fail without the fix.