### PR TITLE
[Python] Use Python floor-modulo semantics for %

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5948,7 +5948,30 @@ class PyASTBridge(ast.NodeVisitor):
 
         if issubclass(nodeType, ast.Mod):
             if IntegerType.isinstance(left.type):
-                self.pushValue(arith.RemUIOp(left, right).result)
+                # Python's `%` yields a remainder that takes the sign of the
+                # divisor (floor modulo), whereas `arith.remsi` truncates the
+                # quotient towards zero and hence yields a remainder with the
+                # sign of the dividend. Correct the truncated remainder by
+                # adding the divisor whenever the remainder is non-zero and
+                # its sign differs from the divisor's. This matches the
+                # `arith.floordivsi` emitted for `//` above, such that the
+                # identity `a == (a // b) * b + a % b` holds.
+                intTy = IntegerType(left.type)
+                zero = self.getConstantInt(0, width=intTy.width)
+                nePred = self.getIntegerAttr(self.getIntegerType(), 1)
+                sltPred = self.getIntegerAttr(self.getIntegerType(), 2)
+                remainder = arith.RemSIOp(left, right).result
+                isNonZero = arith.CmpIOp(nePred, remainder, zero).result
+                # The sign bit of `remainder ^ right` is set exactly when the
+                # remainder and the divisor have opposite signs.
+                signsDiffer = arith.CmpIOp(
+                    sltPred,
+                    arith.XOrIOp(remainder, right).result, zero).result
+                needsCorrection = arith.AndIOp(isNonZero, signsDiffer).result
+                self.pushValue(
+                    arith.SelectOp(needsCorrection,
+                                   arith.AddIOp(remainder, right).result,
+                                   remainder).result)
                 return
             if (F64Type.isinstance(left.type) or F32Type.isinstance(left.type)):
                 self.pushValue(arith.RemFOp(left, right).result)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5974,7 +5974,34 @@ class PyASTBridge(ast.NodeVisitor):
                                    remainder).result)
                 return
             if (F64Type.isinstance(left.type) or F32Type.isinstance(left.type)):
