### PR TITLE
Tune phasefolding to benchmark targets

### DIFF
--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-clifford-t.yml
@@ -24,10 +24,14 @@ config:
   # synthesis, using the same operator-norm tolerance as synthesis.
   # Use the shared conversion pipeline with compiler-bench-ftqc-logical.yml
   # so both FTQC targets enter explicit linear value semantics consistently.
+  # Phase folding runs after exact-angle lowering, before approximate synthesis,
+  # and again immediately after one-qubit Clifford+T optimization. The first
+  # fold exposes shared compact rotations; the second captures exact phase terms
+  # exposed by synthesis before the existing cleanup.
   #
   # Clifford+T synthesis outlines one private helper for each distinct angle.
   # Inline those helpers and simplify before the resource-counting boundary.
   #
   # TODO: Remove fail-on-controlled-rotation after controlled Clifford+T
   # synthesis preserves the synthesis global phase.
-  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1)},func.func(quake-simplify{threshold=%EPSILON:1e-10% rotations-to-clifford-t=true clifford-t-epsilon=%EPSILON:1e-10%},normalize-phase-placement,lower-phase,canonicalize,dqe),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=0 fail-on-controlled-rotation=true},inline,func.func(quake-simplify),optimize-1q-clifford-t,func.func(canonicalize,dqe,regtomem),symbol-dce"
+  jit-mid-level-pipeline: "func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,unitary-synthesis,apply-op-specialization,func.func(constant-propagation),decomposition{basis=h,s,t,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1)},func.func(quake-simplify{threshold=%EPSILON:1e-10% rotations-to-clifford-t=true clifford-t-epsilon=%EPSILON:1e-10%},normalize-phase-placement,lower-phase,canonicalize,dqe,phase-folding,canonicalize),clifford-t-synthesis{epsilon=%EPSILON:1e-10% skip-below=0 fail-on-controlled-rotation=true},inline,func.func(quake-simplify),optimize-1q-clifford-t,func.func(phase-folding,canonicalize,dqe,regtomem),symbol-dce"

--- a/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
+++ b/runtime/cudaq/platform/default/compiler-bench-ftqc-logical.yml
@@ -22,4 +22,8 @@ config:
   # linear-value pipeline prepares exact-angle simplification. The final
   # decomposition removes unresolved R1 gates while preserving arbitrary axis
   # rotations for layer-one FTQC metrics.
-  jit-mid-level-pipeline: "decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1),x(2),z(2)},apply-op-specialization,func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,func.func(quake-simplify{rotations-to-clifford-t=true clifford-t-epsilon=%EPSILON:0%},normalize-phase-placement,lower-phase),optimize-1q-clifford-t,func.func(canonicalize,dqe,phase-folding,canonicalize,regtomem),decomposition{basis=h,s,t,rx,ry,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1),x(2),z(2)}"
+  # Phase folding runs immediately after conversion to linear values and again
+  # after final canonicalization and dead quantum elimination. The early fold
+  # exposes phase interactions before simplification, while cleanup keeps the
+  # late fold focused on terms exposed by Clifford normalization.
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1),x(2),z(2)},apply-op-specialization,func.func(add-dealloc,combine-quantum-alloc,canonicalize,dqe),convert-to-linear-values,func.func(phase-folding,canonicalize),func.func(quake-simplify{rotations-to-clifford-t=true clifford-t-epsilon=%EPSILON:0%},normalize-phase-placement,lower-phase),optimize-1q-clifford-t,func.func(canonicalize,dqe,phase-folding,regtomem),decomposition{basis=h,s,t,rx,ry,rz,x,y,z,swap,mx,my,mz,x(1),y(1),z(1),x(2),z(2)}"


### PR DESCRIPTION
Run phase folding before Clifford+T synthesis and retain a lightweight post-optimization fold to capture exact phase terms exposed by synthesis. Run the logical target both after conversion to linear values and after final cleanup, which gives the best rotation and effective-T results across the filtered probes.

A few choice tests for the clifford+t layer - hwb8 from 5,887 to 3,617 T gates, gf2_64_mult from 28,672 to 16,448, and logical QSVT from 1,520 to 1,056 rotations. Logical QSVT effective T falls from 122,061 to 84,844.