### PR TITLE
Keep negative float literals typed as floats in kernels

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5753,9 +5753,13 @@ class PyASTBridge(ast.NodeVisitor):
                     "qubit", node)
 
         if isinstance(node.op, ast.USub):
-            # Make our lives easier for -1 used in variable subscript extraction
-            if isinstance(node.operand,
-                          ast.Constant) and node.operand.value == 1:
+            # Make our lives easier for -1 used in variable subscript
+            # extraction. The literal must be an integer: `1.0 == 1` holds in
+            # Python, so a bare value comparison would also fold the float
+            # literal `-1.0` to an integer constant and silently turn e.g.
+            # `2 ** -1.0` into an integer power yielding `0.0`.
+            if isinstance(node.operand, ast.Constant) and isinstance(
+                    node.operand.value, int) and node.operand.value == 1:
                 self.pushValue(self.getConstantInt(-1))
                 return
 

--- a/python/tests/kernel/test_kernel_float.py
+++ b/python/tests/kernel/test_kernel_float.py
@@ -72,6 +72,55 @@ def test_float_use():
     assert is_close(np.sin(np.pi / 2 + 1), float_np_use())
 
 
+def test_negative_float_literal_keeps_float_type():
+    """The literal `-1.0` must stay a float, not fold to the integer `-1`."""
+
+    @cudaq.kernel
+    def int_base_neg_one() -> float:
+        return 2**-1.0
+
+    @cudaq.kernel
+    def int_base_neg_two() -> float:
+        return 2**-2.0
+
+    @cudaq.kernel
+    def other_int_base_neg_one() -> float:
+        return 3**-1.0
+
+    @cudaq.kernel
+    def float_base_neg_one() -> float:
+        return 2.0**-1.0
+
+    assert is_close(2**-1.0, int_base_neg_one())
+    assert is_close(2**-2.0, int_base_neg_two())
+    assert is_close(3**-1.0, other_int_base_neg_one())
+    assert is_close(2.0**-1.0, float_base_neg_one())
+
+
+def test_negative_one_literal_still_indexes():
+    """Folding `-1` to an integer constant still works for negative indices."""
+
+    @cudaq.kernel
+    def last_list_item() -> int:
+        values = [1, 2, 3]
+        return values[-1]
+
+    @cudaq.kernel
+    def last_float_list_item() -> float:
+        values = [-1.0, 2.5]
+        return values[-1]
+
+    @cudaq.kernel
+    def last_qubit() -> bool:
+        qubits = cudaq.qvector(3)
+        x(qubits[-1])
+        return mz(qubits[-1])
+
+    assert last_list_item() == 3
+    assert is_close(2.5, last_float_list_item())
+    assert last_qubit()
+
+
 def test_math_functions_match_python():
 
     def python_math(function: int, value: float) -> float:


### PR DESCRIPTION
## Description

Fixes #5160.

Inside a `@cudaq.kernel`, the float literal `-1.0` was folded to the *integer*
constant `-1`, so an integer base raised to `-1.0` silently became an integer
power and returned `0.0`:

```python
@cudaq.kernel
def a() -> float:
    return 2**-1.0

a()  # 0.0, expected 0.5
```

**Root cause.** `PyASTBridge.visit_UnaryOp` short-circuits `ast.USub` on a
constant operand:

```python
if isinstance(node.operand, ast.Constant) and node.operand.value == 1:
    self.pushValue(self.getConstantInt(-1))
    return
```

In Python `1.0 == 1`, so a `-1.0` constant also took this branch and came out
as an i64. That is why the defect is specific to `-1.0`: `2 ** -2.0` and
`2.0 ** -1.0` never matched the guard and were always correct.

**Fix.** Require the literal to actually be an integer before folding. `bool`
is intentionally still accepted (`isinstance(True, int)` is `True`), so `-True`
keeps its current lowering.

After the change the kernel constant-folds to `arith.constant 5.000000e-01 : f64`.

## Testing

`python/tests/kernel/test_kernel_float.py` gains two tests:

- `test_negative_float_literal_keeps_float_type` — the four cases from the
  issue (`2 ** -1.0`, `2 ** -2.0`, `3 ** -1.0`, `2.0 ** -1.0`) checked against
  Python. It fails before this change and passes after.
- `test_negative_one_literal_still_indexes` — guards the fold's original
  purpose, negative indexing into a list, a float list, and a `qvector`.

<!--
Checklist:
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->