-                self.pushValue(arith.RemFOp(left, right).result)
+                # `arith.remf` is C `fmod`: the quotient is truncated towards
+                # zero, so the remainder takes the sign of the dividend.
+                # Python's `%` instead gives the remainder the sign of the
+                # divisor, and gives a zero remainder the divisor's sign.
+                # Apply the same two corrections CPython applies on top of
+                # `fmod`: add the divisor when the remainder is non-zero and
+                # its sign differs from the divisor's, and replace a zero
+                # remainder with a zero carrying the divisor's sign.
+                zero = self.getConstantFloatWithType(0.0, left.type)
+                negZero = self.getConstantFloatWithType(-0.0, left.type)
+                unePred = self.getIntegerAttr(self.getIntegerType(), 13)
+                oltPred = self.getIntegerAttr(self.getIntegerType(), 4)
+                remainder = arith.RemFOp(left, right).result
+                # Unordered inequality, so that a `NaN` remainder counts as
+                # non-zero exactly as it does in CPython's `if (mod)`.
+                isNonZero = arith.CmpFOp(unePred, remainder, zero).result
+                divisorIsNegative = arith.CmpFOp(oltPred, right, zero).result
+                signsDiffer = arith.XOrIOp(
+                    arith.CmpFOp(oltPred, remainder, zero).result,
+                    divisorIsNegative).result
+                needsCorrection = arith.AndIOp(isNonZero, signsDiffer).result
+                corrected = arith.SelectOp(
+                    needsCorrection,
+                    arith.AddFOp(remainder, right).result, remainder).result
+                signedZero = arith.SelectOp(divisorIsNegative, negZero,
+                                            zero).result
+                self.pushValue(
+                    arith.SelectOp(isNonZero, corrected, signedZero).result)
                 return
             else:
                 self.emitFatalError("unhandled BinOp.Mod types",

--- a/python/tests/kernel/test_kernel_float.py
+++ b/python/tests/kernel/test_kernel_float.py
@@ -264,6 +264,39 @@ def test_integer_floor_division_matches_python():
         assert python_floor_div(left, right) == kernel_floor_div(left, right)
 
 
+def test_integer_modulo_matches_python():
+
+    def python_mod(left: int, right: int) -> int:
+        return left % right
+
+    @cudaq.kernel
+    def kernel_mod(left: int, right: int) -> int:
+        return left % right
+
+    @cudaq.kernel
+    def kernel_mod_i32(left: np.int32, right: np.int32) -> np.int32:
+        return left % right
+
+    # The remainder takes the sign of the divisor, as it does in Python.
+    for left, right in [(-1, 3), (-5, 3), (5, -3), (7, 3), (9, 2), (-9, 2),
+                        (9, -2), (-9, -2), (4, 2), (-4, 2), (4, -2), (-4, -2)]:
+        expected = python_mod(left, right)
+        assert kernel_mod(left, right) == expected
+        assert kernel_mod_i32(np.int32(left), np.int32(right)) == expected
+
+
+def test_integer_floor_division_modulo_identity():
+
+    @cudaq.kernel
+    def kernel_identity(left: int, right: int) -> int:
+        return (left // right) * right + left % right
+
+    # `a == (a // b) * b + a % b` must hold for any non-zero divisor.
+    for left in range(-6, 7):
+        for right in [-6, -3, -2, -1, 1, 2, 3, 6]:
+            assert kernel_identity(left, right) == left
+
+
 def test_float_floor_division_error():
     error = ("floor division with floating-point operands is not supported; "
              "use integer operands or math.floor(...), numpy.floor(...), or "

--- a/python/tests/kernel/test_kernel_float.py
+++ b/python/tests/kernel/test_kernel_float.py
@@ -297,6 +297,62 @@ def test_integer_floor_division_modulo_identity():
             assert kernel_identity(left, right) == left
 
 
+def test_float_modulo_matches_python():
+
+    def python_mod(left: float, right: float) -> float:
+        return left % right
+
+    @cudaq.kernel
+    def kernel_mod(left: float, right: float) -> float:
+        return left % right
+
+    @cudaq.kernel
+    def kernel_mod_f32(left: np.float32, right: np.float32) -> np.float32:
+        return left % right
+
+    # The remainder takes the sign of the divisor, as it does in Python, and
+    # not the sign of the dividend as C `fmod` does.
+    for left, right in [(9.0, 2.0), (-9.0, 2.0), (9.0, -2.0), (-9.0, -2.0),
+                        (-0.5, 2.0), (0.5, -2.0), (1.0, 0.1), (-1.0, 0.1),
+                        (7.5, 2.5), (-7.5, 2.5)]:
+        assert kernel_mod(left, right) == python_mod(left, right)
+
+        left32 = np.float32(left)
+        right32 = np.float32(right)
+        assert kernel_mod_f32(left32, right32) == python_mod(left32, right32)
+
+
+def test_float_modulo_zero_remainder_takes_sign_of_divisor():
+
+    @cudaq.kernel
+    def kernel_mod(left: float, right: float) -> float:
+        return left % right
+
+    # Python returns `math.copysign(0.0, right)` when the remainder is zero,
+    # so `-4.0 % 2.0` is `0.0` while `4.0 % -2.0` is `-0.0`. Both compare
+    # equal to zero, so compare the signs explicitly as well.
+    for left, right in [(4.0, 2.0), (-4.0, 2.0), (4.0, -2.0), (-4.0, -2.0),
+                        (0.0, 2.0), (-0.0, 2.0), (0.0, -2.0), (-0.0, -2.0)]:
+        expected = left % right
+        actual = kernel_mod(left, right)
+        assert actual == expected
+        assert math.copysign(1.0, actual) == math.copysign(1.0, expected)
+
+
+def test_float_modulo_infinite_divisor():
+
+    @cudaq.kernel
+    def kernel_mod(left: float, right: float) -> float:
+        return left % right
+
+    # `fmod(x, inf)` is `x`, so it is the sign correction that turns
+    # `-5.0 % inf` into the `inf` that Python returns.
+    infinity = float("inf")
+    for left, right in [(5.0, infinity), (-5.0, infinity), (5.0, -infinity),
+                        (-5.0, -infinity)]:
+        assert kernel_mod(left, right) == left % right
+
+
 def test_float_floor_division_error():
     error = ("floor division with floating-point operands is not supported; "
              "use integer operands or math.floor(...), numpy.floor(...), or "

--- a/python/tests/mlir/ast_break.py
+++ b/python/tests/mlir/ast_break.py
@@ -48,14 +48,20 @@ def test_break():
 # CHECK:           ^bb1:
 # CHECK:             cc.break %[[VAL_14]], %[[VAL_14]], %[[VAL_18]] : i64, i64, f64
 # CHECK:           ^bb2:
-# CHECK:             %[[VAL_24:.*]] = arith.remui %[[VAL_14]], %[[VAL_6]] : i64
-# CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_24]]] : (!quake.veq<4>, i64) -> !quake.ref
-# CHECK:             quake.ry (%[[VAL_18]]) %[[VAL_25]] : (f64, !quake.ref) -> ()
+# CHECK:             %[[VAL_20:.*]] = arith.remsi %[[VAL_14]], %[[VAL_6]] : i64
+# CHECK:             %[[VAL_21:.*]] = arith.cmpi ne, %[[VAL_20]], %[[VAL_5]] : i64
+# CHECK:             %[[VAL_22:.*]] = arith.xori %[[VAL_20]], %[[VAL_6]] : i64
+# CHECK:             %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_5]] : i64
+# CHECK:             %[[VAL_24:.*]] = arith.andi %[[VAL_21]], %[[VAL_23]] : i1
+# CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_20]], %[[VAL_6]] : i64
+# CHECK:             %[[VAL_26:.*]] = arith.select %[[VAL_24]], %[[VAL_25]], %[[VAL_20]] : i64
+# CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_26]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:             quake.ry (%[[VAL_18]]) %[[VAL_27]] : (f64, !quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_14]], %[[VAL_14]], %[[VAL_18]] : i64, i64, f64
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_26:.*]]: i64, %[[VAL_27:.*]]: i64, %[[VAL_28:.*]]: f64):
-# CHECK:             %[[VAL_29:.*]] = arith.addi %[[VAL_26]], %[[VAL_4]] : i64
-# CHECK:             cc.continue %[[VAL_29]], %[[VAL_27]], %[[VAL_28]] : i64, i64, f64
+# CHECK:           ^bb0(%[[VAL_28:.*]]: i64, %[[VAL_29:.*]]: i64, %[[VAL_30:.*]]: f64):
+# CHECK:             %[[VAL_31:.*]] = arith.addi %[[VAL_28]], %[[VAL_4]] : i64
+# CHECK:             cc.continue %[[VAL_31]], %[[VAL_29]], %[[VAL_30]] : i64, i64, f64
 # CHECK:           }
 # CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<4>
 # CHECK:           return

--- a/python/tests/mlir/ast_continue.py
+++ b/python/tests/mlir/ast_continue.py
@@ -46,19 +46,31 @@ def test_continue():
     # CHECK:             %[[VAL_19:.*]] = arith.cmpf ogt, %[[VAL_18]], %[[VAL_1]] : f64
     # CHECK:             cf.cond_br %[[VAL_19]], ^bb1, ^bb2
     # CHECK:           ^bb1:
-    # CHECK:             %[[VAL_22:.*]] = arith.remui %[[VAL_14]], %[[VAL_6]] : i64
-    # CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_22]]] : (!quake.veq<4>, i64) -> !quake.ref
-    # CHECK:             quake.x %[[VAL_23]] : (!quake.ref) -> ()
+    # CHECK:             %[[VAL_20:.*]] = arith.remsi %[[VAL_14]], %[[VAL_6]] : i64
+    # CHECK:             %[[VAL_21:.*]] = arith.cmpi ne, %[[VAL_20]], %[[VAL_5]] : i64
+    # CHECK:             %[[VAL_22:.*]] = arith.xori %[[VAL_20]], %[[VAL_6]] : i64
+    # CHECK:             %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_5]] : i64
+    # CHECK:             %[[VAL_24:.*]] = arith.andi %[[VAL_21]], %[[VAL_23]] : i1
+    # CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_20]], %[[VAL_6]] : i64
+    # CHECK:             %[[VAL_26:.*]] = arith.select %[[VAL_24]], %[[VAL_25]], %[[VAL_20]] : i64
+    # CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_26]]] : (!quake.veq<4>, i64) -> !quake.ref
+    # CHECK:             quake.x %[[VAL_27]] : (!quake.ref) -> ()
     # CHECK:             cc.continue %[[VAL_14]], %[[VAL_14]], %[[VAL_18]] : i64, i64, f64
     # CHECK:           ^bb2:
-    # CHECK:             %[[VAL_26:.*]] = arith.remui %[[VAL_14]], %[[VAL_6]] : i64
-    # CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_26]]] : (!quake.veq<4>, i64) -> !quake.ref
-    # CHECK:             quake.ry (%[[VAL_18]]) %[[VAL_27]] : (f64, !quake.ref) -> ()
+    # CHECK:             %[[VAL_28:.*]] = arith.remsi %[[VAL_14]], %[[VAL_6]] : i64
+    # CHECK:             %[[VAL_29:.*]] = arith.cmpi ne, %[[VAL_28]], %[[VAL_5]] : i64
+    # CHECK:             %[[VAL_30:.*]] = arith.xori %[[VAL_28]], %[[VAL_6]] : i64
+    # CHECK:             %[[VAL_31:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_5]] : i64
+    # CHECK:             %[[VAL_32:.*]] = arith.andi %[[VAL_29]], %[[VAL_31]] : i1
+    # CHECK:             %[[VAL_33:.*]] = arith.addi %[[VAL_28]], %[[VAL_6]] : i64
+    # CHECK:             %[[VAL_34:.*]] = arith.select %[[VAL_32]], %[[VAL_33]], %[[VAL_28]] : i64
+    # CHECK:             %[[VAL_35:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_34]]] : (!quake.veq<4>, i64) -> !quake.ref
+    # CHECK:             quake.ry (%[[VAL_18]]) %[[VAL_35]] : (f64, !quake.ref) -> ()
     # CHECK:             cc.continue %[[VAL_14]], %[[VAL_14]], %[[VAL_18]] : i64, i64, f64
     # CHECK:           } step {
-    # CHECK:           ^bb0(%[[VAL_28:.*]]: i64, %[[VAL_29:.*]]: i64, %[[VAL_30:.*]]: f64):
-    # CHECK:             %[[VAL_31:.*]] = arith.addi %[[VAL_28]], %[[VAL_4]] : i64
-    # CHECK:             cc.continue %[[VAL_31]], %[[VAL_29]], %[[VAL_30]] : i64, i64, f64
+    # CHECK:           ^bb0(%[[VAL_36:.*]]: i64, %[[VAL_37:.*]]: i64, %[[VAL_38:.*]]: f64):
+    # CHECK:             %[[VAL_39:.*]] = arith.addi %[[VAL_36]], %[[VAL_4]] : i64
+    # CHECK:             cc.continue %[[VAL_39]], %[[VAL_37]], %[[VAL_38]] : i64, i64, f64
     # CHECK:           }
     # CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<4>
     # CHECK:           return

--- a/python/tests/mlir/ast_elif.py
+++ b/python/tests/mlir/ast_elif.py
@@ -51,32 +51,38 @@ def test_elif():
 # CHECK:             %[[VAL_21:.*]] = cc.cast signed %[[VAL_15]] : (i64) -> f64
 # CHECK:             %[[VAL_22:.*]] = arith.remf %[[VAL_21]], %[[VAL_2]] : f64
 # CHECK:             %[[VAL_23:.*]] = arith.cmpf une, %[[VAL_22]], %[[VAL_1]] : f64
-# CHECK:             cc.if(%[[VAL_23]]) {
-# CHECK:               %[[VAL_24:.*]] = arith.remsi %[[VAL_15]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_25:.*]] = arith.cmpi ne, %[[VAL_24]], %[[VAL_4]] : i64
-# CHECK:               %[[VAL_26:.*]] = arith.xori %[[VAL_24]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_27:.*]] = arith.cmpi slt, %[[VAL_26]], %[[VAL_4]] : i64
-# CHECK:               %[[VAL_28:.*]] = arith.andi %[[VAL_25]], %[[VAL_27]] : i1
-# CHECK:               %[[VAL_29:.*]] = arith.addi %[[VAL_24]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_30:.*]] = arith.select %[[VAL_28]], %[[VAL_29]], %[[VAL_24]] : i64
-# CHECK:               %[[VAL_31:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_30]]] : (!quake.veq<4>, i64) -> !quake.ref
-# CHECK:               quake.ry (%[[VAL_20]]) %[[VAL_31]] : (f64, !quake.ref) -> ()
+# CHECK:             %[[VAL_24:.*]] = arith.cmpf olt, %[[VAL_22]], %[[VAL_1]] : f64
+# CHECK:             %[[VAL_25:.*]] = arith.andi %[[VAL_23]], %[[VAL_24]] : i1
+# CHECK:             %[[VAL_26:.*]] = arith.addf %[[VAL_22]], %[[VAL_2]] : f64
+# CHECK:             %[[VAL_27:.*]] = arith.select %[[VAL_25]], %[[VAL_26]], %[[VAL_22]] : f64
+# CHECK:             %[[VAL_28:.*]] = arith.select %[[VAL_23]], %[[VAL_27]], %[[VAL_1]] : f64
+# CHECK:             %[[VAL_29:.*]] = arith.cmpf une, %[[VAL_28]], %[[VAL_1]] : f64
+# CHECK:             cc.if(%[[VAL_29]]) {
+# CHECK:               %[[VAL_30:.*]] = arith.remsi %[[VAL_15]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_31:.*]] = arith.cmpi ne, %[[VAL_30]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_32:.*]] = arith.xori %[[VAL_30]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_33:.*]] = arith.cmpi slt, %[[VAL_32]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_34:.*]] = arith.andi %[[VAL_31]], %[[VAL_33]] : i1
+# CHECK:               %[[VAL_35:.*]] = arith.addi %[[VAL_30]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_36:.*]] = arith.select %[[VAL_34]], %[[VAL_35]], %[[VAL_30]] : i64
+# CHECK:               %[[VAL_37:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_36]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:               quake.ry (%[[VAL_20]]) %[[VAL_37]] : (f64, !quake.ref) -> ()
 # CHECK:             } else {
-# CHECK:               %[[VAL_32:.*]] = arith.remsi %[[VAL_15]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_33:.*]] = arith.cmpi ne, %[[VAL_32]], %[[VAL_4]] : i64
-# CHECK:               %[[VAL_34:.*]] = arith.xori %[[VAL_32]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_35:.*]] = arith.cmpi slt, %[[VAL_34]], %[[VAL_4]] : i64
-# CHECK:               %[[VAL_36:.*]] = arith.andi %[[VAL_33]], %[[VAL_35]] : i1
-# CHECK:               %[[VAL_37:.*]] = arith.addi %[[VAL_32]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_38:.*]] = arith.select %[[VAL_36]], %[[VAL_37]], %[[VAL_32]] : i64
-# CHECK:               %[[VAL_39:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_38]]] : (!quake.veq<4>, i64) -> !quake.ref
-# CHECK:               quake.rx (%[[VAL_20]]) %[[VAL_39]] : (f64, !quake.ref) -> ()
+# CHECK:               %[[VAL_38:.*]] = arith.remsi %[[VAL_15]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_39:.*]] = arith.cmpi ne, %[[VAL_38]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_40:.*]] = arith.xori %[[VAL_38]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_41:.*]] = arith.cmpi slt, %[[VAL_40]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_42:.*]] = arith.andi %[[VAL_39]], %[[VAL_41]] : i1
+# CHECK:               %[[VAL_43:.*]] = arith.addi %[[VAL_38]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_44:.*]] = arith.select %[[VAL_42]], %[[VAL_43]], %[[VAL_38]] : i64
+# CHECK:               %[[VAL_45:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_44]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:               quake.rx (%[[VAL_20]]) %[[VAL_45]] : (f64, !quake.ref) -> ()
 # CHECK:             }
 # CHECK:             cc.continue %[[VAL_15]], %[[VAL_15]], %[[VAL_20]] : i64, i64, f64
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_40:.*]]: i64, %[[VAL_41:.*]]: i64, %[[VAL_42:.*]]: f64):
-# CHECK:             %[[VAL_43:.*]] = arith.addi %[[VAL_40]], %[[VAL_3]] : i64
-# CHECK:             cc.continue %[[VAL_43]], %[[VAL_41]], %[[VAL_42]] : i64, i64, f64
+# CHECK:           ^bb0(%[[VAL_46:.*]]: i64, %[[VAL_47:.*]]: i64, %[[VAL_48:.*]]: f64):
+# CHECK:             %[[VAL_49:.*]] = arith.addi %[[VAL_46]], %[[VAL_3]] : i64
+# CHECK:             cc.continue %[[VAL_49]], %[[VAL_47]], %[[VAL_48]] : i64, i64, f64
 # CHECK:           }
 # CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<4>
 # CHECK:           return

