### PR TITLE
fix: incomplete git submodule command in Dockerfile

### DIFF
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -70,7 +70,7 @@ RUN cd /cuda-quantum && git init && \
             git update-index --add --cacheinfo 160000 \
             $(cat /.git_modules/$local_path/HEAD) $local_path; \
         fi; \
-    done && git submodule init && git submodule
+    done && git submodule init && git submodule update
 RUN cd /cuda-quantum && source scripts/configure_build.sh && \
     LLVM_PROJECTS='clang;flang;lld;mlir;openmp;runtimes' BOOTSTRAP_LLVM=true \
     bash scripts/install_prerequisites.sh -t llvm -e qrmi


### PR DESCRIPTION
This PR fixes a script issue in `docker/build/assets.Dockerfile`: incomplete git submodule command in Dockerfile.

## Changes
- `docker/build/assets.Dockerfile`: incomplete git submodule command in Dockerfile.

## Details
```diff
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -1,1 +1,1 @@
-    done && git submodule init && git submodule
+    done && git submodule init && git submodule update
```

## Tests
- `scripts/test_dockerfile_submodule.sh`

```diff
--- /dev/null
+++ b/scripts/test_dockerfile_submodule.sh
@@ -0,0 +1,7 @@
+#!/bin/bash
+set -e
+# Verify the assets Dockerfile uses a complete git submodule command.
+file="docker/build/assets.Dockerfile"
+grep -E 'git submodule update' "$file" || { echo "Missing complete submodule update command"; exit 1; }
+if grep -E 'git submodule[[:space:]]*$' "$file"; then echo "Incomplete submodule command found"; exit 1; fi
```