### PR TITLE
[core] Update combine quantum allocations pass

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -122,20 +122,56 @@ public:
       return;
     }
 
-    // 1. Scan the top-level of the function for all alloca operations. Exit if
-    // any of them are parametric.
+    combineAllocationsInRegion(func.getRegion());
+
+    LLVM_DEBUG(llvm::dbgs() << "Function after combining quake alloca:\n"
+                            << func << "\n\n");
+  }
+
+  /// Combine the `quake.alloca` ops that appear directly in the top level of
+  /// \p region (i.e. not nested inside a further `cc.scope` /
+  /// `cc.create_lambda`, which is handled independently below) into a single
+  /// `quake.alloca` at the top of \p region. \p region may be a func.func's own
+  /// body, or the body of a `cc.scope` / `cc.create_lambda`.
+  ///
+  /// A `cc.scope`'s own body is combined independently of its enclosing
+  /// region, with the merged `alloca` placed at the top of \e that body, rather
+  /// than hoisted out. If the scope executes more than once (i.e. nested in
+  /// a loop), each execution still produces its own fresh merged `alloca`,
+  /// exactly matching the un-combined semantics — this is a \e CORRECTNESS
+  /// constraint that cannot be whimsically ignored and why lowering `cc.scope`
+  /// to CFG form sets `disableQubitCombineAttrName` when it contains quantum
+  /// allocations. A `cc.create_lambda`'s body is likewise combined
+  /// independently: it is an entirely separate callable activation that may be
+  /// invoked any number of times, independent of the enclosing function.
+  void combineAllocationsInRegion(Region &region) {
+    if (region.empty())
+      return;
+
+    // Recurse first (innermost first) into every cc.scope / cc.create_lambda
+    // found directly in this region's own top level. Recursion handled
+    // naturally here, so go no further.
+    for (auto &block : region)
+      for (auto &op : block)
+        if (isa<cudaq::cc::ScopeOp, cudaq::cc::CreateLambdaOp>(op))
+          for (auto &nested : op.getRegions())
+            combineAllocationsInRegion(nested);
+
+    // 1. Scan the top level of \p region for all `alloca` operations. Skip
+    // those that are parametric or married to an initialize with state.
     Analysis analysis;
     std::size_t currentOffset = 0;
-    for (auto &block : func.getRegion())
+    for (auto &block : region)
       for (auto &op : block) {
         if (auto alloc = dyn_cast_or_null<cudaq::quake::AllocaOp>(&op)) {
           if (alloc.getSize() || alloc.hasInitializedState())
-            return;
-          auto size = cudaq::quake::getAllocationSize(alloc.getType());
-          if (size == 0)
-            // Skip zero-size allocas. Merging them would
-            // produce subveq(lo, lo-1) which is invalid.
             continue;
+          auto size = cudaq::quake::getAllocationSize(alloc.getType());
+          if (size == 0) {
+            // Skip zero-size allocas. Merging them would produce
+            // subveq(lo, lo-1) which is invalid.
+            continue;
+          }
           analysis.allocations.push_back(alloc);
           analysis.offsetSizes.emplace_back(currentOffset, size);
           currentOffset += size;
@@ -147,9 +183,8 @@ public:
     if (analysis.empty())
       return;
 
-    // 2. Combine all the allocas into a single alloca at the top of the
-    // function.
-    auto *entryBlock = &func.getRegion().front();
+    // 2. Combine all the allocas into a single alloca at the top of the region.
+    auto *entryBlock = &region.front();
     auto *ctx = &getContext();
     auto loc = analysis.allocations.front().getLoc();
     OpBuilder rewriter(ctx);
@@ -160,7 +195,14 @@ public:
     // 3. Greedily replace the uses of the original alloca ops with uses of
     // partitions of the new alloca op. Replace subveq of subveq with a single
     // new subveq. Replace extract from subveq with extract from original
-    // veq.
+    // veq. AllocaPat only matches ops literally in analysis.allocations (this
+    // call's own, region-scoped list), so it is harmless to always root the
+    // driver at the pass's own top-level function rather than region's
+    // owning op: a cc.scope/cc.create_lambda is not IsolatedFromAbove (it may
+    // reference values from its enclosing region), so applyPatternsGreedily
+    // cannot be rooted there directly, but the func::FuncOp always is and the
+    // driver already walks every nested region regardless of where it's
+    // rooted.
     {
       RewritePatternSet patterns(ctx);
       patterns.insert<AllocaPat>(ctx, analysis);
@@ -168,9 +210,9 @@ public:
       cudaq::quake::GetMemberOp::getCanonicalizationPatterns(patterns, ctx);
       cudaq::quake::SubVeqOp::getCanonicalizationPatterns(patterns, ctx);
       cudaq::quake::ConcatOp::getCanonicalizationPatterns(patterns, ctx);
-      if (failed(applyPatternsGreedily(func.getOperation(),
-                                       std::move(patterns)))) {
-        func.emitOpError("combining alloca, subveq, and extract ops failed");
+      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+        region.getParentOp()->emitOpError(
+            "combining alloca, subveq, and extract ops failed");
         signalPassFailure();
       }
     }
@@ -179,7 +221,7 @@ public:
     if (!analysis.deallocs.empty()) {
       for (auto d : analysis.deallocs)
         d.erase();
-      for (auto &block : func.getRegion()) {
+      for (auto &block : region) {
         if (block.hasNoSuccessors()) {
           rewriter.setInsertionPoint(block.getTerminator());
           cudaq::quake::DeallocOp::create(rewriter, analysis.newAlloc.getLoc(),
@@ -187,9 +229,6 @@ public:
         }
       }
     }
-
-    LLVM_DEBUG(llvm::dbgs() << "Function after combining quake alloca:\n"
-                            << func << "\n\n");
   }
 };
 } // namespace

--- a/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -122,7 +122,7 @@ public:
       return;
     }
 
-    combineAllocationsInRegion(func.getRegion());
+    [[maybe_unused]] bool unused = combineAllocationsInRegion(func.getRegion());
 
     LLVM_DEBUG(llvm::dbgs() << "Function after combining quake alloca:\n"
                             << func << "\n\n");
@@ -144,9 +144,9 @@ public:
   /// allocations. A `cc.create_lambda`'s body is likewise combined
   /// independently: it is an entirely separate callable activation that may be
   /// invoked any number of times, independent of the enclosing function.
-  void combineAllocationsInRegion(Region &region) {
+  bool combineAllocationsInRegion(Region &region) {
     if (region.empty())
-      return;
+      return true;
 
     // Recurse first (innermost first) into every cc.scope / cc.create_lambda
     // found directly in this region's own top level. Recursion handled
@@ -154,24 +154,28 @@ public:
     for (auto &block : region)
       for (auto &op : block)
         if (isa<cudaq::cc::ScopeOp, cudaq::cc::CreateLambdaOp>(op))
-          for (auto &nested : op.getRegions())
-            combineAllocationsInRegion(nested);
+          for (auto &nested : op.getRegions()) {
+            bool ok = combineAllocationsInRegion(nested);
+            if (!ok)
+              return ok;
+          }
 
-    // 1. Scan the top level of \p region for all `alloca` operations. Skip
-    // those that are parametric or married to an initialize with state: they
-    // are left exactly as they are, so their own dealloc must be left alone
-    // too -- only a dealloc of an alloca actually being combined belongs in
-    // analysis.deallocs, or step 4 below would erase the dealloc of a
-    // skipped (untouched) alloca along with the ones actually being merged,
+    // 1. Scan the top level of \p region for all `alloca` operations.
+    // FIXME: other passes rely on this pass to cleanup broken IR. Preserve the
+    // bugs here for now.
+    // Eventually, skip those that are parametric or married to an initialize
+    // with state: they are left exactly as they are, so their own dealloc must
+    // be left alone too -- only a dealloc of an alloca actually being combined
+    // belongs in analysis.deallocs, or step 4 below would erase the dealloc of
+    // a skipped (untouched) alloca along with the ones actually being merged,
     // silently leaving it never deallocated.
     Analysis analysis;
-    SmallPtrSet<Operation *, 8> combinedAllocaOps;
     std::size_t currentOffset = 0;
     for (auto &block : region)
       for (auto &op : block) {
         if (auto alloc = dyn_cast_or_null<cudaq::quake::AllocaOp>(&op)) {
           if (alloc.getSize() || alloc.hasInitializedState())
-            continue;
+            return false;
           auto size = cudaq::quake::getAllocationSize(alloc.getType());
           if (size == 0) {
             // Skip zero-size allocas. Merging them would produce
@@ -181,23 +185,14 @@ public:
           analysis.allocations.push_back(alloc);
           analysis.offsetSizes.emplace_back(currentOffset, size);
           currentOffset += size;
-          combinedAllocaOps.insert(alloc);
         } else if (auto dealloc =
                        dyn_cast_or_null<cudaq::quake::DeallocOp>(&op)) {
-          auto *defOp = dealloc.getReference().getDefiningOp();
-          if (defOp && combinedAllocaOps.count(defOp))
-            analysis.deallocs.push_back(dealloc);
+          analysis.deallocs.push_back(dealloc);
         }
       }
-    // Nothing is gained by "combining" a single eligible alloca: it doesn't
-    // reduce the allocation count, and rewriting it into a 1-element veq
-    // changes its type from ref to veq, which downstream codegen may lower
-    // differently (e.g. a veq-typed control operand gets its 1-element
-    // pointer array built eagerly, right after allocation, while a ref-typed
-    // one defers that until just before the gate that consumes it) --
-    // purely cosmetic churn with no benefit. Leave it untouched.
-    if (analysis.allocations.size() < 2)
-      return;
+
+    if (analysis.empty())
+      return true;
 
     // 2. Combine all the allocas into a single alloca at the top of the region.
     auto *entryBlock = &region.front();
@@ -234,6 +229,9 @@ public:
     }
 
     // 4. Remove the deallocations, if any. Add new dealloc to exits.
+    // FIXME: This unintentionally "fixes" broken IR by potentially removing
+    // any number of bogus deallocs on the same alloca. There are other passes
+    // that rely on this behavior to repair the IR behind themselves.
     if (!analysis.deallocs.empty()) {
       for (auto d : analysis.deallocs)
         d.erase();
@@ -245,6 +243,8 @@ public:
         }
       }
     }
+
+    return true;
   }
 };
 } // namespace

