### PR TITLE
[Python] Evaluate a negative literal exponent in floating point

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -650,6 +650,17 @@ class PyASTBridge(ast.NodeVisitor):
         ty = self.getIntegerType(width)
         return arith.ConstantOp(ty, self.getIntegerAttr(ty, value)).result
 
+    def __integerLiteralValue(self, node):
+        """Return the value of an AST node that is an integer literal, possibly
+        negated, and `None` for any other node.
+        """
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            value = self.__integerLiteralValue(node.operand)
+            return None if value is None else -value
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            return node.value
+        return None
+
     def __arithmetic_to_bool(self, value):
         """Converts an integer or floating point value to a bool by comparing it
         to zero."""
@@ -5810,11 +5821,13 @@ class PyASTBridge(ast.NodeVisitor):
         else:
             cc.ContinueOp([])
 
-    def __process_binary_op(self, left, right, nodeType):
+    def __process_binary_op(self, left, right, nodeType, rightNode=None):
         """Process a binary operation in the AST and map them to equivalents in
         the MLIR.
 
-        This method handles arithmetic operations between values.
+        This method handles arithmetic operations between values. `rightNode` is
+        the AST node the `right` value was created from, if available; it is
+        used to detect literal operands.
         """
 
         # `measure_handle` operands in arithmetic context discriminate
@@ -5927,6 +5940,21 @@ class PyASTBridge(ast.NodeVisitor):
         if issubclass(nodeType, ast.Pow):
             if IntegerType.isinstance(left.type) and IntegerType.isinstance(
                     right.type):
+                # Python raises an integer to a negative integer power in
+                # floating point (`2 ** -1` is `0.5`), and only keeps the
+                # integer type for a non-negative exponent. `math.ipowi` is an
+                # integer power that returns 0 for a negative exponent unless
+                # the base is +/-1, so promote the base and use the
+                # floating-point power when the exponent is a negative literal.
+                # The sign of an exponent that is only known at run time cannot
+                # be taken into account here, since the type of the expression
+                # has to be determined at compile time.
+                exponent = (None if rightNode is None else
+                            self.__integerLiteralValue(rightNode))
+                if exponent is not None and exponent < 0:
+                    left = self.changeOperandToType(self.getFloatType(), left)
+                    self.pushValue(math.FPowIOp(left, right).result)
+                    return
                 # `math.ipowi` does not lower to LLVM as is
                 # workaround, use math to function conversion
                 self.pushValue(math.IPowIOp(left, right).result)
@@ -6019,7 +6047,7 @@ class PyASTBridge(ast.NodeVisitor):
         right = self.popValue()
 
         # pushes to the value stack
-        self.__process_binary_op(left, right, type(node.op))
+        self.__process_binary_op(left, right, type(node.op), node.right)
 
     def visit_AugAssign(self, node):
         """Visit augment-assign operations (e.g. +=)."""
@@ -6054,7 +6082,7 @@ class PyASTBridge(ast.NodeVisitor):
         # some complexity. We hence effectively disallow using any kind of
         # assignment as expression.
         self.valueStack.pushFrame()
-        self.__process_binary_op(loaded, value, type(node.op))
+        self.__process_binary_op(loaded, value, type(node.op), node.value)
         self.valueStack.popFrame()
         res = self.popValue()
 

--- a/python/tests/kernel/test_kernel_float.py
+++ b/python/tests/kernel/test_kernel_float.py
@@ -623,3 +623,89 @@ def test_float32_list_parameter_promotion():
     check([np.float32(np.pi / 2), 0])
     check([1, 0])
     check([np.pi / 2, 0, True])
