### PR TITLE
[docs] Document givens_rotation and fermionic_swap operations

### DIFF
--- a/.github/pre-commit/spelling_allowlist.txt
+++ b/.github/pre-commit/spelling_allowlist.txt
@@ -245,6 +245,7 @@ anharmonicity
 ansatz
 ansatzes
 antiferromagnet
+antisymmetry
 api
 arXiv
 archiver

--- a/docs/sphinx/api/default_ops.rst
+++ b/docs/sphinx/api/default_ops.rst
@@ -9,6 +9,7 @@ decomposes the default operations into the appropriate set of intrinsic operatio
 for that target.
 
 The sections `Unitary Operations on Qubits`_ and `Measurements on Qubits`_ list the default set of quantum operations on qubits.
+The section `Composite Operations`_ lists the operations that CUDA-Q provides as a library on top of that default set.
 
 Operations that implement unitary transformations of the quantum state are templated.
 The template argument allows to invoke the adjoint and controlled version of the quantum transformation, see the section on `Adjoint and Controlled Operations`_.
@@ -661,6 +662,110 @@ operations, each operating on 2 qubits.
   When a custom operation is used on hardware backends, it is synthesized to a
   set of native quantum operations. Currently, only up to 5-qubit custom
   operations are supported on hardware backends.
+
+
+Composite Operations
+====================
+
+In addition to the default operations listed above, CUDA-Q ships a small library
+of composite operations that are defined in terms of those default operations.
+Unlike the default operations, they are not available implicitly within a kernel;
+each operation has to be imported in Python, and the corresponding header has to
+be included in C++.
+
+In the matrices below, the first qubit argument corresponds to the most
+significant bit of the row and column index, which is the same convention that
+`User-Defined Custom Operations`_ above uses for the unitary matrix.
+
+These operations are also available as methods on the kernel builder object
+returned by :code:`cudaq.make_kernel()` in Python, and in the
+:code:`cudaq_internal::builder` namespace in C++.
+
+:code:`givens_rotation`
+-----------------------------
+
+This operation applies a Givens rotation by an angle :math:`\theta` to a pair of
+qubits. It rotates within the two-dimensional subspace spanned by the
+:code:`|01>` and :code:`|10>` basis states and leaves the :code:`|00>` and
+:code:`|11>` basis states unchanged, which makes it a common building block for
+particle-number-conserving circuits in quantum chemistry. It is equivalent to the
+transformation :math:`\exp(-i \theta (Y \otimes X - X \otimes Y) / 2)`.
+The operation is named :code:`givens` in the Python library and
+:code:`givens_rotation` in C++ and on the kernel builder object.
+
+.. tab:: Python
+
+    .. code-block:: python
+
+        from cudaq.lib import givens
+
+        qubit_1, qubit_2 = cudaq.qubit(), cudaq.qubit()
+
+        # Apply the unitary transformation
+        # Givens(θ) = | 1     0        0      0 |
+        #             | 0  cos(θ)  -sin(θ)    0 |
+        #             | 0  sin(θ)   cos(θ)    0 |
+        #             | 0     0        0      1 |
+        givens(math.pi / 2, qubit_1, qubit_2)
+
+.. tab:: C++
+
+    .. code-block:: cpp
+
+        #include "cudaq/kernels/givens_rotation.h"
+
+        cudaq::qubit qubit_1, qubit_2;
+
+        // Apply the unitary transformation
+        // Givens(θ) = | 1     0        0      0 |
+        //             | 0  cos(θ)  -sin(θ)    0 |
+        //             | 0  sin(θ)   cos(θ)    0 |
+        //             | 0     0        0      1 |
+        cudaq_internal::givens_rotation(std::numbers::pi / 2, qubit_1, qubit_2);
+
+:code:`fermionic_swap`
+-----------------------------
+
+This operation applies a rotation by an angle :math:`\phi` on two adjacent
+fermionic modes under the Jordan-Wigner transformation. It exchanges the two
+modes while accounting for the phase that the antisymmetry of fermionic states
+requires. For :math:`\phi = \pi` it reduces to the fermionic SWAP gate, which
+exchanges the :code:`|01>` and :code:`|10>` basis states and maps :code:`|11>`
+to :code:`-|11>`.
+
+.. tab:: Python
+
+    .. code-block:: python
+
+        from cudaq.lib import fermionic_swap
+
+        qubit_1, qubit_2 = cudaq.qubit(), cudaq.qubit()
+
+        # Apply the unitary transformation
+        # FermionicSwap(φ) = | 1   0    0    0 |
+        #                    | 0   a    b    0 |
+        #                    | 0   b    a    0 |
+        #                    | 0   0    0    d |
+        # where a = exp(iφ/2) * cos(φ/2), b = -i * exp(iφ/2) * sin(φ/2),
+        # and d = exp(iφ)
+        fermionic_swap(math.pi, qubit_1, qubit_2)
+
+.. tab:: C++
+
+    .. code-block:: cpp
+
+        #include "cudaq/kernels/fermionic_swap.h"
+
+        cudaq::qubit qubit_1, qubit_2;
+
+        // Apply the unitary transformation
+        // FermionicSwap(φ) = | 1   0    0    0 |
+        //                    | 0   a    b    0 |
+        //                    | 0   b    a    0 |
+        //                    | 0   0    0    d |
+        // where a = exp(iφ/2) * cos(φ/2), b = -i * exp(iφ/2) * sin(φ/2),
+        // and d = exp(iφ)
+        cudaq_internal::fermionic_swap(std::numbers::pi, qubit_1, qubit_2);
 
 
 Photonic Operations on Qudits


