### PR TITLE
Fixing MemToReg producing invalid IR

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
@@ -1207,8 +1207,13 @@ public:
 
             // Parent is not a function.
             if (!isDescendantOf(parent, memuse)) {
-              // `block` is using a value from another scope.
-              if (aliasForBlock) {
+              // block is using a value from another scope.
+              // The aliasing barrier below is about quantum references only.
+              // A veq access cannot alias a stack slot, so a `cc.load` must
+              // still be promoted. Leaving it un-promoted strands it in the IR
+              // while its alloca is erased as dead, producing a null operand.
+              if (aliasForBlock &&
+                  isa<cudaq::quake::RefType>(memuse.getType())) {
                 // A dynamic veq-aliasing event already occurred in this block:
                 // a non-constant extract_ref from a veq defined outside this
                 // scope acts as a barrier — all wire chains must be wrapped

--- a/cudaq/test/Transforms/memtoreg-9.qke
+++ b/cudaq/test/Transforms/memtoreg-9.qke
@@ -1,0 +1,89 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --memtoreg %s | FileCheck %s
+
+// Example:
+//
+//   for (int b = 0; b < 4; b++)
+//     for (int c = b + 1; c < 4; c++)
+//       x<cudaq::ctrl>(q[b], q[c]);
+//
+// The dynamic extract_ref raises the quantum aliasing barrier for the block,
+// but a veq access cannot alias a stack slot, so both induction variables must
+// still be promoted.
+
+func.func @nested_loop_dynamic_extract() {
+  %c1_i32 = arith.constant 1 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c4_i32 = arith.constant 4 : i32
+  %0 = quake.alloca !quake.veq<4>
+  cc.scope {
+    %1 = cc.alloca i32
+    cc.store %c0_i32, %1 : !cc.ptr<i32>
+    cc.loop while {
+      %2 = cc.load %1 : !cc.ptr<i32>
+      %3 = arith.cmpi slt, %2, %c4_i32 : i32
+      cc.condition %3
+    } do {
+      cc.scope {
+        %2 = cc.load %1 : !cc.ptr<i32>
+        %3 = arith.addi %2, %c1_i32 : i32
+        %4 = cc.alloca i32
+        cc.store %3, %4 : !cc.ptr<i32>
+        cc.loop while {
+          %5 = cc.load %4 : !cc.ptr<i32>
+          %6 = arith.cmpi slt, %5, %c4_i32 : i32
+          cc.condition %6
+        } do {
+          %5 = cc.load %1 : !cc.ptr<i32>
+          %6 = cc.cast signed %5 : (i32) -> i64
+          %7 = quake.extract_ref %0[%6] : (!quake.veq<4>, i64) -> !quake.ref
+          %8 = cc.load %4 : !cc.ptr<i32>
+          %9 = cc.cast signed %8 : (i32) -> i64
+          %10 = quake.extract_ref %0[%9] : (!quake.veq<4>, i64) -> !quake.ref
+          quake.x [%7] %10 : (!quake.ref, !quake.ref) -> ()
+          cc.continue
+        } step {
+          %5 = cc.load %4 : !cc.ptr<i32>
+          %6 = arith.addi %5, %c1_i32 : i32
+          cc.store %6, %4 : !cc.ptr<i32>
+        }
+      }
+      cc.continue
+    } step {
+      %2 = cc.load %1 : !cc.ptr<i32>
+      %3 = arith.addi %2, %c1_i32 : i32
+      cc.store %3, %1 : !cc.ptr<i32>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @nested_loop_dynamic_extract() {
+// CHECK-NOT:       cc.alloca i32
+// CHECK-NOT:       cc.load
+// CHECK:           %[[VEQ:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           cc.loop while ((%{{.*}} = %{{.*}}) -> (i32)) {
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[OUTERARG:.*]]: i32):
+// CHECK:             %[[INIT:.*]] = arith.addi %[[OUTERARG]], %{{.*}} : i32
+// CHECK:             cc.loop while ((%{{.*}} = %[[INIT]]) -> (i32)) {
+// CHECK:             } do {
+// CHECK:             ^bb0(%[[INNERARG:.*]]: i32):
+// CHECK:               %[[CO:.*]] = cc.cast signed %[[OUTERARG]] : (i32) -> i64
+// CHECK:               %[[RO:.*]] = quake.extract_ref %[[VEQ]][%[[CO]]]
+// CHECK:               %[[CI:.*]] = cc.cast signed %[[INNERARG]] : (i32) -> i64
+// CHECK:               %[[RI:.*]] = quake.extract_ref %[[VEQ]][%[[CI]]]
+// CHECK:               quake.x
+// CHECK:               cc.continue %[[INNERARG]] : i32
+// CHECK:             }
+// CHECK:             cc.continue %[[OUTERARG]] : i32
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
`MemToReg` could produce invalid IR for nested loops indexing a `veq` with loop induction variables:
```
error: null operand found
```
note: `%14 = "cc.load"(<<NULL VALUE>>) : (<<NULL TYPE>>) -> i32`

A non-constant `quake.extract_ref` raises an aliasing barrier for the block, which was applied to all memory uses. But a `veq` access cannot alias a classical stack slot, so classical `cc.load`s were left un-promoted while their `cc.alloca` was still erased as dead, leaving a null operand behind.

The barrier now applies only to `!quake.ref` memory uses. Quantum wires are still conservatively wrapped/unwrapped around the dynamic extract, as before.