### PR TITLE
Consolidate realtime dependency building.

### DIFF
--- a/.github/workflows/realtime_ci.yml
+++ b/.github/workflows/realtime_ci.yml
@@ -166,12 +166,9 @@ jobs:
             # Build 
             apt update && apt install -y --no-install-recommends cmake git ninja-build nvcomp pkg-config
             cd /workspace/realtime
+            # Installs DOCA/Holoscan and builds HSB into $HSB_ROOT/build.
+            export HSB_ROOT=/workspace/holoscan-sensor-bridge
             bash scripts/install_dev_prerequisites.sh
-            # Build HSB (GPU RoCE transceiver and hololink_core)
-            export CUDA_NATIVE_ARCH="${{ (contains(matrix.cuda_version, '12') && '80-real;90') || '80-real;90-real;100f-real;110-real;120-real;100-virtual' }}"
-            cd /workspace/ && git clone -b 2.6.0-EA2 https://github.com/nvidia-holoscan/holoscan-sensor-bridge.git && cd holoscan-sensor-bridge
-            cmake -G Ninja -S /workspace/holoscan-sensor-bridge -B /workspace/holoscan-sensor-bridge/build -DCMAKE_BUILD_TYPE=Release -DHOLOLINK_BUILD_ONLY_NATIVE=OFF -DHOLOLINK_BUILD_PYTHON=OFF -DHOLOLINK_BUILD_TESTS=OFF -DHOLOLINK_BUILD_TOOLS=OFF -DHOLOLINK_BUILD_EXAMPLES=OFF -DHOLOLINK_BUILD_EMULATOR=OFF
-            cmake --build /workspace/holoscan-sensor-bridge/build --target roce_receiver gpu_roce_transceiver hololink_core
             # Build CUDA-Q Realtime
             cd /workspace/realtime
             mkdir -p build && cd build