--- a/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -158,8 +158,14 @@ public:
             combineAllocationsInRegion(nested);
 
     // 1. Scan the top level of \p region for all `alloca` operations. Skip
-    // those that are parametric or married to an initialize with state.
+    // those that are parametric or married to an initialize with state: they
+    // are left exactly as they are, so their own dealloc must be left alone
+    // too -- only a dealloc of an alloca actually being combined belongs in
+    // analysis.deallocs, or step 4 below would erase the dealloc of a
+    // skipped (untouched) alloca along with the ones actually being merged,
+    // silently leaving it never deallocated.
     Analysis analysis;
+    SmallPtrSet<Operation *, 8> combinedAllocaOps;
     std::size_t currentOffset = 0;
     for (auto &block : region)
       for (auto &op : block) {
@@ -175,12 +181,22 @@ public:
           analysis.allocations.push_back(alloc);
           analysis.offsetSizes.emplace_back(currentOffset, size);
           currentOffset += size;
+          combinedAllocaOps.insert(alloc);
         } else if (auto dealloc =
                        dyn_cast_or_null<cudaq::quake::DeallocOp>(&op)) {
-          analysis.deallocs.push_back(dealloc);
+          auto *defOp = dealloc.getReference().getDefiningOp();
+          if (defOp && combinedAllocaOps.count(defOp))
+            analysis.deallocs.push_back(dealloc);
         }
       }
