### PR TITLE
[python] Emit valid IR when apply_call targets a value-returning kernel

### DIFF
--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -680,11 +680,14 @@ class PyKernel(object):
         """
         self.clearCache()
         with self.insertPoint, self.loc:
+            otherResTy = []
             if isinstance(target, cc.CreateLambdaOp):
                 otherFuncCloned = target
                 otherModule = self.module
-                otherFTy = FunctionType(
-                    TypeAttr(target.attributes['function_type']).value).inputs
+                lambdaTy = FunctionType(
+                    TypeAttr(target.attributes['function_type']).value)
+                otherFTy = lambdaTy.inputs
+                otherResTy = lambdaTy.results
             else:
                 otherFuncCloned, otherModule = self.__cloneOrGetFunction(
                     target.name, self.module, target)
@@ -726,7 +729,10 @@ class PyKernel(object):
                                   otherFuncCloned.name.value),
                               is_adj=isAdjoint)
             elif isinstance(otherFuncCloned, cc.CreateLambdaOp):
-                cc.CallCallableOp([], otherFuncCloned, mlirValues)
+                # The result of the call is unused here (`apply_call` applies
+                # the callee for its effects), but `cc.call_callable` must
+                # still match the coarity of the callable's signature.
+                cc.CallCallableOp(otherResTy, otherFuncCloned, mlirValues)
             else:
                 func.CallOp(otherFuncCloned, mlirValues)
 
@@ -1479,7 +1485,7 @@ class PyKernel(object):
                         v = self.__getMLIRValueFromPythonArg(arg)
                     vs.append(v)
                 if funcTy.results:
-                    call = func.CallOp(fn, vs).result
+                    call = func.CallOp(fn, vs)
                     cc.ReturnOp(call.results)
                 else:
                     func.CallOp(fn, vs)

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -1366,6 +1366,47 @@ def test_apply_call_captures_from_definition_scope():
     cudaq.sample(builder, shots_count=3)
 
 
+def test_apply_call_kernel_with_return_value():
+    """
+    A kernel builder calls (via apply_call) a decorator kernel that returns a
+    value. The builder discards the returned value, but the generated
+    `cc.call_callable` must still match the coarity of the callable's
+    signature.
+    """
+
+    @cudaq.kernel(defer_compilation=False)
+    def flipAndMeasure(qubit: cudaq.qubit) -> bool:
+        x(qubit)
+        return mz(qubit)
+
+    kernel = cudaq.make_kernel()
+    qubit = kernel.qalloc()
+    kernel.apply_call(flipAndMeasure, qubit)
+    kernel.mz(qubit)
+    print(kernel)
+
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert len(counts) == 1
+    assert '1' in counts
+
+    @cudaq.kernel(defer_compilation=False)
+    def flipAndCount(qubits: cudaq.qview) -> int:
+        x(qubits[0])
+        return 1
+
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(2)
+    kernel.apply_call(flipAndCount, qubits)
+    kernel.mz(qubits)
+    print(kernel)
+
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert len(counts) == 1
+    assert '10' in counts
+
+
 def test_sample_with_no_qubits():
     kernel = cudaq.make_kernel()
     histogram = cudaq.sample(kernel)


### PR DESCRIPTION
### Summary

Fixes #5164. `kernel.apply_call(k, ...)` raised
`AttributeError: 'OpResult' object has no attribute 'results'` for any
`@cudaq.kernel` with a return type.

`PyKernel.resolve_callable_arg` builds the `cc.create_lambda` closure that wraps
the decorator kernel. In the branch for a callee with a result it took `.result`
off the `func.CallOp` and then asked that `OpResult` for `.results`:

```python
if funcTy.results:
    call = func.CallOp(fn, vs).result   # OpResult
    cc.ReturnOp(call.results)           # AttributeError
```

Keeping the op and forwarding `call.results` is necessary but not sufficient:
with a result now flowing out of the closure, the lambda's `!cc.callable`
signature has a result, while `__applyControlOrAdjoint` hardcoded
`cc.CallCallableOp([], ...)`, so the module failed verification with
`'cc.call_callable' op call has incorrect coarity`. This PR fixes both, threading
the callable's result types into the `cc.call_callable`.

The result stays unused: `apply_call` applies the callee for its effects and
returns `None`, which is what the plain `func.call` path for builder-to-builder
calls already does with a callee result. Whether `apply_call` should instead hand
back a `QuakeValue` is an API question raised in the issue and deliberately not
decided here.

Only `apply_call` reaches the `cc.create_lambda` / `cc.call_callable` path -
`adjoint()` and `control()` pass their target straight to
`__cloneOrGetFunction` - so those are unaffected.

### Testing

Added `test_apply_call_kernel_with_return_value` to
`python/tests/builder/test_kernel_builder.py`, next to the other `apply_call`
tests. It covers a `-> bool` callee (with `mz`) and a `-> int` callee over a
`cudaq.qview`, prints the module (which runs the verifier + pass pipeline, so it
catches the coarity defect) and samples it. The test fails on `main` with the
`AttributeError` and passes with the fix.
