### PR TITLE
Define mapped Quake based on wiresets and use this for idempotence

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1104,7 +1104,8 @@ def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
     performs mapping of the qubits by inserting the necessary swap operations
     into the Quake IR.
 
-    After mapping, functions borrow device wires from `@mapped_wireset`.
+    The mapping pass emits Mapped Quake IR, in which kernels borrow device wires
+    from `@mapped_wireset`.
 
     Note 1: this pass requires strictly value semantics (in the form of wire
     sets) for any quantum operations. It will throw an error if any memory

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1104,6 +1104,11 @@ def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
     performs mapping of the qubits by inserting the necessary swap operations
     into the Quake IR.
 
+    The output is Mapped Quake IR. The module contains a topology-aware
+    `quake.wire_set @mapped_wireset`, and mapped functions borrow their device
+    qubits from it. A function that already borrows from `@mapped_wireset` is
+    not mapped again.
+
     Note 1: this pass requires strictly value semantics (in the form of wire
     sets) for any quantum operations. It will throw an error if any memory
     reference semantics are present on quantum operations.

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1104,10 +1104,7 @@ def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
     performs mapping of the qubits by inserting the necessary swap operations
     into the Quake IR.
 
-    The output is Mapped Quake IR. The module contains a topology-aware
-    `quake.wire_set @mapped_wireset`, and mapped functions borrow their device
-    qubits from it. A function that already borrows from `@mapped_wireset` is
-    not mapped again.
+    After mapping, functions borrow device wires from `@mapped_wireset`.
 
     Note 1: this pass requires strictly value semantics (in the form of wire
     sets) for any quantum operations. It will throw an error if any memory

--- a/cudaq/lib/Optimizer/Transforms/Mapping.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Mapping.cpp
@@ -2396,7 +2396,14 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
 
   void runOnOperation() override {
     auto func = getOperation();
-    if (func->hasAttr("mapping_v2p"))
+    bool usesMappedWireSet =
+        func.walk<WalkOrder::PreOrder>([](cudaq::quake::BorrowWireOp borrowOp) {
+              return borrowOp.getSetName() == mappedWireSetName
+                         ? WalkResult::interrupt()
+                         : WalkResult::advance();
+            })
+            .wasInterrupted();
+    if (usesMappedWireSet)
       return;
 
     if (deviceBypass)

--- a/cudaq/test/Transforms/mapping_mapped_wireset_idempotent.qke
+++ b/cudaq/test/Transforms/mapping_mapped_wireset_idempotent.qke
@@ -1,0 +1,30 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// A function that borrows device wires is already mapped, even when it does
+// not carry result-reconstruction metadata.
+// RUN: cudaq-opt --verify-each '--qubit-mapping=device=path(2)' %s | FileCheck %s
+
+quake.wire_set @mapped_wireset[2] adjacency sparse<[[0, 1], [1, 0]], true> : tensor<2x2xi1> attributes {sym_visibility = "private"}
+
+func.func @already_mapped() {
+  %q0 = quake.borrow_wire @mapped_wireset[0] : !quake.wire
+  %q1 = quake.borrow_wire @mapped_wireset[1] : !quake.wire
+  %wires:2 = quake.x [%q0] %q1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.return_wire %wires#0 : !quake.wire
+  quake.return_wire %wires#1 : !quake.wire
+  return
+}
+
+// CHECK: quake.wire_set @mapped_wireset[2] adjacency
+// CHECK-LABEL: func.func @already_mapped() {
+// CHECK: %[[Q0:.*]] = quake.borrow_wire @mapped_wireset[0] : !quake.wire
+// CHECK: %[[Q1:.*]] = quake.borrow_wire @mapped_wireset[1] : !quake.wire
+// CHECK: %[[WIRES:.*]]:2 = quake.x [%[[Q0]]] %[[Q1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK: quake.return_wire %[[WIRES]]#0 : !quake.wire
+// CHECK: quake.return_wire %[[WIRES]]#1 : !quake.wire

--- a/docs/sphinx/using/extending/compiler/cudaq_ir.rst
+++ b/docs/sphinx/using/extending/compiler/cudaq_ir.rst
@@ -112,6 +112,15 @@ The command produces:
 
 .. :spellcheck-enable:
 
+Mapped Quake IR
+^^^^^^^^^^^^^^^
+
+The qubit-mapping pass produces Mapped Quake IR. It adds a topology-aware
+``quake.wire_set @mapped_wireset`` and mapped functions borrow CUDA-Q device
+qubits from that set. This structural form marks the mapped stage. Mapping
+metadata attributes support result reconstruction, but do not identify this
+stage.
+
 CC
 --
 

--- a/docs/sphinx/using/extending/compiler/cudaq_ir.rst
+++ b/docs/sphinx/using/extending/compiler/cudaq_ir.rst
@@ -115,11 +115,8 @@ The command produces:
 Mapped Quake IR
 ^^^^^^^^^^^^^^^
 
-The qubit-mapping pass produces Mapped Quake IR. It adds a topology-aware
-``quake.wire_set @mapped_wireset`` and mapped functions borrow CUDA-Q device
-qubits from that set. This structural form marks the mapped stage. Mapping
-metadata attributes support result reconstruction, but do not identify this
-stage.
+Mapped Quake IR is Quake after qubit mapping. Functions borrow device wires
+from ``@mapped_wireset``.
 
 CC
 --

--- a/docs/sphinx/using/extending/compiler/cudaq_ir.rst
+++ b/docs/sphinx/using/extending/compiler/cudaq_ir.rst
@@ -115,7 +115,7 @@ The command produces:
 Mapped Quake IR
 ^^^^^^^^^^^^^^^
 
-Mapped Quake IR is Quake after qubit mapping. Functions borrow device wires
+The mapping pass emits Mapped Quake IR, in which kernels borrow device wires
 from ``@mapped_wireset``.
 
 CC


### PR DESCRIPTION
Follow on to #5146 based on discussion with Eric and decision to do this the right way. 