--- a/python/tests/mlir/ast_elif.py
+++ b/python/tests/mlir/ast_elif.py
@@ -52,19 +52,31 @@ def test_elif():
 # CHECK:             %[[VAL_22:.*]] = arith.remf %[[VAL_21]], %[[VAL_2]] : f64
 # CHECK:             %[[VAL_23:.*]] = arith.cmpf une, %[[VAL_22]], %[[VAL_1]] : f64
 # CHECK:             cc.if(%[[VAL_23]]) {
-# CHECK:               %[[VAL_24:.*]] = arith.remui %[[VAL_15]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_24]]] : (!quake.veq<4>, i64) -> !quake.ref
-# CHECK:               quake.ry (%[[VAL_20]]) %[[VAL_25]] : (f64, !quake.ref) -> ()
+# CHECK:               %[[VAL_24:.*]] = arith.remsi %[[VAL_15]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_25:.*]] = arith.cmpi ne, %[[VAL_24]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_26:.*]] = arith.xori %[[VAL_24]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_27:.*]] = arith.cmpi slt, %[[VAL_26]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_28:.*]] = arith.andi %[[VAL_25]], %[[VAL_27]] : i1
+# CHECK:               %[[VAL_29:.*]] = arith.addi %[[VAL_24]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_30:.*]] = arith.select %[[VAL_28]], %[[VAL_29]], %[[VAL_24]] : i64
+# CHECK:               %[[VAL_31:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_30]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:               quake.ry (%[[VAL_20]]) %[[VAL_31]] : (f64, !quake.ref) -> ()
 # CHECK:             } else {