--- a/realtime/scripts/deps_common.sh
+++ b/realtime/scripts/deps_common.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Version pins and helpers shared by the CUDA-Q Realtime dependency scripts,
+# i.e., install_dev_prerequisites.sh (standard apt path) and install_devdeps.sh
+# (containers that already ship Mellanox OFED).
+#
+# Usage:
+# This file is meant to be sourced, not executed:
+#   . "$(dirname "$0")/deps_common.sh"
+
+CUDAQ_REALTIME_DOCA_VERSION=3.3.0
+CUDAQ_REALTIME_HSB_REPO=https://github.com/nvidia-holoscan/holoscan-sensor-bridge.git
+CUDAQ_REALTIME_HSB_REF=2.6.0-EA2
+
+# Major CUDA version reported by nvcc, e.g., 13.
+cudaq_realtime_cuda_major() {
+  _cudaq_realtime_cuda_major=$(nvcc --version 2>/dev/null |
+    sed -n 's/^.*release \([0-9]\+\).*$/\1/p')
+  if [ -z "$_cudaq_realtime_cuda_major" ]; then
+    echo "Could not determine CUDA version from nvcc. Is the CUDA toolkit installed?" >&2
+    echo "CUDA-Q Realtime requires CUDA toolkit to be installed." >&2
+    return 1
+  fi
+  printf '%s' "$_cudaq_realtime_cuda_major"
+}
+
+# Full CUDA version reported by nvcc, e.g., 13.0.
+cudaq_realtime_cuda_version() {
+  _cudaq_realtime_cuda_version=$(nvcc --version 2>/dev/null |
+    sed -n 's/^.*release \([0-9]\+\.[0-9]\+\).*$/\1/p')
+  if [ -z "$_cudaq_realtime_cuda_version" ]; then
+    echo "Could not determine CUDA version from nvcc. Is the CUDA toolkit installed?" >&2
+    echo "CUDA-Q Realtime requires CUDA toolkit to be installed." >&2
+    return 1
+  fi
+  printf '%s' "$_cudaq_realtime_cuda_version"
+}
+
+# CUDA architectures HSB is compiled for. HSB reads CUDA_NATIVE_ARCH from the
+# environment, so a value set by the caller always wins.
+cudaq_realtime_cuda_native_arch() {
+  if [ -n "${CUDA_NATIVE_ARCH:-}" ]; then
+    printf '%s' "$CUDA_NATIVE_ARCH"
+    return 0
+  fi
+  _cudaq_realtime_arch_cuda_major=$(cudaq_realtime_cuda_major) || return 1
+  if [ "$_cudaq_realtime_arch_cuda_major" = 12 ]; then
+    printf '%s' "80-real;90"
+  else
+    printf '%s' "80-real;90-real;100f-real;110-real;120-real;100-virtual"
+  fi
+}
+
+# Register the DOCA host apt repository for this architecture and distro.
+cudaq_realtime_add_doca_repo() {
+  if [ ! -x "$(command -v curl)" ] || [ ! -x "$(command -v gpg)" ]; then
+    apt-get update && apt-get install -y --no-install-recommends curl gnupg
+  fi
+
+  echo "Installing DOCA version $CUDAQ_REALTIME_DOCA_VERSION..."
+  _cudaq_realtime_doca_arch=$(uname -m)
+  case "$_cudaq_realtime_doca_arch" in
+    aarch64 | arm64) _cudaq_realtime_doca_arch="arm64-sbsa" ;;
+  esac
+  _cudaq_realtime_distro=$(. /etc/os-release && echo ${ID}${VERSION_ID}) # e.g., ubuntu24.04
+  export DOCA_URL="https://linux.mellanox.com/public/repo/doca/$CUDAQ_REALTIME_DOCA_VERSION/$_cudaq_realtime_distro/$_cudaq_realtime_doca_arch/"
+  echo "Using DOCA_REPO_LINK=${DOCA_URL}"
+  curl https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub
+  echo "deb [signed-by=/etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub] $DOCA_URL ./" > /etc/apt/sources.list.d/doca.list
+  apt-get update
+}
+
+# Install the Holoscan SDK matching the CUDA toolkit in use. Set
+# CUDAQ_REALTIME_HOLOSCAN_FORCE_DEPS=1 to fall back to a dependency-forced dpkg
+# install; needed in containers whose pre-installed packages keep apt from
+# resolving the Holoscan dependency chain.
+cudaq_realtime_install_holoscan() {
+  _cudaq_realtime_holoscan_cuda_major=$(cudaq_realtime_cuda_major) || return 1
+  apt-get update
+  if apt-get install -y --no-install-recommends \
+    holoscan-cuda-$_cudaq_realtime_holoscan_cuda_major; then
+    return 0
+  fi
+  if [ "${CUDAQ_REALTIME_HOLOSCAN_FORCE_DEPS:-0}" != 1 ]; then
+    return 1
+  fi
+  _cudaq_realtime_holoscan_tmp=$(mktemp -d)
+  (cd "$_cudaq_realtime_holoscan_tmp" &&
+    apt-get download holoscan holoscan-cuda-$_cudaq_realtime_holoscan_cuda_major &&
+    dpkg --force-depends -i holoscan*.deb)
+  _cudaq_realtime_holoscan_status=$?
+  rm -rf "$_cudaq_realtime_holoscan_tmp"
+  return $_cudaq_realtime_holoscan_status
+}
+
+# Fail early if DOCA or the Holoscan SDK did not land where HSB expects them.
+cudaq_realtime_verify_sdks() {
+  if [ ! -d /opt/mellanox/doca/include ]; then
+    echo "ERROR: DOCA SDK installation failed" >&2
+    return 1
+  fi
+  if [ ! -d /opt/nvidia/holoscan ]; then
+    echo "ERROR: Holoscan SDK installation failed" >&2
+    return 1
+  fi
+}
+
+# Clone and build the Holoscan Sensor Bridge libraries CUDA-Q Realtime links
+# against. HSB_ROOT selects the source tree (default /tmp/holoscan-sensor-bridge)
+# and the build lands in $HSB_ROOT/build; callers pass both to CMake through
+# HOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR and HOLOSCAN_SENSOR_BRIDGE_BUILD_DIR.
+# Set CUDAQ_REALTIME_HSB_STRIP_OPERATORS=1 to drop the operators CUDA-Q Realtime
+# does not use.
+cudaq_realtime_build_hsb() {
+  export HSB_ROOT="${HSB_ROOT:-/tmp/holoscan-sensor-bridge}"
+  export HSB_BUILD="${HSB_ROOT}/build"
+
+  CUDA_NATIVE_ARCH=$(cudaq_realtime_cuda_native_arch) || return 1
+  export CUDA_NATIVE_ARCH
+  echo "Building holoscan-sensor-bridge $CUDAQ_REALTIME_HSB_REF for CUDA_NATIVE_ARCH=$CUDA_NATIVE_ARCH"
+
+  rm -rf "$HSB_ROOT"
+  git clone --depth 1 --branch "$CUDAQ_REALTIME_HSB_REF" \
+    "$CUDAQ_REALTIME_HSB_REPO" "$HSB_ROOT"
+
+  if [ "${CUDAQ_REALTIME_HSB_STRIP_OPERATORS:-0}" = 1 ]; then
+    # Strip operators we don't need to avoid configure failures from missing deps
+    sed -i '/add_subdirectory(audio_packetizer)/d; /add_subdirectory(compute_crc)/d;
+            /add_subdirectory(csi_to_bayer)/d; /add_subdirectory(image_processor)/d;
+            /add_subdirectory(iq_dec)/d; /add_subdirectory(iq_enc)/d;
+            /add_subdirectory(linux_coe_receiver)/d; /add_subdirectory(linux_receiver)/d;
+            /add_subdirectory(packed_format_converter)/d; /add_subdirectory(sub_frame_combiner)/d;
+            /add_subdirectory(udp_transmitter)/d; /add_subdirectory(emulator)/d;
+            /add_subdirectory(sig_gen)/d; /add_subdirectory(sig_viewer)/d' \
+      "$HSB_ROOT/src/hololink/operators/CMakeLists.txt"
+  fi
+
+  cmake -G Ninja -S "$HSB_ROOT" -B "$HSB_BUILD" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DHOLOLINK_BUILD_ONLY_NATIVE=OFF \
+    -DHOLOLINK_BUILD_PYTHON=OFF \
+    -DHOLOLINK_BUILD_TESTS=OFF \
+    -DHOLOLINK_BUILD_TOOLS=OFF \
+    -DHOLOLINK_BUILD_EXAMPLES=OFF \
+    -DHOLOLINK_BUILD_EMULATOR=OFF
+  cmake --build "$HSB_BUILD" \
+    --target roce_receiver gpu_roce_transceiver hololink_core
+  echo "holoscan-sensor-bridge built at $HSB_BUILD"
+}

