### PR TITLE
[CI blocker] Pulling the doxygen tarball from the gitHub release asset instead

### DIFF
--- a/docker/build/devdeps.Dockerfile
+++ b/docker/build/devdeps.Dockerfile
@@ -88,7 +88,9 @@ RUN cd /cuda-quantum && git init && \
 ## [Dev Dependencies]
 RUN if [ "$(uname -m)" == "x86_64" ]; then \
     # Pre-built binaries for doxygen are (only) available for x86_64.
-    wget https://www.doxygen.nl/files/doxygen-1.9.7.linux.bin.tar.gz && \
+    # Downloaded from the GitHub release rather than doxygen.nl, since the
+    # latter only hosts the files for the most recent release.
+    wget https://github.com/doxygen/doxygen/releases/download/Release_1_9_7/doxygen-1.9.7.linux.bin.tar.gz && \
     tar xf doxygen-1.9.7* && mv doxygen-1.9.7/bin/* /usr/local/bin/ && rm -rf doxygen-1.9.7*; \
     else \
     apt-get update && apt-get install -y --no-install-recommends make cmake flex bison g++ && \


### PR DESCRIPTION
Pulling the doxygen tarball from the gitHub release asset instead.

Fixes #5189
