### PR TITLE
[docs] Correct Python docstrings and snippets that contradict the code

### DIFF
--- a/.github/pre-commit/spelling_allowlist.txt
+++ b/.github/pre-commit/spelling_allowlist.txt
@@ -315,6 +315,7 @@ cuTensor
 cudaq
 cudaqPulseRunCanonicalize
 cudm
+cx
 dataclass
 dataflow
 datagram
@@ -525,6 +526,7 @@ queryable
 qumode
 qumodes
 qvec
+qvector
 rabi
 reStructuredText
 realtime

--- a/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
+++ b/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
@@ -86,7 +86,7 @@ extract the result information in the following manner:
     counts.dump()
 
     # Fine-grained access to the bits and counts 
-    for bits, count in counts:
+    for bits, count in counts.items():
         print('Observed: {}, {}'.format(bits, count))
 
 
@@ -540,7 +540,7 @@ This return type can be used in the following way.
   .. code-block:: python 
 
     # I require the result with all generated data 
-    result = cudaq::observe(kernel, spinOp, *args)
+    result = cudaq.observe(kernel, spinOp, *args)
     expVal = result.expectation()
     X0X1Exp = result.expectation(x(0)*x(1))
     X0X1Data = result.counts(x(0)*x(1))
@@ -583,8 +583,8 @@ Here is an example of the utility of the :code:`cudaq::observe` function:
        ry(theta, q[1])
        x.ctrl(q[1], q[0])
     
-    h = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
-                    .21829 * z(0) - 6.125 * z(1)
+    h = (5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
+                    .21829 * z(0) - 6.125 * z(1))
     energy = cudaq.observe(ansatz, h, .59).expectation() 
     print('Energy is {}'.format(energy))
 

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -1145,14 +1145,14 @@ class PyKernel(object):
     def mz(self, target, regName=None):
         """
         Measure the given qubit or qubits in the Z-basis. The optional
-        `register_name` may be used to retrieve results of this measurement
+        `regName` may be used to retrieve results of this measurement
         after execution on the QPU. If the measurement call is saved as a
         variable, it will return a :class:`QuakeValue` handle to the measurement
         instruction.
 
         Args:
         target (:class:`QuakeValue`): The qubit or qubits to measure.
-        register_name (Optional[:obj:`str`]): The optional name to provide the
+        `regName` (Optional[:obj:`str`]): The optional name to provide the
             results of the measurement. Defaults to ``None``, in which case
             no register name is attached to the measurement op.
 
@@ -1178,14 +1178,14 @@ class PyKernel(object):
     def mx(self, target, regName=None):
         """
         Measure the given qubit or qubits in the X-basis. The optional
-        `register_name` may be used to retrieve results of this measurement
+        `regName` may be used to retrieve results of this measurement
         after execution on the QPU. If the measurement call is saved as a
         variable, it will return a :class:`QuakeValue` handle to the measurement
         instruction.
 
         Args:
         target (:class:`QuakeValue`): The qubit or qubits to measure.
-        register_name (Optional[:obj:`str`]): The optional name to provide the
+        `regName` (Optional[:obj:`str`]): The optional name to provide the
             results of the measurement. Defaults to ``None``, in which case
             no register name is attached to the measurement op.
 
@@ -1210,14 +1210,14 @@ class PyKernel(object):
     def my(self, target, regName=None):
         """
         Measure the given qubit or qubits in the Y-basis. The optional
-        `register_name` may be used to retrieve results of this measurement
+        `regName` may be used to retrieve results of this measurement
         after execution on the QPU. If the measurement call is saved as a
         variable, it will return a :class:`QuakeValue` handle to the measurement
         instruction.
 
         Args:
         target (:class:`QuakeValue`): The qubit or qubits to measure.
-        register_name (Optional[:obj:`str`]): The optional name to provide the
+        `regName` (Optional[:obj:`str`]): The optional name to provide the
             results of the measurement. Defaults to ``None``, in which case
             no register name is attached to the measurement op.
 

--- a/python/cudaq/kernel/quake_value.py
+++ b/python/cudaq/kernel/quake_value.py
@@ -127,11 +127,11 @@ class QuakeValue(object):
             The underlying :class:`QuakeValue` must be a `list` or `veq`.
 
         Args:
-            start (int): The index to begin the slice from.
-            count (int): The number of elements to extract after the `start` index.
+            `startIdx` (int): The index to begin the slice from.
+            count (int): The number of elements to extract after the `startIdx` index.
         Returns:
             :class:`QuakeValue`: A new `QuakeValue` containing a slice of `self`
-            from the `start` element to the `start + count` element.
+            from the `startIdx` element to the `startIdx + count` element.
         """
         raise RuntimeError("QuakeValue.slice not implemented")
 
@@ -139,8 +139,8 @@ class QuakeValue(object):
         """
         Return the negation of `self` (:class:`QuakeValue`).
 
-        Raises:
-            RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+            An integer :class:`QuakeValue` is promoted to floating point.
 
         .. code-block:: python
 
@@ -158,8 +158,8 @@ class QuakeValue(object):
         """
         Return the product of `self` (:class:`QuakeValue`) with `other` (float).
         
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
 
         .. code-block:: python
 