+
+
+def test_negative_integer_exponent_is_float():
+    """An integer raised to a negative integer power is a float, as in Python,
+    and not an integer power that truncates to zero."""
+
+    @cudaq.kernel
+    def int_base_neg_one() -> float:
+        return 2**-1
+
+    @cudaq.kernel
+    def int_base_neg_three() -> float:
+        return 2**-3
+
+    @cudaq.kernel
+    def other_int_base_neg_one() -> float:
+        return 3**-1
+
+    @cudaq.kernel
+    def negative_int_base() -> float:
+        return (-2)**-1
+
+    @cudaq.kernel
+    def variable_base(base: int) -> float:
+        return base**-2
+
+    assert is_close(2**-1, int_base_neg_one())
+    assert is_close(2**-3, int_base_neg_three())
+    assert is_close(3**-1, other_int_base_neg_one())
+    assert is_close((-2)**-1, negative_int_base())
+    assert is_close(3**-2, variable_base(3))
+    assert is_close((-2)**-2, variable_base(-2))
+
+
+def test_non_negative_integer_exponent_is_integer():
+    """A non-negative exponent keeps the integer power and the integer type."""
+
+    @cudaq.kernel
+    def cube() -> int:
+        return 2**3
+
+    @cudaq.kernel
+    def zeroth_power() -> int:
+        return 2**0
+
+    @cudaq.kernel
+    def large_power() -> int:
+        return 2**30
+
+    @cudaq.kernel
+    def variable_exponent(base: int, exponent: int) -> int:
+        return base**exponent
+
+    @cudaq.kernel
+    def loop_bound() -> int:
+        total = 0
+        for i in range(2**3):
+            total += i
+        return total
+
+    assert cube() == 2**3
+    assert zeroth_power() == 2**0
+    assert large_power() == 2**30
+    assert variable_exponent(2, 5) == 2**5
+    assert variable_exponent(-2, 3) == (-2)**3
+    assert loop_bound() == sum(range(2**3))
+
+
+def test_float_base_with_integer_exponent():
+    """A floating-point base keeps working for either sign of the exponent."""
+
+    @cudaq.kernel
+    def float_base_neg_one() -> float:
+        return 2.0**-1
+
+    @cudaq.kernel
+    def float_base_neg_three() -> float:
+        return 2.0**-3
+
+    @cudaq.kernel
+    def float_base_cube() -> float:
+        return 2.0**3
+
+    assert is_close(2.0**-1, float_base_neg_one())
+    assert is_close(2.0**-3, float_base_neg_three())
+    assert is_close(2.0**3, float_base_cube())


### PR DESCRIPTION

In Python an integer raised to a negative integer power is a `float`: `2 ** -1`
is `0.5`. The Python AST bridge lowered every integer base with an integer
exponent to `math.ipowi`, an integer power whose lowering returns 0 for a
negative exponent unless the base is `+/-1`, so inside a `@cudaq.kernel`:

```
  2 ** -1      kernel = 0.0   python = 0.5
  2 ** -3      kernel = 0.0   python = 0.125
  3 ** -1      kernel = 0.0   python = 0.3333333333333333
  (-2) ** -1   kernel = 0.0   python = -0.5
```

No error or warning was raised. Type promotion is deliberately skipped for
`Pow`, so nothing moved the expression into floating point.

### What this changes

When the exponent is a negative integer literal — the case Python types as a
`float` — the base is converted to `f64` and `math.fpowi` is used instead of
`math.ipowi`. `math.fpowi` already handles negative exponents correctly, which
is why `2.0 ** -1` has always worked. Everything else is untouched:
`2 ** 3` is still an `i64` `math.ipowi`, and `range(2 ** n)` still compiles.

The exponent is read from the AST rather than from the emitted SSA value,
because the bridge does not constant-fold local variables and only materialises
a constant for the literal `-1` (there is an existing special case for it in
`visit_UnaryOp`); `-3` is emitted as `arith.muli(-1, 3)`. Reading the literal
from the AST is also what the `range()` step handling in this file already does
when it needs the sign of a literal at compile time. `__process_binary_op`
therefore takes the right-hand AST node as an optional argument; both call
sites (`visit_BinOp`, `visit_AugAssign`) pass it.

### What this deliberately does not change

An exponent whose sign is only known at run time — a kernel parameter, or a
local such as `n = -1` — keeps the integer power and the integer result type:

```python
@cudaq.kernel
def kernel(base: int, exponent: int) -> float:
    return base ** exponent      # kernel(2, -1) is still 0.0, not 0.5
```

The type of the expression has to be fixed at compile time, and Python's rule
makes it depend on the *value* of the exponent. Promoting `int ** int` to a
float unconditionally would cover those cases, but it would change the type of
`2 ** 3`, break `range(2 ** n)` and integer indices like `2 ** n - 1`, and
change the IR checked by `python/tests/mlir/qft.py` — which seems worse than
the bug. Diagnosing it at run time would be the complete answer, but there is
no abort/assert facility in the kernel IR to build that on today. I'm happy to
follow up with whichever direction maintainers prefer; the issue lists the
options.

One visible consequence: `x **= -1` on an integer variable now fails to compile
with "augment-assign must not change the variable type" instead of silently
storing `0`. Python rebinds `x` to a float there, which a typed kernel variable
cannot do, so an error is the honest outcome. `x **= -1` on a float variable is
unaffected (`0.5`), as is `x **= 3` on an integer variable (`8`).

