### PR TITLE
fix: Missing regression test for --exclude-libs ODR protection

### DIFF
--- a/runtime/internal/device_call/CMakeLists.txt
+++ b/runtime/internal/device_call/CMakeLists.txt
@@ -80,6 +80,15 @@ if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME)
     "LINKER:--exclude-libs,libcudaq-realtime-udp-transport.a"
     "LINKER:--exclude-libs,libcudaq-realtime-cpu-roce-transport.a")
 
+  # Regression test: the transport archives are implementation details of this
+  # runtime's channels.  If --exclude-libs is missing, their symbols become
+  # exported and bridge providers share one copy of the transceiver code,
+  # causing silent ODR violations and teardown corruption.  Verify with nm that
+  # no cpu_udp_/cpu_roce_* dynamic symbols are exported.
+  add_test(NAME cudaq_device_call_no_exported_transport_symbols
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/verify_no_exported_transport_symbols.sh
+            $<TARGET_FILE:cudaq-device-call-runtime>)
+
   install(TARGETS cudaq-device-call-runtime-headers
           EXPORT cudaq-targets
           COMPONENT Development)

--- a/runtime/internal/device_call/CMakeLists.txt
+++ b/runtime/internal/device_call/CMakeLists.txt
@@ -88,6 +88,8 @@ if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME)
   add_test(NAME cudaq_device_call_no_exported_transport_symbols
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/verify_no_exported_transport_symbols.sh
             $<TARGET_FILE:cudaq-device-call-runtime>)
+  set_tests_properties(cudaq_device_call_no_exported_transport_symbols PROPERTIES
+    LABELS "realtime")
 
   install(TARGETS cudaq-device-call-runtime-headers
           EXPORT cudaq-targets

--- a/runtime/internal/device_call/tests/verify_no_exported_transport_symbols.sh
+++ b/runtime/internal/device_call/tests/verify_no_exported_transport_symbols.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <shared-library>" >&2
+  exit 2
+fi
+
+lib="$1"
+
+# The --exclude-libs flag is ELF/GNU linker specific, so only run this check
+# on ELF platforms.
+case "$(uname -s)" in
+  Linux) ;;
+  *) echo "Skipping symbol-export check on non-ELF platform"
+     exit 0
+     ;;
+esac
+
+if [ ! -f "$lib" ]; then
+  echo "Shared library not found: $lib" >&2
+  exit 1
+fi
+
+if ! command -v nm >/dev/null 2>&1; then
+  echo "nm not found; cannot verify symbol visibility" >&2
+  exit 1
+fi
+
+# Defined dynamic symbols have an address; undefined references do not.
+# --exclude-libs must hide the transport archive symbols, so no cpu_udp_*
+# or cpu_roce_* definitions may appear in the dynamic symbol table.
+exported=$(nm -D "$lib" | grep -E '^[0-9a-fA-F]+[[:space:]]+[^U]' | \
+           grep -E 'cpu_udp_|cpu_roce_' || true)
+
+if [ -n "$exported" ]; then
+  echo "ERROR: transport symbols are exported from $lib:" >&2
+  echo "$exported" >&2
+  exit 1
+fi


### PR DESCRIPTION
This PR addresses the following issue in `runtime/internal/device_call/CMakeLists.txt`: Missing regression test for --exclude-libs ODR protection.

## Changes
- `runtime/internal/device_call/CMakeLists.txt`: Missing regression test for --exclude-libs ODR protection.

## Details
See the Files changed tab for the exact diff.

## Tests
- `runtime/internal/device_call/tests/verify_no_exported_transport_symbols.sh`