### PR TITLE
Support std::fmod in C++ QPU kernels

### DIFF
--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1426,6 +1426,15 @@ bool QuakeBridgeVisitor::visitMathLibFunc(clang::CallExpr *x,
     return pushValue(math::PowFOp::create(builder, loc, base, power));
   }
 
+  // Handle std::fmod(X,Y)
+  if ((isInNamespace(func, "std") || isNotInANamespace(func)) &&
+      (funcName == "fmod" || funcName == "fmodf")) {
+    assert(func->getNumParams() == 2 && "must be binary");
+    SmallVector<Value> args = lastValues(2);
+    [[maybe_unused]] auto funcConst = popValue();
+    return pushValue(arith::RemFOp::create(builder, loc, args[0], args[1]));
+  }
+
   auto floatOperator = [&]<typename Op>(Op, const char *dblName) -> bool {
     assert(func->getNumParams() == 1 && "must be unary");
     Value arg = popValue();

--- a/cudaq/test/AST-Quake/math_functions.cpp
+++ b/cudaq/test/AST-Quake/math_functions.cpp
@@ -16,7 +16,8 @@ struct math_functions {
     cudaq::qubit q;
     double angle = std::sin(theta) + std::cos(theta) + std::tan(theta) +
                    std::asin(theta) + std::acos(theta) + std::atan(theta) +
-                   std::sqrt(theta) + std::exp(theta) + std::log(theta);
+                   std::sqrt(theta) + std::exp(theta) + std::log(theta) +
+                   std::fmod(theta, 2.0);
     rx(angle, q);
   }
 };
@@ -26,7 +27,7 @@ struct math_functions_float {
     cudaq::qubit q;
     float angle = sinf(theta) + cosf(theta) + tanf(theta) + asinf(theta) +
                   acosf(theta) + atanf(theta) + sqrtf(theta) + expf(theta) +
-                  logf(theta);
+                  logf(theta) + fmodf(theta, 2.0f);
     rx(angle, q);
   }
 };
@@ -41,6 +42,7 @@ struct math_functions_float {
 // CHECK-DAG:     math.sqrt
 // CHECK-DAG:     math.exp
 // CHECK-DAG:     math.log
+// CHECK-DAG:     arith.remf
 // CHECK:         quake.rx
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__math_functions_float
@@ -53,4 +55,5 @@ struct math_functions_float {
 // CHECK-DAG:     math.sqrt
 // CHECK-DAG:     math.exp
 // CHECK-DAG:     math.log
+// CHECK-DAG:     arith.remf
 // CHECK:         quake.rx


### PR DESCRIPTION
## Summary
Adds support for `std::fmod` and `fmodf` inside C++ `__qpu__` kernels, alongside the existing math functions.

## Fix
Handle `fmod`/`fmodf` in `QuakeBridgeVisitor::visitMathLibFunc` (`cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp`). Like `std::pow`, it is a binary call, so the two operands are popped and lowered to `arith.remf`, whose semantics match C `fmod`.

## Test Plan
Extended the FileCheck test `cudaq/test/AST-Quake/math_functions.cpp` to call `std::fmod`/`fmodf` in the existing double and float kernels and to check for `arith.remf` in the generated IR.

Authored with an AI assistant.

Fixes #5215