### PR TITLE
[CI] unblock gh runner outage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   changes:
     name: Check for stable CUDA-Q changes
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       pull-requests: read
@@ -56,7 +56,7 @@ jobs:
     name: Retrieve PR info
     needs: changes
     if: needs.changes.outputs.stable == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       pull-requests: read
       contents: read
@@ -75,6 +75,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      # NVIDIA runners may not ship gh.
+      - name: Ensure gh
+        run: |
+          set -eu
+          command -v gh >/dev/null && exit 0
+          S=""; [ "$(id -u)" -eq 0 ] || S=sudo
+          v=2.63.2
+          curl -fsSL "https://github.com/cli/cli/releases/download/v$v/gh_${v}_linux_amd64.tar.gz" | tar -xz -C /tmp
+          $S install -m0755 "/tmp/gh_${v}_linux_amd64/bin/gh" /usr/local/bin/gh
 
       - id: config
         env:
@@ -261,7 +271,7 @@ jobs:
   # (no need to wait for all 14 dependency jobs before any build/test runs).
   config_devdeps:
     name: Configure build (devdeps)
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     needs: devdeps
     outputs:
       json: "${{ steps.read_json.outputs.result }}"
@@ -278,7 +288,7 @@ jobs:
 
   config_wheeldeps:
     name: Configure build (wheeldeps)
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     needs: [metadata, wheeldeps]
     if: needs.metadata.outputs.merge_queue_fast != 'true'
     outputs:
@@ -296,7 +306,7 @@ jobs:
 
   config_source_build:
     name: Configure build (source_build)
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     needs: [metadata, source_build]
     if: github.event_name != 'push' && needs.metadata.outputs.merge_queue_fast != 'true'
     outputs:
@@ -426,7 +436,7 @@ jobs:
   # Fails on `failure` or `cancelled` from any listed job.
   ci_summary:
     name: CI Summary
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       pull-requests: write
       contents: read
@@ -474,13 +484,28 @@ jobs:
             .github/required-checks.yml
           sparse-checkout-cone-mode: false
 
+      # NVIDIA runners may not ship gh/yq.
+      - name: Ensure gh and yq
+        run: |
+          set -eu
+          S=""; [ "$(id -u)" -eq 0 ] || S=sudo
+          if ! command -v yq >/dev/null; then
+            $S curl -fsSL -o /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            $S chmod +x /usr/local/bin/yq
+          fi
+          if ! command -v gh >/dev/null; then
+            v=2.63.2
+            curl -fsSL "https://github.com/cli/cli/releases/download/v$v/gh_${v}_linux_amd64.tar.gz" | tar -xz -C /tmp
+            $S install -m0755 "/tmp/gh_${v}_linux_amd64/bin/gh" /usr/local/bin/gh
+          fi
+
       # Catch the "added a top-level job but forgot to add it to ci_summary.needs"
       # footgun. The aggregator only gates on jobs in its `needs:` list, so any
       # job missing here would silently not block merging.
       - name: Verify ci_summary.needs covers all top-level jobs
         run: |
           set -euo pipefail
-          # yq is preinstalled on ubuntu-latest runners (mikefarah/yq).
           mapfile -t all_jobs < <(yq -r '.jobs | keys | .[]' .github/workflows/ci.yml | sort -u)
           mapfile -t needs_jobs < <(yq -r '.jobs.ci_summary.needs | .[]' .github/workflows/ci.yml | sort -u)
 
@@ -749,7 +774,7 @@ jobs:
 
   clean_up:
     name: Prepare cache clean-up
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     needs:
       - changes
       - metadata

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   changes:
     name: Check for stable CUDA-Q changes
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       pull-requests: read
@@ -64,7 +64,7 @@ jobs:
     name: Retrieve PR info
     needs: changes
     if: needs.changes.outputs.stable == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       pull-requests: read
       contents: read