The C++ frontend has the analogous lowering
(`cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp`, `visitMathLibFunc`): it peels off
the int-to-double conversion clang inserts for `std::pow(int, int)`, emits
`math.ipowi`, and casts the integer result back to `double`, so
`std::pow(2, -1)` cannot return `0.5` there either. Since `std::pow` always
returns `double`, that frontend could simply use `math.fpowi` unconditionally,
with no type question to answer — but it is a separate change with its own
AST-Quake tests, and I could not build the C++ toolchain to validate it, so
this PR leaves it alone.

### Testing

`python/tests/kernel/test_kernel_float.py` gains three tests:

- `test_negative_integer_exponent_is_float` — the reported cases plus a
  negative base and a run-time base with a literal negative exponent. Fails
  before this change, passes after.
- `test_non_negative_integer_exponent_is_integer` — guards the unchanged path:
  `2 ** 3`, `2 ** 0`, `2 ** 30`, a run-time base and exponent, and
  `range(2 ** 3)` as a loop bound, all returning `int`.
- `test_float_base_with_integer_exponent` — guards the floating-point base for
  both signs of the exponent.

No MLIR CHECK test changes: the new lowering only fires for a negative literal
exponent, which no existing test uses.

Fixes #5167

## Validation actually performed (local, on an installed 0.15.1 wheel)

The change was applied to the `ast_bridge.py` of an installed `cudaq` 0.15.1
wheel (`cuda_quantum_cu13`, Python 3.13, macOS 26.5.1 arm64), exercised end to end,
and the wheel restored afterwards.

Before:

```
  2 ** -1        0.0    python 0.5                   wrong
  2 ** -3        0.0    python 0.125                 wrong
  3 ** -1        0.0    python 0.3333333333333333    wrong
  (-2) ** -1     0.0    python -0.5                  wrong
  b ** -2, b=3   0.0    python 0.1111111111111111    wrong
  b ** -2, b=-2  0.0    python 0.25                  wrong
  n=-1; 2 ** n   0.0    python 0.5                   wrong (run-time exponent)
  param(2,-1)    0.0    python 0.5                   wrong (run-time exponent)
  2 ** 3         8      2 ** 0  1     2 ** 30  1073741824      ok
  2.0 ** -1      0.5    2.0 ** -1.5  0.35355339059327373       ok
  range(2**3)    28     range(2**n), n=3  28                   ok
```

After:

```
  2 ** -1        0.5                          ok
  2 ** -3        0.125                        ok
  3 ** -1        0.3333333333333333           ok
  (-2) ** -1     -0.5                         ok
  b ** -2, b=3   0.1111111111111111           ok
  b ** -2, b=-2  0.25                         ok
  n=-1; 2 ** n   0.0                          unchanged (run-time exponent)
  param(2,-1)    0.0                          unchanged (run-time exponent)
  2 ** 3         8 (still int)   2 ** 0  1    2 ** 30  1073741824      ok
  2.0 ** -1      0.5    2.0 ** -1.5  0.35355339059327373              ok
  range(2**3)    28     range(2**n), n=3  28                          ok
```

New tests against the same wheel:

```
  unpatched:  1 failed, 2 passed   (test_negative_integer_exponent_is_float fails)
  patched:    3 passed
```

Wider regression subset (`test_kernel_float.py`, `test_assignments.py`,
`test_cast_kernel.py`, `test_kernel_shift_operators.py`, `test_kernel_return.py`,
`test_kernel_complex.py`) run both ways against the same wheel:

```
  unpatched:  9 failed, 89 passed
  patched:    8 failed, 90 passed
```

The 8 remaining failures are identical in both runs and are wheel-vs-`main`
skew, not regressions: `test_math_*` and `test_float_floor_division_error`
exercise `main`-only math support and error messages, and
`test_assignments.py::test_var_scopes` likewise. The only difference between
the two runs is the new test.

`yapf 0.40.2 --style google` (the version pinned in `.pre-commit-config.yaml`)
reports no diff on both changed files.

### Deferred to CI (not runnable locally)

- No from-source build of `main`: the C++ frontend, the lit/FileCheck suites and
  the full test matrix were not run. The change cannot alter existing CHECK
  output, since it only fires on a negative literal exponent and no existing
  test uses one (verified by grep over `python/tests`).

## Files changed

- `python/cudaq/kernel/ast_bridge.py` (+32/-4) — `__integerLiteralValue` helper,
  the `ast.Pow` integer branch, and the optional right-hand AST node parameter
  on `__process_binary_op` plus its two call sites.
- `python/tests/kernel/test_kernel_float.py` (+86) — three tests.

## Open questions for maintainers

1. What should a run-time negative exponent do — keep integer semantics
   (this PR), diagnose at run time, or something else?
2. Should the C++ frontend switch `std::pow(int, int)` to `math.fpowi`? Its
   result is always `double`, so nothing is lost, and it would make both
   frontends agree with their own source language.