-# CHECK:               %[[VAL_26:.*]] = arith.remui %[[VAL_15]], %[[VAL_5]] : i64
-# CHECK:               %[[VAL_27:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_26]]] : (!quake.veq<4>, i64) -> !quake.ref
-# CHECK:               quake.rx (%[[VAL_20]]) %[[VAL_27]] : (f64, !quake.ref) -> ()
+# CHECK:               %[[VAL_32:.*]] = arith.remsi %[[VAL_15]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_33:.*]] = arith.cmpi ne, %[[VAL_32]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_34:.*]] = arith.xori %[[VAL_32]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_35:.*]] = arith.cmpi slt, %[[VAL_34]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_36:.*]] = arith.andi %[[VAL_33]], %[[VAL_35]] : i1
+# CHECK:               %[[VAL_37:.*]] = arith.addi %[[VAL_32]], %[[VAL_5]] : i64
+# CHECK:               %[[VAL_38:.*]] = arith.select %[[VAL_36]], %[[VAL_37]], %[[VAL_32]] : i64
+# CHECK:               %[[VAL_39:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_38]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:               quake.rx (%[[VAL_20]]) %[[VAL_39]] : (f64, !quake.ref) -> ()
 # CHECK:             }
 # CHECK:             cc.continue %[[VAL_15]], %[[VAL_15]], %[[VAL_20]] : i64, i64, f64
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_28:.*]]: i64, %[[VAL_29:.*]]: i64, %[[VAL_30:.*]]: f64):
-# CHECK:             %[[VAL_31:.*]] = arith.addi %[[VAL_28]], %[[VAL_3]] : i64
-# CHECK:             cc.continue %[[VAL_31]], %[[VAL_29]], %[[VAL_30]] : i64, i64, f64
+# CHECK:           ^bb0(%[[VAL_40:.*]]: i64, %[[VAL_41:.*]]: i64, %[[VAL_42:.*]]: f64):
+# CHECK:             %[[VAL_43:.*]] = arith.addi %[[VAL_40]], %[[VAL_3]] : i64
+# CHECK:             cc.continue %[[VAL_43]], %[[VAL_41]], %[[VAL_42]] : i64, i64, f64
 # CHECK:           }
 # CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<4>
 # CHECK:           return

