### PR TITLE
Respect atomic quantum regions in `QuakeSimplify` rewrites

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/QuakeSimplify.cpp
+++ b/cudaq/lib/Optimizer/Transforms/QuakeSimplify.cpp
@@ -37,6 +37,52 @@ void filterArgs(SmallVector<Value> &args, C collection) {
       args.push_back(item);
 }
 
+// Nearest enclosing `cc.scope` carrying the `atomic_quantum_region` marker,
+// skipping any ordinary scopes in between.
+static cudaq::cc::ScopeOp getEnclosingAtomicQuantumRegion(Operation *op) {
+  for (auto parentScope = op->getParentOfType<cudaq::cc::ScopeOp>();
+       parentScope;
+       parentScope = parentScope->getParentOfType<cudaq::cc::ScopeOp>())
+    if (parentScope.getAtomicQuantumRegionAttr())
+      return parentScope;
+  return {};
+}
+
+// Enforce the atomic-region optimization contract: a pattern may combine
+// two operations only when they have the same nearest enclosing
+// `atomic_quantum_region` scope and every region boundary between them is an
+// ordinary single-block `cc.scope`.
+static bool shareOptimizationRegion(Operation *later, Operation *earlier) {
+  if (getEnclosingAtomicQuantumRegion(later) !=
+      getEnclosingAtomicQuantumRegion(earlier))
+    return false;
+
+  // Defining operations may be visible from nested regions. Only ordinary,
+  // single-block scopes are transparent to these local rewrites.
+  Block *nested = later->getBlock();
+  Block *outer = earlier->getBlock();
+  while (nested != outer) {
+    if (!nested)
+      return false;
+    auto scope = dyn_cast_or_null<cudaq::cc::ScopeOp>(nested->getParentOp());
+    if (!scope || scope.getAtomicQuantumRegionAttr() ||
+        !scope.getInitRegion().hasOneBlock())
+      return false;
+    nested = scope->getBlock();
+  }
+  return true;
+}
+
+// MLIR canonicalization can temporarily duplicate wire uses across blocks, and
+// Quake's verifier accepts that degraded form for later linearity repair.
+// Require every producer result to have exactly one use before rewriting or
+// erasing it.
+static bool shouldSkipRewrite(Operation *later, Operation *earlier) {
+  return !shareOptimizationRegion(later, earlier) ||
+         !llvm::all_of(earlier->getResults(),
+                       [](Value result) { return result.hasOneUse(); });
+}
+
 #include "RewriteRotationsToCliffordT.inc"
 
 // Apply some simple quantum optimizations to quake. The quake operations are
@@ -69,6 +115,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be the same\n");
       return failure();
     }
+    if (shouldSkipRewrite(qop, prev))
+      return failure();
     if (prev.getNegatedQubitControls())
       return failure();
 
@@ -162,6 +210,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "previous operations must be the same\n");
       return failure();
     }
+    if (shouldSkipRewrite(qop, prev0))
+      return failure();
     if (prev0.getNegatedQubitControls())
       return failure();
 
@@ -250,6 +300,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be the same class\n");
       return failure();
     }
+    if (shouldSkipRewrite(qop, prev))
+      return failure();
     if (prev.getNegatedQubitControls())
       return failure();
 
@@ -355,6 +407,8 @@ public:
                               << qop << '\n');
       return failure();
     }
+    if (shouldSkipRewrite(qop, prev))
+      return failure();
     if (prev.getNegatedQubitControls())
       return failure();
 
@@ -515,6 +569,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be the same\n");
       return failure();
     }
+    if (shouldSkipRewrite(qop, prev))
+      return failure();
     if (prev.getNegatedQubitControls())
       return failure();
     if (qop.isAdj() != prev.isAdj()) {
@@ -612,6 +668,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be T\n");
       return failure();
     }
+    if (shouldSkipRewrite(qop, prev))
+      return failure();
     if (prev.getNegatedQubitControls())
       return failure();
     if (qop.isAdj() != prev.isAdj()) {
@@ -717,6 +775,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "previous previous operation must be Y\n");
       return failure();
     }
+    if (shouldSkipRewrite(qop, prev0) || shouldSkipRewrite(qop, prev))
+      return failure();
     if (prev0.getNegatedQubitControls() || prev.getNegatedQubitControls())
       return failure();
 
@@ -799,6 +859,8 @@ public:
       return failure();
     auto reset0 = target.template getDefiningOp<cudaq::quake::ResetOp>();
     if (reset0) {
+      if (shouldSkipRewrite(reset, reset0))
+        return failure();
       LLVM_DEBUG(llvm::dbgs() << "eliminated: " << reset << '\n');
       rewriter.replaceOp(reset, reset0.getResults());
       ++stat;
@@ -810,6 +872,8 @@ public:
                  << "previous operation must be reset or null_wire\n");
       return failure();
     }
