### PR TITLE
Make phase folding scope-aware and respect atomic quantum regions

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
@@ -12,8 +12,10 @@
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace cudaq::opt {
@@ -112,6 +114,7 @@ public:
 class PhaseStorage {
   DenseMap<PhaseKey, cudaq::quake::OperatorInterface, PhaseKeyInfo> phaseToRot;
   size_t numCombined = 0;
+  DominanceInfo &domInfo;
 
   // Returns the angle of a named Z-axis gate as a multiple of pi/4 (mod 8),
   // or nullopt for quake.rz (angle not statically known as a named gate).
@@ -229,13 +232,35 @@ class PhaseStorage {
                                    ValueRange{}, ValueRange{wireIn}, {}));
   }
 
+  bool canUseEarlierAngle(cudaq::quake::OperatorInterface earlier,
+                          cudaq::quake::OperatorInterface later) {
+    auto *earlierOp = earlier.getOperation();
+    auto *laterOp = later.getOperation();
+    if (isa<cudaq::quake::SOp>(earlierOp) ||
+        isa<cudaq::quake::TOp>(earlierOp) ||
+        isa<cudaq::quake::ZOp>(earlierOp)) {
+      return true;
+    }
+    if (auto rzOp = dyn_cast<cudaq::quake::RzOp>(earlierOp)) {
+      Value angleValue = rzOp.getOperand(0);
+      return domInfo.dominates(angleValue, laterOp);
+    }
+    return false;
+  }
+
 public:
