### PR TITLE
fix: use configured PYTHON for wheel build

### DIFF
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -284,7 +284,7 @@ RUN cd /cuda-quantum && \
     CC="$LLVM_INSTALL_PREFIX/bin/clang" \
     CXX="$LLVM_INSTALL_PREFIX/bin/clang++" \
     FC="$LLVM_INSTALL_PREFIX/bin/flang" \
-    python3 -m build --wheel && \
+    ${PYTHON} -m build --wheel && \
     echo "=== ccache stats (python_build) ===" && (ccache -s 2>/dev/null || true)
     ## [<CUDAQuantumPythonBuild]
 
@@ -298,7 +298,7 @@ RUN echo "Patching up wheel using auditwheel..." && \
     CUDAQ_WHEEL="$(find . -name 'cuda_quantum*.whl')" && \
     MANYLINUX_PLATFORM="$(echo ${CUDAQ_WHEEL} | grep -o '[a-z]*linux_[^\.]*' | sed -re 's/^linux_/manylinux_2_28_/')" && \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(pwd)/cuda-quantum/_skbuild/lib" \
-    python3 -m auditwheel -v repair ${CUDAQ_WHEEL} \
+    ${PYTHON} -m auditwheel -v repair ${CUDAQ_WHEEL} \
         --plat ${MANYLINUX_PLATFORM} \
         --exclude libcublas.so.11 \
         --exclude libcublasLt.so.11 \

--- a/scripts/validate_dockerfile_python.sh
+++ b/scripts/validate_dockerfile_python.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate that the wheel build and auditwheel repair commands in
+# docker/build/assets.Dockerfile use the configured PYTHON interpreter.
+set -e
+
+DOCKERFILE="docker/build/assets.Dockerfile"
+
+# Strip comments and check for hardcoded python3 in the relevant commands.
+if sed 's/#.*//' "$DOCKERFILE" | grep -n 'python3 -m build --wheel'; then
+    echo "Error: Found hardcoded python3 in wheel build command" >&2
+    exit 1
+fi
+if sed 's/#.*//' "$DOCKERFILE" | grep -n 'python3 -m auditwheel'; then
+    echo "Error: Found hardcoded python3 in auditwheel command" >&2
+    exit 1
+fi
+
+echo "OK: Dockerfile uses configured PYTHON for wheel build and repair"


### PR DESCRIPTION
This PR addresses the following issue in `docker/build/assets.Dockerfile`: use configured PYTHON for wheel build.

## Changes
- `docker/build/assets.Dockerfile`: use configured PYTHON for wheel build.

## Details
See the Files changed tab for the exact diff.

## Tests
- `scripts/validate_dockerfile_python.sh`