### PR TITLE
Remove skipPipelineSubstitution boolean in getCompileTarget

### DIFF
--- a/docs/sphinx/using/backends/hardware/backend_iqm.rst
+++ b/docs/sphinx/using/backends/hardware/backend_iqm.rst
@@ -20,6 +20,11 @@ Emulation Mode
     This can be done by setting `mapping_file` to point to a file describing the QPU architecture which should be emulated.
     If an architecture is specified no server URL is needed anymore.
 
+    Without an architecture file, the target attempts to fetch the dynamic quantum architecture from the server.
+    If that fetch fails (for example due to missing authentication or no network access), CUDA-Q emits a warning and continues.
+    Execution modes that do not require qubit mapping, such as detector error model generation, still work in that case.
+    Execution that does require qubit mapping will fail later with an unresolved architecture placeholder.
+
     .. code:: python
 
         cudaq.set_target('iqm', emulate=True, mapping_file="<path+filename>")
@@ -52,6 +57,11 @@ Emulation Mode
     Emulation mode will still contact the configured IQM Server to retrieve the dynamic quantum architecture resulting from the active calibration unless a QPU architecture file is explicitly specified.
     This can be done by specifying a file with the architecture either at compile time or in an variable in the environment executing the binary.
     If an architecture is specified no server URL is needed anymore.
+
+    Without an architecture file, the target attempts to fetch the dynamic quantum architecture from the server.
+    If that fetch fails (for example due to missing authentication or no network access), CUDA-Q emits a warning and continues.
+    Execution modes that do not require qubit mapping, such as detector error model generation, still work in that case.
+    Execution that does require qubit mapping will fail later with an unresolved architecture placeholder.
 
     .. code:: bash
 

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -706,9 +706,9 @@ static std::pair<cudaq::CompileTarget, cudaq::CompileOptions>
 getCompileConfig(std::optional<cudaq::CompileTarget> target = std::nullopt) {
   auto *ctx = cudaq::getExecutionContext();
   cudaq::CompileOptions options;
+  if (!target)
+    target = cudaq::get_compile_target();
   if (!ctx) {
-    if (!target)
-      target = cudaq::get_compile_target(cudaq::other_policies{});
     options = cudaq::get_compile_options(cudaq::other_policies{});
   } else {
     cudaq::policies::withPolicy(ctx->name, [&](auto policy) {
@@ -717,8 +717,6 @@ getCompileConfig(std::optional<cudaq::CompileTarget> target = std::nullopt) {
         policy.spin = ctx->spin.value();
       }
 
-      if (!target)
-        target = cudaq::get_compile_target(policy);
       options = cudaq::get_compile_options(policy);
     });
   }

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -221,12 +221,9 @@ public:
                                         serverHelper, executor);
   }
 