+    if (shouldSkipRewrite(reset, nullwire))
+      return failure();
     LLVM_DEBUG(llvm::dbgs() << "eliminated: " << reset << '\n');
     rewriter.replaceOp(reset, nullwire.getResult());
     ++stat;
@@ -838,6 +902,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be reset\n");
       return failure();
     }
+    if (shouldSkipRewrite(sink, reset0))
+      return failure();
 
     LLVM_DEBUG(llvm::dbgs() << "eliminated: " << reset0 << '\n');
     rewriter.replaceOp(reset0, reset0.getTargets());

--- a/cudaq/test/Transforms/optimize_single_qubit_clifford_t.qke
+++ b/cudaq/test/Transforms/optimize_single_qubit_clifford_t.qke
@@ -1,9 +1,9 @@
 // ========================================================================== //
-// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         //
-// All rights reserved.                                                        //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
 //                                                                            //
 // This source code and the accompanying materials are made available under   //
-// the terms of the Apache License 2.0 which accompanies this distribution.    //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
 // RUN: cudaq-opt --optimize-1q-clifford-t %s | FileCheck %s
@@ -467,3 +467,28 @@ func.func @non_linear_boundary(%arg0: !quake.wire)
 // CHECK-NEXT:    %[[RIGHT_S:.*]] = quake.s %[[RIGHT_T0]]
 // CHECK-NEXT:    %[[RIGHT_T1:.*]] = quake.t %[[RIGHT_S]]
 // CHECK-NEXT:    return %[[LEFT_T1]], %[[RIGHT_T1]]
+
+func.func @sibling_atomic_scopes(%arg0: !quake.wire) -> !quake.wire {
+  %0 = cc.scope -> (!quake.wire) {
+    %1 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+    cc.continue %1 : !quake.wire
+  } {atomic_quantum_region}
+  %2 = cc.scope -> (!quake.wire) {
+    %3 = quake.h %0 : (!quake.wire) -> !quake.wire
+    cc.continue %3 : !quake.wire
+  } {atomic_quantum_region}
+  return %2 : !quake.wire
+}
+
+// CHECK-LABEL:   func.func @sibling_atomic_scopes(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[H_0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[H_1:.*]] = quake.h %[[SCOPE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[H_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_1]] : !quake.wire
+// CHECK:         }

