### PR TITLE
Fix Python platform argument matching

### DIFF
--- a/cudaq/lib/Target/Yaml/TargetConfigYaml.cpp
+++ b/cudaq/lib/Target/Yaml/TargetConfigYaml.cpp
@@ -177,14 +177,16 @@ std::string cudaq::config::processRuntimeArgs(
     const auto iter = std::find_if(
         config.TargetArguments.begin(), config.TargetArguments.end(),
         [&](const cudaq::config::TargetArgument &argConfig) {
-          // Here, we handle both cases: the config key as is (python kwargs)
-          // or prefixed with the target name or "target".
+          // Handle the config and platform keys (Python kwargs), or the config
+          // key prefixed with the target name or "target" (nvq++ arguments).
           const std::string nvqppArgKey =
               "--" + config.Name + "-" + argConfig.KeyName;
           const std::string targetPrefixArgKey =
               "--target-" + argConfig.KeyName;
           return llvm::is_contained<llvm::StringRef>(
-              {nvqppArgKey, targetPrefixArgKey, argConfig.KeyName}, argKey);
+              {nvqppArgKey, targetPrefixArgKey, argConfig.KeyName,
+               argConfig.PlatformArgKey},
+              argKey);
         });
     if (iter != config.TargetArguments.end()) {
       if (iter->Type != cudaq::config::ArgumentType::FeatureFlag) {


### PR DESCRIPTION
## Summary

- accept each target argument's `platform-arg` as a Python/runtime key
- retain the existing config-key and prefixed `nvq++` spellings
- restore documented Python kwargs for existing backends such as Scaleway, IonQ, and IQM

## Testing

- `uvx prek run --files cudaq/lib/Target/Yaml/TargetConfigYaml.cpp`
- focused C++ comparison using [setup-mlir](https://github.com/munich-quantum-software/setup-mlir) 22.1.4:
  - unmodified `main` drops Scaleway's `max_duration`
  - patched code forwards Scaleway's `max_duration`, IonQ's `qpu`, and IQM's `url`
  - patched code retains `--scaleway-max-duration`
- `git diff --check`

## Context

This also addresses the target-argument mismatch identified while reviewing #4882 and fixes #5202