--- a/realtime/scripts/install_dev_prerequisites.sh
+++ b/realtime/scripts/install_dev_prerequisites.sh
@@ -14,41 +14,48 @@
 #
 # Usage: 
 # bash install_dev_prerequisites.sh
+#
+# Environment variables:
+#   HSB_ROOT                     Where to clone and build HSB.
+#                                Default: /tmp/holoscan-sensor-bridge
+#   CUDA_NATIVE_ARCH             CUDA architectures to compile HSB for.
+#                                Default: derived from the CUDA toolkit version.
+#   CUDAQ_REALTIME_SKIP_HSB=1    Install the SDKs but skip the HSB build.
+#
+# Containers that already ship Mellanox OFED cannot use this script, because
+# doca-all conflicts with the OFED packages; use install_devdeps.sh instead.
 
+set -e
+
+. "$(dirname "$0")/deps_common.sh"
 
 if [ -x "$(command -v apt-get)" ]; then
-  CUDA_MAJOR_VERSION=$(nvcc --version | sed -n 's/^.*release \([0-9]\+\).*$/\1/p')
-  if [ -z "$CUDA_MAJOR_VERSION" ]; then
-    echo "Could not determine CUDA version from nvcc. Is the CUDA toolkit installed?" >&2
-    echo "CUDA-Q Realtime requires CUDA toolkit to be installed." >&2
-    exit 1
-  fi
-  
+  # Fail early if the CUDA toolkit is missing.
+  cudaq_realtime_cuda_major > /dev/null
+
+  # [Build tools]
+  # Needed to build HSB from source below.
+  apt-get update && apt-get install -y --no-install-recommends git ninja-build pkg-config
+
   # [libibverbs]
   echo "Installing libibverbs..."
   apt-get update && apt-get install -y --no-install-recommends libibverbs-dev
 
   # [DOCA Host]