@@ -78,6 +78,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      # NVIDIA runners may not ship gh.
+      - name: Ensure gh
+        run: |
+          set -eu
+          command -v gh >/dev/null && exit 0
+          S=""; [ "$(id -u)" -eq 0 ] || S=sudo
+          v=2.63.2
+          curl -fsSL "https://github.com/cli/cli/releases/download/v$v/gh_${v}_linux_amd64.tar.gz" | tar -xz -C /tmp
+          $S install -m0755 "/tmp/gh_${v}_linux_amd64/bin/gh" /usr/local/bin/gh
 
       - id: pr_info
         run: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -74,10 +74,29 @@ jobs:
       pull_request_base: ${{ steps.pr_info.outputs.pr_base }}
       cache_base: ${{ steps.pr_info.outputs.pr_base }}
       cudaq_version: ${{ steps.version.outputs.cudaq_version }}
+      skip_macos: ${{ steps.skip.outputs.skip_macos }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - id: skip
+        env:
+          # Repo variable. Unset/true keeps macOS out of PR and merge-queue
+          # builds while GitHub-hosted macOS runners are unavailable.
+          SKIP_MACOS_CI: ${{ vars.SKIP_MACOS_CI }}
+        run: |
+          # PR and merge queue only; schedule and dispatch keep macOS coverage.
+          skip=false
+          case "${{ github.event_name }}" in
+            push|merge_group)
+              case "$(echo "${SKIP_MACOS_CI:-true}" | tr '[:upper:]' '[:lower:]')" in
+                false|0|no|off) skip=false ;;
+                *) skip=true ;;
+              esac ;;
+          esac
+          echo "skip_macos=$skip" >> $GITHUB_OUTPUT
+          echo "Skip macOS CI: $skip (SKIP_MACOS_CI='${SKIP_MACOS_CI:-<unset>}')"
 
       # NVIDIA runners may not ship gh.
       - name: Ensure gh
@@ -130,6 +149,7 @@ jobs:
   devdeps:
     name: Load macOS dependencies
     needs: metadata
+    if: needs.metadata.outputs.skip_macos != 'true'
     uses: ./.github/workflows/dev_environment_macos.yml
     with:
       platforms: darwin/arm64
@@ -143,6 +163,7 @@ jobs:
   build_and_test:
     name: Build & Test (arm64)
     needs: [devdeps, metadata]
+    if: needs.metadata.outputs.skip_macos != 'true'
     runs-on: macos-26
     permissions:
       contents: read
@@ -234,6 +255,7 @@ jobs:
   wheel:
     name: Wheel (arm64, py${{ matrix.python_version }})
     needs: [devdeps, metadata]
+    if: needs.metadata.outputs.skip_macos != 'true'
     strategy:
       matrix:
         python_version: ['3.11', '3.12', '3.13', '3.14']
@@ -342,7 +364,8 @@ jobs:
   # ============================================================================
   validate_wheel:
     name: Validate (arm64, py${{ matrix.python_version }})
-    needs: wheel
+    needs: [wheel, metadata]
+    if: needs.metadata.outputs.skip_macos != 'true'
     strategy:
       matrix:
         python_version: ['3.11', '3.12', '3.13', '3.14']
@@ -395,6 +418,7 @@ jobs:
   installer:
     name: Installer (arm64)
     needs: [devdeps, metadata]
+    if: needs.metadata.outputs.skip_macos != 'true'
     runs-on: macos-26
     permissions:
       contents: read
@@ -499,7 +523,8 @@ jobs:
   # ============================================================================
   validate_installation:
     name: Validate Installation (arm64)
-    needs: [installer, wheel]
+    needs: [installer, wheel, metadata]
+    if: needs.metadata.outputs.skip_macos != 'true'
     runs-on: macos-26
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   changes:
     name: Check for stable CUDA-Q changes
-    runs-on: linux-amd64-cpu4
+    runs-on: ${{ (github.event_name == 'pull_request' && 'ubuntu-latest') || 'linux-amd64-cpu4' }}
     permissions:
       contents: read
       pull-requests: read
@@ -59,7 +59,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: linux-amd64-cpu4
+    runs-on: ${{ (github.event_name == 'pull_request' && 'ubuntu-latest') || 'linux-amd64-cpu4' }}
     permissions:
       packages: read # required to fetch internal or private CodeQL packs
       security-events: write
@@ -123,20 +123,11 @@ jobs:
           contents: read
           checks: read
           pull-requests: read
