### PR TITLE
[python] Pass the loop-carried arguments to a bare break or continue

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5788,12 +5788,12 @@ class PyASTBridge(ast.NodeVisitor):
             self.emitFatalError("break statement outside of for loop body.",
                                 node)
 
+        # Get the innermost enclosing `for` or `while` loop
+        inArgs = [b for b in self.inForBodyStack[-1]]
         if self.isInIfStmtBlock():
-            # Get the innermost enclosing `for` or `while` loop
-            inArgs = [b for b in self.inForBodyStack[-1]]
             cc.UnwindBreakOp(inArgs)
         else:
-            cc.BreakOp([])
+            cc.BreakOp(inArgs)
 
         return
 
@@ -5803,12 +5803,12 @@ class PyASTBridge(ast.NodeVisitor):
             self.emitFatalError("continue statement outside of for loop body.",
                                 node)
 
+        # Get the innermost enclosing `for` or `while` loop
+        inArgs = [b for b in self.inForBodyStack[-1]]
         if self.isInIfStmtBlock():
-            # Get the innermost enclosing `for` or `while` loop
-            inArgs = [b for b in self.inForBodyStack[-1]]
             cc.UnwindContinueOp(inArgs)
         else:
-            cc.ContinueOp([])
+            cc.ContinueOp(inArgs)
 
     def __process_binary_op(self, left, right, nodeType):
         """Process a binary operation in the AST and map them to equivalents in

--- a/python/tests/mlir/ast_break.py
+++ b/python/tests/mlir/ast_break.py
@@ -60,3 +60,43 @@ def test_break():
 # CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<4>
 # CHECK:           return
 # CHECK:         }
+
+
+def test_bare_break():
+    # A `break` that is *not* nested in an `if` must still forward the
+    # loop-carried block arguments to the `cc.break` terminator.
+
+    @cudaq.kernel(verbose=False)
+    def bare_break_kernel(x: float):
+        q = cudaq.qvector(4)
+        for i in range(4):
+            ry(x, q[i])
+            break
+
+    print(bare_break_kernel)
+    bare_break_kernel(1.2)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__bare_break_kernel..
+# CHECK-SAME:      %[[VAL_30:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+# CHECK-DAG:       %[[VAL_31:.*]] = arith.constant 1 : i64
+# CHECK-DAG:       %[[VAL_32:.*]] = arith.constant 0 : i64
+# CHECK-DAG:       %[[VAL_33:.*]] = arith.constant 4 : i64
+# CHECK-DAG:       %[[VAL_34:.*]] = cc.undef i64
+# CHECK-DAG:       %[[VAL_35:.*]] = quake.alloca !quake.veq<4>
+# CHECK:           %[[VAL_36:.*]]:2 = cc.loop while ((%[[VAL_37:.*]] = %[[VAL_32]], %[[VAL_38:.*]] = %[[VAL_34]]) -> (i64, i64)) {
+# CHECK:             %[[VAL_39:.*]] = arith.cmpi slt, %[[VAL_37]], %[[VAL_33]] : i64
+# CHECK:             cc.condition %[[VAL_39]](%[[VAL_37]], %[[VAL_38]] : i64, i64)
+# CHECK:           } do {
+# CHECK:           ^bb0(%[[VAL_40:.*]]: i64, %[[VAL_41:.*]]: i64):
+# CHECK:             %[[VAL_42:.*]] = quake.extract_ref %[[VAL_35]]{{\[}}%[[VAL_40]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:             quake.ry (%[[VAL_30]]) %[[VAL_42]] : (f64, !quake.ref) -> ()
+# CHECK:             cc.break %[[VAL_40]], %[[VAL_40]] : i64, i64
+# CHECK:           } step {
+# CHECK:           ^bb0(%[[VAL_43:.*]]: i64, %[[VAL_44:.*]]: i64):
+# CHECK:             %[[VAL_45:.*]] = arith.addi %[[VAL_43]], %[[VAL_31]] : i64
+# CHECK:             cc.continue %[[VAL_45]], %[[VAL_44]] : i64, i64
+# CHECK:           }
+# CHECK:           quake.dealloc %[[VAL_35]] : !quake.veq<4>
+# CHECK:           return
+# CHECK:         }

--- a/python/tests/mlir/ast_continue.py
+++ b/python/tests/mlir/ast_continue.py
@@ -84,3 +84,43 @@ def test_continue():
 # CHECK-LABEL: kernel:
 # CHECK-NEXT: object is not callable
 # CHECK-NEXT: offending source -> x(q
+
+
+def test_bare_continue():
+    # A `continue` that is *not* nested in an `if` must still forward the
+    # loop-carried block arguments to the `cc.continue` terminator.
+
+    @cudaq.kernel
+    def bare_continue_kernel(x: float):
+        q = cudaq.qvector(4)
+        for i in range(4):
+            ry(x, q[i])
+            continue
+
+    print(bare_continue_kernel)
+    bare_continue_kernel(1.2)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__bare_continue_kernel..
+# CHECK-SAME:      %[[VAL_40:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+# CHECK-DAG:       %[[VAL_41:.*]] = arith.constant 1 : i64
+# CHECK-DAG:       %[[VAL_42:.*]] = arith.constant 0 : i64
+# CHECK-DAG:       %[[VAL_43:.*]] = arith.constant 4 : i64
+# CHECK-DAG:       %[[VAL_44:.*]] = cc.undef i64
+# CHECK-DAG:       %[[VAL_45:.*]] = quake.alloca !quake.veq<4>
+# CHECK:           %[[VAL_46:.*]]:2 = cc.loop while ((%[[VAL_47:.*]] = %[[VAL_42]], %[[VAL_48:.*]] = %[[VAL_44]]) -> (i64, i64)) {
+# CHECK:             %[[VAL_49:.*]] = arith.cmpi slt, %[[VAL_47]], %[[VAL_43]] : i64
+# CHECK:             cc.condition %[[VAL_49]](%[[VAL_47]], %[[VAL_48]] : i64, i64)
+# CHECK:           } do {
+# CHECK:           ^bb0(%[[VAL_50:.*]]: i64, %[[VAL_51:.*]]: i64):
+# CHECK:             %[[VAL_52:.*]] = quake.extract_ref %[[VAL_45]]{{\[}}%[[VAL_50]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:             quake.ry (%[[VAL_40]]) %[[VAL_52]] : (f64, !quake.ref) -> ()
+# CHECK:             cc.continue %[[VAL_50]], %[[VAL_50]] : i64, i64
+# CHECK:           } step {
+# CHECK:           ^bb0(%[[VAL_53:.*]]: i64, %[[VAL_54:.*]]: i64):
+# CHECK:             %[[VAL_55:.*]] = arith.addi %[[VAL_53]], %[[VAL_41]] : i64
+# CHECK:             cc.continue %[[VAL_55]], %[[VAL_54]] : i64, i64
+# CHECK:           }
+# CHECK:           quake.dealloc %[[VAL_45]] : !quake.veq<4>
+# CHECK:           return
+# CHECK:         }


### PR DESCRIPTION

A `break` or `continue` written directly in a `for` body, rather than nested inside an `if`, emitted
its `cc.break` / `cc.continue` terminator with an empty operand list, so the kernel failed to
compile:

```python
@cudaq.kernel
def bare_cont() -> int:
    r = 0
    for j in range(3):
        r = r + 1
        continue
    return r
```

```
error: 'cc.loop' op along control flow edge from Operation cc.continue to Region #2:
       region branch point has 0 operands, but region successor needs 1 inputs

RuntimeError: pass pipeline failed
RuntimeError: could not compile code for 'bare_cont..'.
```

The same happens for `break`, in nested loops, when iterating a `qvector`, and in purely quantum
kernels with no classical return value.

### What this changes

Every terminator in a `cc.loop` body region has to forward that region's block arguments.
`createForLoop` establishes the invariant itself — the implicit fall-through terminator it appends
uses `bodyBlock.arguments`, and that is exactly the tuple `pushForBodyStack` records. The
`isInIfStmtBlock()` branch of `visit_Break` / `visit_Continue` already forwards it; only the other
branch hardcoded `[]`. Hoisting the binding above the `if` and using it in both branches is a
net-zero-line change:

```python
        # Get the innermost enclosing `for` or `while` loop
        inArgs = [b for b in self.inForBodyStack[-1]]
        if self.isInIfStmtBlock():
            cc.UnwindContinueOp(inArgs)
        else:
            cc.ContinueOp(inArgs)
```

The resulting terminator has the same shape `python/tests/mlir/ast_break.py` already asserts for the
`if`-nested path.

`while` loops are unaffected either way: `visit_While` builds the loop with no block arguments, so
the forwarded list is empty. I confirmed the printed module for a `while` loop with a bare
`continue` and with a bare `break` is byte-identical before and after this change, as is the module
for each of the two kernels the existing tests in these files already cover.

This is the same class of arity mismatch as #1682, fixed in #1693 — that fix corrected
`inForBodyStack[0]` → `inForBodyStack[-1]` in the `isInIfStmtBlock()` branch and left the other
branch emitting `[]`.

### Testing

`python/tests/mlir/ast_break.py` gains `test_bare_break` and `python/tests/mlir/ast_continue.py`
gains `test_bare_continue`, each a `for` loop whose `break` / `continue` is not nested in an `if`,
with a CHECK block in the files' existing style asserting the terminator now carries the
loop-carried operands. Both tests also invoke the kernel, exercising the JIT path that raised the
`RuntimeError`. Both fail before this change and pass after it.

There was no coverage of this branch before: both files place the statement under an `if`, and an
AST scan of `python/` finds no `@cudaq.kernel` anywhere in the tree with a `break` or `continue`
that is not nested in an `if`.

### Validation

The change was applied to the `ast_bridge.py` of an installed `cudaq` 0.15.1 wheel
(`cuda_quantum_cu13`, Python 3.13, macOS 26.5.1 arm64), exercised end to end, and the wheel restored
afterwards. Before, all eight `for`-loop forms failed to compile; after, every one matches CPython
(`3`, `1`, `6`, `2`, `5`, and the expected measurement distributions), and every case that worked
before is unchanged.

Fixes #5176