--- a/cudaq/test/Transforms/quake_simplify_atomic_region.qke
+++ b/cudaq/test/Transforms/quake_simplify_atomic_region.qke
@@ -1,0 +1,296 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --quake-simplify %s | FileCheck %s
+
+// Multi-operation quake-simplify rewrites must honor the atomic-region
+// contract: optimize freely inside one marked scope and on disjoint wires,
+// but never combine operations across a marked-scope boundary. Ordinary
+// single-block scopes remain transparent, and unsupported structured control
+// conservatively ends the search.
+
+func.func @preserve_atomic_scope_entry() {
+  %q0 = quake.null_wire
+  %q1 = quake.h %q0 : (!quake.wire) -> !quake.wire
+  %q2 = cc.scope -> (!quake.wire) {
+    %q3 = quake.h %q1 : (!quake.wire) -> !quake.wire
+    cc.continue %q3 : !quake.wire
+  } {atomic_quantum_region}
+  quake.sink %q2 : !quake.wire
+  return
+}
+
+func.func @simplify_inside_atomic_scope(%arg0: !quake.wire) -> !quake.wire {
+  %0 = cc.scope -> (!quake.wire) {
+    %1 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+    %2 = quake.h %1 : (!quake.wire) -> !quake.wire
+    cc.continue %2 : !quake.wire
+  } {atomic_quantum_region}
+  return %0 : !quake.wire
+}
+
+func.func @ordinary_scope_entry_is_transparent(%arg0: !quake.wire) -> !quake.wire {
+  %0 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+  %1 = cc.scope -> (!quake.wire) {
+    %2 = quake.h %0 : (!quake.wire) -> !quake.wire
+    cc.continue %2 : !quake.wire
+  }
+  return %1 : !quake.wire
+}
+
+func.func @nested_atomic_scopes_block(%arg0: !quake.wire) -> !quake.wire {
+  %0 = cc.scope -> (!quake.wire) {
+    %1 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+    %2 = cc.scope -> (!quake.wire) {
+      %3 = quake.h %1 : (!quake.wire) -> !quake.wire
+      cc.continue %3 : !quake.wire
+    } {atomic_quantum_region}
+    cc.continue %2 : !quake.wire
+  } {atomic_quantum_region}
+  return %0 : !quake.wire
+}
+
+func.func @disjoint_outside_pair_still_simplifies() -> (!quake.wire, !quake.wire) {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2 = quake.x %0 : (!quake.wire) -> !quake.wire
+  %3 = cc.scope -> (!quake.wire) {
+    %4 = quake.h %1 : (!quake.wire) -> !quake.wire
+    cc.continue %4 : !quake.wire
+  } {atomic_quantum_region}
+  %5 = quake.x %2 : (!quake.wire) -> !quake.wire
+  return %5, %3 : !quake.wire, !quake.wire
+}
+
+func.func @conditional_region_stops_rewrite(%arg0: !quake.wire, %cond: i1) {
+  cc.scope {
+    %0 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+    cc.if(%cond) {
+      %1 = quake.h %0 : (!quake.wire) -> !quake.wire
+      quake.sink %1 : !quake.wire
+    }
+    cc.continue
+  } {atomic_quantum_region}
+  return
+}
+
+func.func @marked_scope_use_prevents_outside_rewrite(%arg0: !quake.wire) -> (!quake.wire, !quake.wire) {
+  %0 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+  %1 = cc.scope -> (!quake.wire) {
+    %2 = quake.x %0 : (!quake.wire) -> !quake.wire
+    cc.continue %2 : !quake.wire
+  } {atomic_quantum_region}
+  %3 = quake.h %0 : (!quake.wire) -> !quake.wire
+  return %1, %3 : !quake.wire, !quake.wire
+}
+
+func.func @preserve_swap_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wire) -> (!quake.wire, !quake.wire) {
+  %0:2 = quake.swap %arg0, %arg1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %1:2 = cc.scope -> (!quake.wire, !quake.wire) {
+    %2:2 = quake.swap %0#1, %0#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %2#0, %2#1 : !quake.wire, !quake.wire
+  } {atomic_quantum_region}
+  return %1#0, %1#1 : !quake.wire, !quake.wire
+}
+
+func.func @preserve_phase_pairs_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wire, %arg2: !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire) {
+  %0 = quake.s %arg0 : (!quake.wire) -> !quake.wire
+  %1 = quake.s %arg1 : (!quake.wire) -> !quake.wire
+  %2 = quake.t %arg2 : (!quake.wire) -> !quake.wire
+  %3:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
+    %4 = quake.s<adj> %0 : (!quake.wire) -> !quake.wire
+    %5 = quake.s %1 : (!quake.wire) -> !quake.wire
+    %6 = quake.t %2 : (!quake.wire) -> !quake.wire
+    cc.continue %4, %5, %6 : !quake.wire, !quake.wire, !quake.wire
+  } {atomic_quantum_region}
+  return %3#0, %3#1, %3#2 : !quake.wire, !quake.wire, !quake.wire
+}
+
+func.func @preserve_rotation_at_atomic_entry(%arg0: !quake.wire) -> !quake.wire {
+  %a = arith.constant 1.0 : f64
+  %b = arith.constant 2.0 : f64
+  %0 = quake.rx (%a) %arg0 : (f64, !quake.wire) -> !quake.wire
+  %1 = cc.scope -> (!quake.wire) {
+    %2 = quake.rx (%b) %0 : (f64, !quake.wire) -> !quake.wire
+    cc.continue %2 : !quake.wire
+  } {atomic_quantum_region}
+  return %1 : !quake.wire
+}
+
+func.func @preserve_ysx_at_atomic_entry(%arg0: !quake.wire) -> !quake.wire {
+  %0 = quake.y %arg0 : (!quake.wire) -> !quake.wire
+  %1 = cc.scope -> (!quake.wire) {
+    %2 = quake.s %0 : (!quake.wire) -> !quake.wire
+    %3 = quake.x %2 : (!quake.wire) -> !quake.wire
+    cc.continue %3 : !quake.wire
+  } {atomic_quantum_region}
+  return %1 : !quake.wire
+}
+
+func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wire) -> (!quake.wire, !quake.wire) {
+  %0 = quake.reset %arg0 : (!quake.wire) -> !quake.wire
+  %1 = cc.scope -> (!quake.wire) {
+    %2 = quake.reset %0 : (!quake.wire) -> !quake.wire
+    cc.continue %2 : !quake.wire
+  } {atomic_quantum_region}
+  %3 = quake.null_wire
+  %4 = cc.scope -> (!quake.wire) {
+    %5 = quake.reset %3 : (!quake.wire) -> !quake.wire
+    cc.continue %5 : !quake.wire
+  } {atomic_quantum_region}
+  %6 = quake.reset %arg1 : (!quake.wire) -> !quake.wire
+  cc.scope {
+    quake.sink %6 : !quake.wire
+    cc.continue
+  } {atomic_quantum_region}
+  return %1, %4 : !quake.wire, !quake.wire
+}
+
+// CHECK-LABEL:   func.func @preserve_atomic_scope_entry() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[H_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           quake.sink %[[SCOPE_0]] : !quake.wire
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @simplify_inside_atomic_scope(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             cc.continue %[[ARG0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]] : !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @ordinary_scope_entry_is_transparent(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             cc.continue %[[ARG0]] : !quake.wire
+// CHECK:           }
+// CHECK:           return %[[SCOPE_0]] : !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @nested_atomic_scopes_block(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:               %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
+// CHECK:               cc.continue %[[H_1]] : !quake.wire
+// CHECK:             } {atomic_quantum_region}
+// CHECK:             cc.continue %[[SCOPE_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]] : !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @disjoint_outside_pair_still_simplifies() -> (!quake.wire, !quake.wire) {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[H_0:.*]] = quake.h %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[H_0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[NULL_WIRE_0]], %[[SCOPE_0]] : !quake.wire, !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @conditional_region_stops_rewrite(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1) {
+// CHECK:           cc.scope {
+// CHECK:             %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.if(%[[ARG1]]) {
+// CHECK:               %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
+// CHECK:               quake.sink %[[H_1]] : !quake.wire
+// CHECK:             }
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @marked_scope_use_prevents_outside_rewrite(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> (!quake.wire, !quake.wire) {
+// CHECK:           %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[X_0:.*]] = quake.x %[[H_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[X_0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           return %[[SCOPE_0]], %[[H_1]] : !quake.wire, !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @preserve_swap_at_atomic_entry(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> (!quake.wire, !quake.wire) {
+// CHECK:           %[[SWAP_0:.*]]:2 = quake.swap %[[ARG0]], %[[ARG1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[SCOPE_0:.*]]:2 = cc.scope -> (!quake.wire, !quake.wire) {
+// CHECK:             %[[SWAP_1:.*]]:2 = quake.swap %[[SWAP_0]]#1, %[[SWAP_0]]#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[SWAP_1]]#0, %[[SWAP_1]]#1 : !quake.wire, !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]]#0, %[[SCOPE_0]]#1 : !quake.wire, !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @preserve_phase_pairs_at_atomic_entry(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire) {
+// CHECK:           %[[S_0:.*]] = quake.s %[[ARG0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[S_1:.*]] = quake.s %[[ARG1]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[T_0:.*]] = quake.t %[[ARG2]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[SCOPE_0:.*]]:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
+// CHECK:             %[[S_2:.*]] = quake.s<adj> %[[S_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[S_3:.*]] = quake.s %[[S_1]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[T_1:.*]] = quake.t %[[T_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[S_2]], %[[S_3]], %[[T_1]] : !quake.wire, !quake.wire, !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]]#0, %[[SCOPE_0]]#1, %[[SCOPE_0]]#2 : !quake.wire, !quake.wire, !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @preserve_rotation_at_atomic_entry(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2.000000e+00 : f64
+// CHECK:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_0]]) %[[ARG0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[RX_1:.*]] = quake.rx (%[[CONSTANT_1]]) %[[RX_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[RX_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]] : !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @preserve_ysx_at_atomic_entry(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[Y_0:.*]] = quake.y %[[ARG0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[S_0:.*]] = quake.s %[[Y_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[X_0:.*]] = quake.x %[[S_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[X_0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]] : !quake.wire
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @preserve_resets_at_atomic_entry(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> (!quake.wire, !quake.wire) {
+// CHECK:           %[[RESET_0:.*]] = quake.reset %[[ARG0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[RESET_1:.*]] = quake.reset %[[RESET_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[RESET_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[RESET_2:.*]] = quake.reset %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[RESET_2]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[RESET_3:.*]] = quake.reset %[[ARG1]] : (!quake.wire) -> !quake.wire
+// CHECK:           cc.scope {
+// CHECK:             quake.sink %[[RESET_3]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return %[[SCOPE_0]], %[[SCOPE_1]] : !quake.wire, !quake.wire
+// CHECK:         }


### PR DESCRIPTION
 ### Summary

This PR completes the remaining `QuakeSimplify` portion of atomic quantum region optimization boundaries on top of merged PRs #5128, #5129, and #5123.

  - Prevent multi-operation QuakeSimplify rewrites from combining operations across an `atomic_quantum_region` scope boundary.
  - Continue optimizing wholly inside a marked scope and through supported ordinary single-block `cc.scope` regions.