--- a/python/tests/mlir/ast_iterate_loop_init.py
+++ b/python/tests/mlir/ast_iterate_loop_init.py
@@ -51,14 +51,20 @@ def test_iterate_list_init():
 # CHECK:             %[[VAL_22:.*]] = cc.load %[[VAL_21]] : !cc.ptr<i64>
 # CHECK:             %[[VAL_23:.*]] = cc.cast signed %[[VAL_22]] : (i64) -> f64
 # CHECK:             %[[VAL_24:.*]] = arith.addf %[[VAL_20]], %[[VAL_23]] : f64
-# CHECK:             %[[VAL_25:.*]] = arith.remui %[[VAL_22]], %[[VAL_5]] : i64
-# CHECK:             %[[VAL_26:.*]] = quake.extract_ref %[[VAL_7]]{{\[}}%[[VAL_25]]] : (!quake.veq<4>, i64) -> !quake.ref
-# CHECK:             quake.ry (%[[VAL_24]]) %[[VAL_26]] : (f64, !quake.ref) -> ()
+# CHECK:             %[[VAL_25:.*]] = arith.remsi %[[VAL_22]], %[[VAL_5]] : i64
+# CHECK:             %[[VAL_26:.*]] = arith.cmpi ne, %[[VAL_25]], %[[VAL_4]] : i64
+# CHECK:             %[[VAL_27:.*]] = arith.xori %[[VAL_25]], %[[VAL_5]] : i64
+# CHECK:             %[[VAL_28:.*]] = arith.cmpi slt, %[[VAL_27]], %[[VAL_4]] : i64
+# CHECK:             %[[VAL_29:.*]] = arith.andi %[[VAL_26]], %[[VAL_28]] : i1
+# CHECK:             %[[VAL_30:.*]] = arith.addi %[[VAL_25]], %[[VAL_5]] : i64
+# CHECK:             %[[VAL_31:.*]] = arith.select %[[VAL_29]], %[[VAL_30]], %[[VAL_25]] : i64
+# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_7]]{{\[}}%[[VAL_31]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:             quake.ry (%[[VAL_24]]) %[[VAL_32]] : (f64, !quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_18]], %[[VAL_22]], %[[VAL_24]] : i64, i64, f64
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_27:.*]]: i64, %[[VAL_28:.*]]: i64, %[[VAL_29:.*]]: f64):
-# CHECK:             %[[VAL_30:.*]] = arith.addi %[[VAL_27]], %[[VAL_3]] : i64
-# CHECK:             cc.continue %[[VAL_30]], %[[VAL_28]], %[[VAL_29]] : i64, i64, f64
+# CHECK:           ^bb0(%[[VAL_33:.*]]: i64, %[[VAL_34:.*]]: i64, %[[VAL_35:.*]]: f64):
+# CHECK:             %[[VAL_36:.*]] = arith.addi %[[VAL_33]], %[[VAL_3]] : i64
+# CHECK:             cc.continue %[[VAL_36]], %[[VAL_34]], %[[VAL_35]] : i64, i64, f64
 # CHECK:           }
 # CHECK:           quake.dealloc %[[VAL_7]] : !quake.veq<4>
 # CHECK:           return