-  if [ ! -x "$(command -v curl)" ]; then
-    apt-get update && apt-get install -y --no-install-recommends curl
-  fi
-
-  DOCA_VERSION=3.3.0
-  echo "Installing DOCA version $DOCA_VERSION..."
-  arch=$(uname -m)
-  if [ "$arch" == "aarch64" ] || [ "$arch" == "arm64" ]; then
-    arch="arm64-sbsa"
-  fi
-  distro=$(. /etc/os-release && echo ${ID}${VERSION_ID}) # e.g., ubuntu24.04
-  export DOCA_URL="https://linux.mellanox.com/public/repo/doca/$DOCA_VERSION/$distro/$arch/"
-  echo "Using DOCA_REPO_LINK=${DOCA_URL}" 
-  curl https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub
-  echo "deb [signed-by=/etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub] $DOCA_URL ./" > /etc/apt/sources.list.d/doca.list
-  apt-get update
+  cudaq_realtime_add_doca_repo
   DEBIAN_FRONTEND=noninteractive apt-get -y install doca-all libdoca-sdk-gpunetio-dev
 
   # [Holoscan SDK]
-  apt-get update && apt-get install -y --no-install-recommends holoscan-cuda-$CUDA_MAJOR_VERSION
+  cudaq_realtime_install_holoscan
+
+  cudaq_realtime_verify_sdks
+
+  # [Holoscan Sensor Bridge]
+  if [ "${CUDAQ_REALTIME_SKIP_HSB:-0}" == "1" ]; then
+    echo "CUDAQ_REALTIME_SKIP_HSB is set, skipping the HSB build."
+  else
+    cudaq_realtime_build_hsb
+  fi
 
 elif [ -x "$(command -v dnf)" ]; then
   echo "RHEL is not supported. Please install DOCA and Holoscan SDK manually." >&2

--- a/realtime/scripts/install_devdeps.sh
+++ b/realtime/scripts/install_devdeps.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# This script installs the DOCA/HSB dependencies needed to build CUDA-Q realtime
+# inside a CI container that already ships Mellanox OFED. Such containers cannot
+# use install_dev_prerequisites.sh, because doca-all and the Ubuntu libibverbs
+# packages conflict with the container's OFED packages; only the GPUNetIO dev
+# package is installed here.
+#
+# Usage:
+# bash install_devdeps.sh
+#
+# Environment variables:
+#   HSB_ROOT           Where to clone and build HSB.
+#                      Default: /tmp/holoscan-sensor-bridge
+#   CUDA_NATIVE_ARCH   CUDA architectures to compile HSB for.
+#                      Default: derived from the CUDA toolkit version.
+
+set -e
+
+. "$(dirname "$0")/deps_common.sh"
+
+if [ ! -x "$(command -v apt-get)" ]; then
+  echo "install_devdeps.sh requires apt-get." >&2
+  exit 1
+fi
+
+# Fail early if the CUDA toolkit is missing; the exact version is needed below.
+CUDA_FULL_VERSION=$(cudaq_realtime_cuda_version)
+
+apt-get update && apt-get install -y --no-install-recommends \
+  git ninja-build curl pkg-config
+
+# [DOCA Host]
+# Only the GPUNetIO dev package, not doca-all.
+cudaq_realtime_add_doca_repo
+apt-get -y install --no-install-recommends libdoca-sdk-gpunetio-dev
+
+# hololink_core links CUDA::nvrtc -- must match the exact toolkit version
+CUDA_VER_DASH=$(echo $CUDA_FULL_VERSION | sed 's/\./-/')
+apt-get install -y cuda-nvrtc-dev-$CUDA_VER_DASH 2>/dev/null || true
+
+# [Holoscan SDK]
+export CUDAQ_REALTIME_HOLOSCAN_FORCE_DEPS=1
+cudaq_realtime_install_holoscan
+
+cudaq_realtime_verify_sdks
+
+# [Holoscan Sensor Bridge]
+export CUDAQ_REALTIME_HSB_STRIP_OPERATORS=1
+cudaq_realtime_build_hsb


### PR DESCRIPTION
## Summary

The DOCA + Holoscan SDK + Holoscan Sensor Bridge (HSB) install-and-build sequence
had been copied into four places, each with its own pinned versions and its own
subtly different cmake invocation. This PR extracts the shared logic into
`realtime/scripts/deps_common.sh` and reduces the callers to thin entry points.

## Where the duplication was

