### PR TITLE
[build] Don't link libcudaqMLIR into CustomPassPlugin

### DIFF
--- a/cudaq/test/plugin/CMakeLists.txt
+++ b/cudaq/test/plugin/CMakeLists.txt
@@ -10,6 +10,7 @@ include(HandleLLVMOptions)
 add_llvm_pass_plugin(CustomPassPlugin CustomPassPlugin.cpp)
 # Depends on QuakeDialect TableGen to use the generated `.h.inc` files.
 add_dependencies(CustomPassPlugin QuakeDialect)
-# Resolve CUDA-Q and MLIR symbols through the shared plugin boundary. Linking
-# static OptTransforms here would duplicate bundled compiler state in the DSO.
-target_link_libraries(CustomPassPlugin PRIVATE cudaqMLIR)
+# Link no CUDA-Q or MLIR library: cudaq-opt links MLIR/LLVM statically and
+# re-exports it for plugins, so every symbol resolves from the host. Linking
+# libcudaqMLIR would pull a second copy of LLVM's globals into the process and
+# abort on duplicate cl::opt registration.


### PR DESCRIPTION
CustomPassPlugin is dlopen'd into cudaq-opt, which links MLIR/LLVM statically and re-exports it for plugins. Linking libcudaqMLIR pulled a second copy of LLVM's globals into the process, so loading the plugin re-ran every cl::opt constructor against cudaq-opt's already-populated registry and Transforms/custom_pass.qke aborted before emitting output:

  : CommandLine Error: Option 'print-inst-addrs' registered more than once!
  LLVM ERROR: inconsistency in registered CommandLine options
  FileCheck error: '<stdin>' is empty.

Drop the link. cudaq-opt already exports every MLIR and CUDA-Q symbol the plugin leaves undefined, including CommutationAwareRewriteDriver, which quake-simplify pulls in from OptTransforms. This restores the arrangement that predates #5012.

The abort only reproduces when libcudaqMLIR is built without -Bsymbolic-functions, which cudaqMLIR-shlib.cmake omits once CUDAQ_STATIC_CXX_RUNTIME is TRUE. That flag keeps the second registry private, so a default local build passes while CI aborts.

Fixes #5222