### PR TITLE
Preserve qubit mapping metadata on repeated mapping

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1103,6 +1103,9 @@ def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
     performs mapping of the qubits by inserting the necessary swap operations
     into the Quake IR.
 
+    A function that already carries `mapping_v2p` remains unchanged, and
+    retargeting mapped IR requires starting from unmapped IR.
+
     Note 1: this pass requires strictly value semantics (in the form of wire
     sets) for any quantum operations. It will throw an error if any memory
     reference semantics are present on quantum operations.

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1103,9 +1103,6 @@ def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
     performs mapping of the qubits by inserting the necessary swap operations
     into the Quake IR.
 
-    A function that already carries `mapping_v2p` remains unchanged, and
-    retargeting mapped IR requires starting from unmapped IR.
-
     Note 1: this pass requires strictly value semantics (in the form of wire
     sets) for any quantum operations. It will throw an error if any memory
     reference semantics are present on quantum operations.

--- a/cudaq/lib/Optimizer/Transforms/Mapping.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Mapping.cpp
@@ -2395,6 +2395,10 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
   }
 
   void runOnOperation() override {
+    auto func = getOperation();
+    if (func->hasAttr("mapping_v2p"))
+      return;
+
     if (deviceBypass)
       return;
 
@@ -2403,7 +2407,6 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
     if (!deviceInstance)
       return;
 
-    auto func = getOperation();
     if (func.empty())
       return;
     auto &blocks = func.getBlocks();

--- a/cudaq/test/Transforms/mapping_non_unitaries.qke
+++ b/cudaq/test/Transforms/mapping_non_unitaries.qke
@@ -20,6 +20,7 @@
 // RUN: cudaq-opt --qubit-mapping=device=grid\(3,3\) %s | FileCheck %s
 // RUN: cudaq-opt --qubit-mapping=device=grid\(1,5\) %s | FileCheck %s
 // RUN: cudaq-opt --qubit-mapping=device=grid\(5,1\) %s | FileCheck %s
+// RUN: cudaq-opt --qubit-mapping=device=path\(5\) --qubit-mapping=device=path\(5\) %s | FileCheck --check-prefix=IDEMPOTENT %s
 
 quake.wire_set @wires[2147483647]
 
@@ -54,3 +55,4 @@ func.func @test_measurement() {
 
 // STAR52-LABEL:   func.func @test_measurement() attributes {mapping_reorder_idx = [0, 1, 2], mapping_v2p = [0, 1, 2]} {
 // STAR50-LABEL:   func.func @test_measurement() attributes {mapping_reorder_idx = [2, 1, 0], mapping_v2p = [2, 1, 0]} {
+// IDEMPOTENT-LABEL: func.func @test_measurement() attributes {mapping_reorder_idx = [0, 2, 1], mapping_v2p = [0, 2, 1]} {


### PR DESCRIPTION
Closes #5144. Make mapping idempotent.