### PR TITLE
Normalize controlled Clifford+T chains

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -291,17 +291,20 @@ def OptimizeSingleQubitCliffordT
     Consumes and produces the scalar linear SSA `!quake.wire` form created by
     `convert-to-linear-values`.
 
-    Rewrites exact, uncontrolled one-qubit Clifford+T chains on scalar
-    `!quake.wire` values to Matsumoto-Amano normal form. Supports chains
-    through single-block `cc.scope`. Scalar normal-form phases are emitted as
-    anchored `quake.phase` operations, preserving the exact unitary.
+    Rewrites exact one-qubit Clifford+T chains on scalar `!quake.wire` values
+    into Matsumoto-Amano normal form while preserving the exact unitary.
+    Controlled chains are supported when their controls and polarities remain
+    unchanged, including through single-block `cc.scope` operations. The pass
+    optimizes the one-qubit gate sequence itself, not any subsequent
+    decomposition of its controlled gates.
 
     The normal form is defined by K. Matsumoto and K. Amano, "Representation
     of Quantum Circuits with Clifford and pi/8 Gates," arXiv:0806.3834,
     https://arxiv.org/abs/0806.3834.
 
   }];
-  let dependentDialects = ["quake::QuakeDialect"];
+  let dependentDialects = ["mlir::arith::ArithDialect",
+                           "quake::QuakeDialect"];
 }
 
 def PruneNegligibleRotations

--- a/cudaq/lib/Optimizer/Transforms/OptimizeSingleQubitCliffordT.cpp
+++ b/cudaq/lib/Optimizer/Transforms/OptimizeSingleQubitCliffordT.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "PhaseUtilities.h"
 #include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