+  PhaseStorage(DominanceInfo &domInfo) : domInfo(domInfo) {}
+
   // Returns the stored or combined op (nullptr if identity cancellation).
   Operation *addOrCombineRotationForPhase(cudaq::quake::OperatorInterface rot,
                                           Phase phase) {
     auto key = phase.toKey();
     auto it = phaseToRot.find(key);
     if (it != phaseToRot.end()) {
+      if (!canUseEarlierAngle(it->second, rot)) {
+        it->second = rot;
+        return rot.getOperation();
+      }
       auto *newOp = combineRotations(it->second, rot);
       if (newOp)
         it->second = cast<cudaq::quake::OperatorInterface>(newOp);
@@ -295,7 +320,22 @@ static bool isControlledOp(Operation *op) {
   return true;
 }
 
-static bool isTerminationPoint(Operation *op) {
+static Block *getPhaseFoldingBlock(Operation *op) {
+  auto *block = op->getBlock();
+  auto *parent = block->getParentOp();
+  // A wire captured by an ordinary scope reaches nested operations without
+  // passing through the ScopeOp, so compare the enclosing folding domains
+  // rather than relying on the wire walk to encounter the boundary itself.
+  while (auto scope = dyn_cast_or_null<cudaq::cc::ScopeOp>(parent)) {
+    if (scope.getAtomicQuantumRegionAttr() || !scope.getRegion().hasOneBlock())
+      break;
+    block = scope->getBlock();
+    parent = block->getParentOp();
+  }
+  return block;
+}
+
+static bool isSubCircuitTerminationPoint(Operation *op) {
   if (!op)
     return true;
   if (!isQuakeOperation(op))
@@ -331,6 +371,17 @@ protected:
   SetVector<Value> termination_points;
   SetVector<Value> anchor_points;
   SetVector<Value> seen;
+  // Keep the operand slot, not its current value: combining rotations rewires
+  // the slot before erasing the old value that it used to reference.
+  DenseMap<Value, OpOperand *> scope_result_to_continue_operand;
+
+  bool isTerminationPoint(Operation *op) {
+    if (!op)
+      return true;
+    if (isSubCircuitTerminationPoint(op))
+      return true;
+    return getPhaseFoldingBlock(op) != getPhaseFoldingBlock(start);
+  }
 
   bool isAfterTerminationPoint(Value wire) {
     return isTerminationPoint(wire.getDefiningOp());
@@ -347,7 +398,30 @@ protected:
       addTerminationPoint(v);
       return;
     }
-    Operation *op = v.getUses().begin().getUser();
+    OpOperand *use = &*v.getUses().begin();
+    Operation *op = use->getOwner();
+    if (auto cont = dyn_cast<cudaq::cc::ContinueOp>(op)) {
+      // Ordinary single-block scopes preserve wire identity, so their yielded
+      // wire can remain in this subcircuit. Marked or CFG-bearing scopes do not
+      // have that transparent-boundary contract.
+      auto scope = dyn_cast<cudaq::cc::ScopeOp>(cont->getParentOp());
+      if (!scope || scope.getAtomicQuantumRegionAttr() ||
+          !scope.getInitRegion().hasOneBlock() ||
+          scope.getInitRegion().front().getTerminator() != op ||
+          cont.getNumOperands() != scope->getNumResults() ||
+          use->getOperandNumber() >= scope->getNumResults()) {
+        addTerminationPoint(v);
+        return;
+      }
+      auto nextResult = scope->getResult(use->getOperandNumber());
+      if (!isa<cudaq::quake::WireType>(nextResult.getType())) {
+        addTerminationPoint(v);
+        return;
+      }
+      scope_result_to_continue_operand[nextResult] = use;
+      calculateSubcircuitForQubitForward(nextResult);
+      return;
+    }
     if (isTerminationPoint(op)) {
       addTerminationPoint(v);
       return;
@@ -371,6 +445,27 @@ protected:
       return;
     seen.insert(v);
     Operation *op = v.getDefiningOp();
+    if (auto scope = dyn_cast_or_null<cudaq::cc::ScopeOp>(op)) {
+      // The ScopeOp result hides the quantum operation that produced the
+      // yielded wire. Recover that wire so the backward walk follows the same
+      // path as the forward walk.
+      if (scope.getAtomicQuantumRegionAttr() ||
+          !scope.getRegion().hasOneBlock()) {
+        addTerminationPoint(v);
+        return;
+      }
+      auto resultIndex = cast<OpResult>(v).getResultNumber();
+      auto continueOp = dyn_cast_or_null<cudaq::cc::ContinueOp>(
+          scope.getInitRegion().front().getTerminator());
+      if (!continueOp || continueOp.getNumOperands() <= resultIndex) {
+        addTerminationPoint(v);
+        return;
+      }
+      OpOperand *continueOperand = &continueOp->getOpOperand(resultIndex);
+      scope_result_to_continue_operand[v] = continueOperand;
+      calculateSubcircuitForQubitBackward(continueOperand->get());
+      return;
+    }
     if (isTerminationPoint(op)) {
       addTerminationPoint(v);
       return;
@@ -412,6 +507,9 @@ protected:
 
 public:
   Subcircuit(Operation *cnot, DenseSet<Operation *> &processedOps) {
+    // Boundary checks compare discovered operations with the anchor's folding
+    // domain, so the anchor must be available before either wire walk begins.
+    start = cnot;
     calculateInitialSubcircuit(cnot);
     // TODO: there is a performance issue that the current pruning definition
     // will always preference earlier operations, so a large interconnected
@@ -423,7 +521,7 @@ public:
     // `processedOps`. This is likely also an issue in the ref semantics form.
     for (auto *op : ops)
       processedOps.insert(op);
-    start = cnot;
+
     for (auto w : termination_points)
       if (isAfterTerminationPoint(w))
         initial_wires.insert(w);
@@ -432,7 +530,6 @@ public:
   }
 
   SetVector<Value> getInitialWires() { return initial_wires; }
-  bool isInSubcircuit(Operation *op) { return ops.contains(op); }
   size_t getNumOps() { return ops.size(); }
 
   float getRotationWeight() {
@@ -446,10 +543,19 @@ public:
   }
 
   SmallVector<Operation *> getOrderedOps() {
-    SmallVector<Operation *> ordered(ops.begin(), ops.end());
-    sort(ordered,
-         [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
-    return ordered;
+    // Transparent scopes place subcircuit operations in different blocks;
+    // region-aware ordering preserves producer-before-consumer phase updates.
+    auto ordered = topologicalSort(ops);
+    return {ordered.begin(), ordered.end()};
+  }
+
+  Value resolveScopeResult(Value v) {
+    auto it = scope_result_to_continue_operand.find(v);
+    while (it != scope_result_to_continue_operand.end()) {
+      v = it->second->get();
+      it = scope_result_to_continue_operand.find(v);
+    }
+    return v;
   }
 };
 
@@ -490,10 +596,16 @@ class PhaseFoldingPass
     : public cudaq::opt::impl::PhaseFoldingBase<PhaseFoldingPass> {
   using PhaseFoldingBase::PhaseFoldingBase;
 
-  void doWirePhaseFolding(wire::Subcircuit *subcircuit) {
+  void doWirePhaseFolding(wire::Subcircuit *subcircuit,
+                          DominanceInfo &domInfo) {
     DenseMap<Value, Phase> wirePhase;
+    auto getWirePhase = [&](Value v) -> Phase {
+      // A scope result and its continue operand name the same wire but are
+      // distinct SSA keys. Normalize them before consulting the phase map.
+      return wirePhase[subcircuit->resolveScopeResult(v)];
+    };
     SmallVector<std::unique_ptr<PhaseVariable>> vars;
-    PhaseStorage store;
+    PhaseStorage store(domInfo);
     size_t i = 0;
 
     for (auto w : subcircuit->getInitialWires()) {
@@ -504,24 +616,24 @@ class PhaseFoldingPass
     for (auto *op : subcircuit->getOrderedOps()) {
       if (wire::isControlledOp(op)) {
         auto opi = dyn_cast<cudaq::quake::OperatorInterface>(op);
-        Phase ctrlPhase = wirePhase[opi.getControls().front()];
-        Phase tgtPhase = wirePhase[opi.getTarget(0)];
+        Phase ctrlPhase = getWirePhase(opi.getControls().front());
+        Phase tgtPhase = getWirePhase(opi.getTarget(0));
         wirePhase[op->getResult(0)] = ctrlPhase;
         wirePhase[op->getResult(1)] = Phase::sum(ctrlPhase, tgtPhase);
       } else if (isa<cudaq::quake::XOp>(op)) {
         // AXIS-SPECIFIC: Would want to handle y and z gates here too
         auto opi = dyn_cast<cudaq::quake::OperatorInterface>(op);
         wirePhase[op->getResult(0)] =
-            Phase::invert(wirePhase[opi.getTarget(0)]);
+            Phase::invert(getWirePhase(opi.getTarget(0)));
       } else if (isa<RAW_Z_AXIS_ROTATIONS>(op)) {
         auto opi = cast<cudaq::quake::OperatorInterface>(op);
-        Phase p = wirePhase[opi.getTarget(0)];
+        Phase p = getWirePhase(opi.getTarget(0));
         auto *newOp = store.addOrCombineRotationForPhase(opi, p);
         if (newOp)
           wirePhase[newOp->getResult(0)] = p;
       } else if (auto swap = dyn_cast<cudaq::quake::SwapOp>(op)) {
-        Phase p0 = wirePhase[swap.getTarget(0)];
-        Phase p1 = wirePhase[swap.getTarget(1)];
+        Phase p0 = getWirePhase(swap.getTarget(0));
+        Phase p1 = getWirePhase(swap.getTarget(1));
         wirePhase[op->getResult(0)] = p1;
         wirePhase[op->getResult(1)] = p0;
       }
@@ -535,6 +647,8 @@ public:
       return;
     if (func->hasAttr(cudaq::runtime::disableQuantumOpts))
       return;
+
+    DominanceInfo domInfo(func);
 
     // Collect CNOTs first to avoid iterator invalidation: combineRotations
     // erases Rz ops which may be the stored next-pointer in the walk iterator.
@@ -558,7 +672,7 @@ public:
         LLVM_DEBUG(llvm::dbgs() << "Subcircuit below threshold, skipping!\n");
         continue;
       }
-      doWirePhaseFolding(&subcircuit);
+      doWirePhaseFolding(&subcircuit, domInfo);
     }
   }
 };

--- a/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
@@ -147,35 +147,48 @@ class PhaseStorage {
     return cudaq::opt::factory::createF64Constant(op->getLoc(), builder, angle);
   }
 
-  // Combine rot1 (stored) and rot2 (new, the surviving position).
-  // rot2's wire input (= rot1's output) is used for the new op.
-  // rot1 is bypassed (its output replaced by its own input), then erased.
+  // Keep chronological order separate from the insertion position so the
+  // combined angle can be materialized wherever both operands are available.
   // Returns the new combined op, or nullptr if they cancel to identity.
-  Operation *combineRotations(cudaq::quake::OperatorInterface rot1,
-                              cudaq::quake::OperatorInterface rot2) {
-    auto *op1 = rot1.getOperation();
-    auto *op2 = rot2.getOperation();
-    OpBuilder builder(op2);
-    auto loc = op2->getLoc();
-    auto *ctx = op2->getContext();
+  Operation *
+  combineRotations(cudaq::quake::OperatorInterface earlier,
+                   cudaq::quake::OperatorInterface later,
+                   cudaq::quake::OperatorInterface insertionRotation) {
+    auto *earlierOp = earlier.getOperation();
+    auto *laterOp = later.getOperation();
+    auto *insertionOp = insertionRotation.getOperation();
+    bool combineAtEarlier = insertionOp == earlierOp;
+    OpBuilder builder(insertionOp);
+    auto loc = insertionOp->getLoc();
+    auto *ctx = insertionOp->getContext();
     auto wireTy = cudaq::quake::WireType::get(ctx);
-    Value wireIn = rot2.getTarget(0); // rot1's result (B)
-    Value prevIn = rot1.getTarget(0); // rot1's input (A)
+    Value wireIn = insertionRotation.getTarget(0);
+    Value earlierIn = earlier.getTarget(0);
+    Value laterIn = later.getTarget(0);
     numCombined++;
 
     auto finalize = [&](Operation *newOp) -> Operation * {
-      op2->getResult(0).replaceAllUsesWith(newOp ? newOp->getResult(0)
-                                                 : wireIn);
-      op2->erase();
-      op1->getResult(0).replaceAllUsesWith(prevIn);
-      op1->erase();
+      Value combinedResult = newOp ? newOp->getResult(0) : wireIn;
+      if (combineAtEarlier) {
+        // Bypass the later rotation before erasing the earlier one. Its input
+        // may still be the earlier result when the rotations are adjacent.
+        laterOp->getResult(0).replaceAllUsesWith(laterIn);
+        laterOp->erase();
+        earlierOp->getResult(0).replaceAllUsesWith(combinedResult);
+        earlierOp->erase();
+      } else {
+        laterOp->getResult(0).replaceAllUsesWith(combinedResult);
+        laterOp->erase();
+        earlierOp->getResult(0).replaceAllUsesWith(earlierIn);
+        earlierOp->erase();
+      }
       return newOp;
     };
 
     // If both are named gates (S/T/Z), combine via exact integer arithmetic
     // on quarter-pi units (0..7 mod 8) — no floating-point comparison.
-    auto u1 = getQuarterPiUnits(rot1);
-    auto u2 = getQuarterPiUnits(rot2);
+    auto u1 = getQuarterPiUnits(earlier);
+    auto u2 = getQuarterPiUnits(later);
     if (u1 && u2) {
       int combined = (*u1 + *u2) & 7;
       switch (combined) {
@@ -223,8 +236,8 @@ class PhaseStorage {
     }
 
     // Rz + anything, or named-gate combo not landing on a named gate: addf
-    Value angle1 = getRotAngleValue(builder, rot1);
-    Value angle2 = getRotAngleValue(builder, rot2);
+    Value angle1 = getRotAngleValue(builder, earlier);
+    Value angle2 = getRotAngleValue(builder, later);
     auto sumAngle = arith::AddFOp::create(builder, loc, angle1, angle2);
     return finalize(
         cudaq::quake::RzOp::create(builder, loc, TypeRange{wireTy}, false,
@@ -232,18 +245,17 @@ class PhaseStorage {
                                    ValueRange{}, ValueRange{wireIn}, {}));
   }
 
-  bool canUseEarlierAngle(cudaq::quake::OperatorInterface earlier,
-                          cudaq::quake::OperatorInterface later) {
-    auto *earlierOp = earlier.getOperation();
-    auto *laterOp = later.getOperation();
-    if (isa<cudaq::quake::SOp>(earlierOp) ||
-        isa<cudaq::quake::TOp>(earlierOp) ||
-        isa<cudaq::quake::ZOp>(earlierOp)) {
+  bool canUseAngleAt(cudaq::quake::OperatorInterface rotation,
+                     Operation *insertionPoint) {
+    auto *rotationOp = rotation.getOperation();
+    if (isa<cudaq::quake::SOp>(rotationOp) ||
+        isa<cudaq::quake::TOp>(rotationOp) ||
+        isa<cudaq::quake::ZOp>(rotationOp)) {
       return true;
     }
-    if (auto rzOp = dyn_cast<cudaq::quake::RzOp>(earlierOp)) {
+    if (auto rzOp = dyn_cast<cudaq::quake::RzOp>(rotationOp)) {
       Value angleValue = rzOp.getOperand(0);
-      return domInfo.dominates(angleValue, laterOp);
+      return domInfo.dominates(angleValue, insertionPoint);
     }
     return false;
   }
@@ -257,11 +269,16 @@ public:
     auto key = phase.toKey();
     auto it = phaseToRot.find(key);
     if (it != phaseToRot.end()) {
-      if (!canUseEarlierAngle(it->second, rot)) {
-        it->second = rot;
-        return rot.getOperation();
+      bool combineAtEarlier = false;
+      if (!canUseAngleAt(it->second, rot.getOperation())) {
+        if (!canUseAngleAt(rot, it->second.getOperation())) {
+          it->second = rot;
+          return rot.getOperation();
+        }
+        combineAtEarlier = true;
       }
-      auto *newOp = combineRotations(it->second, rot);
+      auto insertionRotation = combineAtEarlier ? it->second : rot;
+      auto *newOp = combineRotations(it->second, rot, insertionRotation);
       if (newOp)
         it->second = cast<cudaq::quake::OperatorInterface>(newOp);
       else
@@ -365,7 +382,7 @@ protected:
   SetVector<Operation *> ops;
   SetVector<Value> initial_wires;
   SetVector<Value> terminal_wires;
-  Operation *start;
+  Block *start;
   // TODO: these three are really intermediate state for constructing the
   // subcircuit; would be nice to turn them into local arguments instead
   SetVector<Value> termination_points;
@@ -380,7 +397,7 @@ protected:
       return true;
     if (isSubCircuitTerminationPoint(op))
       return true;
-    return getPhaseFoldingBlock(op) != getPhaseFoldingBlock(start);
+    return getPhaseFoldingBlock(op) != start;
   }
 
   bool isAfterTerminationPoint(Value wire) {
@@ -507,9 +524,9 @@ protected:
 
 public:
   Subcircuit(Operation *cnot, DenseSet<Operation *> &processedOps) {
-    // Boundary checks compare discovered operations with the anchor's folding
-    // domain, so the anchor must be available before either wire walk begins.
-    start = cnot;
+    // The anchor's folding domain does not change while building the
+    // subcircuit, so cache it.
+    start = getPhaseFoldingBlock(cnot);
     calculateInitialSubcircuit(cnot);
     // TODO: there is a performance issue that the current pruning definition
     // will always preference earlier operations, so a large interconnected

--- a/cudaq/test/Transforms/phase_folding_atomic_region.qke
+++ b/cudaq/test/Transforms/phase_folding_atomic_region.qke
@@ -135,10 +135,10 @@ func.func @fold_dynamic_phases_across_ordinary_scope(%first: f64,
 // CHECK:           return
 // CHECK:         }
 
-// An ordinary scope is transparent to phase analysis, but the inner angle does
-// not dominate the later rotation outside the scope. The pass must decline the
-// fold rather than make the angle escape or create invalid SSA.
-func.func @inner_angle_does_not_escape_ordinary_scope(%outer: f64) {
+// The inner angle cannot escape the scope, but the later angle is a function
+// argument that already dominates the earlier rotation. Combine at the earlier
+// rotation.
+func.func @later_dynamic_angle_folds_at_earlier_rotation(%later: f64) {
   %control = quake.null_wire
   %target = quake.null_wire
   %scope = cc.scope -> (!quake.wire) {
@@ -148,12 +148,75 @@ func.func @inner_angle_does_not_escape_ordinary_scope(%outer: f64) {
     %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     cc.continue %cx1#1 : !quake.wire
   }
-  %after = quake.rz (%outer) %scope : (f64, !quake.wire) -> !quake.wire
+  %after = quake.rz (%later) %scope : (f64, !quake.wire) -> !quake.wire
   return
 }
 
-// CHECK-LABEL:   func.func @inner_angle_does_not_escape_ordinary_scope(
+// CHECK-LABEL:   func.func @later_dynamic_angle_folds_at_earlier_rotation(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: f64) {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[CONSTANT_0:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[CONSTANT_0]], %[[ARG0]] : f64
+// CHECK:             %[[RZ_0:.*]] = quake.rz (%[[ADDF_0]]) %[[NULL_WIRE_1]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[RZ_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
+// CHECK:           }
+// CHECK-NEXT:      return
+// CHECK:         }
+
+// A named gate has no SSA angle dependency, so it can always be combined at
+// the earlier dynamic rotation when that is the legal insertion point.
+func.func @later_named_angle_folds_at_earlier_rotation() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %scope = cc.scope -> (!quake.wire) {
+    %inner = arith.constant 1.000000e+00 : f64
+    %before = quake.rz (%inner) %target : (f64, !quake.wire) -> !quake.wire
+    %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %cx1#1 : !quake.wire
+  }
+  %after = quake.s %scope : (!quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @later_named_angle_folds_at_earlier_rotation() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[CONSTANT_0:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:             %[[CONSTANT_1:.*]] = arith.constant 1.5707963267948966 : f64
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[CONSTANT_0]], %[[CONSTANT_1]] : f64
+// CHECK:             %[[RZ_0:.*]] = quake.rz (%[[ADDF_0]]) %[[NULL_WIRE_1]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[RZ_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
+// CHECK:           }
+// CHECK-NEXT:      return
+// CHECK:         }
+
+// If each dynamic angle is defined on its own side of the scope boundary,
+// neither rotation is a legal insertion point for their sum. Leave both
+// rotations unchanged.
+func.func @angles_without_a_common_insertion_point_do_not_fold() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %scope = cc.scope -> (!quake.wire) {
+    %inner = arith.constant 1.000000e+00 : f64
+    %before = quake.rz (%inner) %target : (f64, !quake.wire) -> !quake.wire
+    %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %cx1#1 : !quake.wire
+  }
+  %later = arith.constant 2.000000e+00 : f64
+  %after = quake.rz (%later) %scope : (f64, !quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @angles_without_a_common_insertion_point_do_not_fold() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
 // CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
@@ -163,8 +226,9 @@ func.func @inner_angle_does_not_escape_ordinary_scope(%outer: f64) {
 // CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
 // CHECK:           }
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2.000000e+00 : f64
 // CHECK-NOT:       arith.addf
-// CHECK:           %[[RZ_1:.*]] = quake.rz (%[[ARG0]]) %[[SCOPE_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           %[[RZ_1:.*]] = quake.rz (%[[CONSTANT_1]]) %[[SCOPE_0]] : (f64, !quake.wire) -> !quake.wire
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/phase_folding_atomic_region.qke
+++ b/cudaq/test/Transforms/phase_folding_atomic_region.qke
@@ -1,0 +1,340 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --phase-folding="min-length=0 min-rz-weight=0" %s | FileCheck %s
+
+// An ordinary single-block scope is transparent to phase analysis. The two
+// CNOTs restore the target's phase, so the two S gates have the same phase and
+// combine to Z.
+func.func @fold_named_phases_across_ordinary_scope() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %before = quake.s %target : (!quake.wire) -> !quake.wire
+  %scope = cc.scope -> (!quake.wire) {
+    %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %cx1#1 : !quake.wire
+  }
+  %after = quake.s %scope : (!quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @fold_named_phases_across_ordinary_scope() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
+// CHECK:           }
+// CHECK:           %[[Z_0:.*]] = quake.z %[[SCOPE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }
+
+// An inner marked scope is a distinct folding domain from its marked parent.
+// Rotations immediately outside and inside the nested boundary must not merge.
+func.func @nested_marked_scopes_do_not_share_phases() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %outer = cc.scope -> (!quake.wire) {
+    %before = quake.s %target : (!quake.wire) -> !quake.wire
+    %inner = cc.scope -> (!quake.wire) {
+      %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+      %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+      %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
+      cc.continue %after : !quake.wire
+    } {atomic_quantum_region}
+    cc.continue %inner : !quake.wire
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @nested_marked_scopes_do_not_share_phases() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:               %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[S_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:               %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:               %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
+// CHECK:               cc.continue %[[S_1]] : !quake.wire
+// CHECK:             } {atomic_quantum_region}
+// CHECK:             cc.continue %[[SCOPE_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return
+// CHECK:         }
+
+// Sequential marked scopes are separate folding domains even when the second
+// consumes the first scope's result on the same wire path.
+func.func @sibling_marked_scopes_do_not_share_phases() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %first = cc.scope -> (!quake.wire) {
+    %before = quake.s %target : (!quake.wire) -> !quake.wire
+    cc.continue %before : !quake.wire
+  } {atomic_quantum_region}
+  %second = cc.scope -> (!quake.wire) {
+    %cx0:2 = quake.x [%control] %first : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
+    cc.continue %after : !quake.wire
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @sibling_marked_scopes_do_not_share_phases() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[S_0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[SCOPE_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[S_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return
+// CHECK:         }
+
+// Dynamic angles may also combine across an ordinary scope when both angle
+// values already dominate the surviving rotation outside the scope.
+func.func @fold_dynamic_phases_across_ordinary_scope(%first: f64,
+                                                     %second: f64) {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %before = quake.rz (%first) %target : (f64, !quake.wire) -> !quake.wire
+  %scope = cc.scope -> (!quake.wire) {
+    %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %cx1#1 : !quake.wire
+  }
+  %after = quake.rz (%second) %scope : (f64, !quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @fold_dynamic_phases_across_ordinary_scope(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: f64,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: f64) {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
+// CHECK:           }
+// CHECK:           %[[ADDF_0:.*]] = arith.addf %[[ARG0]], %[[ARG1]] : f64
+// CHECK:           %[[RZ_0:.*]] = quake.rz (%[[ADDF_0]]) %[[SCOPE_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }
+
+// An ordinary scope is transparent to phase analysis, but the inner angle does
+// not dominate the later rotation outside the scope. The pass must decline the
+// fold rather than make the angle escape or create invalid SSA.
+func.func @inner_angle_does_not_escape_ordinary_scope(%outer: f64) {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %scope = cc.scope -> (!quake.wire) {
+    %inner = arith.constant 1.000000e+00 : f64
+    %before = quake.rz (%inner) %target : (f64, !quake.wire) -> !quake.wire
+    %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %cx1#1 : !quake.wire
+  }
+  %after = quake.rz (%outer) %scope : (f64, !quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @inner_angle_does_not_escape_ordinary_scope(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: f64) {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[CONSTANT_0:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:             %[[RZ_0:.*]] = quake.rz (%[[CONSTANT_0]]) %[[NULL_WIRE_1]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[RZ_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
+// CHECK:           }
+// CHECK-NOT:       arith.addf
+// CHECK:           %[[RZ_1:.*]] = quake.rz (%[[ARG0]]) %[[SCOPE_0]] : (f64, !quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }
+
+// Backward phase analysis crosses an ordinary scope result through the
+// matching cc.continue operand. The CNOT pair restores the target's phase, so
+// the S gates inside and outside the scope combine to Z.
+func.func @fold_named_phases_backward_through_ordinary_scope() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %scope = cc.scope -> (!quake.wire) {
+    %inside = quake.s %target : (!quake.wire) -> !quake.wire
+    cc.continue %inside : !quake.wire
+  }
+  %cx0:2 = quake.x [%control] %scope : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %outside = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @fold_named_phases_backward_through_ordinary_scope() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             cc.continue %[[NULL_WIRE_1]] : !quake.wire
+// CHECK:           }
+// CHECK:           %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[SCOPE_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[Z_0:.*]] = quake.z %[[X_1]]#1 : (!quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }
+
+// The same backward step must stop when the scope is an atomic quantum
+// region, leaving the inside and outside rotations unchanged.
+func.func @phases_do_not_fold_backward_through_marked_scope() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %scope = cc.scope -> (!quake.wire) {
+    %inside = quake.s %target : (!quake.wire) -> !quake.wire
+    cc.continue %inside : !quake.wire
+  } {atomic_quantum_region}
+  %cx0:2 = quake.x [%control] %scope : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %outside = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @phases_do_not_fold_backward_through_marked_scope() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[S_0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[SCOPE_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }
+
+// A marked scope blocks phase folding at its entry. Even though the CNOT pair
+// restores the target's phase, the rotation outside the scope must not combine
+// with the rotation inside it.
+func.func @phases_do_not_fold_across_marked_scope_entry() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %outside = quake.s %target : (!quake.wire) -> !quake.wire
+  %scope = cc.scope -> (!quake.wire) {
+    %cx0:2 = quake.x [%control] %outside : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %inside = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
+    cc.continue %inside : !quake.wire
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @phases_do_not_fold_across_marked_scope_entry() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[S_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[S_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return
+// CHECK:         }
+
+// A marked scope also blocks phase folding at its exit. A rotation inside the
+// scope must not combine with a rotation consuming the scope result.
+func.func @phases_do_not_fold_across_marked_scope_exit() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %scope = cc.scope -> (!quake.wire) {
+    %inside = quake.s %target : (!quake.wire) -> !quake.wire
+    %cx0:2 = quake.x [%control] %inside : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %cx1#1 : !quake.wire
+  } {atomic_quantum_region}
+  %outside = quake.s %scope : (!quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @phases_do_not_fold_across_marked_scope_exit() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[S_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[S_1:.*]] = quake.s %[[SCOPE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }
+
+// The marker is a boundary, not a request to disable optimization. Rotations
+// wholly inside the marked scope still combine.
+func.func @phases_fold_inside_marked_scope() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %scope = cc.scope -> (!quake.wire) {
+    %before = quake.s %target : (!quake.wire) -> !quake.wire
+    %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
+    cc.continue %after : !quake.wire
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @phases_fold_inside_marked_scope() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[Z_0:.*]] = quake.z %[[X_1]]#1 : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[Z_0]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           return
+// CHECK:         }
+
+// A marked scope on a disjoint wire is not a global pass fence. The outside
+// target wire never crosses the scope, so its two S gates may still combine.
+func.func @disjoint_phases_fold_around_marked_scope() {
+  %control = quake.null_wire
+  %target = quake.null_wire
+  %disjoint = quake.null_wire
+  %before = quake.s %target : (!quake.wire) -> !quake.wire
+  %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %scope = cc.scope -> (!quake.wire) {
+    %inside = quake.x %disjoint : (!quake.wire) -> !quake.wire
+    cc.continue %inside : !quake.wire
+  } {atomic_quantum_region}
+  %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @disjoint_phases_fold_around_marked_scope() {
+// CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[NULL_WIRE_2:.*]] = quake.null_wire
+// CHECK:           %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[X_1:.*]] = quake.x %[[NULL_WIRE_2]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[X_1]] : !quake.wire
+// CHECK:           } {atomic_quantum_region}
+// CHECK:           %[[X_2:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[Z_0:.*]] = quake.z %[[X_2]]#1 : (!quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
### Summary

- Traverse wires through ordinary single-block `cc.scope` operations in both directions.
- Stop same-wire phase folding at atomic quantum region boundaries while retaining optimization inside marked regions and around disjoint ones.
- Use MLIR topological ordering and dominance information for SSA-safe cross-scope folding.