### PR TITLE
Expose dependency-aware T-depth resource metric

### DIFF
--- a/python/runtime/common/py_Resources.cpp
+++ b/python/runtime/common/py_Resources.cpp
@@ -82,6 +82,8 @@ This includes all gate counts.)#")
            nanobind::arg("arity"),
            "Get circuit depth considering only gates of a specific qubit "
            "arity. Returns 0 if no gates of that arity exist.")
+      .def_prop_ro("t_depth", &Resources::getTDepth,
+                   "The dependency-aware depth of T and T-dagger gates.\n")
       .def_prop_ro("multi_qubit_gate_count", &Resources::getMultiQubitGateCount,
                    "Total count of gates with 2 or more qubits.\n")
       .def_prop_ro("multi_qubit_depth", &Resources::getMultiQubitDepth,

--- a/python/runtime/common/py_Resources.cpp
+++ b/python/runtime/common/py_Resources.cpp
@@ -69,6 +69,8 @@ This includes all gate counts.)#")
                    "operation.\n")
       .def_prop_ro("depth", &Resources::getCircuitDepth,
                    "The circuit depth (longest gate chain on any qubit).\n")
+      .def_prop_ro("t_depth", &Resources::getTDepth,
+                   "The dependency-aware depth of T and T-dagger gates.\n")
       .def_prop_ro(
           "gate_count_by_arity",
           [](Resources &self) { return self.getGateCountsByArity(); },
@@ -82,8 +84,6 @@ This includes all gate counts.)#")
            nanobind::arg("arity"),
            "Get circuit depth considering only gates of a specific qubit "
            "arity. Returns 0 if no gates of that arity exist.")
