### PR TITLE
[CI blocker] Making ccache setup resilient to transient apt mirror failures

### DIFF
--- a/.github/actions/ccache-setup/action.yml
+++ b/.github/actions/ccache-setup/action.yml
@@ -33,12 +33,20 @@ runs:
     - name: Install and configure ccache
       shell: bash
       run: |
+        retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
         if ! command -v ccache &>/dev/null; then
           if [ "$(uname)" = "Darwin" ]; then
-            brew install ccache
+            retry brew install ccache
           else
-            sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ccache
+            # Treat a partially failed update (e.g. a 503 from a mirror) as an
+            # error so that it is retried instead of silently leaving a stale
+            # index behind that the install then fails on.
+            retry sudo apt-get update -qq -o APT::Update::Error-Mode=any
+            retry sudo apt-get install -y --no-install-recommends ccache
           fi
+        fi
+        if ! command -v ccache &>/dev/null; then
+          echo "::error::Failed to install ccache." && exit 1
         fi
         ccache --set-config=max_size=${{ inputs.max-size }}
         ccache --set-config=compression=${{ inputs.compression }}


### PR DESCRIPTION
`ccache-setup` intermittently fails with a confusing error:

```
 E: Failed to fetch http://us-east-2.ec2.ports.ubuntu.com/ubuntu-ports/dists/noble/InRelease  503  Service Unavailable [IP: 18.190.157.201 80]
  E: Failed to fetch http://us-east-2.ec2.ports.ubuntu.com/ubuntu-ports/dists/noble-updates/InRelease  503  Service Unavailable [IP: 18.190.157.201 80]
  E: Failed to fetch http://us-east-2.ec2.ports.ubuntu.com/ubuntu-ports/dists/noble-backports/InRelease  503  Service Unavailable [IP: 18.190.157.201 80]
  E: Some index files failed to download. They have been ignored, or old ones used instead.
  /home/runner/_work/_temp/44f45fb4-2653-4371-8f08-f8428a39adcd.sh: line 8: ccache: command not found
  Error: Process completed with exit code 127.
```

The Ubuntu mirror returns a 503, apt falls back to stale indices, and because the failure occurs on the left side of an `&&` list, `set -e` does not abort the step. The install never runs, and the step continues to `ccache --set-config`, surfacing as `command not found` instead of the actual cause.