### PR DESCRIPTION
## Summary

`givens_rotation` and `fermionic_swap` ship with CUDA-Q but are not described
anywhere in the documentation. `docs/sphinx/api/default_ops.rst` currently
documents only `x`, `y`, `z`, `h`, `r1`, `rx`, `ry`, `rz`, `s`, `t`, `swap` and
`u3`, so a user who runs into `kernel.givens_rotation(...)` — for example in the
AFQMC application example under `docs/sphinx/applications/python/` — has nothing
to look up. The issue asks, literally, "In the first place, what is `givens`?"

This adds a **Composite Operations** section to the quantum operations page with
an entry for each of the two gates, following the structure of the existing gate
entries: a prose description, the unitary matrix, and Python and C++ usage
examples in the same `.. tab::` / `.. code-block::` form.

## Scope: `exp_pauli` is intentionally left out

The issue title also names `exp_pauli`. That is tracked separately by
**#3776 ("[docs] Missing documentation for `exp_pauli`")**, which is already
assigned, so documenting it here would duplicate someone else's in-flight work.
This PR therefore covers the two undocumented gates only.

Because of that I have used a **non-closing reference** rather than `Fixes`:

```
Refs #2141
```

If maintainers agree that #3776 fully covers the remaining `exp_pauli` item,
#2141 can be closed when this merges — I have deliberately left that call to
you rather than auto-closing an issue whose text still mentions a third gate.

## What the new section says

* Both operations are **library kernels**, not default operations: they need
  `from cudaq.lib import ...` in Python and a `#include "cudaq/kernels/..."` in
  C++, and they are also reachable as `cudaq.make_kernel()` builder methods
  (`kernel.givens_rotation`, `kernel.fermionic_swap`) and via the
  `cudaq_internal::builder` namespace in C++. The section says so explicitly,
  since that is the difference from every other operation on the page.
* In the matrices, **the first qubit argument is the most significant bit of the
  row and column index** — the same convention this page already documents for
  `register_operation`. This matters here: `givens_rotation` is not symmetric
  under exchange of its two qubit arguments. The wording deliberately avoids the
  words "big-endian"/"little-endian", which are used with *opposite* meanings in
  different parts of this repository (see #2716).
* The Python library name (`givens`) differs from the C++ / builder name
  (`givens_rotation`); the entry calls that out so readers are not left guessing.

`givens_rotation(θ)`:

```
| 1     0        0      0 |
| 0  cos(θ)  -sin(θ)    0 |
| 0  sin(θ)   cos(θ)    0 |
| 0     0        0      1 |
```

equivalently `exp(-i θ (Y ⊗ X - X ⊗ Y) / 2)`.

`fermionic_swap(φ)`:

```
| 1   0    0    0 |
| 0   a    b    0 |
| 0   b    a    0 |
| 0   0    0    d |

a = exp(iφ/2) * cos(φ/2), b = -i * exp(iφ/2) * sin(φ/2), d = exp(iφ)
```

## Verification

Both matrices were checked against the running simulator, not just against the
header comments. Each documented matrix was passed to `cudaq.register_operation`
and applied to a generic (non-basis) input state, and the resulting state was
compared against the real gate, for five angles each — exact agreement
(max |difference| ~1e-16). They also reproduce the amplitudes asserted in
`python/tests/kernel/test_library_kernels.py`.

`pre-commit run --all-files --hook-stage pre-push` passes locally (the one
failure, `markdown-link-check`, is a pre-existing dead badge URL in `README.md`
and is unrelated to this change — no Markdown file is touched here).

`antisymmetry` is added to `.github/pre-commit/spelling_allowlist.txt`, kept in
`LC_ALL=C` sort order as `scripts/pre-commit/check_allowlist_sorted.sh` requires.

Refs #2141