### PR DESCRIPTION
The Python AST bridge lowered `%` on integers to `arith.remui`, an unsigned
remainder, so any expression with a negative operand silently produced a wrong
result inside a `@cudaq.kernel`:

```
    a   b   kernel   python
   -1   3      0        2     <- wrong
   -5   3      2        1     <- wrong
    5  -3      5       -1     <- wrong
    7   3      1        1     ok
```

This also broke the identity `a == (a // b) * b + a % b`, because `//` in the
same bridge already lowers to the correctly signed `arith.floordivsi`.

`%` on floating-point operands has the same defect for a different reason: it
lowers to `arith.remf`, which is C `fmod`, so the remainder takes the sign of
the dividend rather than the sign of the divisor:

```
      a      b     kernel                 python
    9.0    2.0      1.0                    1.0                  ok
   -9.0    2.0     -1.0                    1.0                  <- wrong
    9.0   -2.0      1.0                   -1.0                  <- wrong
   -0.5    2.0     -0.5                    1.5                  <- wrong
   -1.0    0.1     -0.09999999999999995    5.551115123125783e-17 <- wrong
   -4.0    2.0     -0.0                    0.0                  <- wrong sign
    4.0   -2.0      0.0                   -0.0                  <- wrong sign
```

Fixing only the integer path would leave `-9 % 2` and `-9.0 % 2.0` disagreeing
with each other inside the same language, so both are addressed here, in two
separate commits.