-  CompileTarget
-  getCompileTarget(bool skipPipelineSubstitutions = false) override {
-    std::map<std::string, std::string> pipelineSubstitutions{};
-    if (!skipPipelineSubstitutions)
-      pipelineSubstitutions =
-          serverHelper->getPipelineSubstitutions(platformPath);
+  CompileTarget getCompileTarget() override {
+    auto pipelineSubstitutions =
+        serverHelper->getPipelineSubstitutions(platformPath);
     auto target = CompileTarget::createFromConfig(targetConfig, backendConfig,
                                                   pipelineSubstitutions);
     target.pipelineConfig.replaceStateWithKernel = true;

--- a/runtime/cudaq/algorithms/launch.h
+++ b/runtime/cudaq/algorithms/launch.h
@@ -80,11 +80,10 @@ auto launch(const Policy &policy, std::size_t qpu_id, ExecutionContext &ctx,
       cudaq::CompileOptions options;
       if constexpr (requires { policy.inner; }) {
         options = cudaq::get_compile_options(policy.inner);
-        target = platform.getCompileTarget(policy.inner, qpu_id);
       } else {
         options = cudaq::get_compile_options(policy);
-        target = platform.getCompileTarget(policy, qpu_id);
       }
+      target = platform.getCompileTarget(qpu_id);
       const bool isEmulated = platform.is_emulated(qpu_id);
       const bool isRemote = platform.is_remote(qpu_id);
       options.emulate = isEmulated;

--- a/runtime/cudaq/platform.h
+++ b/runtime/cudaq/platform.h
@@ -42,9 +42,8 @@ inline bool is_simulator_platform() {
   return getQuantumPlatformInternal()->is_simulator();
 }
 
-template <typename Policy>
-cudaq::CompileTarget get_compile_target(const Policy &policy) {
-  return getQuantumPlatformInternal()->getCompileTarget(policy);
+inline cudaq::CompileTarget get_compile_target() {
+  return getQuantumPlatformInternal()->getCompileTarget();
 }
 
 /// Get the default compile target configuration for the given platform

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -169,7 +169,7 @@ cudaq::DefaultQPU::launchKernel(const cudaq::ptsbe::sample_policy &policy,
   });
 }
 
-cudaq::CompileTarget cudaq::DefaultQPU::getCompileTarget(bool) {
+cudaq::CompileTarget cudaq::DefaultQPU::getCompileTarget() {
   return createDefaultCompileTarget();
 }
 

--- a/runtime/cudaq/platform/default/DefaultQPU.h
+++ b/runtime/cudaq/platform/default/DefaultQPU.h
@@ -72,8 +72,7 @@ public:
   launchKernel(const ptsbe::sample_policy &policy, const CompiledModule &module,
                KernelArgs args) override;
 
-  CompileTarget
-  getCompileTarget(bool skipPipelineSubstitutions = false) override;
+  CompileTarget getCompileTarget() override;
 
   void configureExecutionContext(ExecutionContext &context) const override;
   void beginExecution() override;

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -450,9 +450,18 @@ std::map<std::string, std::string> IQMServerHelper::getPipelineSubstitutions(
       // Use provided string as path+filename
       pathToFile = iter->second;
     } else {
-      // Use the dynamic quantum architecture of the configured IQM server
-      fetchQuantumArchitecture();
-      pathToFile = writeQuantumArchitectureFile();
+      // Use the dynamic quantum architecture of the configured IQM server.
+      // Fallback to an empty substitution map and let the pipeline report the
+      // problem if it is ever actually used.
+      try {
+        fetchQuantumArchitecture();
+        pathToFile = writeQuantumArchitectureFile();
+      } catch (const std::exception &e) {
+        CUDAQ_WARN("Leaving %QPU_ARCH% unresolved: {}. Set IQM_QPU_QA or pass "
+                   "--mapping-file to supply it offline.",
+                   e.what());
+        return {};
+      }
     }
   }
   CUDAQ_INFO("Using quantum architecture file: {}", pathToFile);

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -36,10 +36,8 @@ public:
     }
   }
 
