### PR TITLE
fix: quote install prefix in nvidia backend check

### DIFF
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -167,7 +167,7 @@ RUN cd /cuda-quantum && source scripts/configure_build.sh && \
 
 # Validate that the nvidia backend was built.
 RUN source /cuda-quantum/scripts/configure_build.sh && \
-    if [ -z "$(ls $CUDAQ_INSTALL_PREFIX/targets/nvidia.yml)" ]; then \
+    if [ ! -e "$CUDAQ_INSTALL_PREFIX/targets/nvidia.yml" ]; then \
         echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2; \
         exit 1; \
     fi
@@ -316,7 +316,7 @@ RUN echo "Patching up wheel using auditwheel..." && \
     ## [<CUDAQuantumWheel]
 
 # Validate that the nvidia backend was built.
-RUN if [ -z "$(ls /cuda-quantum/_skbuild/targets/nvidia.yml)" ]; then \
+RUN if [ ! -e "/cuda-quantum/_skbuild/targets/nvidia.yml" ]; then \
         echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2; \
         exit 1; \
     fi

--- a/scripts/test_nvidia_backend_check.sh
+++ b/scripts/test_nvidia_backend_check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+#
+# Regression test for the nvidia backend existence check.
+# Verifies that a CUDAQ_INSTALL_PREFIX containing spaces is handled correctly.
+
+set -e
+
+CUDAQ_INSTALL_PREFIX="$(mktemp -d)/cuda quantum install"
+mkdir -p "$CUDAQ_INSTALL_PREFIX/targets"
+touch "$CUDAQ_INSTALL_PREFIX/targets/nvidia.yml"
+
+if [ ! -e "$CUDAQ_INSTALL_PREFIX/targets/nvidia.yml" ]; then
+    echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2
+    rm -rf "$(dirname "$CUDAQ_INSTALL_PREFIX")"
+    exit 1
+fi
+
+rm -rf "$(dirname "$CUDAQ_INSTALL_PREFIX")"
+echo "PASS"


### PR DESCRIPTION
This PR addresses the following issue in `docker/build/assets.Dockerfile`: quote install prefix in nvidia backend check.

## Changes
- `docker/build/assets.Dockerfile`: quote install prefix in nvidia backend check.

## Details
```diff
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -1,14 +1,14 @@
-# Validate that the nvidia backend was built.
-RUN source /cuda-quantum/scripts/configure_build.sh && \
-    if [ -z "$(ls $CUDAQ_INSTALL_PREFIX/targets/nvidia.yml)" ]; then \
-        echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2; \
-        exit 1; \
-    fi
-
-...
-
-# Validate that the nvidia backend was built.
-RUN if [ -z "$(ls /cuda-quantum/_skbuild/targets/nvidia.yml)" ]; then \
-        echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2; \
-        exit 1; \
-    fi
+# Validate that the nvidia backend was built.
+RUN source /cuda-quantum/scripts/configure_build.sh && \
+    if [ ! -e "$CUDAQ_INSTALL_PREFIX/targets/nvidia.yml" ]; then \
+        echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2; \
+        exit 1; \
+    fi
+
+...
+
+# Validate that the nvidia backend was built.
+RUN if [ ! -e "/cuda-quantum/_skbuild/targets/nvidia.yml" ]; then \
+        echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2; \
+        exit 1; \
+    fi
```

## Tests
- `scripts/test_nvidia_backend_check.sh`

```diff
--- /dev/null
+++ b/scripts/test_nvidia_backend_check.sh
@@ -0,0 +1,26 @@
+#!/bin/bash
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+#
+# Regression test for the nvidia backend existence check.
+# Verifies that a CUDAQ_INSTALL_PREFIX containing spaces is handled correctly.
+
+set -e
+
+CUDAQ_INSTALL_PREFIX="$(mktemp -d)/cuda quantum install"
+mkdir -p "$CUDAQ_INSTALL_PREFIX/targets"
+touch "$CUDAQ_INSTALL_PREFIX/targets/nvidia.yml"
+
+if [ ! -e "$CUDAQ_INSTALL_PREFIX/targets/nvidia.yml" ]; then
+    echo -e "\e[01;31mError: Missing nvidia backend.\e[0m" >&2
+    rm -rf "$(dirname "$CUDAQ_INSTALL_PREFIX")"
+    exit 1
+fi
+
+rm -rf "$(dirname "$CUDAQ_INSTALL_PREFIX")"
+echo "PASS"
```