### What this changes for integers

`%` on integers now emits `arith.remsi` plus the floor correction that Python's
`%` requires:

```mlir
%r    = arith.remsi %a, %b
%nz   = arith.cmpi ne, %r, %c0
%x    = arith.xori %r, %b          // sign bit set <=> signs differ
%sd   = arith.cmpi slt, %x, %c0
%need = arith.andi %nz, %sd
%adj  = arith.addi %r, %b
%res  = arith.select %need, %adj, %r
```

`arith.remsi` alone would not be enough: it truncates towards zero, so it fixes
the negative-dividend cases but still disagrees with Python whenever the divisor
is negative (`5 % -3` would give `2`, not `-1`), and it would leave the
`(a // b) * b + a % b` identity broken against `arith.floordivsi`. Adding the
divisor when the remainder is non-zero and its sign differs from the divisor's
gives the remainder the sign of the divisor, which is exactly Python's rule.

The correction is branch-free and only costs a compare/xor/compare/and/add/select
around the existing division; `arith` canonicalization folds it away when both
operands are known constants.

### What this changes for floats

`arith.remf` is kept and corrected the same way CPython's `float_rem` corrects
`fmod`, which is the same floor-modulo rule plus the signed-zero case:

```mlir
%r    = arith.remf %a, %b
%nz   = arith.cmpf une, %r, %zero  // unordered: a NaN remainder is non-zero
%rn   = arith.cmpf olt, %r, %zero
%bn   = arith.cmpf olt, %b, %zero
%sd   = arith.xori %rn, %bn
%need = arith.andi %nz, %sd
%adj  = arith.addf %r, %b
%cor  = arith.select %need, %adj, %r
%sz   = arith.select %bn, %negzero, %zero
%res  = arith.select %nz, %cor, %sz
```

Two details are worth calling out:

- **The zero-remainder case needs its own branch.** Python returns
  `math.copysign(0.0, divisor)` when the remainder is zero, so `-4.0 % 2.0` is
  `0.0` while `4.0 % -2.0` is `-0.0`. The sign correction above cannot produce
  that, because it is skipped precisely when the remainder is zero. It is
  expressed with two constants and a select rather than `math.copysign` so that
  the bridge does not start depending on another dialect for this.
