### PR TITLE
Remove duplicate compilation from RemoteREST codegen

### DIFF
--- a/python/tests/backends/test_Ionq_LocalEmulation_kernel.py
+++ b/python/tests/backends/test_Ionq_LocalEmulation_kernel.py
@@ -11,9 +11,6 @@ import cudaq.kernels
 from cudaq import spin
 import pytest
 import os
-
-pytestmark = pytest.mark.skip(
-    reason="pre-existing failures: disabled pending fix")
 from typing import List
 import numpy as np
 

--- a/python/tests/backends/test_Quantinuum_LocalEmulation_builder.py
+++ b/python/tests/backends/test_Quantinuum_LocalEmulation_builder.py
@@ -13,8 +13,6 @@ import numpy as np
 from typing import List
 
 pytestmark = pytest.mark.xdist_group("quantinuum_emulation")
-pytestmark = pytest.mark.skip(
-    reason="pre-existing failures: disabled pending fix")
 
 
 def assert_close(got) -> bool:

--- a/python/tests/backends/test_Quantinuum_LocalEmulation_kernel.py
+++ b/python/tests/backends/test_Quantinuum_LocalEmulation_kernel.py
@@ -13,8 +13,6 @@ import numpy as np
 from typing import List
 
 pytestmark = pytest.mark.xdist_group("quantinuum_emulation")
-pytestmark = pytest.mark.skip(
-    reason="pre-existing failures: disabled pending fix")
 
 
 def requires_openfermion():

--- a/python/tests/mlir/compiled_module_cache.py
+++ b/python/tests/mlir/compiled_module_cache.py
@@ -6,7 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# XFAIL: *
 # clang-format off
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s run 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=RUNLOOP %s
 # RUN: CUDAQ_LOG_LEVEL=info PYTHONPATH=../../ python3 %s sample 2>&1 | grep 'py_alt_launch_kernel.cpp' | FileCheck --check-prefix=SAMPLE %s

--- a/python/tests/mlir/target/cudaq_observe.py
+++ b/python/tests/mlir/target/cudaq_observe.py
@@ -6,7 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# XFAIL: *
 # RUN: PYTHONPATH=../../.. python3 %s
 # RUN: PYTHONPATH=../../.. python3 %s --target quantinuum --emulate
 

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -10,72 +10,13 @@
 #include "common/CompiledModule.h"
 #include "common/KernelExecution.h"
 #include "cudaq_internal/compiler/Compiler.h"
-#include "cudaq/Optimizer/Builder/CompilerNames.h"
 #include "cudaq/algorithms/policy_cpos.h"
-#include "mlir/IR/BuiltinOps.h"
-
-/// Return true if \p modulePtr is a Python-compiled kernel.  Python kernels
-/// carry the `quake.python_uniqued` attribute (set by the Python bridge) and
-/// have only been through the generic `aot-prep-pipeline`.  C++ kernels
-/// compiled by nvq++ do not carry this attribute and have already been through
-/// the full target-specific pipeline (including any jit-mid-level-pipeline).
-static bool isPythonKernel(const void *modulePtr) {
-  auto mod = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
-  return mod->hasAttr(cudaq::runtime::pythonUniqueAttrName);
-}
 
 static std::vector<cudaq::KernelExecution>
 runCodegen(const cudaq::CompiledModule &module, cudaq::CompileTarget target) {
-  auto mlirArtifacts = module.getMlirArtifacts();
-  if (mlirArtifacts.empty())
+  if (module.getMlirArtifacts().empty())
     CUDAQ_ERROR("QPU does not support launching a "
                 "CompiledModule without MLIR artifacts.");
-
-  // For Python kernels the aot-prep-pipeline has been applied but NOT the
-  // target's jit-mid-level-pipeline.  runPassPipeline is needed in two cases:
-  //   1. The target sends raw Quake MLIR (codegenTranslation == "nop", e.g.
-  //      quake_fake) and requires wireset/borrow-wire ops from the mid-level.
-  //   2. The target runs locally via emulation and needs a JIT artifact.  The
-  //      aot-prep-pipeline never creates a JIT (emitJit defaults to false), so
-  //      the cached CompiledModule has no JIT; we must produce one here.
-  //
-  // C++ kernels compiled by nvq++ have already been through the full pipeline
-  // and must NOT be reprocessed — doing so would double-apply passes.
-  // Determine what the module needs that the aot-prep-pipeline didn't provide:
-  //   • needsWireset: target sends raw Quake MLIR (codegenTranslation=="nop")
-  //     and the server requires add-wireset / assign-wire-indices ops.
-  //   • needsJit: target runs locally via emulation and a JIT artifact is
-  //     required for cudaq::sample / run.  The aot-prep-pipeline produces
-  //     compiled modules with emitJit=false, so there is no JIT yet.
-  //
-  // If the module already has a JIT (e.g. compileModule was called earlier in
-  // the same launch with emitJit=true from the policy options), we must NOT
-  // call runPassPipeline again — that would double-apply mapping/decomposition
-  // passes and produce wrong results.
-  //
-  // C++ kernels compiled by nvq++ have been through the full pipeline already
-  // and must not be reprocessed.
-  const bool isPython =
-      !mlirArtifacts.empty() &&
-      isPythonKernel(mlirArtifacts.front().second.getOpaqueModulePtr());
-  const bool needsWireset = target.pipelineConfig.codegenTranslation == "nop" &&
-                            !target.pipelineConfig.midLevelPipeline.empty();
-  const bool needsJit = target.emulate && !module.getJit().has_value();
-
-  if (isPython && (needsWireset || needsJit)) {
-    cudaq::CompileOptions opts;
-    opts.emitJit = needsJit;
-    cudaq_internal::compiler::Compiler compiler(std::move(target), opts);
-    std::vector<cudaq::KernelExecution> allCodes;
-    for (const auto &[name, artifact] : mlirArtifacts) {
-      auto compiled = compiler.runPassPipeline(
-          name, artifact.getOpaqueModulePtr(), {},
-          /*isEntryPoint=*/true, artifact.getContext());
-      auto codes = compiler.emitKernelExecutions(compiled);
-      allCodes.insert(allCodes.end(), codes.begin(), codes.end());
-    }
-    return allCodes;
-  }
 
   cudaq_internal::compiler::Compiler compiler(std::move(target), {});
   return compiler.emitKernelExecutions(module);


### PR DESCRIPTION
See discussion in #5154.

Full CI currently running: https://github.com/NVIDIA/cuda-quantum/actions/runs/32159094079

Are there any tests that are not run in CI that we should validate this against?