### PR TITLE
[nvq++] Give `__nvqpp_vectorCopyCtor` internal linkage to avoid symbol collisions

### DIFF
--- a/cudaq/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/cudaq/lib/Optimizer/Builder/Intrinsics.cpp
@@ -579,8 +579,10 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     // Keep this function no_inline until RunSemanticsHackery removes the copy
     // from generated `.run` clones; otherwise malloc/memcpy reaches remote
     // targets.
+    // If it survives lowering, keep the compiler-generated definition local to
+    // its translation unit.
     {"__nvqpp_vectorCopyCtor", {cudaq::llvmMemCopyIntrinsic, "malloc"}, R"#(
-  func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8>, %arg1: i64, %arg2: i64) -> !cc.ptr<i8> attributes {no_inline} {
+  func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8>, %arg1: i64, %arg2: i64) -> !cc.ptr<i8> attributes {no_inline, llvm.linkage = #llvm.linkage<internal>} {
     %size = arith.muli %arg1, %arg2 : i64
     %0 = call @malloc(%size) : (i64) -> !cc.ptr<i8>
     %false = arith.constant false

--- a/cudaq/test/Transforms/aot_run_vector_copy.qke
+++ b/cudaq/test/Transforms/aot_run_vector_copy.qke
@@ -6,6 +6,7 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt --pass-pipeline='builtin.module(aot-prep-pipeline)' %s | FileCheck %s
+// RUN: cudaq-opt -cc-to-llvm %s | FileCheck %s --check-prefix=LLVM
 
 // Regression test for the Python AOT pipeline's vector-return handling.
 // `__nvqpp_vectorCopyCtor` must remain a direct call until
@@ -25,7 +26,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__aot_run_vector_co
 
   func.func private @llvm.memcpy.p0.p0.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
   func.func private @malloc(i64) -> !cc.ptr<i8>
-  func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8>, %arg1: i64, %arg2: i64) -> !cc.ptr<i8> attributes {no_inline} {
+  func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8>, %arg1: i64, %arg2: i64) -> !cc.ptr<i8> attributes {no_inline, llvm.linkage = #llvm.linkage<internal>} {
     %size = arith.muli %arg1, %arg2 : i64
     %heap = func.call @malloc(%size) : (i64) -> !cc.ptr<i8>
     %false = arith.constant false
@@ -36,6 +37,9 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__aot_run_vector_co
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__aot_run_vector_copy()
 // CHECK: call @__nvqpp_vectorCopyCtor
+
+// CHECK-LABEL: func.func private @__nvqpp_vectorCopyCtor(
+// CHECK-SAME: attributes {llvm.linkage = #llvm.linkage<internal>, no_inline} {
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__aot_run_vector_copy.run()
 // CHECK-NOT: call @__nvqpp_vectorCopyCtor
@@ -53,3 +57,6 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__aot_run_vector_co
 // CHECK-NOT: call @malloc
 // CHECK-NOT: call @llvm.memcpy
 // CHECK: return
+
+// LLVM-LABEL: llvm.func internal @__nvqpp_vectorCopyCtor(
+// LLVM-SAME: attributes {sym_visibility = "private"} {


### PR DESCRIPTION
Fixes #5199 

As pointed out by @bmhowe23, `__nvqpp_vectorCopyCtor` was marked with the `no_inline` attribute in a2f5846555434a67e2dde2139fc1322559378d17, which caused a symbol collision if more than one source file is compiled with that injected helper function. To fix this, `__nvqpp_vectorCopyCtor` now has the additional attribute `llvm.linkage = #llvm.linkage<internal>`. So while the helper isn't inlined, the helper function now becomes local to the respective object file where the helper is defined.