-      runs-on: linux-amd64-cpu4
+      runs-on: ${{ (github.event_name == 'pull_request' && 'ubuntu-latest') || 'linux-amd64-cpu4' }}
       if: >-
         ${{ github.event_name == 'pull_request' &&
             needs.changes.outputs.stable == 'true' }}
       steps:
-          # NVIDIA runners may not ship gh.
-          - name: Ensure gh
-            run: |
-                set -eu
-                command -v gh >/dev/null && exit 0
-                S=""; [ "$(id -u)" -eq 0 ] || S=sudo
-                v=2.63.2
-                curl -fsSL "https://github.com/cli/cli/releases/download/v$v/gh_${v}_linux_amd64.tar.gz" | tar -xz -C /tmp
-                $S install -m0755 "/tmp/gh_${v}_linux_amd64/bin/gh" /usr/local/bin/gh
           - name: Authenticate gh CLI
             run: |
                 gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   changes:
     name: Check for stable CUDA-Q changes
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       pull-requests: read
@@ -59,7 +59,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: 'ubuntu-latest'
+    runs-on: linux-amd64-cpu4
     permissions:
       packages: read # required to fetch internal or private CodeQL packs
       security-events: write
@@ -123,11 +123,20 @@ jobs:
           contents: read
           checks: read
           pull-requests: read
-      runs-on: ubuntu-latest
+      runs-on: linux-amd64-cpu4
       if: >-
         ${{ github.event_name == 'pull_request' &&
             needs.changes.outputs.stable == 'true' }}
       steps:
+          # NVIDIA runners may not ship gh.
+          - name: Ensure gh
+            run: |
+                set -eu
+                command -v gh >/dev/null && exit 0
+                S=""; [ "$(id -u)" -eq 0 ] || S=sudo
+                v=2.63.2
+                curl -fsSL "https://github.com/cli/cli/releases/download/v$v/gh_${v}_linux_amd64.tar.gz" | tar -xz -C /tmp
+                $S install -m0755 "/tmp/gh_${v}_linux_amd64/bin/gh" /usr/local/bin/gh
           - name: Authenticate gh CLI
             run: |
                 gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/dco_merge_queue.yml
+++ b/.github/workflows/dco_merge_queue.yml
@@ -10,7 +10,7 @@ permissions: {} # no permissions needed.
 
 jobs:
   DCO:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       - run: 
           echo "Enable merge_queue check to pass."

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -88,7 +88,7 @@ name: CUDA Quantum cached dev images
 jobs:
   metadata:
     name: Metadata
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -470,7 +470,7 @@ jobs:
 
   finalize:
     name: Finalize
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     if: always() && !cancelled()
     needs: [metadata, build]
 

--- a/.github/workflows/dev_environment_macos.yml
+++ b/.github/workflows/dev_environment_macos.yml
@@ -41,7 +41,7 @@ name: CUDA Quantum macOS dev environment cache
 jobs:
   metadata:
     name: Metadata
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -263,7 +263,7 @@ jobs:
 
   finalize:
     name: Finalize
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     if: always() && !cancelled()
     needs: [metadata, build]
 

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -50,7 +50,7 @@ name: Docker images
 jobs:
   metadata:
     name: Metadata
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions: {}
 
     outputs:
@@ -1075,7 +1075,7 @@ jobs:
     # Unfortunately, we basically inherit this from the cudaq_image job;
     # all jobs that depend on it will need to add the same condition.
     if: always() && !cancelled() && inputs.environment && needs.metadata.outputs.platform_tag == '' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions: 
       contents: read
 
@@ -1118,7 +1118,7 @@ jobs:
     needs: [metadata, cudaqdev_image, cudaq_image, ompi_image, documentation, validation]
     # We need to clean up even if the workflow is cancelled or fails.
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
 
     steps:
       - name: Save cache keys

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   label-prs:
     name: Apply labels based on changed files
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   label-prs:
     name: Apply labels based on changed files
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -330,7 +330,7 @@ jobs:
 
   create_test_config:
     name: Prepare validation
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -590,7 +590,7 @@ jobs:
     name: Staging
     needs: [build_installer, build_openmpi, create_test_config]
     if: inputs.environment
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -631,7 +631,7 @@ jobs:
     needs: [build_installer, validation]
     # We need to clean up even if the workflow is cancelled or fails.
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
 
     steps:
       - name: Delete artifacts

