### PR TITLE
[docs] Correct the relative phase in the r1 docstring

### DIFF
--- a/python/cudaq/qis/qis.py
+++ b/python/cudaq/qis/qis.py
@@ -79,7 +79,7 @@ def rz(*args):
 
 def r1(*args):
     """
-    This operation is an arbitrary rotation about the |1> state or the Z axis, which introduces a relative phase factor of lambda/2.
+    This operation is an arbitrary rotation about the |1> state or the Z axis, which introduces a relative phase factor of lambda.
     """
     raise_error
 


### PR DESCRIPTION
### Description

The `r1` docstring in `python/cudaq/qis/qis.py` says the operation "introduces a
relative phase factor of lambda/2".

`R1(lambda)` is `diag(1, exp(i*lambda))`, so the relative phase it applies
between the `|0>` and `|1>` states is `lambda`. `lambda/2` is the *global* phase
separating `R1` from `Rz`, which is not the quantity that sentence describes.

This corrects that one word and changes nothing else.

### Changes

- `python/cudaq/qis/qis.py` — in the `r1` docstring, `lambda/2` becomes `lambda`.

### Verification

Documentation only; no functional code is touched.

Measured on `cudaq` 0.15.1 (`aca5853a7`), Python 3.13, macOS 26.5.1 arm64. A
qubit is prepared in `|+>` and the gate applied with `lambda = 0.7`; the first
row is a control with no rotation:

```
id : amps=[0.7071+0.j     0.7071+0.j    ]  relative_phase=+0.000000
r1 : amps=[0.7071+0.j     0.5408+0.4555j]  relative_phase=+0.700000
rz : amps=[0.6642-0.2425j 0.6642+0.2425j]  relative_phase=+0.700000
```

`r1` applies a relative phase of `lambda`, not `lambda/2`.

`pre-commit run --hook-stage pre-push --files python/cudaq/qis/qis.py` passes
(yapf, license header validation, pyspelling).

### Note on the linked issue

This PR no longer addresses all of #2160. That issue asks for the `r1` and `rz`
descriptions to convey how the two gates differ, and after this narrowing both
docstrings say "introduces a relative phase factor of lambda", differing only in
the axis they name. The factual error is fixed; the clarity request is not.

#2160 is therefore left open and the reference is non-closing. Happy for it to
be closed separately if the comparison is not wanted in the reference docs.

Related to #2160