-    if (analysis.empty())
+    // Nothing is gained by "combining" a single eligible alloca: it doesn't
+    // reduce the allocation count, and rewriting it into a 1-element veq
+    // changes its type from ref to veq, which downstream codegen may lower
+    // differently (e.g. a veq-typed control operand gets its 1-element
+    // pointer array built eagerly, right after allocation, while a ref-typed
+    // one defers that until just before the gate that consumes it) --
+    // purely cosmetic churn with no benefit. Leave it untouched.
+    if (analysis.allocations.size() < 2)
       return;
 
     // 2. Combine all the allocas into a single alloca at the top of the region.

--- a/cudaq/test/Transforms/combine.qke
+++ b/cudaq/test/Transforms/combine.qke
@@ -213,3 +213,40 @@ func.func @d(%c2: i64, %c3: i64, %c1: i64, %off: i16) {
 // FACTOR:           quake.x %[[VAL_12]] : (!quake.ref) -> ()
 // FACTOR:           return
 // FACTOR:         }
+
+// Negative case: a parametric (dynamically sized) alloca and an alloca that
+// is paired with an init_state must be skipped -- neither can be safely
+// folded into a combined veq -- while the other, ordinary allocas around
+// them are still combined together.
+func.func @e(%n: i64) {
+  %0 = quake.alloca !quake.ref
+  quake.x %0 : (!quake.ref) -> ()
+  %1 = quake.alloca !quake.veq<2>
+  %a1 = quake.extract_ref %1[0] : (!quake.veq<2>) -> !quake.ref
+  quake.y %a1 : (!quake.ref) -> ()
+  %ptr = cc.address_of @__nvqpp__rodata_e : !cc.ptr<!cc.array<f64 x 2>>
+  %2 = quake.alloca !quake.veq<2>
+  %3 = quake.init_state %2, %ptr : (!quake.veq<2>, !cc.ptr<!cc.array<f64 x 2>>) -> !quake.veq<2>
+  %4 = quake.alloca !quake.veq<?>[%n : i64]
+  %5 = quake.alloca !quake.ref
+  quake.z %5 : (!quake.ref) -> ()
+  return
+}
+cc.global constant private @__nvqpp__rodata_e (
+    dense<[1.000000e+00, 0.000000e+00]> : tensor<2xf64>) : !cc.array<f64 x 2>
+
+// CHECK-LABEL:   func.func @e(
+// CHECK-SAME:                 %[[VAL_0:.*]]: i64) {
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<4>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<4>) -> !quake.ref
+// CHECK:           quake.y %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = cc.address_of @__nvqpp__rodata_e : !cc.ptr<!cc.array<f64 x 2>>
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<2>, !cc.ptr<!cc.array<f64 x 2>>) -> !quake.veq<2>
+// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_0]] : i64]
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_1]][3] : (!quake.veq<4>) -> !quake.ref
+// CHECK:           quake.z %[[VAL_8]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/Transforms/combine.qke
+++ b/cudaq/test/Transforms/combine.qke
@@ -218,6 +218,7 @@ func.func @d(%c2: i64, %c3: i64, %c1: i64, %off: i16) {
 // is paired with an init_state must be skipped -- neither can be safely
 // folded into a combined veq -- while the other, ordinary allocas around
 // them are still combined together.
+// FIXME: Not so fast. Must be bug compatible for the moment.
 func.func @e(%n: i64) {
   %0 = quake.alloca !quake.ref
   quake.x %0 : (!quake.ref) -> ()
@@ -232,21 +233,20 @@ func.func @e(%n: i64) {
   quake.z %5 : (!quake.ref) -> ()
   return
 }
+
 cc.global constant private @__nvqpp__rodata_e (
     dense<[1.000000e+00, 0.000000e+00]> : tensor<2xf64>) : !cc.array<f64 x 2>
 
 // CHECK-LABEL:   func.func @e(
-// CHECK-SAME:                 %[[VAL_0:.*]]: i64) {
-// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<4>) -> !quake.ref
-// CHECK:           quake.x %[[VAL_2]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<4>) -> !quake.ref
-// CHECK:           quake.y %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = cc.address_of @__nvqpp__rodata_e : !cc.ptr<!cc.array<f64 x 2>>
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<2>, !cc.ptr<!cc.array<f64 x 2>>) -> !quake.veq<2>
-// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_0]] : i64]
-// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_1]][3] : (!quake.veq<4>) -> !quake.ref
-// CHECK:           quake.z %[[VAL_8]] : (!quake.ref) -> ()
-// CHECK:           return
-// CHECK:         }
+// CHECK-SAME:                 %[[ARG0:.*]]: i64) {
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.x %[[ALLOCA_0]] : (!quake.ref) -> ()
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_1]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.y %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
+// CHECK:           %[[ADDRESS_OF_0:.*]] = cc.address_of @__nvqpp__rodata_e : !cc.ptr<!cc.array<f64 x 2>>
+// CHECK:           %[[ALLOCA_2:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[INIT_STATE_0:.*]] = quake.init_state %[[ALLOCA_2]], %[[ADDRESS_OF_0]] : (!quake.veq<2>, !cc.ptr<!cc.array<f64 x 2>>) -> !quake.veq<2>
+// CHECK:           %[[ALLOCA_3:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[ARG0]] : i64]
+// CHECK:           %[[ALLOCA_4:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.z %[[ALLOCA_4]] : (!quake.ref) -> ()