--- a/.github/workflows/python_metapackages.yml
+++ b/.github/workflows/python_metapackages.yml
@@ -31,7 +31,7 @@ name: Python metapackages
 jobs:
   build_metapackages:
     name: Build Python metapackages
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -103,7 +103,7 @@ jobs:
   test_metapackages:
     name: Test Python metapackages
     needs: build_metapackages
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -214,7 +214,7 @@ jobs:
 
   create_test_config:
     name: Prepare validation
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -612,7 +612,7 @@ jobs:
     name: Staging
     needs: [build_wheel]
     if: inputs.create_staging_info
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 

--- a/.github/workflows/realtime_ci.yml
+++ b/.github/workflows/realtime_ci.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   changes:
     name: Check for realtime changes
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   changes:
     name: Check for stable CUDA-Q changes
-    runs-on: linux-amd64-cpu4
+    runs-on: ${{ (github.event_name == 'pull_request' && 'ubuntu-latest') || 'linux-amd64-cpu4' }}
     permissions:
       contents: read
       pull-requests: read
@@ -50,7 +50,7 @@ jobs:
   # ==========================================================================
   formatting:
     name: Check code formatting
-    runs-on: linux-amd64-cpu4
+    runs-on: ${{ (github.event_name == 'pull_request' && 'ubuntu-latest') || 'linux-amd64-cpu4' }}
     permissions:
       contents: read
 
@@ -87,7 +87,7 @@ jobs:
     name: Check license headers
     needs: changes
     if: needs.changes.outputs.stable == 'true'
-    runs-on: linux-amd64-cpu4
+    runs-on: ${{ (github.event_name == 'pull_request' && 'ubuntu-latest') || 'linux-amd64-cpu4' }}
     permissions:
       contents: read
 
@@ -120,7 +120,7 @@ jobs:
     name: Check spelling
     needs: changes
     if: needs.changes.outputs.stable == 'true'
-    runs-on: linux-amd64-cpu4
+    runs-on: ${{ (github.event_name == 'pull_request' && 'ubuntu-latest') || 'linux-amd64-cpu4' }}
     permissions:
       contents: read
 

--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   changes:
     name: Check for stable CUDA-Q changes
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       pull-requests: read
@@ -50,7 +50,7 @@ jobs:
   # ==========================================================================
   formatting:
     name: Check code formatting
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -87,7 +87,7 @@ jobs:
     name: Check license headers
     needs: changes
     if: needs.changes.outputs.stable == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 
@@ -120,7 +120,7 @@ jobs:
     name: Check spelling
     needs: changes
     if: needs.changes.outputs.stable == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
 


### PR DESCRIPTION
GitHub-hosted runners are stalled, blocking every workflow. The heavy
build and test jobs already run on NVIDIA runners; only the lightweight
orchestration layer was still on ubuntu-latest.

Switch all 33 ubuntu-latest jobs in the PR and merge-queue path to
linux-amd64-cpu4, across ci, ci_macos, codeql, repo_checks, realtime_ci,
dco_merge_queue, label_prs, and the reusable workflows they call.

NVIDIA runners are not guaranteed to ship gh or yq, which ubuntu-latest
preinstalls. Add an install-if-missing guard to the four jobs that need
them, so a missing tool cannot fail the metadata and CI Summary jobs.

---

GitHub-hosted macOS runners are unavailable, and Build & Test (arm64),
Installer (arm64), and Validate Installation (arm64) are required checks
on main. PRs cannot reach the queue and the queue cannot drain until
they report.

Gate the macOS jobs on a new skip_macos output, computed in the metadata
job from the SKIP_MACOS_CI repo variable. Unset or true skips them on
push and merge_group; set false to restore.

The merge_group trigger stays. A workflow skipped by trigger filtering
leaves its checks pending forever, while a job skipped by a conditional
reports success, which is what satisfies the rulesets.

The nightly schedule, workflow_dispatch, and the deployments
workflow_call path still run macOS in full, so coverage returns as soon
as the variable is flipped.


