### PR TITLE
Adding set_function_entry to brige API (#5155)

### DIFF
--- a/realtime/docs/cudaq_realtime_network_interface.md
+++ b/realtime/docs/cudaq_realtime_network_interface.md
@@ -113,8 +113,42 @@ typedef struct {
   cudaq_status_t (*launch)(cudaq_realtime_bridge_handle_t);
   cudaq_status_t (*disconnect)(cudaq_realtime_bridge_handle_t);
 
+  // Version 2 fields.
+  cudaq_status_t (*get_cpu_dataplane)(cudaq_realtime_bridge_handle_t,
+                                      cudaq_cpu_dataplane_t *out);
+  cudaq_status_t (*get_endpoint_info)(cudaq_realtime_bridge_handle_t, char *buf,
+                                      size_t buf_len);
+  cudaq_status_t (*get_ring_geometry)(cudaq_realtime_bridge_handle_t,
+                                      uint32_t *out_num_slots,
+                                      uint32_t *out_slot_size);
+
+  // Version 3 field.
+  cudaq_status_t (*set_function_table)(cudaq_realtime_bridge_handle_t,
+                                       const cudaq_function_table_t *table);
+
 } cudaq_realtime_bridge_interface_t;
 ```
+
+### Interface versioning
+
+Set `version` to `CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION`. A provider must be
+built against the headers it runs against: the loader reads the whole struct
+and does not adapt to older layouts. A provider reporting a different value is
+rejected by `cudaq_bridge_create*`, which returns `CUDAQ_ERR_INTERNAL` after
+printing a message naming both versions, so a stale plug-in is identified
+rather than failing in obscure ways. Rebuild the provider whenever this value
+changes.
+
+A provider that does not implement an optional capability sets that entry to
+`NULL`, and the corresponding `cudaq_bridge_get_*` call then returns
+`CUDAQ_ERR_UNSUPPORTED` instead of dispatching into the provider.
+
+`set_function_table` (version 3) hands the provider the same
+`cudaq_function_table_t` the dispatcher receives from
+`cudaq_dispatcher_set_function_table`. Some providers may need the table
+for pre-staging. A transport that does not need the table simply leaves
+the entry `NULL`, and the call then returns `CUDAQ_OK` instead of
+dispatching into the provider.  
 
 At runtime, when a `CUDAQ_PROVIDER_EXTERNAL` is requested in `cudaq_bridge_create`,
 CUDA-Q will retrieve the environment variable `CUDAQ_REALTIME_BRIDGE_LIB`
@@ -224,6 +258,13 @@ cudaq_realtime_bridge_interface_t *cudaq_realtime_get_bridge_interface() {
       provider_name_bridge_connect,
       provider_name_bridge_launch,
       provider_name_bridge_disconnect,
+      // Optional capabilities: implement the ones this transport supports and
+      // leave the rest NULL (the matching cudaq_bridge_* call then returns
+      // CUDAQ_ERR_UNSUPPORTED).
+      /*get_cpu_dataplane=*/nullptr,
+      /*get_endpoint_info=*/nullptr,
+      /*get_ring_geometry=*/nullptr,
+      /*set_function_table=*/nullptr,
   };
   return &cudaq_provider_name_bridge_interface;
 }

--- a/realtime/include/cudaq/realtime/daemon/bridge/bridge_interface.h
+++ b/realtime/include/cudaq/realtime/daemon/bridge/bridge_interface.h
@@ -166,8 +166,8 @@ cudaq_status_t cudaq_bridge_launch(cudaq_realtime_bridge_handle_t bridge);
 cudaq_status_t cudaq_bridge_disconnect(cudaq_realtime_bridge_handle_t bridge);
 
 /// @brief Retrieve the CPU data-plane for the single-thread unified host
-/// dispatch loop.  Returns CUDAQ_ERR_UNSUPPORTED when the provider predates
-/// interface version 2 or does not implement the unified shape.
+/// dispatch loop.  Returns CUDAQ_ERR_UNSUPPORTED when the provider does not
+/// implement the unified shape.
 cudaq_status_t
 cudaq_bridge_get_cpu_dataplane(cudaq_realtime_bridge_handle_t bridge,
                                cudaq_cpu_dataplane_t *out_dataplane);
@@ -177,29 +177,36 @@ cudaq_bridge_get_cpu_dataplane(cudaq_realtime_bridge_handle_t bridge,
 /// `transport=cpu_roce port=9000 roce_ip=10.0.0.2 qp=0x1a rkey=1234`) into
 /// `buf`.  Valid as soon as create() returns, so a server can publish its
 /// rendezvous endpoint BEFORE connect() blocks waiting for the peer.  Returns
-/// CUDAQ_ERR_UNSUPPORTED when the provider predates interface version 2 or
-/// has nothing to report.
+/// CUDAQ_ERR_UNSUPPORTED when the provider has nothing to report.
 cudaq_status_t
 cudaq_bridge_get_endpoint_info(cudaq_realtime_bridge_handle_t bridge, char *buf,
                                size_t buf_len);
 
 /// @brief Retrieve the provider's ring geometry so dispatcher configuration
 /// can be derived from the transport instead of duplicated by the caller.
-/// Returns CUDAQ_ERR_UNSUPPORTED when the provider predates interface
-/// version 2.
+/// Returns CUDAQ_ERR_UNSUPPORTED when the provider does not report geometry.
 cudaq_status_t
 cudaq_bridge_get_ring_geometry(cudaq_realtime_bridge_handle_t bridge,
                                uint32_t *out_num_slots,
                                uint32_t *out_slot_size);
 
-/// Version 2 adds the capability queries after `disconnect`:
-/// `get_cpu_dataplane`, `get_endpoint_info`, and `get_ring_geometry`.  The
-/// loader accepts providers reporting any version in [1, CURRENT]; fields
-/// beyond `disconnect` are only read from providers reporting version >= 2
-/// (a v1 provider's struct may simply end at `disconnect`).  A v2 provider
-/// sets entries it does not support to NULL; the corresponding API calls
-/// return CUDAQ_ERR_UNSUPPORTED.
-#define CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION 2
+/// @brief Hand the provider the same function table the dispatcher will run
+/// (the `cudaq_function_table_t` passed to
+/// `cudaq_dispatcher_set_function_table`). Some providers may need the table
+/// for pre-staging. A transport that does not need the table simply leaves
+/// the entry `NULL`, and the call then returns `CUDAQ_OK` instead of
+/// dispatching into the provider.
+cudaq_status_t
+cudaq_bridge_set_function_table(cudaq_realtime_bridge_handle_t bridge,
+                                const cudaq_function_table_t *table);
+
+/// A provider must be built against this header: the loader reads the whole
+/// struct and does not adapt to older layouts.  A provider reporting a
+/// different value is rejected at load with a message naming both versions,
+/// so a stale plug-in is identified instead of failing in obscure ways.  A
+/// provider sets entries it does not implement to NULL; the corresponding API
+/// calls then return CUDAQ_ERR_UNSUPPORTED.
+#define CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION 3
 
 /// @brief Interface struct for transport layer providers.  Each provider must
 /// implement this interface and provide a `getter` function
@@ -218,9 +225,8 @@ typedef struct {
   cudaq_status_t (*disconnect)(cudaq_realtime_bridge_handle_t);
 
   //--------------------------------------------------------------------------
-  // Version 2 fields.  Read only when `version >= 2`; each may be NULL when
-  // the provider does not support the capability (the API wrappers then
-  // return CUDAQ_ERR_UNSUPPORTED).
+  // Added in version 2.  Each may be NULL when the provider does not support
+  // the capability (the API wrappers then return CUDAQ_ERR_UNSUPPORTED).
   //--------------------------------------------------------------------------
 
   /// Fills *out with the ring data-plane the library's single-thread
@@ -239,6 +245,16 @@ typedef struct {
   cudaq_status_t (*get_ring_geometry)(cudaq_realtime_bridge_handle_t,
                                       uint32_t *out_num_slots,
                                       uint32_t *out_slot_size);
+
+  //--------------------------------------------------------------------------
+  // Added in version 3.  NULL when the provider does not consume the table
+  // (the API wrapper then returns CUDAQ_OK).
+  //--------------------------------------------------------------------------
+
+  /// Registers the dispatcher's function table with the transport; see
+  /// cudaq_bridge_set_function_table.
+  cudaq_status_t (*set_function_table)(cudaq_realtime_bridge_handle_t,
+                                       const cudaq_function_table_t *table);
 
 } cudaq_realtime_bridge_interface_t;
 

--- a/realtime/lib/daemon/bridge/bridge_interface_api.cpp
+++ b/realtime/lib/daemon/bridge/bridge_interface_api.cpp
@@ -97,17 +97,18 @@ cudaq_status_t cudaq_bridge_create_from_library(
     return CUDAQ_ERR_INTERNAL;
   }
 
-  // Check interface version compatibility BEFORE caching the interface:
-  // versions older than CURRENT are accepted (fields beyond `disconnect` are
-  // guarded by version checks at the call sites); newer versions are rejected
-  // since the provider's struct may reference callbacks this library does not
-  // know how to drive.
-  if (bridge_interface->version < 1 ||
-      bridge_interface->version > CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION) {
+  // Reject a version mismatch BEFORE caching the interface.  The whole struct
+  // is read from every provider, so a provider built against a different
+  // header may be a different shape; continuing past this point would read
+  // fields it never defined.
+  if (bridge_interface->version != CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION) {
     std::cerr << "ERROR: Bridge interface version mismatch for '" << lib_name
-              << "': this library supports versions 1.."
-              << CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION << ", got "
-              << bridge_interface->version << std::endl;
+              << "': this library was built against version "
+              << CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION
+              << ", provider reports " << bridge_interface->version
+              << ".  Rebuild the provider against the matching CUDA-Q "
+                 "realtime headers."
+              << std::endl;
     dlclose(lib_handle);
     return CUDAQ_ERR_INTERNAL;
   }
@@ -213,41 +214,17 @@ cudaq_status_t cudaq_bridge_disconnect(cudaq_realtime_bridge_handle_t bridge) {
 }
 
 //==============================================================================
-// Version-2 capability queries.  Fields beyond `disconnect` may only be read
-// from providers reporting version >= 2 (a v1 provider's struct may simply
-// end at `disconnect`); missing capability => CUDAQ_ERR_UNSUPPORTED.
+// Optional capabilities.  A provider leaves the entries it does not implement
+// NULL; missing capability => CUDAQ_ERR_UNSUPPORTED, except for
+// set_function_table, where nothing to register is not an error.
 //==============================================================================
-
-namespace {
-// Look up the interface for `bridge` and return it only if it is a v2+
-// provider; sets `*status` and returns nullptr otherwise.
-cudaq_realtime_bridge_interface_t *
-find_v2_interface(cudaq_realtime_bridge_handle_t bridge, const char *what,
-                  cudaq_status_t *status) {
-  const auto it = bridge_handle_interface_map.find(bridge);
-  if (it == bridge_handle_interface_map.end()) {
-    std::cerr << "ERROR: Invalid bridge handle in " << what << std::endl;
-    *status = CUDAQ_ERR_INVALID_ARG;
-    return nullptr;
-  }
-  if (it->second->version < 2) {
-    *status = CUDAQ_ERR_UNSUPPORTED;
-    return nullptr;
-  }
-  *status = CUDAQ_OK;
-  return it->second;
-}
-} // namespace
 
 cudaq_status_t
 cudaq_bridge_get_cpu_dataplane(cudaq_realtime_bridge_handle_t bridge,
                                cudaq_cpu_dataplane_t *out_dataplane) {
-  std::shared_lock<std::shared_mutex> lock(bridge_interface_mutex);
-  cudaq_status_t status;
-  auto *bridge_interface =
-      find_v2_interface(bridge, "get_cpu_dataplane", &status);
+  auto *bridge_interface = find_interface(bridge, "get_cpu_dataplane");
   if (!bridge_interface)
-    return status;
+    return CUDAQ_ERR_INVALID_ARG;
   if (!bridge_interface->get_cpu_dataplane)
     return CUDAQ_ERR_UNSUPPORTED;
   return bridge_interface->get_cpu_dataplane(bridge, out_dataplane);
@@ -256,12 +233,9 @@ cudaq_bridge_get_cpu_dataplane(cudaq_realtime_bridge_handle_t bridge,
 cudaq_status_t
 cudaq_bridge_get_endpoint_info(cudaq_realtime_bridge_handle_t bridge, char *buf,
                                size_t buf_len) {
-  std::shared_lock<std::shared_mutex> lock(bridge_interface_mutex);
-  cudaq_status_t status;
-  auto *bridge_interface =
-      find_v2_interface(bridge, "get_endpoint_info", &status);
+  auto *bridge_interface = find_interface(bridge, "get_endpoint_info");
   if (!bridge_interface)
-    return status;
+    return CUDAQ_ERR_INVALID_ARG;
   if (!bridge_interface->get_endpoint_info)
     return CUDAQ_ERR_UNSUPPORTED;
   return bridge_interface->get_endpoint_info(bridge, buf, buf_len);
@@ -271,14 +245,24 @@ cudaq_status_t
 cudaq_bridge_get_ring_geometry(cudaq_realtime_bridge_handle_t bridge,
                                uint32_t *out_num_slots,
                                uint32_t *out_slot_size) {
-  std::shared_lock<std::shared_mutex> lock(bridge_interface_mutex);
-  cudaq_status_t status;
-  auto *bridge_interface =
-      find_v2_interface(bridge, "get_ring_geometry", &status);
+  auto *bridge_interface = find_interface(bridge, "get_ring_geometry");
   if (!bridge_interface)
-    return status;
+    return CUDAQ_ERR_INVALID_ARG;
   if (!bridge_interface->get_ring_geometry)
     return CUDAQ_ERR_UNSUPPORTED;
   return bridge_interface->get_ring_geometry(bridge, out_num_slots,
                                              out_slot_size);
+}
+
+cudaq_status_t
+cudaq_bridge_set_function_table(cudaq_realtime_bridge_handle_t bridge,
+                                const cudaq_function_table_t *table) {
+  if (!table || !table->entries || table->count == 0)
+    return CUDAQ_ERR_INVALID_ARG;
+  auto *bridge_interface = find_interface(bridge, "set_function_table");
+  if (!bridge_interface)
+    return CUDAQ_ERR_INVALID_ARG;
+  if (!bridge_interface->set_function_table)
+    return CUDAQ_OK;
+  return bridge_interface->set_function_table(bridge, table);
 }

--- a/realtime/lib/daemon/bridge/cpu_roce/bridge_impl.cpp
+++ b/realtime/lib/daemon/bridge/cpu_roce/bridge_impl.cpp
@@ -534,6 +534,7 @@ cudaq_realtime_bridge_interface_t *cudaq_realtime_get_bridge_interface() {
       /*get_cpu_dataplane=*/nullptr, // ring path only
       cpu_roce_bridge_get_endpoint_info,
       cpu_roce_bridge_get_ring_geometry,
+      /*set_function_table=*/nullptr, // no function table needed
   };
   return &cudaq_cpu_roce_bridge_interface;
 }

--- a/realtime/lib/daemon/bridge/gpu_roce/bridge_impl.cpp
+++ b/realtime/lib/daemon/bridge/gpu_roce/bridge_impl.cpp
@@ -326,6 +326,7 @@ cudaq_realtime_bridge_interface_t *cudaq_realtime_get_bridge_interface() {
       /*get_cpu_dataplane=*/nullptr, // GPU rings; no host unified shape
       gpu_roce_bridge_get_endpoint_info,
       gpu_roce_bridge_get_ring_geometry,
+      /*set_function_table=*/nullptr, // no function table needed
   };
   return &cudaq_gpu_roce_bridge_interface;
 }

--- a/realtime/lib/daemon/bridge/udp/bridge_impl.cpp
+++ b/realtime/lib/daemon/bridge/udp/bridge_impl.cpp
@@ -272,6 +272,7 @@ cudaq_realtime_bridge_interface_t *cudaq_realtime_get_bridge_interface() {
                                      // contract)
       udp_bridge_get_endpoint_info,
       udp_bridge_get_ring_geometry,
+      /*set_function_table=*/nullptr, // no function table needed
   };
   return &cudaq_udp_bridge_interface;
 }

--- a/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
+++ b/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
@@ -63,5 +63,26 @@ TEST(UdpBridgeProvider, LoadsAndCreatesPlainBridgeWithoutCudaRuntime) {
             CUDAQ_OK);
   EXPECT_NE(std::strstr(endpoint, "transport=udp"), nullptr);
 
+  // The v3 set_function_table slot is NULL for this provider (the dispatcher
+  // owns dispatch, so the transport never reads the table): a well-formed
+  // registration must report the capability as succeeding.
+  cudaq_function_entry_t entries[1] = {};
+  cudaq_function_table_t table = {entries, 1};
+  EXPECT_EQ(cudaq_bridge_set_function_table(bridge, &table), CUDAQ_OK);
+
+  // Argument validation happens ahead of the capability lookup.
+  EXPECT_EQ(cudaq_bridge_set_function_table(bridge, nullptr),
+            CUDAQ_ERR_INVALID_ARG);
+  const cudaq_function_table_t no_entries = {nullptr, 1};
+  EXPECT_EQ(cudaq_bridge_set_function_table(bridge, &no_entries),
+            CUDAQ_ERR_INVALID_ARG);
+  const cudaq_function_table_t empty = {entries, 0};
+  EXPECT_EQ(cudaq_bridge_set_function_table(bridge, &empty),
+            CUDAQ_ERR_INVALID_ARG);
+
   EXPECT_EQ(cudaq_bridge_destroy(bridge), CUDAQ_OK);
+
+  // An unknown handle (here: the destroyed one) is rejected.
+  EXPECT_EQ(cudaq_bridge_set_function_table(bridge, &table),
+            CUDAQ_ERR_INVALID_ARG);
 }


### PR DESCRIPTION
Adds an optional `set_function_table` entry point to the realtime bridge provider interface and bumps `CUDAQ_REALTIME_BRIDGE_INTERFACE_VERSION` to 3.

The downside of this approach is that every app will have to call this function irrespective of the transport. It is not ideal but considering the alternatives, it is a good approach while we are still trying the define the final API.

These a cherry-pick of https://github.com/NVIDIA/cuda-quantum/pull/5155

See https://github.com/NVIDIA/cuda-quantum/pull/5155 for the alternatives considered.