@@ -36,10 +37,11 @@ namespace {
 
 enum class ExactGate { H, S, T, X, Y, Z };
 
-struct UnaryWireOp {
+struct ExactWireOp {
   Operation *operation;
-  Value input;
-  Value output;
+  llvm::SmallVector<Value> inputs;
+  llvm::SmallVector<Value> outputs;
+  llvm::SmallVector<bool> controlPolarities;
   ExactGate gate;
   bool isAdj;
 };
@@ -56,9 +58,10 @@ struct ScalarWireStep {
 
 struct Candidate {
   llvm::SmallVector<Operation *> operations;
-  llvm::SmallVector<ScopeStep> scopeSteps;
-  Value input;
-  Value output;
+  llvm::SmallVector<llvm::SmallVector<ScopeStep>> scopeSteps;
+  llvm::SmallVector<Value> inputs;
+  llvm::SmallVector<Value> outputs;
+  llvm::SmallVector<bool> controlPolarities;
   cudaq::synth::Circuit normalized;
 };
 
@@ -95,23 +98,24 @@ static std::optional<ExactGate> getExactGate(Operation *operation) {
   return std::nullopt;
 }
 
-// Accept only uncontrolled, unary scalar-wire operations. Every other
-// operand/result shape is a chain boundary and remains unchanged.
-static std::optional<UnaryWireOp> getUnaryWireOp(Operation *operation) {
+// Accept one-target exact gates whose complete predicate is in scalar linear
+// form. Every other operand or result shape is a chain boundary.
+static std::optional<ExactWireOp> getExactWireOp(Operation *operation) {
   std::optional<ExactGate> gate = getExactGate(operation);
   if (!gate)
     return std::nullopt;
 
   auto gateInterface = dyn_cast<cudaq::quake::OperatorInterface>(operation);
-  if (!gateInterface || !gateInterface.getControls().empty() ||
-      gateInterface.getTargets().size() != 1 ||
-      !isa<cudaq::quake::WireType>(gateInterface.getTargets()[0].getType()) ||
-      operation->getNumResults() != 1 ||
-      !isa<cudaq::quake::WireType>(operation->getResult(0).getType()))
+  auto flow = cudaq::quake::detail::getScalarWireFlow(operation);
+  if (!gateInterface || !flow || gateInterface.getTargets().size() != 1)
     return std::nullopt;
 
-  return UnaryWireOp{operation, gateInterface.getTargets()[0],
-                     operation->getResult(0), *gate, gateInterface.isAdj()};
+  return ExactWireOp{operation,
+                     std::move(flow->inputs),
+                     std::move(flow->results),
+                     cudaq::quake::getControlPolarities(gateInterface),
+                     *gate,
+                     gateInterface.isAdj()};
 }
 
 // Returns whether `nested` is inside `outer` through only single-block
@@ -168,49 +172,87 @@ static std::optional<ScalarWireStep> traverseScalarWire(Value wire) {
   return ScalarWireStep{user, std::nullopt};
 }
 
-// Follow a unique scalar-wire use to another unary gate.
-static std::optional<UnaryWireOp>
-getNextUnaryWireOp(const UnaryWireOp &current,
-                   llvm::SmallVectorImpl<ScopeStep> &scopeSteps) {
-  auto step = traverseScalarWire(current.output);
+struct WirePathEnd {
+  Operation *operation;
+  Value wire;
+};
+
+// Follow one tuple lane through transparent scopes to its next direct user.
+static std::optional<WirePathEnd>
+traceWire(Value wire, llvm::SmallVectorImpl<ScopeStep> &scopeSteps) {
+  auto step = traverseScalarWire(wire);
   while (step && step->scopeStep) {
     scopeSteps.push_back(*step->scopeStep);
-    step = traverseScalarWire(step->scopeStep->wire);
+    wire = step->scopeStep->wire;
+    step = traverseScalarWire(wire);
   }
-  return step ? getUnaryWireOp(step->operation) : std::nullopt;
+  return step ? std::optional<WirePathEnd>{WirePathEnd{step->operation, wire}}
+              : std::nullopt;
+}
+
+// A controlled chain continues only when every output lane reaches the same
+// gate at its corresponding input position with the same ordered predicate.
+static std::optional<ExactWireOp> matchNextExactGate(
+    const ExactWireOp &current,
+    llvm::MutableArrayRef<llvm::SmallVector<ScopeStep>> scopeSteps) {
+  llvm::SmallVector<std::optional<WirePathEnd>> pathEnds;
+  pathEnds.reserve(current.outputs.size());
+  for (auto [output, steps] : llvm::zip(current.outputs, scopeSteps))
+    pathEnds.push_back(traceWire(output, steps));
+
+  if (llvm::any_of(pathEnds, [](const auto &path) { return !path; }))
+    return std::nullopt;
+
+  Operation *nextOperation = pathEnds.front()->operation;
+  if (llvm::any_of(pathEnds, [&](const auto &path) {
+        return path->operation != nextOperation;
+      }))
+    return std::nullopt;
+
+  std::optional<ExactWireOp> next = getExactWireOp(nextOperation);
+  if (!next || next->inputs.size() != current.outputs.size() ||
+      next->controlPolarities != current.controlPolarities)
+    return std::nullopt;
+
+  for (auto [index, path] : llvm::enumerate(pathEnds))
+    if (next->inputs[index] != path->wire)
+      return std::nullopt;
+  return next;
 }
 
 // Collect a maximal chain through exactly-once scalar-wire values. Unsupported
 // operations and non-linear wire flow terminate the chain.
-static llvm::SmallVector<UnaryWireOp>
-collectLinearChain(Operation *operation,
-                   llvm::SmallDenseSet<Operation *> &collected,
-                   llvm::SmallVectorImpl<ScopeStep> &scopeSteps) {
+static llvm::SmallVector<ExactWireOp> collectLinearChain(
+    Operation *operation, llvm::SmallDenseSet<Operation *> &collected,
+    llvm::SmallVectorImpl<llvm::SmallVector<ScopeStep>> &scopeSteps) {
   if (collected.contains(operation))
     return {};
 
-  std::optional<UnaryWireOp> first = getUnaryWireOp(operation);
-  if (!first || !first->input.hasOneUse())
+  std::optional<ExactWireOp> first = getExactWireOp(operation);
+  if (!first || llvm::any_of(first->inputs,
+                             [](Value input) { return !input.hasOneUse(); }))
     return {};
 
-  llvm::SmallVector<UnaryWireOp> chain;
-  std::optional<UnaryWireOp> current = first;
+  scopeSteps.resize(first->inputs.size());
+  llvm::SmallVector<ExactWireOp> chain;
+  std::optional<ExactWireOp> current = std::move(first);
   while (current) {
     chain.push_back(*current);
     collected.insert(current->operation);
-    if (!current->output.hasOneUse())
+    if (llvm::any_of(current->outputs,
+                     [](Value output) { return !output.hasOneUse(); }))
       break;
-    std::optional<UnaryWireOp> nextGate =
-        getNextUnaryWireOp(*current, scopeSteps);
+    std::optional<ExactWireOp> nextGate =
+        matchNextExactGate(*current, scopeSteps);
     if (!nextGate)
       break;
-    current = nextGate;
+    current = std::move(nextGate);
   }
   return chain;
 }
 
 static void appendExactGate(cudaq::synth::Circuit &circuit,
-                            const UnaryWireOp &operation) {
+                            const ExactWireOp &operation) {
   using cudaq::synth::Gate;
   switch (operation.gate) {
   case ExactGate::H:
@@ -249,15 +291,17 @@ static void appendExactGate(cudaq::synth::Circuit &circuit,
 }
 
 static cudaq::synth::Circuit
-buildMatrixProduct(llvm::ArrayRef<UnaryWireOp> operations) {
+buildMatrixProduct(llvm::ArrayRef<ExactWireOp> operations) {
   cudaq::synth::Circuit circuit;
-  for (const UnaryWireOp &operation : llvm::reverse(operations))
+  for (const ExactWireOp &operation : llvm::reverse(operations))
     appendExactGate(circuit, operation);
   return circuit;
 }
 
-// Prefer lower T-count, then fewer emitted Clifford gates. Scalar W phases do
-// not contribute to the gate-count cost.
+// Prefer lower T-count, then fewer gates in the underlying one-qubit word.
+// W is phase bookkeeping for that cost, including when the exact correction
+// becomes observable under control. This is not a controlled-decomposition
+// cost model.
 static CircuitCost emittedCost(const cudaq::synth::Circuit &circuit) {
   std::size_t emittedGateCount = 0;
   for (cudaq::synth::Gate gate : circuit)
@@ -265,63 +309,80 @@ static CircuitCost emittedCost(const cudaq::synth::Circuit &circuit) {
   return {circuit.t_count(), emittedGateCount};
 }
 
-static CircuitCost inputCost(llvm::ArrayRef<UnaryWireOp> chain) {
+static CircuitCost inputCost(llvm::ArrayRef<ExactWireOp> chain) {
   return {static_cast<int>(llvm::count_if(chain,
-                                          [](const UnaryWireOp &gate) {
+                                          [](const ExactWireOp &gate) {
                                             return gate.gate == ExactGate::T;
                                           })),
           chain.size()};
 }
 
 template <typename OpTy>
-static Value emitGate(OpBuilder &builder, Location location, Value input) {
-  auto operation =
-      OpTy::create(builder, location, TypeRange{input.getType()},
-                   /*is_adj=*/false, /*parameters=*/ValueRange{},
-                   /*controls=*/ValueRange{}, /*targets=*/ValueRange{input},
-                   /*negated_qubit_controls=*/DenseBoolArrayAttr{});
-  return operation.getWires()[0];
+static void emitGate(OpBuilder &builder, Location location,
+                     llvm::SmallVectorImpl<Value> &controls, Value &target,
+                     DenseBoolArrayAttr negatedControls) {
+  llvm::SmallVector<Value> targets{target};
+  auto resultTypes =
+      cudaq::quake::getWireResultTypes(builder, controls, targets);
+  auto operation = OpTy::create(
+      builder, location, resultTypes, /*is_adj=*/false,
+      /*parameters=*/ValueRange{}, controls, targets, negatedControls);
+  cudaq::quake::threadWireResults(operation, controls, targets);
+  target = targets.front();
 }
 
-static Value emitCircuit(OpBuilder &builder, Location location, Value input,
-                         const cudaq::synth::Circuit &circuit) {
-  Value current = input;
+static llvm::SmallVector<Value>
+emitCircuit(OpBuilder &builder, Location location, ValueRange inputs,
+            llvm::ArrayRef<bool> controlPolarities,
+            const cudaq::synth::Circuit &circuit) {
+  ValueRange controlInputs = inputs.drop_back();
+  llvm::SmallVector<Value> controls(controlInputs.begin(), controlInputs.end());
+  Value target = inputs.back();
+  DenseBoolArrayAttr negatedControls =
+      cudaq::opt::makeNegatedControlsAttr(builder, controlPolarities);
   for (cudaq::synth::Gate gate : llvm::reverse(circuit)) {
     switch (gate) {
     case cudaq::synth::Gate::H:
-      current = emitGate<cudaq::quake::HOp>(builder, location, current);
+      emitGate<cudaq::quake::HOp>(builder, location, controls, target,
+                                  negatedControls);
       break;
     case cudaq::synth::Gate::S:
-      current = emitGate<cudaq::quake::SOp>(builder, location, current);
+      emitGate<cudaq::quake::SOp>(builder, location, controls, target,
+                                  negatedControls);
       break;
     case cudaq::synth::Gate::T:
-      current = emitGate<cudaq::quake::TOp>(builder, location, current);
+      emitGate<cudaq::quake::TOp>(builder, location, controls, target,
+                                  negatedControls);
       break;
     case cudaq::synth::Gate::X:
-      current = emitGate<cudaq::quake::XOp>(builder, location, current);
+      emitGate<cudaq::quake::XOp>(builder, location, controls, target,
+                                  negatedControls);
       break;
     case cudaq::synth::Gate::W:
       Value angle =
           cudaq::opt::factory::createF64Constant(location, builder, M_PI_4);
+      llvm::SmallVector<Value> targets{target};
+      auto resultTypes =
+          cudaq::quake::getWireResultTypes(builder, controls, targets);
       auto phase = cudaq::quake::PhaseOp::create(
-          builder, location, TypeRange{current.getType()}, /*is_adj=*/false,
-          ValueRange{angle}, /*controls=*/ValueRange{},
-          /*targets=*/ValueRange{current},
-          /*negated_qubit_controls=*/DenseBoolArrayAttr{});
-      current = phase.getWires()[0];
+          builder, location, resultTypes, /*is_adj=*/false, ValueRange{angle},
+          controls, targets, negatedControls);
+      cudaq::quake::threadWireResults(phase, controls, targets);
+      target = targets.front();
       break;
     }
   }
-  return current;
+  controls.push_back(target);
+  return controls;
 }
 
 static void optimizeBlock(Block &block) {
-  llvm::SmallVector<Candidate> candidates;
+  llvm::SmallVector<Candidate, 0> candidates;
   llvm::SmallDenseSet<Operation *> collected;
 
   for (Operation &operation : block) {
-    llvm::SmallVector<ScopeStep> scopeSteps;
-    llvm::SmallVector<UnaryWireOp> chain =
+    llvm::SmallVector<llvm::SmallVector<ScopeStep>> scopeSteps;
+    llvm::SmallVector<ExactWireOp> chain =
         collectLinearChain(&operation, collected, scopeSteps);
     if (chain.empty())
       continue;
@@ -337,11 +398,12 @@ static void optimizeBlock(Block &block) {
       continue;
 
     Candidate candidate;
-    candidate.input = chain.front().input;
-    candidate.output = chain.back().output;
+    candidate.inputs = chain.front().inputs;
+    candidate.outputs = chain.back().outputs;
+    candidate.controlPolarities = chain.front().controlPolarities;
     candidate.scopeSteps = std::move(scopeSteps);
     candidate.normalized = std::move(normalized);
-    for (const UnaryWireOp &gate : chain)
+    for (const ExactWireOp &gate : chain)
       candidate.operations.push_back(gate.operation);
     candidates.push_back(std::move(candidate));
   }
@@ -350,17 +412,18 @@ static void optimizeBlock(Block &block) {
   // chains remain valid throughout block mutation.
   for (Candidate &candidate : llvm::reverse(candidates)) {
     OpBuilder builder(candidate.operations.front());
-    Value output = emitCircuit(builder, candidate.operations.front()->getLoc(),
-                               candidate.input, candidate.normalized);
-    // Thread the normalized output through lexical-scope forwarding in
-    // traversal order, then replace the original chain's final value with the
-    // last scope result visible at that point.
-    Value replacement = output;
-    for (ScopeStep &scopeStep : candidate.scopeSteps) {
-      scopeStep.continueOperand->set(replacement);
-      replacement = scopeStep.wire;
+    llvm::SmallVector<Value> outputs = emitCircuit(
+        builder, candidate.operations.front()->getLoc(), candidate.inputs,
+        candidate.controlPolarities, candidate.normalized);
+    for (auto [output, original, steps] :
+         llvm::zip(outputs, candidate.outputs, candidate.scopeSteps)) {
+      Value replacement = output;
+      for (ScopeStep &scopeStep : steps) {
+        scopeStep.continueOperand->set(replacement);
+        replacement = scopeStep.wire;
+      }
+      original.replaceAllUsesWith(replacement);
     }
-    candidate.output.replaceAllUsesWith(replacement);
     for (Operation *operation : llvm::reverse(candidate.operations))
       operation->erase();
   }

--- a/cudaq/test/Transforms/optimize_single_qubit_clifford_t_controlled.qke
+++ b/cudaq/test/Transforms/optimize_single_qubit_clifford_t_controlled.qke
@@ -1,0 +1,151 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --optimize-1q-clifford-t %s | FileCheck %s
+// RUN: sed -n '/SEMANTIC-BEGIN$/,/SEMANTIC-END$/p' %s > %t.semantic.qke
+// RUN: cudaq-opt --verify-each --optimize-1q-clifford-t %t.semantic.qke | CircuitCheck %t.semantic.qke
+
+// The complete control predicate must follow the normal form through an
+// ordinary scope. The target remains the phase anchor.
+func.func @controlled_scope(%control0: !quake.wire,
+                            %control1: !quake.wire,
+                            %target: !quake.wire)
+    -> (!quake.wire, !quake.wire, !quake.wire) {
+  %0:3 = quake.s [%control0, %control1 neg [false, true]] %target
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  %1:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
+    %2:3 = quake.x [%0#0, %0#1 neg [false, true]] %0#2
+        : (!quake.wire, !quake.wire, !quake.wire)
+          -> (!quake.wire, !quake.wire, !quake.wire)
+    cc.continue %2#0, %2#1, %2#2
+        : !quake.wire, !quake.wire, !quake.wire
+  }
+  %3:3 = quake.s [%1#0, %1#1 neg [false, true]] %1#2
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  return %3#0, %3#1, %3#2
+      : !quake.wire, !quake.wire, !quake.wire
+}
+
+// CHECK-LABEL: func.func @controlled_scope
+// CHECK-SAME:  (%[[CONTROL0:.*]]: !quake.wire, %[[CONTROL1:.*]]: !quake.wire, %[[TARGET:.*]]: !quake.wire)
+// CHECK:         %[[ANGLE0:.*]] = arith.constant {{0\.7853981633974482[0-9]}} : f64
+// CHECK-NEXT:    %[[PHASE0:.*]]:3 = quake.phase (%[[ANGLE0]]) [%[[CONTROL0]], %[[CONTROL1]] neg [false, true]] %[[TARGET]]
+// CHECK-NEXT:    %[[ANGLE1:.*]] = arith.constant {{0\.7853981633974482[0-9]}} : f64
+// CHECK-NEXT:    %[[PHASE1:.*]]:3 = quake.phase (%[[ANGLE1]]) [%[[PHASE0]]#0, %[[PHASE0]]#1 neg [false, true]] %[[PHASE0]]#2
+// CHECK-NEXT:    %[[X:.*]]:3 = quake.x [%[[PHASE1]]#0, %[[PHASE1]]#1 neg [false, true]] %[[PHASE1]]#2
+// CHECK-NEXT:    %[[SCOPE:.*]]:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
+// CHECK-NEXT:      cc.continue %[[X]]#0, %[[X]]#1, %[[X]]#2
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[SCOPE]]#0, %[[SCOPE]]#1, %[[SCOPE]]#2
+
+// Reordering the threaded controls changes the ordered predicate and ends the
+// chain even when the same qubits remain controls.
+func.func @reordered_control_boundary(%control0: !quake.wire,
+                                      %control1: !quake.wire,
+                                      %target: !quake.wire)
+    -> (!quake.wire, !quake.wire, !quake.wire) {
+  %0:3 = quake.s [%control0, %control1 neg [false, true]] %target
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  %1:3 = quake.x [%0#1, %0#0 neg [false, true]] %0#2
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  %2:3 = quake.s [%1#0, %1#1 neg [false, true]] %1#2
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  return %2#0, %2#1, %2#2
+      : !quake.wire, !quake.wire, !quake.wire
+}
+
+// CHECK-LABEL: func.func @reordered_control_boundary
+// CHECK-SAME:  (%[[R_CONTROL0:.*]]: !quake.wire, %[[R_CONTROL1:.*]]: !quake.wire, %[[R_TARGET:.*]]: !quake.wire)
+// CHECK-NOT:     quake.phase
+// CHECK:         %[[S:.*]]:3 = quake.s [%[[R_CONTROL0]], %[[R_CONTROL1]] neg [false, true]] %[[R_TARGET]]
+// CHECK-NEXT:    %[[BOUNDARY_X:.*]]:3 = quake.x [%[[S]]#1, %[[S]]#0 neg [false, true]] %[[S]]#2
+// CHECK-NEXT:    %[[LAST_S:.*]]:3 = quake.s [%[[BOUNDARY_X]]#0, %[[BOUNDARY_X]]#1 neg [false, true]] %[[BOUNDARY_X]]#2
+// CHECK-NEXT:    return %[[LAST_S]]#0, %[[LAST_S]]#1, %[[LAST_S]]#2
+
+// Changing only a control polarity is also a chain boundary.
+func.func @changed_polarity_boundary(%control0: !quake.wire,
+                                     %control1: !quake.wire,
+                                     %target: !quake.wire)
+    -> (!quake.wire, !quake.wire, !quake.wire) {
+  %0:3 = quake.s [%control0, %control1 neg [false, true]] %target
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  %1:3 = quake.x [%0#0, %0#1 neg [true, false]] %0#2
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  %2:3 = quake.s [%1#0, %1#1 neg [true, false]] %1#2
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  return %2#0, %2#1, %2#2
+      : !quake.wire, !quake.wire, !quake.wire
+}
+
+// CHECK-LABEL: func.func @changed_polarity_boundary
+// CHECK-SAME:  (%[[P_CONTROL0:.*]]: !quake.wire, %[[P_CONTROL1:.*]]: !quake.wire, %[[P_TARGET:.*]]: !quake.wire)
+// CHECK-NOT:     quake.phase
+// CHECK:         %[[POLARITY_S:.*]]:3 = quake.s [%[[P_CONTROL0]], %[[P_CONTROL1]] neg [false, true]] %[[P_TARGET]]
+// CHECK-NEXT:    %[[POLARITY_X:.*]]:3 = quake.x [%[[POLARITY_S]]#0, %[[POLARITY_S]]#1 neg [true, false]] %[[POLARITY_S]]#2
+// CHECK-NEXT:    %[[POLARITY_LAST_S:.*]]:3 = quake.s [%[[POLARITY_X]]#0, %[[POLARITY_X]]#1 neg [true, false]] %[[POLARITY_X]]#2
+// CHECK-NEXT:    return %[[POLARITY_LAST_S]]#0, %[[POLARITY_LAST_S]]#1, %[[POLARITY_LAST_S]]#2
+
+// SEMANTIC-BEGIN
+
+func.func @semantic_controlled(%control0: !quake.ref,
+                               %control1: !quake.ref,
+                               %target: !quake.ref) {
+  %control_wire0 = quake.unwrap %control0 : (!quake.ref) -> !quake.wire
+  %control_wire1 = quake.unwrap %control1 : (!quake.ref) -> !quake.wire
+  %target_wire = quake.unwrap %target : (!quake.ref) -> !quake.wire
+  %0:3 = quake.s [%control_wire0, %control_wire1 neg [false, true]] %target_wire
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  %1:3 = quake.x [%0#0, %0#1 neg [false, true]] %0#2
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  %2:3 = quake.s [%1#0, %1#1 neg [false, true]] %1#2
+      : (!quake.wire, !quake.wire, !quake.wire)
+        -> (!quake.wire, !quake.wire, !quake.wire)
+  quake.wrap %2#0 to %control0 : !quake.wire, !quake.ref
+  quake.wrap %2#1 to %control1 : !quake.wire, !quake.ref
+  quake.wrap %2#2 to %target : !quake.wire, !quake.ref
+  return
+}
+
+// Three T-family gates normalize to the canonical `S S S T` representation
+// of T-dagger, reducing T-count while retaining the control predicate.
+func.func @semantic_controlled_adjoint_t(%control: !quake.ref,
+                                         %target: !quake.ref) {
+  %control_wire = quake.unwrap %control : (!quake.ref) -> !quake.wire
+  %target_wire = quake.unwrap %target : (!quake.ref) -> !quake.wire
+  %0:2 = quake.t<adj> [%control_wire] %target_wire
+      : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %1:2 = quake.t<adj> [%0#0] %0#1
+      : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %2:2 = quake.t [%1#0] %1#1
+      : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.wrap %2#0 to %control : !quake.wire, !quake.ref
+  quake.wrap %2#1 to %target : !quake.wire, !quake.ref
+  return
+}
+
+// CHECK-LABEL: func.func @semantic_controlled_adjoint_t
+// CHECK:         %[[ADJ_CONTROL:.*]] = quake.unwrap %arg0
+// CHECK-NEXT:    %[[ADJ_TARGET:.*]] = quake.unwrap %arg1
+// CHECK-NEXT:    %[[ADJ_S0:.*]]:2 = quake.s [%[[ADJ_CONTROL]]] %[[ADJ_TARGET]]
+// CHECK-NEXT:    %[[ADJ_S1:.*]]:2 = quake.s [%[[ADJ_S0]]#0] %[[ADJ_S0]]#1
+// CHECK-NEXT:    %[[ADJ_S2:.*]]:2 = quake.s [%[[ADJ_S1]]#0] %[[ADJ_S1]]#1
+// CHECK-NEXT:    %[[ADJ_T:.*]]:2 = quake.t [%[[ADJ_S2]]#0] %[[ADJ_S2]]#1
+// CHECK-NEXT:    quake.wrap %[[ADJ_T]]#0 to %arg0
+// CHECK-NEXT:    quake.wrap %[[ADJ_T]]#1 to %arg1
+
+// SEMANTIC-END


### PR DESCRIPTION
## Summary

This change extends exact single-qubit Clifford+T normalization to one-target chains.

This is a follow-up to #5123. A phase that is global for an uncontrolled one-qubit word becomes relative when the op is controlled, so the phase correction must retain the complete control predicate to preserve the exact unitary.
