### PR TITLE
[core] Do not unroll a loop whose Python else region would be discarded

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
+++ b/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
@@ -162,6 +162,17 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
     // Check for cases that are clearly not going to be unrolled.
     if (loop->hasAttr(cudaq::opt::DeadLoopAttr))
       return failure();
+    // A Python `for ... else` / `while ... else` loop carries an else region
+    // that is entered exactly when the loop terminates without a break. This
+    // pattern clones only the while, body, and step regions, so unrolling such
+    // a loop would silently discard the else code. Leave the loop rolled and
+    // let LowerToCFG, which handles the else region, lower it. (The mapping
+    // pass declines these loops for the same reason.)
+    if (loop.hasPythonElse()) {
+      if (signalFailure)
+        loop.emitOpError("python for/while-else loop cannot be unrolled");
+      return failure();
+    }
     // Opt-in selective unrolling for value-semantics pipelines: a loop that
     // does not itself index or slice qubits dynamically is left rolled unless
     // it must be unrolled first to make a nested wire-blocking loop's trip

--- a/cudaq/test/Transforms/unroll_python_for_else.qke
+++ b/cudaq/test/Transforms/unroll_python_for_else.qke
@@ -1,0 +1,46 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --cc-loop-unroll %s | FileCheck %s
+
+// A Python `for ... else` loop carries an else region that the unroller does
+// not clone. Unrolling it would silently drop the else code, so the loop must
+// be left rolled for LowerToCFG, which does handle the else region.
+
+func.func @python_for_else_is_not_unrolled() -> i64 {
+  %c0_i64 = arith.constant 0 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c2_i64 = arith.constant 2 : i64
+  %c7_i64 = arith.constant 7 : i64
+  %0:2 = cc.loop while ((%arg0 = %c0_i64, %arg1 = %c0_i64) -> (i64, i64)) {
+    %1 = arith.cmpi slt, %arg0, %c2_i64 : i64
+    cc.condition %1(%arg0, %arg1 : i64, i64)
+  } do {
+  ^bb0(%arg0: i64, %arg1: i64):
+    %1 = arith.addi %arg1, %c1_i64 : i64
+    cc.continue %arg0, %1 : i64, i64
+  } step {
+  ^bb0(%arg0: i64, %arg1: i64):
+    %1 = arith.addi %arg0, %c1_i64 : i64
+    cc.continue %1, %arg1 : i64, i64
+  } else {
+  ^bb0(%arg0: i64, %arg1: i64):
+    %1 = arith.addi %arg1, %c7_i64 : i64
+    cc.continue %arg0, %1 : i64, i64
+  }
+  return %0#1 : i64
+}
+
+// CHECK-LABEL:   func.func @python_for_else_is_not_unrolled() -> i64 {
+// CHECK:           cc.loop while
+// CHECK:           } do {
+// CHECK:           } step {
+// CHECK:           } else {
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -2166,6 +2166,68 @@ def test_nested_loops_with_continue():
     print(prog)
 
 
+def test_for_else_with_constant_trip_count():
+    # A `for ... else` whose trip count is a compile-time constant must still
+    # run the else body. The loop unroller used to drop the else region.
+
+    @cudaq.kernel
+    def counter() -> int:
+        r = 0
+        for i in range(4):
+            r = r + 1
+        else:
+            r = r + 7
+        return r
+
+    assert counter() == 11
+
+    @cudaq.kernel
+    def circuit():
+        q = cudaq.qvector(2)
+        for i in range(2):
+            h(q[0])
+        else:
+            x(q[1])
+
+    # `h` applied twice to q0 is the identity, so q0 is |0>; the else body
+    # flips q1.
+    counts = cudaq.sample(circuit, shots_count=100)
+    assert counts['01'] == 100
+
+
+def test_while_else_with_constant_trip_count():
+
+    @cudaq.kernel
+    def counter() -> int:
+        r = 0
+        i = 0
+        while i < 4:
+            r = r + 1
+            i = i + 1
+        else:
+            r = r + 7
+        return r
+
+    assert counter() == 11
+
+
+def test_for_else_break_skips_else():
+
+    @cudaq.kernel
+    def counter() -> int:
+        r = 0
+        for i in range(4):
+            if i == 2:
+                r = r + 100
+                break
+            r = r + 1
+        else:
+            r = r + 7
+        return r
+
+    assert counter() == 102
+
+
 def test_issue_1682():
 
     @cudaq.kernel


### PR DESCRIPTION

## Loop unrolling silently discards the `else` region of a Python `for`/`while` loop

### The bug

A `@cudaq.kernel` `for…else` / `while…else` whose trip count is a compile-time constant
produces a **silently wrong result**: the `else` body is dropped. There is no warning and no
error, and the emitted quantum circuit is simply missing the gates.

```python
import cudaq

@cudaq.kernel
def circ():
    q = cudaq.qvector(2)
    for i in range(2):
        h(q[0])
    else:
        x(q[1])          # no break, so Python runs this -> q1 must be |1>

print(cudaq.sample(circ, shots_count=200))
```

