### PR TITLE
Fail decomposition when no basis is supplied

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/Decomposition.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Decomposition.cpp
@@ -36,6 +36,12 @@ struct Decomposition
   /// Initialize the decomposer by building the set of patterns used during
   /// execution.
   LogicalResult initialize(MLIRContext *context) override {
+    if (basis.empty() && enabledPatterns.empty()) {
+      mlir::emitWarning(mlir::UnknownLoc::get(context),
+                        "Decomposition: 'basis' must be specified");
+      return failure();
+    }
+
     RewritePatternSet owningPatterns(context);
 
     if (!basis.empty() && !enabledPatterns.empty()) {

--- a/cudaq/test/Transforms/DecompositionPatterns/empty-basis.qke
+++ b/cudaq/test/Transforms/DecompositionPatterns/empty-basis.qke
@@ -1,0 +1,21 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: not cudaq-opt --decomposition %s 2>&1 | FileCheck %s
+
+// CHECK: warning: Decomposition: 'basis' must be specified
+module {
+  func.func @exp_pauli_without_basis()
+      attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+    %qubits = quake.alloca !quake.veq<2>
+    %angle = arith.constant 5.000000e-01 : f64
+    quake.exp_pauli (%angle) %qubits to "ZZ" : (f64, !quake.veq<2>) -> ()
+    quake.dealloc %qubits : !quake.veq<2>
+    return
+  }
+}


### PR DESCRIPTION
## Summary

- fail decomposition initialization when neither a basis nor explicit patterns are supplied
- add a regression test for multi-qubit `exp_pauli` decomposition without a basis

Loading every decomposition pattern without a target basis can cause cyclic rewrites and prevent the greedy rewriter from reaching a fixed point. Rejecting the invalid configuration during pass initialization makes the command fail immediately instead of hanging.



Closes #5106