-  CompileTarget
-  getCompileTarget(bool skipPipelineSubstitutions = false) override {
-    auto target =
-        BaseRemoteRESTQPU::getCompileTarget(skipPipelineSubstitutions);
+  CompileTarget getCompileTarget() override {
+    auto target = BaseRemoteRESTQPU::getCompileTarget();
     target.supportObservableMeasurements = true;
     return target;
   }

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -92,8 +92,7 @@ public:
   [[nodiscard]] KernelThunkResultType
   launchKernelCommon(const std::string &kernelName, void *args);
 
-  CompileTarget
-  getCompileTarget(bool skipPipelineSubstitutions = false) override {
+  CompileTarget getCompileTarget() override {
     return {
         .supportExplicitMeasurements = false,
     };

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -106,7 +106,6 @@ cudaq::QPU::launchKernel(const ptsbe::sample_policy &policy,
       "This QPU does not support launching the ptsbe::sample_policy.");
 }
 
-cudaq::CompileTarget
-cudaq::QPU::getCompileTarget(bool skipPipelineSubstitutions) {
+cudaq::CompileTarget cudaq::QPU::getCompileTarget() {
   throw std::runtime_error("No CompileTarget defined for this QPU");
 }

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -179,9 +179,7 @@ public:
   [[nodiscard]] virtual KernelThunkResultType
   unifiedLaunchModule(const AnyModule &module, KernelArgs args);
 
-  /// Get the compile target of the QPU.
-  [[nodiscard]] virtual CompileTarget
-  getCompileTarget(bool skipPipelineSubstitutions = false);
+  [[nodiscard]] virtual CompileTarget getCompileTarget();
 
   /// @brief Notify the QPU that a new random seed value is set.
   /// By default do nothing, let subclasses override.

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -273,11 +273,18 @@ std::size_t quantum_platform::get_num_qubits(std::size_t qpu_id) const {
   return platformQPUs[qpu_id]->getNumQubits();
 }
 
+cudaq::CompileTarget
+quantum_platform::getCompileTarget(std::size_t qpu_id) const {
+  validateQpuId(qpu_id, /*acceptRuntimeEndpoints=*/true);
+  if (compileTarget.has_value()) {
+    return compileTarget.value();
+  }
+  return platformQPUs[qpu_id]->getCompileTarget();
+}
+
 bool quantum_platform::supports_explicit_measurements(
     std::size_t qpu_id) const {
-  auto ct = getCompileTarget(other_policies{}, qpu_id,
-                             /*skipPipelineSubstitutions=*/true);
-  return ct.supportExplicitMeasurements;
+  return getCompileTarget(qpu_id).supportExplicitMeasurements;
 }
 
 void quantum_platform::launchVQE(const std::string kernelName,

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -20,7 +20,6 @@
 #include "nvqpp_interface.h"
 #include "cudaq/Target/CompileTarget.h"
 #include "cudaq/Target/RuntimeEndpoint.h"
-#include "cudaq/algorithms/dem/policy.h"
 #include "cudaq/platform/qpu.h"
 #include "cudaq/remote_capabilities.h"
 #include "cudaq/utils/cudaq_utils.h"
@@ -225,19 +224,8 @@ public:
   unifiedLaunchModule(const AnyModule &module, KernelArgs args,
                       std::size_t qpu_id = 0);
 
-  template <typename Policy>
   [[nodiscard]] cudaq::CompileTarget
-  getCompileTarget(const Policy &policy, std::size_t qpu_id = 0,
-                   bool skipPipelineSubstitutions = false) const {
-    validateQpuId(qpu_id, /*acceptRuntimeEndpoints=*/true);
-    if (compileTarget.has_value()) {
-      return compileTarget.value();
-    }
-    // Fallback to old behaviour: query the QPU for its compile target.
-    auto &qpu = platformQPUs[qpu_id];
-    skipPipelineSubstitutions |= std::is_same_v<Policy, cudaq::dem_policy>;
-    return qpu->getCompileTarget(skipPipelineSubstitutions);
-  }
+  getCompileTarget(std::size_t qpu_id = 0) const;
 
   /// List all available platforms
   static std::vector<std::string> list_platforms();

--- a/targettests/execution/dem_from_kernel_emulate.cpp
+++ b/targettests/execution/dem_from_kernel_emulate.cpp
@@ -10,7 +10,6 @@
 // RUN: nvq++ --target anyon      --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target infleqtion --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target ionq       --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
 // RUN: nvq++ --target oqc        --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target qbraid     --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s

--- a/targettests/execution/dem_from_kernel_emulate_iqm.cpp
+++ b/targettests/execution/dem_from_kernel_emulate_iqm.cpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: nvq++ --target iqm --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
+// RUN: nvq++ --target iqm --emulate --mapping-file %iqm_tests_dir/Crystal_20.txt %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target iqm --emulate %s -o %t && IQM_SERVER_URL=fake-fake-fake CUDAQ_LOG_LEVEL=warn %t 2> %t.err | FileCheck %s
+// RUN: FileCheck --check-prefix=INVALIDURL %s < %t.err
+
+#include "dem_from_kernel_emulate.cpp"
+
+// CHECK: SINGLE detectors=1 observables=0
+// CHECK: THREE_MZ detectors=1 observables=1
+// CHECK: CORRELATED_XX_RAW hyperedge=1 caret=0
+// CHECK: CORRELATED_XX_DECOMPOSED hyperedge=0 caret=1
+// CHECK: SAMPLE_QEC_KERNEL most_probable=0
+
+// INVALIDURL: Leaving %QPU_ARCH% unresolved: Unable to get quantum architecture from
+// INVALIDURL-SAME: fake-fake-fake
+// INVALIDURL: Path %QPU_ARCH% does not exist
+// clang-format on

--- a/unittests/common/QuantumPlatformTester.cpp
+++ b/unittests/common/QuantumPlatformTester.cpp
@@ -34,8 +34,7 @@ public:
   /// Number of times `launchKernel(sample_policy)` was called on this QPU.
   std::size_t sampleLaunchCount = 0;
 
-  CompileTarget
-  getCompileTarget(bool skipPipelineSubstitutions = false) override {
+  CompileTarget getCompileTarget() override {
     CompileTarget ct;
     ct.pipelineConfig.highLevelPipeline = "custom_pipeline";
     ct.fullySpecialize = false;
@@ -177,9 +176,8 @@ void expectOverrideDisabled(Fn &&fn, const std::string &what) {
 
 TEST(QuantumPlatformCompileTargetTester, fallsBackToQpuWhenUnset) {
   TestPlatform platform;
-  sample_policy policy{.kernelName = "test_kernel"};
 
-  auto ct = platform.getCompileTarget(policy);
+  auto ct = platform.getCompileTarget();
   EXPECT_EQ(ct.pipelineConfig.highLevelPipeline, "custom_pipeline");
   EXPECT_FALSE(ct.fullySpecialize);
   EXPECT_TRUE(ct.overrideAOTCompilation);
@@ -188,9 +186,8 @@ TEST(QuantumPlatformCompileTargetTester, fallsBackToQpuWhenUnset) {
 TEST(QuantumPlatformCompileTargetTester, usesPlatformOverrideWhenSet) {
   TestPlatform platform;
   platform.setCompileTarget(makePlatformCompileTarget());
-  sample_policy policy{.kernelName = "test_kernel"};
 
-  auto ct = platform.getCompileTarget(policy);
+  auto ct = platform.getCompileTarget();
   EXPECT_EQ(ct.pipelineConfig.highLevelPipeline, "custom_platform");
   EXPECT_TRUE(ct.fullySpecialize);
   EXPECT_FALSE(ct.overrideAOTCompilation);
@@ -210,39 +207,35 @@ TEST(QuantumPlatformCompileTargetTester,
 
 TEST(QuantumPlatformCompileTargetTester, otherPoliciesFallsBackToQpuWhenUnset) {
   TestPlatform platform;
-  other_policies policy;
 
-  auto ct = platform.getCompileTarget(policy);
+  auto ct = platform.getCompileTarget();
   EXPECT_EQ(ct.pipelineConfig.highLevelPipeline, "custom_pipeline");
 }
 
 TEST(QuantumPlatformCompileTargetTester, otherPoliciesUsesPlatformOverride) {
   TestPlatform platform;
   platform.setCompileTarget(makePlatformCompileTarget());
-  other_policies policy;
 
-  auto ct = platform.getCompileTarget(policy);
+  auto ct = platform.getCompileTarget();
   EXPECT_EQ(ct.pipelineConfig.highLevelPipeline, "custom_platform");
   EXPECT_TRUE(ct.fullySpecialize);
 }
 
 TEST(QuantumPlatformCompileTargetTester, rejectsInvalidQpuId) {
   TestPlatform platform;
-  sample_policy policy{.kernelName = "test_kernel"};
 
   expectThrows<std::invalid_argument>(
-      [&] { (void)platform.getCompileTarget(policy, /*qpu_id=*/1); },
+      [&] { (void)platform.getCompileTarget(/*qpu_id=*/1); },
       "invalid_argument");
 }
 
 TEST(QuantumPlatformCompileTargetTester, clearingOverrideFallsBackToQpu) {
   TestPlatform platform;
   platform.setCompileTarget(makePlatformCompileTarget());
-  sample_policy policy{.kernelName = "test_kernel"};
 
   platform.setCompileTarget(std::nullopt);
 
-  auto ct = platform.getCompileTarget(policy);
+  auto ct = platform.getCompileTarget();
   EXPECT_EQ(ct.pipelineConfig.highLevelPipeline, "custom_pipeline");
   EXPECT_TRUE(ct.overrideAOTCompilation);
 }
@@ -353,17 +346,16 @@ TEST(QuantumPlatformRuntimeEndpointTester, recreatingQpusResetsEndpoints) {
 // that caused it and shadow every later target's own compile target.
 TEST(QuantumPlatformRuntimeEndpointTester, recreatingQpusResetsCompileTarget) {
   TestPlatform platform;
-  sample_policy policy{.kernelName = "test_kernel"};
   platform.setRuntimeEndpoint(RuntimeEndpoint{.impl = 42});
   // The installed default describes a local simulator, unlike the test QPU's.
-  ASSERT_NE(platform.getCompileTarget(policy).pipelineConfig.highLevelPipeline,
+  ASSERT_NE(platform.getCompileTarget().pipelineConfig.highLevelPipeline,
             "custom_pipeline");
 
   platform.resetQpus();
 
   // Back to the QPU's own compile target.
-  auto ct = platform.getCompileTarget(policy);
-  ASSERT_EQ(platform.getCompileTarget(policy).pipelineConfig.highLevelPipeline,
+  auto ct = platform.getCompileTarget();
+  ASSERT_EQ(platform.getCompileTarget().pipelineConfig.highLevelPipeline,
             "custom_pipeline");
   EXPECT_TRUE(ct.overrideAOTCompilation);
 }


### PR DESCRIPTION
This PR makes `QPU::getCompileTarget` independent of the launch policy by removing the last blocker: the `skipPipelineSubstitution` argument.

## Motivation
This is what will enable us to cache the compile target in the `quantum_platform` and no longer need to query the `QPU` (or even store it) once constructed. In other words, the flow we are aiming for is:
1. [unchanged] When a new target is set, cudaq calls `quantum_platform::addQPU(newQPU)`
2. `addQPU` constructs a runtime endpoint `re = RuntimeEndpoint::wrapQPU(newQPU)` and a compile target `ct = newQPU.getCompileTarget())`
3. the platform stores `re` and `ct`
4. `newQPU` can be discarded (in practice, it's stored within `re`, but the platform doesn't need to know about this).
5. Whenever a kernel gets launched, the compile target gets resolved to `ct` without any queries to the QPU.

Outside of the construction within `addQPU`, the `quantum_platform` can be totally agnostic to where the `CompileTarget`s and `RuntimeEndpoint`s are coming from -- whether they were set explicitly or were inferred from a QPU is irrelevant.

## Disadvantage
With this change, the full compile target of a QPU is always computed once, irrespective of the number of kernel launches and their types. This is an improvement for cases where there are >1 launches for which the compile target is required. It is a regression in the cases where
- no kernel launch is executed at all
- the kernel launch executed does not require the full compile target information (example: DEM).

Previously, we were handling DEM policy launches specially: in case a DEM launch was executed, we'd set a `skipPipelineSubstitution` flag that would avoid computing the full compilation pipeline. In the case of IQM, this meant avoiding an API call to their servers. Now one API call will always be performed when setting the platform to IQM.

To mitigate this regression, the IQM serverhelper now handles a failing API call gracefully: instead of a hard error, CUDA-Q emits a warning and proceeds normally; a hard error only gets thrown down the line if the pipeline is actually required. Otherwise, the kernel launch will succeed. Thus DEM launches will always succeed just as before, even when the API call was unsuccessful.