@@ -177,8 +177,8 @@ class QuakeValue(object):
         """
         Return the product of `other` (float) with `self` (:class:`QuakeValue`).
 
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
         
         .. code-block:: python
 
@@ -196,8 +196,8 @@ class QuakeValue(object):
         """
         Return the division of `self` (:class:`QuakeValue`) with `other` (float).
 
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
 
         .. code-block:: python
 
@@ -218,8 +218,8 @@ class QuakeValue(object):
         """
         Return the division of `other` (float) with `self` (:class:`QuakeValue`).
 
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
         
         .. code-block:: python
 
@@ -240,8 +240,8 @@ class QuakeValue(object):
         """
         Return the sum of `self` (:class:`QuakeValue`) and `other` (float).
 
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
         
         .. code-block:: python
 
@@ -259,8 +259,8 @@ class QuakeValue(object):
         """
         Return the sum of `other` (float) and `self` (:class:`QuakeValue`).
 
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
         
         .. code-block:: python
 
@@ -278,8 +278,8 @@ class QuakeValue(object):
         """
         Return the difference of `self` (:class:`QuakeValue`) and `other` (float).
 
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
         
         .. code-block:: python
 
@@ -297,8 +297,8 @@ class QuakeValue(object):
         """
         Return the difference of `other` (float) and `self` (:class:`QuakeValue`).
 
-        Raises:
-	        RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+        Note:
+	        `other` may be an `int`, a `float`, or another :class:`QuakeValue`.
 
         .. code-block:: python
 

--- a/python/cudaq/operators/custom/__init__.py
+++ b/python/cudaq/operators/custom/__init__.py
@@ -35,7 +35,7 @@ def define(id: str,
     function does not need to do this.
 
     Arguments:
-        op_id: A string that uniquely identifies the defined operator.
+        id: A string that uniquely identifies the defined operator.
         expected_dimensions: defines the number of levels, that is the dimension,
             for each degree of freedom in canonical (that is sorted) order. A
             negative or zero value for one (or more) of the expected dimensions
@@ -59,7 +59,7 @@ def instantiate(op_id: str,
     Instantiates a product operator containing a previously defined operator element.
 
     Arguments:
-        operator_id: The id of the operator element as specified when it was defined.
+        op_id: The id of the operator element as specified when it was defined.
         degrees: The degree(s) of freedom that the operator acts on.
     """
     if isinstance(degrees, int):

--- a/python/cudaq/runtime/translate.py
+++ b/python/cudaq/runtime/translate.py
@@ -15,8 +15,8 @@ from cudaq.util import trace
 @trace.traced
 def translate(kernel, *args, format="qir:0.1"):
     """
-    Return a `UTF-8` encoded string representing drawing of the execution path,
-    i.e., the trace, of the provided `kernel`.
+    Return a `UTF-8` encoded string containing the provided `kernel` translated
+    to the requested `format`.
 
     Args:
       format (`str`): format to translate to, <name[:version]>.
@@ -29,7 +29,8 @@ def translate(kernel, *args, format="qir:0.1"):
     Note: Translating functions with arguments to OpenQASM 2.0 is not supported.
 
     Returns:
-      The `UTF-8` encoded string of the circuit, without measurement operations.
+      The `UTF-8` encoded string of the circuit in the requested `format`,
+      including any measurement operations present in the `kernel`.
 
     # Example:
     import cudaq

--- a/python/cudaq/runtime/unitary.py
+++ b/python/cudaq/runtime/unitary.py
@@ -28,11 +28,11 @@ def get_unitary(kernel, *args):
       import cudaq
       @cudaq.kernel
       def bell():
-        `q = cudaq.qvector(2)`
+        q = cudaq.qvector(2)
         h(q[0])
-        `cx(q[0], q[1])`
+        cx(q[0], q[1])
       U = cudaq.get_unitary(bell)
-     print(U)
+      print(U)
     """
     if isa_kernel_decorator(kernel):
         decorator = kernel

--- a/python/runtime/common/py_SampleResult.cpp
+++ b/python/runtime/common/py_SampleResult.cpp
@@ -123,7 +123,7 @@ Args:
 	bitstring (str): The binary string to return the measurement data of.
 
 Returns:
