### PR TITLE
[CI] Scale dev-env Python test workers with the runner

### DIFF
--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -305,7 +305,11 @@ jobs:
             fi
 
             retry python -m pip install pytest pytest-xdist
-            python -m pytest -v --durations=0 -n auto python/tests/ \
+            # Uncapped, 16 workers x 16 OMP threads on a cpu16 runner starve 
+            # memory and surface as `std::bad_alloc`. See PR#4530.
+            export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+            pytest_workers="${PYTEST_WORKERS:-$(( ($(nproc) + 1) / 2 ))}"
+            python -m pytest -v --durations=0 -n "$pytest_workers" python/tests/ \
               --ignore python/tests/backends \
               --ignore python/tests/contrib
             pytest_status=$?


### PR DESCRIPTION
### Summary

Caps OMP threads per pytest worker and scales the xdist worker count with the runner in the `Dev environment (Python)` job, which was running uncapped.

### Motivation

* `test_in_devenv.yml` ran `pytest -n auto python/tests/` on a `linux-{amd64,arm64}-cpu16` runner with no `OMP_NUM_THREADS` setting, so 16 workers each spawned up to 16 OMP threads. The peak footprint intermittently starves the runner and fails whichever test holds the largest allocation with `MemoryError: std::bad_alloc`. This ejected PR #5128 from the merge queue on `arm64/gcc12 Python` while the other three Python legs passed.
* PR #4530 diagnosed the identical symptom on the identical tests and fixed it with `OMP_NUM_THREADS=1` plus `PYTEST_WORKERS:-4`, but only in `scripts/validate_pycudaq.sh`. This workflow was never covered.