-      .def_prop_ro("t_depth", &Resources::getTDepth,
-                   "The dependency-aware depth of T and T-dagger gates.\n")
       .def_prop_ro("multi_qubit_gate_count", &Resources::getMultiQubitGateCount,
                    "Total count of gates with 2 or more qubits.\n")
       .def_prop_ro("multi_qubit_depth", &Resources::getMultiQubitDepth,

--- a/python/tests/builder/test_resource_metrics.py
+++ b/python/tests/builder/test_resource_metrics.py
@@ -68,6 +68,22 @@ def test_parallel_cx_disjoint_qubits():
     assert resources.depth_for_arity(2) == 1
 
 
+def test_t_depth_tracks_dependencies_and_parallel_layers():
+    """T-depth propagates dependencies through non-T operations."""
+    kernel = cudaq.make_kernel()
+    q = kernel.qalloc(3)
+    kernel.t(q[0])
+    kernel.t(q[1])
+    kernel.cx(q[0], q[2])
+    kernel.cx(q[1], q[2])
+    kernel.tdg(q[2])
+
+    resources = cudaq.estimate_resources(kernel)
+    assert resources.t_depth == 2
+    resources.clear()
+    assert resources.t_depth == 0
+
+
 def test_ccx_arity():
     """CCX is arity-3, not arity-2."""
 

--- a/runtime/common/Resources.cpp
+++ b/runtime/common/Resources.cpp
@@ -87,9 +87,8 @@ void Resources::appendInstruction(const std::string &name,
   for (auto q : allQubits)
     perQubitDepth[q] = newDepth;
 
-  // Track T depth using the same dependency propagation as total circuit
-  // depth. A non-T operation carries the latest T layer across all operands;
-  // a T or T-dagger operation starts the next T layer on its operands.
+  // Propagate T depth through dependencies. T and T-dagger begin a new layer;
+  // other operations carry forward the deepest incoming layer.
   std::size_t maxTDepth = 0;
   for (auto q : allQubits)
     maxTDepth = std::max(maxTDepth, perQubitTDepth[q]);
@@ -124,6 +123,13 @@ std::size_t Resources::getCircuitDepth() const {
   return maxDepth;
 }
 
+std::size_t Resources::getTDepth() const {
+  std::size_t maxDepth = 0;
+  for (auto &[qubit, depth] : perQubitTDepth)
+    maxDepth = std::max(maxDepth, depth);
+  return maxDepth;
+}
+
 std::size_t Resources::getGateCountByArity(std::size_t arity) const {
   auto it = gateCountByArity.find(arity);
   return it != gateCountByArity.end() ? it->second : 0;
@@ -135,13 +141,6 @@ std::size_t Resources::getDepthByArity(std::size_t arity) const {
     return 0;
   std::size_t maxDepth = 0;
   for (auto &[qubit, depth] : it->second)
-    maxDepth = std::max(maxDepth, depth);
-  return maxDepth;
-}
-
-std::size_t Resources::getTDepth() const {
-  std::size_t maxDepth = 0;
-  for (auto &[qubit, depth] : perQubitTDepth)
     maxDepth = std::max(maxDepth, depth);
   return maxDepth;
 }

--- a/runtime/common/Resources.cpp
+++ b/runtime/common/Resources.cpp
@@ -87,6 +87,17 @@ void Resources::appendInstruction(const std::string &name,
   for (auto q : allQubits)
     perQubitDepth[q] = newDepth;
 
+  // Track T depth using the same dependency propagation as total circuit
+  // depth. A non-T operation carries the latest T layer across all operands;
+  // a T or T-dagger operation starts the next T layer on its operands.
+  std::size_t maxTDepth = 0;
+  for (auto q : allQubits)
+    maxTDepth = std::max(maxTDepth, perQubitTDepth[q]);
+  const auto isTFamily = name == "t" || name == "tdg";
+  const auto newTDepth = maxTDepth + (isTFamily ? 1 : 0);
+  for (auto q : allQubits)
+    perQubitTDepth[q] = newTDepth;
+
   // Track gate count and depth by arity (total qubit count = controls +
   // targets, distinct from nControls used in the Instruction key).
   auto arity = allQubits.size();
@@ -124,6 +135,13 @@ std::size_t Resources::getDepthByArity(std::size_t arity) const {
     return 0;
   std::size_t maxDepth = 0;
   for (auto &[qubit, depth] : it->second)
+    maxDepth = std::max(maxDepth, depth);
+  return maxDepth;
+}
+
+std::size_t Resources::getTDepth() const {
+  std::size_t maxDepth = 0;
+  for (auto &[qubit, depth] : perQubitTDepth)
     maxDepth = std::max(maxDepth, depth);
   return maxDepth;
 }
@@ -183,6 +201,7 @@ void Resources::clear() {
   numQubits = 0;
   totalGates = 0;
   perQubitDepth.clear();
+  perQubitTDepth.clear();
   gateCountByArity.clear();
   perQubitDepthByArity.clear();
 }

--- a/runtime/common/Resources.h
+++ b/runtime/common/Resources.h
@@ -102,17 +102,15 @@ public:
   /// @brief Return the circuit depth (longest gate chain on any qubit).
   std::size_t getCircuitDepth() const;
 
+  /// @brief Return the maximum number of T and T-dagger operations along any
+  /// qubit dependency path.
+  std::size_t getTDepth() const;
+
   /// @brief Return gate count for a specific qubit arity.
   std::size_t getGateCountByArity(std::size_t arity) const;
 
   /// @brief Return circuit depth for a specific qubit arity.
   std::size_t getDepthByArity(std::size_t arity) const;
-
-  /// @brief Return the dependency-aware depth of T-family operations.
-  ///
-  /// This counts T and T-dagger layers while propagating dependencies through
-  /// every operation that touches the affected qubits.
-  std::size_t getTDepth() const;
 
   /// @brief Return total gate count for all multi-qubit gates (arity >= 2).
   std::size_t getMultiQubitGateCount() const;
@@ -141,8 +139,7 @@ private:
   /// @brief Per-qubit depth map for all gates.
   std::unordered_map<std::size_t, std::size_t> perQubitDepth;
 
-  /// @brief Per-qubit T-family depth map. Non-T operations propagate the
-  /// current depth across their operands; T-family operations add one layer.
+  /// @brief Maximum T depth reaching each qubit.
   std::unordered_map<std::size_t, std::size_t> perQubitTDepth;
 
   /// @brief Gate counts by qubit arity: {arity -> count}.

--- a/runtime/common/Resources.h
+++ b/runtime/common/Resources.h
@@ -108,6 +108,12 @@ public:
   /// @brief Return circuit depth for a specific qubit arity.
   std::size_t getDepthByArity(std::size_t arity) const;
 
+  /// @brief Return the dependency-aware depth of T-family operations.
+  ///
+  /// This counts T and T-dagger layers while propagating dependencies through
+  /// every operation that touches the affected qubits.
+  std::size_t getTDepth() const;
+
   /// @brief Return total gate count for all multi-qubit gates (arity >= 2).
   std::size_t getMultiQubitGateCount() const;
 
@@ -134,6 +140,10 @@ private:
 
   /// @brief Per-qubit depth map for all gates.
   std::unordered_map<std::size_t, std::size_t> perQubitDepth;
+
+  /// @brief Per-qubit T-family depth map. Non-T operations propagate the
+  /// current depth across their operands; T-family operations add one layer.
+  std::unordered_map<std::size_t, std::size_t> perQubitTDepth;
 
   /// @brief Gate counts by qubit arity: {arity -> count}.
   std::map<std::size_t, std::size_t> gateCountByArity;


### PR DESCRIPTION
- expose dependency-aware T-depth through `Resources::getTDepth()` and read-only Python `Resources.t_depth`
- count `t` and `tdg` as T layers while propagating the maximum layer through every operation's operands

Useful for benchmarking