-	float: The number of times the given `bitstring` was measured
+	int: The number of times the given `bitstring` was measured
 	during the `shots_count` number of executions on the QPU.)#")
       .def(
           "__len__", [](sample_result &self) { return self.to_map().size(); },


### PR DESCRIPTION
Fixes #5181.

Nine places in the Python documentation state something the code does not do.
Each was verified against an installed `cudaq` 0.15.1 package before and after
the change. In every case the code is correct and the documentation is wrong,
so this PR changes only comments, docstrings and whitespace — **no executable
line changes**.

One of them fails quietly, which is why this is worth a PR rather than a nit:

**The `SampleResult` iteration example in the specification prints wrong data
silently.** `algorithmic_primitives.rst` uses `for bits, count in counts:`.
`SampleResult` iterates over bit-string keys, like a `dict`, so for the
two-qubit `bell` kernel the example demonstrates:

```
Observed: 0, 0
Observed: 1, 1
```

Python unpacked `'00'` into two characters; the real counts never appear, and
the output looks plausible next to the C++ tab's `Observed: 00, 514`. With
`counts.items()`:

```
Observed: 00, 479
Observed: 11, 521
```

At any other qubit count the documented form raises
`ValueError: too many values to unpack (expected 2)`.

### The rest

- Two `.. code-block:: python` blocks in `algorithmic_primitives.rst` are not
  Python: one uses the C++ scope operator (`cudaq::observe`), the other splits
  an expression across two lines without parentheses. Both are `SyntaxError`.
  After this change, `ast.parse` succeeds on all nine Python code blocks in
  that file; before it, these two failed.
- `Kernel.mz` / `mx` / `my` document `register_name`; the parameter is
  `regName`. The documented name raises `TypeError`.
- `cudaq.operators.custom.define` documents `op_id` (it is `id`) and
  `instantiate` documents `operator_id` (it is `op_id`). Both raise `TypeError`.
- `cudaq.translate` says its result is "the circuit, without measurement
  operations". It is not: `format="openqasm2"` on a kernel containing `mz(q)`
  emits `creg`/`measure`, `format="qir"` emits `__quantum__qis__mz` calls, and
  the docstring's own example output shows those calls. The sentence is copied
  from `cudaq.draw`, where it is correct.
- `SampleResult.__getitem__` documents a `float` return and returns `int` — as
  the nanobind-generated signature two lines above in the same `__doc__`
  already says, and as the sibling `count()` documents correctly.
- `QuakeValue.slice` documents `start`; the parameter is `startIdx`.
- The nine `QuakeValue` arithmetic dunders document
  `Raises: RuntimeError: if the underlying QuakeValue type is not a float`.
  No such error is raised: integer operands emit
  `arith.muli`/`addi`/`subi`/`divsi`, and `__neg__` promotes to `arith.negf`.
  Integer support predates these `Raises:` lines, so the claim was never
  accurate; replaced with a note on the accepted operand types.
- `cudaq.get_unitary`'s docstring code block wraps two lines in literal
  backticks and under-indents the trailing `print`, so it renders with the
  backticks visible and fails with `SyntaxError` if copied. Fixed; the block now
  extracts and runs, printing the Bell unitary.

### One thing that is not a doc fix

Commit `d7fabc860` adds `cx` and `qvector` to
`.github/pre-commit/spelling_allowlist.txt`. The literal backticks in the
`get_unitary` example were load-bearing: the `python` matrix in
`spellcheck_config.yml` skips docstring content between inline backticks, so
removing them exposes those two words. Both are CUDA-Q vocabulary and `qvec` was
already in the list. That is the only hunk outside docstrings and `.rst`.

It shares a commit with the `unitary.py` docstring fix rather than standing
alone, so dropping the commit would also drop one of the nine corrections. If
you would rather solve the spelling side another way, say so and I will split
the commit and drop only the allowlist hunk.

### Overlaps I checked

- **#2969** also rewrites the `apply_noise` block in `python_api.rst`, replacing
  it with a `literalinclude` whose extracted snippet has the indentation right.
  This PR therefore leaves `python_api.rst` alone entirely, so the two cannot
  conflict; see the scope note below.
- **#3017** implements `QuakeValue.slice`. I deliberately left the `Returns:`
  block alone so this does not conflict with it, and changed only the wrong
  parameter name, which #3017 does not touch.
- **#4950** touches `algorithmic_primitives.rst` at lines 191-266 and 300-312;
  the hunks here are at 89, 543 and 586.
- **#2981** rewrites `examples.rst`, which carries a very similar defect in the
  deuteron parameter-sweep example. I have kept `examples.rst` out of this PR
  entirely and raised it there instead.
- `default_ops.rst` is untouched — #5162 is open on it.

### Verification

`cudaq` 0.15.1 (`aca5853a7`), Python 3.13, macOS 26.5.1 arm64. Every claim above was
executed, both before and after.

`pre-commit run --all-files --hook-stage pre-push` was run on `upstream/main`
and on this branch. Both give the same result: 13 hooks pass, and
`Check links in Markdown files` fails on a pre-existing dead CI-badge URL in
`README.md`, a file this branch does not touch. `pyspelling` passes.

The Sphinx build was not run locally — `conf.py` needs autodoc against a full
source build. As a substitute I parsed both edited `.rst` files with docutils
before and after (identical diagnostics, nothing new), `ast.parse`d every
`.. code-block:: python` in the edited files, and extracted and executed the
two blocks that were re-indented.

---

**Scope note:** an earlier draft of this branch also re-indented the `apply_noise` example in `python_api.rst`. That change was dropped because open PR #2969 already replaces that block with a `literalinclude`. This PR deliberately leaves it alone.
