### PR TITLE
[python] Allow kernel arguments with cudaq.draw's format overload

### DIFF
--- a/python/cudaq/runtime/draw.py
+++ b/python/cudaq/runtime/draw.py
@@ -39,7 +39,7 @@ def draw(decoratorOrFormat, *args):
     """
     if isinstance(decoratorOrFormat, str):
         # User specified output format.
-        assert (len(args) == 1) and "must have a kernel"
+        assert len(args) >= 1, "must have a kernel"
         vargs = args[1:]
         return _detail_draw(decoratorOrFormat, args[0], *vargs)
     # Default to the UTF-8 code points (confusingly named `"ascii"`).

--- a/python/tests/visualization/test_draw.py
+++ b/python/tests/visualization/test_draw.py
@@ -105,6 +105,26 @@ q3 : ┤ h ├──────────────────────
     assert expected_str == produced_string
 
 
+def test_draw_format_with_arguments():
+    """The `cudaq.draw("<format>", kernel, ...)` overload must forward the
+    kernel arguments, just like the `cudaq.draw(kernel, ...)` overload."""
+
+    @cudaq.kernel
+    def kernel(theta: float):
+        q = cudaq.qvector(2)
+        ry(theta, q[0])
+        x.ctrl(q[0], q[1])
+
+    produced_string = cudaq.draw("ascii", kernel, 0.59)
+    assert produced_string == cudaq.draw(kernel, 0.59)
+    assert "ry(0.59)" in produced_string
+    assert "R_y(0.59)" in cudaq.draw("latex", kernel, 0.59)
+
+    # A format string must still be followed by a kernel.
+    with pytest.raises(AssertionError, match="must have a kernel"):
+        cudaq.draw("ascii")
+
+
 # This test will run on the default simulator. For machines with GPUs, that
 # will be a GPU-accelerated simulator, but for machines without GPUs, it
 # will run on a CPU simulator.


### PR DESCRIPTION

The format-string overload of `cudaq.draw` cannot be used with a kernel that takes
arguments:

```python
@cudaq.kernel
def kernel(theta: float):
    q = cudaq.qvector(2)
    ry(theta, q[0])
    x.ctrl(q[0], q[1])


cudaq.draw(kernel, 0.59)           # works
cudaq.draw("ascii", kernel, 0.59)  # AssertionError
```

In `python/cudaq/runtime/draw.py` the format branch asserted `len(args) == 1`, but in that
overload `args` is `(kernel, *kernel_args)`, so the assertion holds only for a kernel with
no arguments. The following line, `vargs = args[1:]`, exists to forward those arguments and
could never carry a non-empty value. The non-format branch forwards `*args` correctly, so
the two overloads disagreed with each other, and the signature documented in the function's
own docstring, in the `py_draw.cpp` docstring, and in the published API reference was not
usable.

`cudaq.getSVGstring` and `cudaq.displaySVG` hit the same path — `display_trace.py` calls
`cudaq.draw("latex", kernel, *args)` — so the SVG renderer was broken for every
parameterized kernel.

This is a regression from #3693, which replaced the C++ `draw` overload set with this
Python shim. The previous `pyDraw(std::string format, py::object &kernel, py::args args)`
forwarded `args` in both its `ascii` and `latex` branches.

### What this changes

```diff
-        assert (len(args) == 1) and "must have a kernel"
+        assert len(args) >= 1, "must have a kernel"
```

Two things on that one line:

- `==` becomes `>=`, so the assertion only checks what it is named for — that a kernel
  was supplied after the format string — and `vargs = args[1:]` becomes meaningful.
  Argument-count validation is not weakened: `_detail_draw` already compares the kernel's
  formal arity against the arguments given and raises
  `RuntimeError: Invalid number of arguments passed to run. N given and M expected.`
  for both too few and too many, in both overloads.
- `assert COND and "msg"` becomes `assert COND, "msg"`. In the first form the string is
  folded into the condition — it is truthy, so it never changed the outcome — and the
  `AssertionError` was raised with no message. Calling `cudaq.draw("ascii")` with no
  kernel now reports `AssertionError: must have a kernel` instead of a bare
  `AssertionError`.

A useful control while confirming the diagnosis: the failing script runs correctly under
`python -O`, which strips `assert` statements and changes nothing else. The rest of the
path already handled the arguments; the assertion was the only thing rejecting them.

### Testing

`python/tests/visualization/test_draw.py` gains `test_draw_format_with_arguments`, placed
next to `test_draw`, which owns the existing zero-argument `cudaq.draw("latex", kernel)`
case. It checks that the format overload agrees with the non-format overload, that the
parameter value actually reaches the drawing in both `ascii` and `latex`, and that the
no-kernel guard still fires with its message. It fails on `main` at `draw.py:42` and
passes with this change.

No existing test covered this combination: the only format-string call sites in the repo
are `test_draw.py:104` and `docs/sphinx/examples/python/visualization.ipynb:352`, both
with a zero-argument kernel, while every call site that passes kernel arguments uses the
non-format overload. That is why this survived.

Fixes #5179