1. **`realtime/scripts/install_dev_prerequisites.sh`** — the apt path: DOCA repo
   setup, `doca-all`, `holoscan-cuda-$CUDA_MAJOR`. It stopped short of HSB, so
   every caller had to build HSB itself.

2. **`.github/workflows/realtime_ci.yml`**, [lines 169-180](https://github.com/Renaud-K/cuda-quantum/blob/main/.github/workflows/realtime_ci.yml#L169-L180) —
   the `CUDA_NATIVE_ARCH` matrix expression, the HSB clone at `2.6.0-EA2`, and a
   seven-flag cmake configure plus three-target build, all inline in YAML where
   nothing can lint or reuse it.

3. **cudaqx `.github/actions/build-lib/build_qec.sh`** — roughly 65 lines
   repeating the same sequence, except that the cudaqx CI container ships
   Mellanox OFED, so `doca-all` conflicts and it installs only
   `libdoca-sdk-gpunetio-dev`, pins `cuda-nvrtc-dev` to the toolkit version, and
   force-installs Holoscan with `dpkg --force-depends`.

4. **`realtime/docker/assets.Dockerfile`** — the rpm/UBI DOCA install, plus yet
   another copy of the HSB clone/configure/build with its own `hsb_version` and
   `cuda_native_arg` defaults.

The practical cost was that DOCA 3.3.0, the HSB ref `2.6.0-EA2`, the architecture
lists and the HSB cmake flags each had to be bumped in several unrelated files,
and they had already drifted: `build_qec.sh` built only two of the three HSB
targets and hard-coded `CUDA_NATIVE_ARCH=80`, while CI passed a full architecture
list per CUDA version.

## What changed

- **New `realtime/scripts/deps_common.sh`** holds the version pins
  (`CUDAQ_REALTIME_DOCA_VERSION`, HSB repo and ref) and the shared helpers:
  CUDA version detection, `CUDA_NATIVE_ARCH` derivation, DOCA repo registration,
  Holoscan install, an SDK sanity check, and the HSB clone/configure/build. It is
  meant to be sourced rather than executed.

- **`install_dev_prerequisites.sh`** keeps the standard `doca-all` path but now
  also builds HSB, so callers no longer have to. It runs under `set -e`,
  `HSB_ROOT` selects where the tree lands, and `CUDAQ_REALTIME_SKIP_HSB=1`
  installs the SDKs only.

- **New `install_devdeps.sh`** is the entry point for containers that already
  ship Mellanox OFED, where `doca-all` cannot be installed. It is the
  consolidation target for the cudaqx logic above: minimal DOCA, `cuda-nvrtc-dev`
  pinned to the exact toolkit version, the dependency-forced Holoscan fallback,
  and HSB built with the unused operators stripped.

- **`realtime_ci.yml`** loses the twelve inline lines in favor of exporting
  `HSB_ROOT` and calling the script. The architecture list is now derived from
  `nvcc` instead of a matrix expression, which is what lets the same script serve
  CI, the cudaqx action and local development.

Both entry points always build all three HSB targets
(`roce_receiver`, `gpu_roce_transceiver`, `hololink_core`), removing another way
for callers to diverge.

## Architecture derivation

CUDA 12 gets `80-real;90` and anything newer gets
`80-real;90-real;100f-real;110-real;120-real;100-virtual`, the same values the CI
matrix expression produced. A `CUDA_NATIVE_ARCH` set by the caller always wins,
so pinning a single architecture for a faster build still works.

## Testing

Ran the consolidated scripts end to end in containers based on
`cuda-quantum-devcontainer:amd64-cu12.6-gcc12-main` and
`amd64-cu13.0-gcc12-main`. On CUDA 13 this installs DOCA 3.3.0 and
`holoscan-cuda-13` 4.5.0.0, produces all six HSB static libraries, and the
compiled kernel object carries cubins for sm_80, sm_90, sm_100, sm_110 and
sm_120, confirming the derived architecture list reaches nvcc. `apt-get check`
and `dpkg -C` are clean afterwards, so the forced Holoscan path leaves no broken
dependencies. The dependency step takes about 72 seconds and adds roughly 700 MB.

## Follow-ups

After these changes are pushed, cudaqx PR https://github.com/NVIDIA/cudaqx/pull/794 can proceed to using the consolidated scripts.