### PR TITLE
Computing CuDensityMatState overlap on the GPU

### DIFF
--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -51,37 +51,29 @@ CuDensityMatState::overlap(const cudaq::SimulationState &other) {
     throw std::runtime_error(
         "[CuDensityMatState] overlap error - precision mismatch.");
 
-  if (!isDensityMatrix) {
-    Eigen::VectorXcd state(dimension);
-    HANDLE_CUDA_ERROR(cudaMemcpy(state.data(), devicePtr,
-                                 dimension * sizeof(std::complex<double>),
-                                 cudaMemcpyDeviceToHost));
-
-    Eigen::VectorXcd otherState(dimension);
-    HANDLE_CUDA_ERROR(cudaMemcpy(otherState.data(), other.getTensor().data,
-                                 dimension * sizeof(std::complex<double>),
-                                 cudaMemcpyDeviceToHost));
-    return std::abs(std::inner_product(
-        state.begin(), state.end(), otherState.begin(),
-        std::complex<double>{0., 0.}, [](auto a, auto b) { return a + b; },
-        [](auto a, auto b) { return a * std::conj(b); }));
+  const std::size_t bufferSizeBytes = dimension * sizeof(std::complex<double>);
+  const void *otherData = other.getTensor().data;
+  void *stagedData = nullptr;
+  if (!other.isDeviceData()) {
+    stagedData = cudaq::dynamics::DeviceAllocator::allocate(bufferSizeBytes);
+    HANDLE_CUDA_ERROR(cudaMemcpy(stagedData, otherData, bufferSizeBytes,
+                                 cudaMemcpyHostToDevice));
+    otherData = stagedData;
   }
 
-  // FIXME: implement this in GPU memory
-  // For density matrices, `dimension` is the total number of elements (N^2).
-  // The matrix side length is sqrt(dimension).
-  const std::size_t matDim = static_cast<std::size_t>(std::sqrt(dimension));
-  Eigen::MatrixXcd state(matDim, matDim);
-  HANDLE_CUDA_ERROR(cudaMemcpy(state.data(), devicePtr,
-                               dimension * sizeof(std::complex<double>),
-                               cudaMemcpyDeviceToHost));
+  cuDoubleComplex dotResult;
+  const auto status = cublasZdotc(
+      dynamics::Context::getCurrentContext()->getCublasHandle(), dimension,
+      static_cast<const cuDoubleComplex *>(devicePtr), 1,
+      static_cast<const cuDoubleComplex *>(otherData), 1, &dotResult);
+  if (stagedData)
+    cudaq::dynamics::DeviceAllocator::free(stagedData);
+  HANDLE_CUBLAS_ERROR(status);
 
-  Eigen::MatrixXcd otherState(matDim, matDim);
-  HANDLE_CUDA_ERROR(cudaMemcpy(otherState.data(), other.getTensor().data,
-                               dimension * sizeof(std::complex<double>),
-                               cudaMemcpyDeviceToHost));
-
-  return (state.adjoint() * otherState).trace();
+  const std::complex<double> dot{cuCreal(dotResult), cuCimag(dotResult)};
+  // State vectors report the magnitude of the overlap and density matrices
+  // report the Hilbert-Schmidt inner product itself.
+  return isDensityMatrix ? dot : std::complex<double>{std::abs(dot), 0.0};
 }
 
 std::complex<double>

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -62,8 +62,9 @@ CuDensityMatState::overlap(const cudaq::SimulationState &other) {
   }
 
   cuDoubleComplex dotResult;
-  const auto status = cublasZdotc(
-      dynamics::Context::getCurrentContext()->getCublasHandle(), dimension,
+  const auto status = cublasZdotc_64(
+      dynamics::Context::getCurrentContext()->getCublasHandle(),
+      static_cast<int64_t>(dimension),
       static_cast<const cuDoubleComplex *>(devicePtr), 1,
       static_cast<const cuDoubleComplex *>(otherData), 1, &dotResult);
   if (stagedData)

--- a/unittests/dynamics/test_CuDensityMatState.cpp
+++ b/unittests/dynamics/test_CuDensityMatState.cpp
@@ -322,6 +322,61 @@ TEST_F(CuDensityMatStateTest, DensityMatrixOverlapPartial) {
   EXPECT_NEAR(result.imag(), 0.0, 1e-12);
 }
 
+// The Hilbert-Schmidt inner product conjugates the left operand, so a
+// complex-valued density matrix pins down the conjugation. Dropping it would
+// make the self-overlap below 0 instead of 1.
+TEST_F(CuDensityMatStateTest, DensityMatrixOverlapComplex) {
+  std::vector<int64_t> dims1q = {2};
+
+  std::vector<std::complex<double>> dmPlusI = {
+      {0.5, 0.0}, {0.0, 0.5}, {0.0, -0.5}, {0.5, 0.0}};
+  CuDensityMatState statePlusI(dmPlusI.size(),
+                               cudaq::dynamics::createArrayGpu(dmPlusI));
+  statePlusI.initialize_cudm(handle, dims1q, /*batchSize=*/1);
+
+  auto self = statePlusI.overlap(statePlusI);
+  EXPECT_NEAR(self.real(), 1.0, 1e-12);
+  EXPECT_NEAR(self.imag(), 0.0, 1e-12);
+
+  std::vector<std::complex<double>> dmPlus = {
+      {0.5, 0.0}, {0.5, 0.0}, {0.5, 0.0}, {0.5, 0.0}};
+  CuDensityMatState statePlus(dmPlus.size(),
+                              cudaq::dynamics::createArrayGpu(dmPlus));
+  statePlus.initialize_cudm(handle, dims1q, /*batchSize=*/1);
+
+  auto cross = statePlusI.overlap(statePlus);
+  EXPECT_NEAR(cross.real(), 0.5, 1e-12);
+  EXPECT_NEAR(cross.imag(), 0.0, 1e-12);
+}
+
+// State vectors report the magnitude of <psi|phi>.
+TEST_F(CuDensityMatStateTest, StateVectorOverlap) {
+  CuDensityMatState state00(stateVectorData.size(),
+                            cudaq::dynamics::createArrayGpu(stateVectorData));
+  state00.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
+  EXPECT_FALSE(state00.is_density_matrix());
+
+  auto self = state00.overlap(state00);
+  EXPECT_NEAR(self.real(), 1.0, 1e-12);
+
+  const double invSqrt2 = 1.0 / std::sqrt(2.0);
+  std::vector<std::complex<double>> phiData = {
+      {invSqrt2, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, invSqrt2}};
+  CuDensityMatState phi(phiData.size(),
+                        cudaq::dynamics::createArrayGpu(phiData));
+  phi.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
+
+  auto cross = state00.overlap(phi);
+  EXPECT_NEAR(cross.real(), invSqrt2, 1e-12);
+
+  std::vector<std::complex<double>> ketData = {
+      {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}};
+  CuDensityMatState ket11(ketData.size(),
+                          cudaq::dynamics::createArrayGpu(ketData));
+  ket11.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
+  EXPECT_NEAR(state00.overlap(ket11).real(), 0.0, 1e-12);
+}
+
 // Test indexing for single-qubit density matrix
 TEST_F(CuDensityMatStateTest, SingleQubitDensityMatrixIndexing) {
   // 1-qubit system: 2x2 density matrix (4 elements)


### PR DESCRIPTION
The density-matrix branch of `overlap()` computed `Tr(rho1^dag rho2)` by copying both N x N matrices to host memory and forming the full Eigen matrix product `(state.adjoint() * otherState)`, then discarding everything but the diagonal. That is O(N^3) host flops, two device-to-host transfers, and two N^2-element host allocations to produce a value that is just the element-wise sum `sum_ij conj(a_ij) * b_ij`. The state-vector branch had the same host round-trip.

Both branches are the same conjugated dot product over the flat element buffer, so `overlap()` is now a single `cublasZdotc` on the device (O(N^2), no host copies, no host allocation). State vectors still report the magnitude of `<psi|phi>` and density matrices still report the Hilbert-Schmidt inner product itself.

- Performance

| Qubits | N | Before | After | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| 6 | 64 | 0.07 ms | 0.018 ms | 3.7x |
| 8 | 256 | 1.07 ms | 0.025 ms | 42.6x |
| 10 | 1024 | 11.49 ms | 0.066 ms | 175.0x |
| 11 | 2048 | 43.78 ms | 0.207 ms | 211.1x |

where, N is the Hilbert-space dimension (the side length of the density matrix, i.e. 2 ^ (number of qubits)).

Note: Host memory per call drops from 2 * N ^ 2 complex doubles (128 MB at 11 qubits) to zero.