Observed: `{ 00:200 }` — `x(q[1])` never applied.
Expected: `{ 01:200 }` (`h` twice on q0 is the identity, q1 is flipped by the `else`).

The classical form is just as clear:

```python
@cudaq.kernel
def k() -> int:
    r = 0
    for i in range(4):
        r = r + 1
    else:
        r = r + 7
    return r
```

Python gives `11`; CUDA-Q gives `4`. The same happens for `while…else`.

Making the trip count a runtime value so the loop cannot be unrolled makes every case correct,
including `break` correctly skipping the `else`. That isolates the defect to the unroll path.

### Root cause

`UnrollCountedLoop::matchAndRewrite` in
`cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc` clones the loop's `while`, `body` and
`step` regions and then replaces the op:

```cpp
rewriter.cloneRegionBefore(loop.getWhileRegion(), endBlock);   // ~line 231
rewriter.cloneRegionBefore(bodyRegion, endBlock);              // ~line 234
rewriter.cloneRegionBefore(loop.getStepRegion(), endBlock);    // ~line 247
...
rewriter.replaceOp(loop, endBlock->getArguments());            // ~line 307
```

`loop.getElseRegion()` is never cloned or even inspected, so it dies with the op. The Python
bridge emits a correct `cc.loop … else { … }`, `cc-loop-normalize` preserves it, and
`LowerToCFG` / `LowerUnwind` both handle it correctly — only the unroller loses it.

### The fix in this PR

Decline to unroll a loop that carries a Python `else` region, mirroring the existing bail-out
for the same construct in `Mapping.cpp` (`loopOp.hasPythonElse()`). The loop is left rolled and
`LowerToCFG`, which handles the else region correctly, takes over. On the default simulator
targets this turns today's wrong answer into the right answer.

### Tradeoff — please read before merging

This is a conservative guard, not the complete fix. **It trades a silently wrong answer for a
hard compile error on pipelines that require full unrolling.**

Concretely:

* `signalFailure` defaults to `false` in the pass, and every in-tree `createLoopUnroll` call
  site (`Pipelines.cpp:68,168,211`, `py_alt_launch_kernel.cpp:1207`,
  `kernel_builder.cpp:1001`) leaves it at that default. Those paths simply keep the loop rolled
  and produce correct results.
* A pipeline that explicitly sets
  `signal-failure-if-any-loop-cannot-be-completely-unrolled` — including the `unrolling-pipeline`
  cudaq-opt pipeline, where it defaults to `true` — will now report an error for a
  constant-bound `for…else` kernel instead of silently emitting the wrong circuit.
* Targets that genuinely require a fully expanded circuit (QIR base profile, hardware) will
  reach a downstream error rather than accepting a wrong circuit.

I believe an error is strictly better than a wrong quantum circuit, but this is a behaviour
change on those targets and a maintainer should weigh it rather than have it slipped in.

**The complete alternative**, which avoids the tradeoff entirely, is to clone the else region
into the fall-through after the last unrolled iteration so the loop still unrolls and the else
body still runs. The structure is already favourable: `break` ops in the body are branched
directly to `endBlock` (line ~264), so they would naturally bypass a cloned else region placed
on the fall-through edge, and the else region's `cc.continue` terminators would be rewritten to
branch to `endBlock` exactly as `LowerToCFG` does. I did not implement that here because I have
no LLVM/MLIR build available and would be shipping an untested rewriter change; the sketch is
in the linked issue and I am happy to implement it if maintainers prefer it.

### Tests

* `cudaq/test/Transforms/unroll_python_for_else.qke` — new FileCheck test asserting the
  `cc.loop … else { … }` survives `--cc-loop-unroll` instead of being replaced.
* `python/tests/kernel/test_kernel_features.py` — two behaviour tests
  (`test_for_else_with_constant_trip_count`, `test_while_else_with_constant_trip_count`)
  asserting the `else` body runs, plus a `break`-skips-`else` case, next to the existing
  `test_nested_loops_with_break` / `test_nested_loops_with_continue`.

### Verification performed

Reproduced and diagnosed on the released `cudaq` 0.15.1 wheel (macOS arm64), including the
positive control above. **I could not build LLVM/MLIR locally, so neither the new FileCheck test
nor the Python tests have been executed against a build carrying this change.** The evidence
that the not-unrolled path is correct is the executed runtime-bound positive control, which
exercises exactly the path this guard routes constant-bound `for…else` loops into.
`pre-commit run --hook-stage pre-push` output is below.

Fixes #5174

---

**Note for reviewers on the FileCheck fixture:** I could not run `lit`/`cudaq-opt` locally (no LLVM build available), so the added FileCheck test is **not executed** — I modelled it on `unroll_loop_with_break.qke`'s proven-counted shape. If the loop in that fixture is not recognized as counted, the test would pass vacuously both before and after this change. A maintainer running lit settles that in seconds; please flag it and I will correct the fixture.
