### PR TITLE
Pin nanobind to <3 to fix Python wheel builds

### DIFF
--- a/docker/release/cudaq.wheel.Dockerfile
+++ b/docker/release/cudaq.wheel.Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=from=ccache-data,target=/tmp/ccache-import,rw \
         mkdir -p /root/.ccache; \
     fi
 RUN echo "Building MLIR bindings for python${python_version}" && \
-    CCACHE_DISABLE=1 python${python_version} -m pip install --no-cache-dir numpy "nanobind>=2.12.0" && \
+    CCACHE_DISABLE=1 python${python_version} -m pip install --no-cache-dir numpy "nanobind>=2.12.0,<3" && \
     rm -rf "$LLVM_INSTALL_PREFIX/src" "$LLVM_INSTALL_PREFIX/python_packages" && \
     Python3_EXECUTABLE="$(which python${python_version})" \
     LLVM_SOURCE=/llvm-project \

--- a/docs/sphinx/examples/plugins/mlir_extension/README.md
+++ b/docs/sphinx/examples/plugins/mlir_extension/README.md
@@ -31,7 +31,7 @@ Python interpreter explicitly using the `-DPython3_EXECUTABLE` flag.
 
 ```bash
 pip install cudaq-devel
-pip install nanobind
+pip install 'nanobind>=2.12.0,<3'
 
 site=$(python -c 'import site; print(site.getsitepackages()[0])')
 cmake -S examples/plugins/mlir_extension -B build \

--- a/pyproject.toml.cu12
+++ b/pyproject.toml.cu12
@@ -64,7 +64,7 @@ visualization = [ "qutip>5" , "matplotlib>=3.5" ]
 integrators = [ "torchdiffeq" ]
 
 [build-system]
-requires = ["scikit-build-core==0.11.6", "cmake>=4.0", "numpy>=1.24", "pytest==9.0.3", "nanobind>=2.12.0"]
+requires = ["scikit-build-core==0.11.6", "cmake>=4.0", "numpy>=1.24", "pytest==9.0.3", "nanobind>=2.12.0,<3"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml.cu13
+++ b/pyproject.toml.cu13
@@ -66,7 +66,7 @@ visualization = [ "qutip>5" , "matplotlib>=3.5" ]
 integrators = [ "torchdiffeq" ]
 
 [build-system]
-requires = ["scikit-build-core==0.11.6", "cmake>=4.0", "numpy>=1.24", "pytest==9.0.3", "nanobind>=2.12.0"]
+requires = ["scikit-build-core==0.11.6", "cmake>=4.0", "numpy>=1.24", "pytest==9.0.3", "nanobind>=2.12.0,<3"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml.devel
+++ b/pyproject.toml.devel
@@ -33,7 +33,7 @@ Documentation = "https://nvidia.github.io/cuda-quantum"
 Repository = "https://github.com/NVIDIA/cuda-quantum"
 
 [build-system]
-requires = ["scikit-build-core==0.11.6", "cmake>=4.0", "numpy>=1.24", "nanobind>=2.12.0"]
+requires = ["scikit-build-core==0.11.6", "cmake>=4.0", "numpy>=1.24", "nanobind>=2.12.0,<3"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,5 +27,5 @@ h5py==3.12.1; python_version < "3.14"
 matplotlib
 pyspelling==2.10
 pymdown-extensions==11.0.1
-nanobind>=2.12.0
+nanobind>=2.12.0,<3
 yapf==0.43.0

--- a/scripts/build_mlir_python_bindings.sh
+++ b/scripts/build_mlir_python_bindings.sh
@@ -49,7 +49,7 @@ fi
 nanobind_cmake_dir=$("$Python3_EXECUTABLE" -m nanobind --cmake_dir)
 if [ ! -d "$nanobind_cmake_dir" ]; then
   echo "Could not locate nanobind cmake dir from $Python3_EXECUTABLE."
-  echo "Install with: $Python3_EXECUTABLE -m pip install 'nanobind>=2.9.0'"
+  echo "Install with: $Python3_EXECUTABLE -m pip install 'nanobind>=2.12.0,<3'"
   exit 1
 fi
 

--- a/scripts/validate_devel_wheel.sh
+++ b/scripts/validate_devel_wheel.sh
@@ -97,7 +97,7 @@ smoke_dir=$(mktemp -d)
 "$python" -m venv "$venv_dir"
 # shellcheck source=/dev/null
 source "$venv_dir/bin/activate"
-pip install -q pip wheel nanobind
+pip install -q pip wheel 'nanobind>=2.12.0,<3'
 
 runtime_wheel=""
 if [ -n "$runtime_dir" ]; then


### PR DESCRIPTION
### Summary

nanobind 3.0.0 was released on PyPI on 2026-08-22 at 04:23 UTC. The wheel build
installs nanobind with `pip install "nanobind>=2.12.0"` before building the LLVM
MLIR Python bindings, and LLVM's `MLIRDetectPythonEnv.cmake` does
`find_package(nanobind 2.9 ...)`. nanobind's CMake package config declares
same-major-version compatibility, so 3.0.0 is rejected and the configure step
fails:

```
CMake Error at /llvm-project/mlir/cmake/modules/MLIRDetectPythonEnv.cmake:79 (find_package):
  Could not find a configuration file for package "nanobind" that is
  compatible with requested version "2.9".

  The following configuration files were considered but not accepted:

    /opt/python/cp311-cp311/lib/python3.11/site-packages/nanobind/cmake/nanobind-config.cmake, version: 3.0.0
```

Every fresh (non-layer-cached) wheel build has failed since the release:

- This repo: all 16 `Create Python wheels` jobs in Deployments run
  https://github.com/NVIDIA/cuda-quantum/actions/runs/32576595456 (2026-08-22, 13:43 UTC)
- Downstream CUDA-QX nightly (builds these wheels against `main` via
  `docker/release/cudaq.wheel.Dockerfile`): all 4 `Wheels against CUDA-Q main /
  Build CUDA-Q wheels` jobs in
  https://github.com/NVIDIA/cudaqx/actions/runs/32554870424 (2026-08-22, 05:38 UTC)

Regular PR CI does not hit this because it builds in the devenv container and
does not run the wheel Dockerfile; the failures only surface when wheels are
actually rebuilt.

### Changes

Constrain nanobind to `>=2.12.0,<3` everywhere it is pip-installed for builds:

- `docker/release/cudaq.wheel.Dockerfile` — the install that feeds
  `build_mlir_python_bindings.sh` (the failing CI path)
- `pyproject.toml.cu12` / `pyproject.toml.cu13` — `[build-system] requires`,
  same constraint and the same MLIR-bindings hazard for source builds
- `requirements-dev.txt`
- `scripts/build_mlir_python_bindings.sh` — the install hint printed when
  nanobind is missing still suggested `>=2.9.0`, which would now resolve to an
  incompatible 3.x

No functional change for any environment that already resolved a 2.x nanobind.
The pin can be dropped once the bundled LLVM accepts nanobind 3
(`MLIRDetectPythonEnv.cmake` currently requires 2.9-compatible, i.e. 2.x).
