### PR TITLE
fix: remove no-op git submodule from submodule setup

### DIFF
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -70,7 +70,7 @@ RUN cd /cuda-quantum && git init && \
             git update-index --add --cacheinfo 160000 \
             $(cat /.git_modules/$local_path/HEAD) $local_path; \
         fi; \
-    done && git submodule init && git submodule
+    done && git submodule init
 RUN cd /cuda-quantum && source scripts/configure_build.sh && \
     LLVM_PROJECTS='clang;flang;lld;mlir;openmp;runtimes' BOOTSTRAP_LLVM=true \
     bash scripts/install_prerequisites.sh -t llvm -e qrmi


### PR DESCRIPTION
This PR addresses the following issue in `docker/build/assets.Dockerfile`: remove no-op git submodule from submodule setup.

## Changes
- `docker/build/assets.Dockerfile`: remove no-op git submodule from submodule setup.

## Details
```diff
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -1,1 +1,1 @@
-    done && git submodule init && git submodule
+    done && git submodule init
```

## Tests

> Let me know if you want tests added for this fix or not.