- **The non-zero test is unordered.** `arith.cmpf une` treats a `NaN` remainder
  as non-zero, matching the `if (mod)` in CPython that a `NaN` also passes.

Infinite operands need no special case: `fmod(-5.0, inf)` is `-5.0`, the signs
differ, and `-5.0 + inf` is the `inf` that Python returns.

With a constant divisor, `arith` canonicalization folds the expansion down to
`remf`, `cmpf`, `cmpf`, `andi`, `addf`, `select`, `select` and drops the `-0.0`
constant, since the divisor's sign is then known.

### Notes

- **No unsigned path is regressed.** The Python bridge only ever builds signless
  integer types (`IntegerType.get_signless`) for Python `int`, `bool`, and the
  `numpy.int8/16/32/64` annotations — all signed. There is no unsigned integer
  annotation in `python/cudaq/kernel/utils.py`, so nothing relied on `remui`.
- **The C++ bridge is unaffected and stays correct.** In
  `cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp` (`BO_Rem`) it already dispatches on
  signedness — `arith::RemUIOp` for unsigned C++ integer types, `arith::RemSIOp`
  for signed ones — which is the right lowering for C++'s truncating `%`. No
  change is needed or wanted there; the two frontends now each match their own
  source language instead of the Python one accidentally using an unsigned
  lowering for signed types.
- **The undefined-behaviour edges are unchanged in kind.** `arith.remsi` by zero
  and `arith.remsi(INT_MIN, -1)` are UB in LLVM, exactly as the `arith.divsi`
  underlying the `arith.floordivsi` already emitted for `//` is. So a kernel
  computing `a // b` is already exposed to both today, and this change does not
  add a new class of exposure — but it does move `%` onto the signed division
  instruction, so on targets where signed division traps (x86 `idiv`),
  `a % b` with `b == 0` or `(a, b) == (INT_MIN, -1)` can now trap where the old
  `remui` silently returned a wrong value (`INT_MIN % -1` returned `INT_MIN`;
  Python says `0`). Guarding it was deliberately not done: it would cost every
  modulo an extra compare and select, and would be inconsistent with the
  unguarded `//` right above it. Happy to guard both together if maintainers
  prefer.
- **The correction itself cannot overflow.** `arith.remsi` gives `|r| < |b|`, and
  the `r + b` is only selected when `r != 0` and `r` and `b` have opposite
  signs, so the sum lies strictly between `0` and `b` and is always
  representable — including for `b == INT_MIN`.
- **A zero float divisor still gives `NaN` rather than raising.** `x % 0.0`
  returns `NaN` in a kernel where CPython raises `ZeroDivisionError`. That is
  unchanged by this PR and matches how the integer operators behave, so it is
  left alone here.
- **Float `//` is untouched** and keeps refusing to compile. Unlike `%`, it
  cannot be matched by correcting a single instruction — CPython also needs a
  division, a `floor`, a rounding correction and a second `copysign` — and it
  compiles for nobody today, so there is no working code to keep working.

### Testing

- `python/tests/kernel/test_kernel_float.py`: adds
  `test_integer_modulo_matches_python` (the reported cases, for `int` and
  `np.int32`) and `test_integer_floor_division_modulo_identity` (checks
  `a == (a // b) * b + a % b` over a sweep of signed pairs), next to the
  existing `test_integer_floor_division_matches_python`. For floats it adds
  `test_float_modulo_matches_python` (the sign matrix, for `float` and
  `np.float32`), `test_float_modulo_zero_remainder_takes_sign_of_divisor`
  (compares `math.copysign(1.0, ...)`, since `-0.0 == 0.0` would pass either
  way), and `test_float_modulo_infinite_divisor`.
- `python/tests/mlir/{ast_break,ast_continue,ast_elif,ast_iterate_loop_init}.py`:
  CHECK lines updated for the new `i % 4` expansion. No new constant appears in
  the entry block — the `0` constant CSEs with the one already there, so the
  existing `CHECK-DAG` constant block is untouched. `ast_elif.py` is also the
  only file under `python/tests/mlir` containing an `arith.remf`, so its
  `if i % 2.0:` CHECK block is updated for the float expansion as well; there
  too the folded form needs no new constant. The trailing `VAL_*` capture names
  in each file are renumbered so they stay unique and increasing, matching how
  these generated files are written; FileCheck itself would accept the old
  numbers, but leaving them would make two different values share a name inside
  one function's CHECK block.

Fixes #5159