--- a/cudaq/test/Transforms/combine_scoped.qke
+++ b/cudaq/test/Transforms/combine_scoped.qke
@@ -29,10 +29,13 @@ func.func @scope_combine() {
   return
 }
 
+// The top-level %0 is the only eligible alloca at the function's own top
+// level, so it is left as a plain ref: combining a single alloca reduces
+// nothing and would only change its type for no benefit (see
+// combineAllocationsInRegion's size<2 guard).
 // CHECK-LABEL:   func.func @scope_combine() {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<1>
-// CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
-// CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
 // CHECK:             %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<4>) -> !quake.ref
@@ -41,7 +44,7 @@ func.func @scope_combine() {
 // CHECK:             quake.y %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:             quake.dealloc %[[VAL_2]] : !quake.veq<4>
 // CHECK:           }
-// CHECK:           quake.dealloc %[[VAL_0]] : !quake.veq<1>
+// CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
 // CHECK:           return
 // CHECK:         }
 
@@ -95,11 +98,12 @@ func.func @nested_scope_lambda() {
   return
 }
 
+// The cc.scope's own top level likewise has only one eligible alloca (%0);
+// it is left as a plain ref for the same reason.
 // CHECK-LABEL:   func.func @nested_scope_lambda() {
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.veq<1>
-// CHECK:             %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
-// CHECK:             quake.x %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:             quake.x %[[VAL_0]] : (!quake.ref) -> ()
 // CHECK:             %[[VAL_2:.*]] = cc.create_lambda {
 // CHECK:               %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
 // CHECK:               %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<3>) -> !quake.ref
@@ -107,7 +111,7 @@ func.func @nested_scope_lambda() {
 // CHECK:               quake.dealloc %[[VAL_3]] : !quake.veq<3>
 // CHECK:               cc.return
 // CHECK:             } : !cc.callable<() -> ()>
-// CHECK:             quake.dealloc %[[VAL_0]] : !quake.veq<1>
+// CHECK:             quake.dealloc %[[VAL_0]] : !quake.ref
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/combine_scoped.qke
+++ b/cudaq/test/Transforms/combine_scoped.qke
@@ -1,0 +1,113 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --combine-quantum-alloc --canonicalize %s | FileCheck %s
+
+// combine-quantum-alloc must recurse into cc.scope and cc.create_lambda:
+// each is combined independently, with the merged alloca placed at the top
+// of that op's own body rather than hoisted out to the function (or an
+// enclosing scope). See combine.qke for the base (top-level only) behavior.
+
+func.func @scope_combine() {
+  %0 = quake.alloca !quake.ref
+  quake.x %0 : (!quake.ref) -> ()
+  cc.scope {
+    %1 = quake.alloca !quake.ref
+    quake.x %1 : (!quake.ref) -> ()
+    %2 = quake.alloca !quake.veq<3>
+    %a = quake.extract_ref %2[0] : (!quake.veq<3>) -> !quake.ref
+    quake.y %a : (!quake.ref) -> ()
+    quake.dealloc %1 : !quake.ref
+    quake.dealloc %2 : !quake.veq<3>
+  }
+  quake.dealloc %0 : !quake.ref
+  return
+}
+
+// CHECK-LABEL:   func.func @scope_combine() {
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<1>
+// CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
+// CHECK:             %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<4>) -> !quake.ref
+// CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:             %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<4>) -> !quake.ref
+// CHECK:             quake.y %[[VAL_4]] : (!quake.ref) -> ()
+// CHECK:             quake.dealloc %[[VAL_2]] : !quake.veq<4>
+// CHECK:           }
+// CHECK:           quake.dealloc %[[VAL_0]] : !quake.veq<1>
+// CHECK:           return
+// CHECK:         }
+
+// A cc.create_lambda's allocations are combined into its own body, never
+// into the enclosing func.func: it is a separate callable activation that
+// may be invoked any number of times.
+func.func @lambda_combine() {
+  %lam = cc.create_lambda {
+    %1 = quake.alloca !quake.ref
+    quake.x %1 : (!quake.ref) -> ()
+    %2 = quake.alloca !quake.veq<2>
+    %a = quake.extract_ref %2[0] : (!quake.veq<2>) -> !quake.ref
+    quake.y %a : (!quake.ref) -> ()
+    quake.dealloc %1 : !quake.ref
+    quake.dealloc %2 : !quake.veq<2>
+    cc.return
+  } : !cc.callable<() -> ()>
+  return
+}
+
+// CHECK-LABEL:   func.func @lambda_combine() {
+// CHECK:           %[[VAL_0:.*]] = cc.create_lambda {
+// CHECK:             %[[VAL_1:.*]] = quake.alloca !quake.veq<3>
+// CHECK:             %[[VAL_2:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<3>) -> !quake.ref
+// CHECK:             quake.x %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:             %[[VAL_3:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<3>) -> !quake.ref
+// CHECK:             quake.y %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:             quake.dealloc %[[VAL_1]] : !quake.veq<3>
+// CHECK:             cc.return
+// CHECK:           } : !cc.callable<() -> ()>
+// CHECK:           return
+// CHECK:         }
+
+// A cc.create_lambda nested inside a cc.scope is still its own,
+// independent combining unit: its allocations are never pulled up into the
+// enclosing scope's merged alloca.
+func.func @nested_scope_lambda() {
+  cc.scope {
+    %1 = quake.alloca !quake.ref
+    quake.x %1 : (!quake.ref) -> ()
+    %lam = cc.create_lambda {
+      %2 = quake.alloca !quake.ref
+      quake.y %2 : (!quake.ref) -> ()
+      %3 = quake.alloca !quake.veq<2>
+      quake.dealloc %2 : !quake.ref
+      quake.dealloc %3 : !quake.veq<2>
+      cc.return
+    } : !cc.callable<() -> ()>
+    quake.dealloc %1 : !quake.ref
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @nested_scope_lambda() {
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.veq<1>
+// CHECK:             %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
+// CHECK:             quake.x %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:             %[[VAL_2:.*]] = cc.create_lambda {
+// CHECK:               %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
+// CHECK:               %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<3>) -> !quake.ref
+// CHECK:               quake.y %[[VAL_4]] : (!quake.ref) -> ()
+// CHECK:               quake.dealloc %[[VAL_3]] : !quake.veq<3>
+// CHECK:               cc.return
+// CHECK:             } : !cc.callable<() -> ()>
+// CHECK:             quake.dealloc %[[VAL_0]] : !quake.veq<1>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/Transforms/combine_scoped.qke
+++ b/cudaq/test/Transforms/combine_scoped.qke
@@ -29,24 +29,20 @@ func.func @scope_combine() {
   return
 }
 
-// The top-level %0 is the only eligible alloca at the function's own top
-// level, so it is left as a plain ref: combining a single alloca reduces
-// nothing and would only change its type for no benefit (see
-// combineAllocationsInRegion's size<2 guard).
 // CHECK-LABEL:   func.func @scope_combine() {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
-// CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<1>
+// CHECK:           %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_0]][0] : (!quake.veq<1>) -> !quake.ref
+// CHECK:           quake.x %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
-// CHECK:             %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<4>) -> !quake.ref
-// CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:             %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<4>) -> !quake.ref
-// CHECK:             quake.y %[[VAL_4]] : (!quake.ref) -> ()
-// CHECK:             quake.dealloc %[[VAL_2]] : !quake.veq<4>
+// CHECK:             %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<4>
+// CHECK:             %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_1]][0] : (!quake.veq<4>) -> !quake.ref
+// CHECK:             quake.x %[[EXTRACT_REF_1]] : (!quake.ref) -> ()
+// CHECK:             %[[EXTRACT_REF_2:.*]] = quake.extract_ref %[[ALLOCA_1]][1] : (!quake.veq<4>) -> !quake.ref
+// CHECK:             quake.y %[[EXTRACT_REF_2]] : (!quake.ref) -> ()
+// CHECK:             quake.dealloc %[[ALLOCA_1]] : !quake.veq<4>
 // CHECK:           }
-// CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
+// CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<1>
 // CHECK:           return
-// CHECK:         }
 
 // A cc.create_lambda's allocations are combined into its own body, never
 // into the enclosing func.func: it is a separate callable activation that
@@ -81,6 +77,7 @@ func.func @lambda_combine() {
 // A cc.create_lambda nested inside a cc.scope is still its own,
 // independent combining unit: its allocations are never pulled up into the
 // enclosing scope's merged alloca.
+
 func.func @nested_scope_lambda() {
   cc.scope {
     %1 = quake.alloca !quake.ref
@@ -98,20 +95,18 @@ func.func @nested_scope_lambda() {
   return
 }
 
-// The cc.scope's own top level likewise has only one eligible alloca (%0);
-// it is left as a plain ref for the same reason.
 // CHECK-LABEL:   func.func @nested_scope_lambda() {
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.ref
-// CHECK:             quake.x %[[VAL_0]] : (!quake.ref) -> ()
-// CHECK:             %[[VAL_2:.*]] = cc.create_lambda {
-// CHECK:               %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
-// CHECK:               %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<3>) -> !quake.ref
-// CHECK:               quake.y %[[VAL_4]] : (!quake.ref) -> ()
-// CHECK:               quake.dealloc %[[VAL_3]] : !quake.veq<3>
+// CHECK:             %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<1>
+// CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_0]][0] : (!quake.veq<1>) -> !quake.ref
+// CHECK:             quake.x %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
+// CHECK:             %[[CREATE_LAMBDA_0:.*]] = cc.create_lambda {
+// CHECK:               %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<3>
+// CHECK:               %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_1]][0] : (!quake.veq<3>) -> !quake.ref
+// CHECK:               quake.y %[[EXTRACT_REF_1]] : (!quake.ref) -> ()
+// CHECK:               quake.dealloc %[[ALLOCA_1]] : !quake.veq<3>
 // CHECK:               cc.return
 // CHECK:             } : !cc.callable<() -> ()>
-// CHECK:             quake.dealloc %[[VAL_0]] : !quake.ref
+// CHECK:             quake.dealloc %[[ALLOCA_0]] : !quake.veq<1>
 // CHECK:           }
 // CHECK:           return
-// CHECK:         }

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4104,7 +4104,10 @@ class PyASTBridge(ast.NodeVisitor):
                                     f'{otherFuncName} that returns a value',
                                     node)
                             invert_controls()
-                            quake.ApplyOp([], indirectCallee, controls, args,
+                            quake.ApplyOp([],
+                                          controls,
+                                          args,
+                                          indirect_callee=indirectCallee[0],
                                           **kwargs)
                             invert_controls()
                         return

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4104,10 +4104,7 @@ class PyASTBridge(ast.NodeVisitor):
                                     f'{otherFuncName} that returns a value',
                                     node)
                             invert_controls()
-                            quake.ApplyOp([],
-                                          controls,
-                                          args,
-                                          indirect_callee=indirectCallee[0],
+                            quake.ApplyOp([], indirectCallee, controls, args,
                                           **kwargs)
                             invert_controls()
                         return


### PR DESCRIPTION
Remove the restrictions of which quake allocas got combined to allow this pass to be more effective in multiple pipelines.