### PR TITLE
Ergonomic improvements for downstream packages

### DIFF
--- a/.github/actions/wheel-cache-lookup/action.yml
+++ b/.github/actions/wheel-cache-lookup/action.yml
@@ -1,7 +1,7 @@
 name: Wheel cache lookup
 description: |
   Restore the wheel index entry for a cache key and confirm the recorded
-  artifact is still alive.
+  artifact is still alive and downloadable.
 
 inputs:
   key:
@@ -61,13 +61,22 @@ runs:
           run_id=$(jq -r '.run_id // empty' "$ENTRY_FILE")
           artifact_id=$(jq -r '.artifact_id // empty' "$ENTRY_FILE")
           artifact_name=$(jq -r '.artifact_name // empty' "$ENTRY_FILE")
-          if [ -n "$artifact_id" ]; then
-            expired=$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" \
-              --jq '.expired' 2>/dev/null || echo true)
-            if [ "$expired" = "false" ]; then
-              hit=true
+          if [ -n "$run_id" ] && [ -n "$artifact_name" ]; then
+            # Retrieve artifact by name rather than ID to handle name shadowing.
+            newest=$(gh api --method GET \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
+              -f "name=$artifact_name" \
+              --jq '[.artifacts[]] | max_by(.id) | select(.expired == false) | .id' \
+              2>/dev/null || true)
+            if [ -z "$newest" ]; then
+              echo "Index hit but no live artifact named $artifact_name in run $run_id."
             else
-              echo "Index hit but artifact $artifact_id is expired or missing."
+              if [ "$newest" != "$artifact_id" ]; then
+                echo "::warning::Artifact $artifact_id ($artifact_name) is shadowed by " \
+                  "a newer artifact; downloading $newest instead."
+                artifact_id="$newest"
+              fi
+              hit=true
             fi
           fi
         fi

--- a/.github/actions/wheel-restore/action.yml
+++ b/.github/actions/wheel-restore/action.yml
@@ -58,7 +58,7 @@ runs:
       with:
         name: ${{ inputs.artifact_name }}
         path: /tmp/restamped-wheel
-        retention-days: 1
+        retention-days: 7
         if-no-files-found: error
 
     - name: Refresh index entry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,7 @@ jobs:
       devdeps_image: ${{ fromJson(needs.config_wheeldeps.outputs.json).image_hash[format('{0}-cu{1}-python', matrix.platform, matrix.cuda_version)] }}
       devdeps_cache: ${{ fromJson(needs.config_wheeldeps.outputs.json).cache_key[format('{0}-cu{1}-python', matrix.platform, matrix.cuda_version)] }}
       devdeps_archive: ${{ fromJson(needs.config_wheeldeps.outputs.json).tar_archive[format('{0}-cu{1}-python', matrix.platform, matrix.cuda_version)] }}
-      build_devel_wheel: ${{ matrix.platform == 'amd64' && matrix.python_version == '3.11' && matrix.cuda_version == '13.0' }}
+      build_devel_wheel: ${{ matrix.python_version == '3.11' && matrix.cuda_version == '13.0' }}
 
   python_metapackages:
     name: Create Python metapackages

--- a/.github/workflows/retrieve_python_wheels.yml
+++ b/.github/workflows/retrieve_python_wheels.yml
@@ -90,6 +90,9 @@ on:
       devel_artifact_name:
         description: "Artifact name of the devel wheel (built or restored), if requested."
         value: ${{ jobs.build.outputs.devel_artifact_name || jobs.resolve.outputs.devel_artifact_name }}
+      metapackage_artifact_name:
+        description: "Artifact name of the cudaq metapackage."
+        value: ${{ jobs.metapackage.outputs.artifact_name }}
       bundle_artifact_name:
         description: "Artifact name of the combined all-wheels bundle."
         value: "all-wheels-${{ jobs.resolve.outputs.wheel_platform }}-py${{ inputs.python_version }}"

--- a/.github/workflows/retrieve_python_wheels.yml
+++ b/.github/workflows/retrieve_python_wheels.yml
@@ -90,6 +90,9 @@ on:
       devel_artifact_name:
         description: "Artifact name of the devel wheel (built or restored), if requested."
         value: ${{ jobs.build.outputs.devel_artifact_name || jobs.resolve.outputs.devel_artifact_name }}
+      bundle_artifact_name:
+        description: "Artifact name of the combined all-wheels bundle."
+        value: "all-wheels-${{ jobs.resolve.outputs.wheel_platform }}-py${{ inputs.python_version }}"
     secrets:
       DOCKERHUB_USERNAME:
         required: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ project(cudaq LANGUAGES CXX C)
 # By default, install everything to the "Runtime" component.
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME Runtime)
 
+# Use DESTINATION lib for every explicit install() in this project
+set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Object code libraries (lib)" FORCE)
+
 # Prevent In-source builds
 # ==============================================================================
 # Using the undocumented `CMAKE_DISABLE_IN_SOURCE_BUILDS` and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ project(cudaq LANGUAGES CXX C)
 # By default, install everything to the "Runtime" component.
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME Runtime)
 
-# Use DESTINATION lib for every explicit install() in this project
+# Always install to `lib`. This avoids the `lib` vs `lib64` mismatch depending
+# on distribution.
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Object code libraries (lib)" FORCE)
 
 # Prevent In-source builds

--- a/cmake/modules/AddCUDAQ.cmake
+++ b/cmake/modules/AddCUDAQ.cmake
@@ -322,8 +322,13 @@ endfunction()
 
 # Adds a CUDA Quantum dialect library target for installation. This should normally
 # only be called from add_cudaq_library().
+#
+# <name> will be registered as part of the `cudaq-dev-targets` export set.
 function(add_cudaq_library_install name)
-  install(TARGETS ${name} COMPONENT Development EXPORT CUDAQTargets)
+  install(TARGETS ${name} COMPONENT Development EXPORT cudaq-dev-targets
+          ARCHIVE DESTINATION lib
+          LIBRARY DESTINATION lib
+          RUNTIME DESTINATION bin)
   set_property(GLOBAL APPEND PROPERTY CUDAQ_ALL_LIBS ${name})
   set_property(GLOBAL APPEND PROPERTY CUDAQ_EXPORTS ${name})
 endfunction()
@@ -356,10 +361,22 @@ function(cudaq_use_static_mlir target)
   set_target_properties(${target} PROPERTIES CUDAQ_MLIR_STATIC ON)
 endfunction()
 
+# Define the CUDAQ dev targets for downstream projects when they exist.
+if(NOT TARGET QuakeDialect
+    AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/CUDAQDevTargets.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/CUDAQDevTargets.cmake")
+endif()
+
 # Define the public alias ``cudaq::MLIR`` for use in downstream projects.
 if(NOT TARGET cudaq::MLIR)
   add_library(cudaq::MLIR INTERFACE IMPORTED GLOBAL)
   set_target_properties(cudaq::MLIR PROPERTIES
     INTERFACE_LINK_LIBRARIES cudaq::cudaqMLIR
   )
+  # Also expose the header files through `cudaq::MLIR`
+  if(CUDAQ_INCLUDE_DIR AND IS_DIRECTORY "${CUDAQ_INCLUDE_DIR}")
+    set_target_properties(cudaq::MLIR PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CUDAQ_INCLUDE_DIR}"
+    )
+  endif()
 endif()

--- a/cmake/modules/AddCUDAQ.cmake
+++ b/cmake/modules/AddCUDAQ.cmake
@@ -59,9 +59,32 @@ function(add_cudaq_dialect_doc dialect dialect_namespace)
     -gen-dialect-doc -dialect ${dialect_namespace})
 endfunction()
 
+# Replicate all build configs on `${name}` to `obj.${name}`
+function(_cudaq_forward_object_usage_requirements name)
+  if(NOT TARGET obj.${name})
+    return()
+  endif()
+  target_include_directories(obj.${name} SYSTEM PRIVATE
+    $<TARGET_PROPERTY:${name},INTERFACE_INCLUDE_DIRECTORIES>)
+  target_compile_definitions(obj.${name} PRIVATE
+    $<TARGET_PROPERTY:${name},INTERFACE_COMPILE_DEFINITIONS>)
+  target_compile_options(obj.${name} PRIVATE
+    $<TARGET_PROPERTY:${name},INTERFACE_COMPILE_OPTIONS>)
+endfunction()
+
+# target_link_libraries() for a library created by add_cudaq_library().  This ensures
+# the dependency is also set on obj.<target>, (used to build the `cudaqMLIR` shared library.
+function(cudaq_target_link_libraries target visibility)
+  target_link_libraries(${target} ${visibility} ${ARGN})
+  if(TARGET obj.${target})
+    target_link_libraries(obj.${target} PRIVATE ${ARGN})
+  endif()
+endfunction()
+
 function(add_cudaq_library name)
   add_mlir_library(${ARGV} DISABLE_INSTALL ENABLE_AGGREGATION)
   add_cudaq_library_install(${name})
+  _cudaq_forward_object_usage_requirements(${name})
 endfunction()
 
 # Define `CUDAQ_MLIR_BUNDLED_LIBS_PATH`: the file that lists all bundled MLIR libraries.
@@ -325,10 +348,7 @@ endfunction()
 #
 # <name> will be registered as part of the `cudaq-dev-targets` export set.
 function(add_cudaq_library_install name)
-  install(TARGETS ${name} COMPONENT Development EXPORT cudaq-dev-targets
-          ARCHIVE DESTINATION lib
-          LIBRARY DESTINATION lib
-          RUNTIME DESTINATION bin)
+  install(TARGETS ${name} COMPONENT Development EXPORT cudaq-dev-targets)
   set_property(GLOBAL APPEND PROPERTY CUDAQ_ALL_LIBS ${name})
   set_property(GLOBAL APPEND PROPERTY CUDAQ_EXPORTS ${name})
 endfunction()

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -24,6 +24,10 @@ set(LANG_FILES
   CMakeDetermineCUDAQCompiler.cmake
   CMakeTestCUDAQCompiler.cmake
 )
+set(FIND_MODULE_FILES
+  FindGMP.cmake
+  FindMPFR.cmake
+)
 
 # The installed NVQIRConfig.cmake fetches fmt at the commit CUDA-Q was built
 # against, so that out-of-tree simulator plugins compile against the same
@@ -59,6 +63,9 @@ install(FILES ${CONFIG_FILES}
         DESTINATION lib/cmake/cudaq
         COMPONENT Development)
 install(FILES ${LANG_FILES}
+        DESTINATION lib/cmake/cudaq
+        COMPONENT Development)
+install(FILES ${FIND_MODULE_FILES}
         DESTINATION lib/cmake/cudaq
         COMPONENT Development)
 install(FILES ${CMAKE_BINARY_DIR}/cmake/modules/NVQIRConfig.cmake

--- a/cmake/modules/CUDAQConfig.cmake
+++ b/cmake/modules/CUDAQConfig.cmake
@@ -69,6 +69,9 @@ get_filename_component(CUDAQ_LIBRARY_DIR ${PARENT_DIRECTORY} DIRECTORY)
 get_filename_component(CUDAQ_INSTALL_DIR ${CUDAQ_LIBRARY_DIR} DIRECTORY)
 set(CUDAQ_INCLUDE_DIR ${CUDAQ_INSTALL_DIR}/include)
 
+find_dependency(GMP)
+find_dependency(MPFR)
+
 set (NVQIR_DIR "${PARENT_DIRECTORY}/nvqir")
 find_dependency(NVQIR REQUIRED)
 

--- a/cmake/modules/FindGMP.cmake
+++ b/cmake/modules/FindGMP.cmake
@@ -1,0 +1,86 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+#[=======================================================================[.rst:
+FindGMP
+-------
+
+Find the GNU Multiple Precision Arithmetic Library.
+
+Only the shared library is searched for: CUDA-Q links GMP dynamically and
+redistributes it under the LGPL v3, which requires that it remain replaceable.
+
+This module is installed alongside ``CUDAQConfig.cmake``, which uses it to
+re-resolve GMP for consumers of the exported ``cudaq-synth`` target.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+``GMP_FOUND``, ``GMP_LIBRARY``, ``GMP_INCLUDE_DIR``, ``GMP_VERSION``.
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+# CUDAQ_INCLUDE_DIR / CUDAQ_LIBRARY_DIR are set when this module is loaded from
+# CUDAQConfig.cmake, and point at the GMP the installation was built against.
+# They are hints rather than roots so that GMP_ROOT still wins in-tree.
+find_path(GMP_INCLUDE_DIR
+  NAMES gmp.h
+  HINTS "${CUDAQ_INCLUDE_DIR}"
+  DOC "Directory containing gmp.h")
+
+set(_gmp_saved_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+find_library(GMP_LIBRARY
+  NAMES gmp
+  HINTS "${CUDAQ_LIBRARY_DIR}"
+  DOC "GMP shared library")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_gmp_saved_suffixes})
+unset(_gmp_saved_suffixes)
+
+set(GMP_VERSION "")
+if(GMP_INCLUDE_DIR AND EXISTS "${GMP_INCLUDE_DIR}/gmp.h")
+  set(_gmp_version_parts)
+  foreach(_gmp_macro IN ITEMS
+      __GNU_MP_VERSION __GNU_MP_VERSION_MINOR __GNU_MP_VERSION_PATCHLEVEL)
+    file(STRINGS "${GMP_INCLUDE_DIR}/gmp.h" _gmp_define
+      REGEX "^#define[ \t]+${_gmp_macro}[ \t]+[0-9]+")
+    if(_gmp_define MATCHES "[ \t]([0-9]+)[ \t]*$")
+      list(APPEND _gmp_version_parts "${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+  list(JOIN _gmp_version_parts "." GMP_VERSION)
+  unset(_gmp_version_parts)
+  unset(_gmp_define)
+endif()
+
+if(GMP_INCLUDE_DIR)
+  set(GMP_Headers_FOUND TRUE)
+else()
+  set(GMP_Headers_FOUND FALSE)
+endif()
+
+find_package_handle_standard_args(GMP
+  REQUIRED_VARS GMP_LIBRARY
+  VERSION_VAR GMP_VERSION
+  HANDLE_COMPONENTS
+  REASON_FAILURE_MESSAGE
+  "Run scripts/install_prerequisites.sh to build GMP from source, or install \
+it with your package manager (libgmp-dev on apt, gmp on brew) and set GMP_ROOT \
+or the GMP_INSTALL_PREFIX environment variable.")
+
+if(GMP_FOUND AND NOT TARGET GMP::gmp)
+  add_library(GMP::gmp UNKNOWN IMPORTED)
+  set_target_properties(GMP::gmp PROPERTIES IMPORTED_LOCATION "${GMP_LIBRARY}")
+  if(GMP_INCLUDE_DIR)
+    set_target_properties(GMP::gmp PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}")
+  endif()
+endif()
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARY)

--- a/cmake/modules/FindGMP.cmake
+++ b/cmake/modules/FindGMP.cmake
@@ -18,6 +18,22 @@ redistributes it under the LGPL v3, which requires that it remain replaceable.
 This module is installed alongside ``CUDAQConfig.cmake``, which uses it to
 re-resolve GMP for consumers of the exported ``cudaq-synth`` target.
 
+Components
+^^^^^^^^^^
+
+``Headers``
+  Require ``gmp.h`` in addition to the library. CUDA-Q redistributes the shared
+  library but not the GMP headers, so consumers that compile against ``gmp.h``
+  (for instance through ``cudaq/Synthesis/Math/Integer.h``) must request this
+  component and provide their own GMP development files.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+``GMP::gmp``
+  The GMP shared library, carrying the ``gmp.h`` directory as a usage
+  requirement when the headers were found.
+
 Result variables
 ^^^^^^^^^^^^^^^^
 
@@ -26,25 +42,22 @@ Result variables
 
 include(FindPackageHandleStandardArgs)
 
-# CUDAQ_INCLUDE_DIR / CUDAQ_LIBRARY_DIR are set when this module is loaded from
-# CUDAQConfig.cmake, and point at the GMP the installation was built against.
-# They are hints rather than roots so that GMP_ROOT still wins in-tree.
 find_path(GMP_INCLUDE_DIR
   NAMES gmp.h
-  HINTS "${CUDAQ_INCLUDE_DIR}"
   DOC "Directory containing gmp.h")
 
-set(_gmp_saved_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
-find_library(GMP_LIBRARY
-  NAMES gmp
-  HINTS "${CUDAQ_LIBRARY_DIR}"
-  DOC "GMP shared library")
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_gmp_saved_suffixes})
-unset(_gmp_saved_suffixes)
+block()
+  # Never accept libgmp.a: only the dynamically linked library may be
+  # redistributed under the terms CUDA-Q relies on.
+  set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  find_library(GMP_LIBRARY
+    NAMES gmp
+    HINTS "${CUDAQ_LIBRARY_DIR}"
+    DOC "GMP shared library")
+endblock()
 
-set(GMP_VERSION "")
-if(GMP_INCLUDE_DIR AND EXISTS "${GMP_INCLUDE_DIR}/gmp.h")
+unset(GMP_VERSION)
+if(EXISTS "${GMP_INCLUDE_DIR}/gmp.h")
   set(_gmp_version_parts)
   foreach(_gmp_macro IN ITEMS
       __GNU_MP_VERSION __GNU_MP_VERSION_MINOR __GNU_MP_VERSION_PATCHLEVEL)
@@ -57,12 +70,7 @@ if(GMP_INCLUDE_DIR AND EXISTS "${GMP_INCLUDE_DIR}/gmp.h")
   list(JOIN _gmp_version_parts "." GMP_VERSION)
   unset(_gmp_version_parts)
   unset(_gmp_define)
-endif()
-
-if(GMP_INCLUDE_DIR)
   set(GMP_Headers_FOUND TRUE)
-else()
-  set(GMP_Headers_FOUND FALSE)
 endif()
 
 find_package_handle_standard_args(GMP
@@ -74,13 +82,13 @@ find_package_handle_standard_args(GMP
 it with your package manager (libgmp-dev on apt, gmp on brew) and set GMP_ROOT \
 or the GMP_INSTALL_PREFIX environment variable.")
 
-if(GMP_FOUND AND NOT TARGET GMP::gmp)
-  add_library(GMP::gmp UNKNOWN IMPORTED)
-  set_target_properties(GMP::gmp PROPERTIES IMPORTED_LOCATION "${GMP_LIBRARY}")
+if(GMP_FOUND)
+  if(NOT TARGET GMP::gmp)
+    add_library(GMP::gmp SHARED IMPORTED)
+    set_property(TARGET GMP::gmp PROPERTY IMPORTED_LOCATION "${GMP_LIBRARY}")
+  endif()
   if(GMP_INCLUDE_DIR)
-    set_target_properties(GMP::gmp PROPERTIES
+    set_property(TARGET GMP::gmp PROPERTY
       INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}")
   endif()
 endif()
-
-mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARY)

--- a/cmake/modules/FindMPFR.cmake
+++ b/cmake/modules/FindMPFR.cmake
@@ -18,6 +18,26 @@ redistributes it under the LGPL v3, which requires that it remain replaceable.
 This module is installed alongside ``CUDAQConfig.cmake``, which uses it to
 re-resolve MPFR for consumers of the exported ``cudaq-synth`` target.
 
+GMP is a hard requirement: ``libmpfr`` is built on ``libgmp`` and ``mpfr.h``
+includes ``gmp.h``, so this module fails unless ``FindGMP`` succeeds too.
+
+Components
+^^^^^^^^^^
+
+``Headers``
+  Require ``mpfr.h`` (and, since it includes ``gmp.h``, the GMP headers) in
+  addition to the library. CUDA-Q redistributes the shared library but not the
+  MPFR headers, so consumers that compile against ``mpfr.h`` (for instance
+  through ``cudaq/Synthesis/Math/Real.h``) must request this component and
+  provide their own MPFR development files.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+``MPFR::mpfr``
+  The MPFR shared library, linking ``GMP::gmp`` and carrying the ``mpfr.h``
+  directory as a usage requirement when the headers were found.
+
 Result variables
 ^^^^^^^^^^^^^^^^
 
@@ -26,61 +46,56 @@ Result variables
 
 include(FindPackageHandleStandardArgs)
 
-# CUDAQ_INCLUDE_DIR / CUDAQ_LIBRARY_DIR are set when this module is loaded from
-# CUDAQConfig.cmake, and point at the MPFR the installation was built against.
-# They are hints rather than roots so that MPFR_ROOT still wins in-tree.
+find_package(GMP QUIET)
+
 find_path(MPFR_INCLUDE_DIR
   NAMES mpfr.h
-  HINTS "${CUDAQ_INCLUDE_DIR}"
   DOC "Directory containing mpfr.h")
 
-set(_mpfr_saved_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
-find_library(MPFR_LIBRARY
-  NAMES mpfr
-  HINTS "${CUDAQ_LIBRARY_DIR}"
-  DOC "MPFR shared library")
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_mpfr_saved_suffixes})
-unset(_mpfr_saved_suffixes)
+block()
+  # Never accept libmpfr.a: only the dynamically linked library may be
+  # redistributed under the terms CUDA-Q relies on.
+  set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  find_library(MPFR_LIBRARY
+    NAMES mpfr
+    HINTS "${CUDAQ_LIBRARY_DIR}"
+    DOC "MPFR shared library")
+endblock()
 
-set(MPFR_VERSION "")
-if(MPFR_INCLUDE_DIR AND EXISTS "${MPFR_INCLUDE_DIR}/mpfr.h")
+unset(MPFR_VERSION)
+if(EXISTS "${MPFR_INCLUDE_DIR}/mpfr.h")
   file(STRINGS "${MPFR_INCLUDE_DIR}/mpfr.h" _mpfr_define
     REGEX "^#define[ \t]+MPFR_VERSION_STRING[ \t]+\"[^\"]+\"")
   if(_mpfr_define MATCHES "\"([^\"]+)\"")
     set(MPFR_VERSION "${CMAKE_MATCH_1}")
   endif()
   unset(_mpfr_define)
-endif()
-
-if(MPFR_INCLUDE_DIR)
-  set(MPFR_Headers_FOUND TRUE)
-else()
-  set(MPFR_Headers_FOUND FALSE)
+  # Anything that includes mpfr.h also needs gmp.h.
+  if(GMP_INCLUDE_DIR)
+    set(MPFR_Headers_FOUND TRUE)
+  endif()
 endif()
 
 find_package_handle_standard_args(MPFR
-  REQUIRED_VARS MPFR_LIBRARY
+  REQUIRED_VARS MPFR_LIBRARY GMP_FOUND
   VERSION_VAR MPFR_VERSION
   HANDLE_COMPONENTS
   REASON_FAILURE_MESSAGE
   "Run scripts/install_prerequisites.sh to build MPFR from source, or install \
 it with your package manager (libmpfr-dev on apt, mpfr on brew) and set \
-MPFR_ROOT or the MPFR_INSTALL_PREFIX environment variable.")
+MPFR_ROOT or the MPFR_INSTALL_PREFIX environment variable. MPFR also needs GMP, \
+which FindGMP reports on separately.")
 
-if(MPFR_FOUND AND NOT TARGET MPFR::mpfr)
-  # mpfr.h includes gmp.h and libmpfr is built on libgmp, so GMP is part of
-  # MPFR's usage requirements.
-  find_package(GMP QUIET)
-  add_library(MPFR::mpfr UNKNOWN IMPORTED)
-  set_target_properties(MPFR::mpfr PROPERTIES IMPORTED_LOCATION "${MPFR_LIBRARY}")
-  if(MPFR_INCLUDE_DIR)
-    set_target_properties(MPFR::mpfr PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${MPFR_INCLUDE_DIR}")
-  endif()
-  if(TARGET GMP::gmp)
+if(MPFR_FOUND)
+  if(NOT TARGET MPFR::mpfr)
+    add_library(MPFR::mpfr SHARED IMPORTED)
+    set_property(TARGET MPFR::mpfr PROPERTY IMPORTED_LOCATION "${MPFR_LIBRARY}")
     set_property(TARGET MPFR::mpfr APPEND PROPERTY
       INTERFACE_LINK_LIBRARIES GMP::gmp)
+  endif()
+  if(MPFR_INCLUDE_DIR)
+    set_property(TARGET MPFR::mpfr PROPERTY
+      INTERFACE_INCLUDE_DIRECTORIES "${MPFR_INCLUDE_DIR}")
   endif()
 endif()
 

--- a/cmake/modules/FindMPFR.cmake
+++ b/cmake/modules/FindMPFR.cmake
@@ -1,0 +1,87 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+#[=======================================================================[.rst:
+FindMPFR
+--------
+
+Find the GNU Multiple Precision Floating-Point Reliable Library.
+
+Only the shared library is searched for: CUDA-Q links MPFR dynamically and
+redistributes it under the LGPL v3, which requires that it remain replaceable.
+
+This module is installed alongside ``CUDAQConfig.cmake``, which uses it to
+re-resolve MPFR for consumers of the exported ``cudaq-synth`` target.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+``MPFR_FOUND``, ``MPFR_LIBRARY``, ``MPFR_INCLUDE_DIR``, ``MPFR_VERSION``.
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+# CUDAQ_INCLUDE_DIR / CUDAQ_LIBRARY_DIR are set when this module is loaded from
+# CUDAQConfig.cmake, and point at the MPFR the installation was built against.
+# They are hints rather than roots so that MPFR_ROOT still wins in-tree.
+find_path(MPFR_INCLUDE_DIR
+  NAMES mpfr.h
+  HINTS "${CUDAQ_INCLUDE_DIR}"
+  DOC "Directory containing mpfr.h")
+
+set(_mpfr_saved_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+find_library(MPFR_LIBRARY
+  NAMES mpfr
+  HINTS "${CUDAQ_LIBRARY_DIR}"
+  DOC "MPFR shared library")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_mpfr_saved_suffixes})
+unset(_mpfr_saved_suffixes)
+
+set(MPFR_VERSION "")
+if(MPFR_INCLUDE_DIR AND EXISTS "${MPFR_INCLUDE_DIR}/mpfr.h")
+  file(STRINGS "${MPFR_INCLUDE_DIR}/mpfr.h" _mpfr_define
+    REGEX "^#define[ \t]+MPFR_VERSION_STRING[ \t]+\"[^\"]+\"")
+  if(_mpfr_define MATCHES "\"([^\"]+)\"")
+    set(MPFR_VERSION "${CMAKE_MATCH_1}")
+  endif()
+  unset(_mpfr_define)
+endif()
+
+if(MPFR_INCLUDE_DIR)
+  set(MPFR_Headers_FOUND TRUE)
+else()
+  set(MPFR_Headers_FOUND FALSE)
+endif()
+
+find_package_handle_standard_args(MPFR
+  REQUIRED_VARS MPFR_LIBRARY
+  VERSION_VAR MPFR_VERSION
+  HANDLE_COMPONENTS
+  REASON_FAILURE_MESSAGE
+  "Run scripts/install_prerequisites.sh to build MPFR from source, or install \
+it with your package manager (libmpfr-dev on apt, mpfr on brew) and set \
+MPFR_ROOT or the MPFR_INSTALL_PREFIX environment variable.")
+
+if(MPFR_FOUND AND NOT TARGET MPFR::mpfr)
+  # mpfr.h includes gmp.h and libmpfr is built on libgmp, so GMP is part of
+  # MPFR's usage requirements.
+  find_package(GMP QUIET)
+  add_library(MPFR::mpfr UNKNOWN IMPORTED)
+  set_target_properties(MPFR::mpfr PROPERTIES IMPORTED_LOCATION "${MPFR_LIBRARY}")
+  if(MPFR_INCLUDE_DIR)
+    set_target_properties(MPFR::mpfr PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${MPFR_INCLUDE_DIR}")
+  endif()
+  if(TARGET GMP::gmp)
+    set_property(TARGET MPFR::mpfr APPEND PROPERTY
+      INTERFACE_LINK_LIBRARIES GMP::gmp)
+  endif()
+endif()
+
+mark_as_advanced(MPFR_INCLUDE_DIR MPFR_LIBRARY)

--- a/cmake/modules/mlir-bundled-libs.txt
+++ b/cmake/modules/mlir-bundled-libs.txt
@@ -21,6 +21,7 @@ OptTransforms
 OptCodeGen
 OptimBuilder
 OptAnalysis
+cudaq-synth
 
 # Core IR + support
 MLIRIR
@@ -44,12 +45,14 @@ MLIRTransforms
 MLIRPluginsLib
 
 # Common op/type interfaces a custom dialect or pass builds on
+MLIRBytecodeOpInterface
 MLIRCallInterfaces
 MLIRCastInterfaces
 MLIRControlFlowInterfaces
 MLIRDataLayoutInterfaces
 MLIRFunctionInterfaces
 MLIRInferTypeOpInterface
+MLIRLoopLikeInterface
 MLIRSideEffectInterfaces
 
 # Foundational building-block dialects most custom dialects/lowerings reuse
@@ -62,6 +65,7 @@ MLIRSCFDialect
 MLIRComplexDialect
 MLIRMathDialect
 MLIRLLVMDialect
+MLIRUBDialect
 MLIROpenMPDialect
 MLIROpenACCDialect
 

--- a/cudaq/CMakeLists.txt
+++ b/cudaq/CMakeLists.txt
@@ -18,11 +18,6 @@ if(CUDAQ_ENABLE_CORE)
     add_subdirectory(test)
   endif()
 
-  # The static archives behind libcudaqMLIR, exported under their bare names --
-  # QuakeDialect, CCDialect, cudaq-synth, ... -- the same convention LLVM and
-  # MLIR use for their component libraries, and the names CUDAQ_MLIR_BUNDLED_LIBS
-  # already refers to. A downstream tool that opts into cudaq_use_static_mlir()
-  # links these instead of libcudaqMLIR.
   install(EXPORT cudaq-dev-targets
           FILE CUDAQDevTargets.cmake
           DESTINATION lib/cmake/cudaq

--- a/cudaq/CMakeLists.txt
+++ b/cudaq/CMakeLists.txt
@@ -17,4 +17,14 @@ if(CUDAQ_ENABLE_CORE)
   if(CUDAQ_BUILD_TESTS AND NOT CUDAQ_DISABLE_CPP_FRONTEND)
     add_subdirectory(test)
   endif()
+
+  # The static archives behind libcudaqMLIR, exported under their bare names --
+  # QuakeDialect, CCDialect, cudaq-synth, ... -- the same convention LLVM and
+  # MLIR use for their component libraries, and the names CUDAQ_MLIR_BUNDLED_LIBS
+  # already refers to. A downstream tool that opts into cudaq_use_static_mlir()
+  # links these instead of libcudaqMLIR.
+  install(EXPORT cudaq-dev-targets
+          FILE CUDAQDevTargets.cmake
+          DESTINATION lib/cmake/cudaq
+          COMPONENT Development)
 endif()

--- a/cudaq/include/CMakeLists.txt
+++ b/cudaq/include/CMakeLists.txt
@@ -11,15 +11,13 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/nvqpp_config.h.in"
                @ONLY)
 add_subdirectory(cudaq)
 
-# The Clifford+T rotation-synthesis headers under cudaq/Synthesis back an
-# internal-only C++ library (cudaq-synth). The public surface is the Python
-# cudaq.synth module. cudaq-synth is not part of the exported CMake package,
-# so excluding the headers keeps the install tree from implying a supported
-# standalone C++ API.
+# The Clifford+T rotation-synthesis headers under cudaq/Synthesis are part of
+# the development surface: their implementation (cudaq-synth) is linked into
+# libcudaqMLIR via OptTransforms, so downstream MLIR extensions that need
+# gridsynth/KMM resolve it from cudaq::MLIR like every other CUDA-Q symbol.
 install(DIRECTORY cudaq
         DESTINATION include
         COMPONENT Development
         FILES_MATCHING
           PATTERN "*.h"
-          PATTERN "*.td"
-          PATTERN "Synthesis" EXCLUDE)
+          PATTERN "*.td")

--- a/cudaq/lib/Optimizer/Builder/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Builder/CMakeLists.txt
@@ -6,12 +6,10 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-add_mlir_dialect_library(OptimBuilder
+add_cudaq_library(OptimBuilder
   Factory.cpp
   Intrinsics.cpp
   Marshal.cpp
-
-  ENABLE_AGGREGATION
 
   DEPENDS
     CCDialect

--- a/cudaq/lib/Optimizer/README.md
+++ b/cudaq/lib/Optimizer/README.md
@@ -47,3 +47,18 @@ Add `MyNewLib` to `cmake/modules/mlir-bundled-libs.txt` under the CUDA-Q section
 
 If the library needs additional upstream MLIR symbols, add the corresponding
 `MLIR*` target to the MLIR/LLVM section of that file.
+
+### Usage requirements and object libraries
+
+`add_cudaq_library` produces `obj.<lib>` targets, used for aggregation into
+`libcudaqMLIR.so`. LLVM forwards only `INCLUDE_DIRECTORIES` to the object
+library.
+
+To ensure dependencies are correctly reflected in the object library, use
+`cudaq_target_link_libraries()` instead of `target_link_libraries()` when
+adding dependencies after having used `add_cudaq_library`:
+
+```cmake
+add_cudaq_library(MyNewLib ...)
+cudaq_target_link_libraries(MyNewLib PRIVATE SomeOtherLib)
+```

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -114,12 +114,7 @@ target_include_directories(OptTransforms SYSTEM
 
 check_registered_mlir_lib(OptTransforms)
 
-target_link_libraries(OptTransforms PRIVATE cudaq-synth)
-# The object library compiles the sources but does not inherit the link
-# interface of the library it belongs to; linking it separately gives it the
-# usage requirements of cudaq-synth (its own headers, plus GMP/MPFR) without
-# contributing to any link line.
-target_link_libraries(obj.OptTransforms PRIVATE cudaq-synth)
+cudaq_target_link_libraries(OptTransforms PRIVATE cudaq-synth)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set_source_files_properties(CliffordTSynthesis.cpp PROPERTIES
     COMPILE_OPTIONS "-Wno-maybe-uninitialized")

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -115,8 +115,11 @@ target_include_directories(OptTransforms SYSTEM
 check_registered_mlir_lib(OptTransforms)
 
 target_link_libraries(OptTransforms PRIVATE cudaq-synth)
-target_include_directories(obj.OptTransforms SYSTEM PRIVATE
-  $<TARGET_PROPERTY:cudaq-synth,INTERFACE_INCLUDE_DIRECTORIES>)
+# The object library compiles the sources but does not inherit the link
+# interface of the library it belongs to; linking it separately gives it the
+# usage requirements of cudaq-synth (its own headers, plus GMP/MPFR) without
+# contributing to any link line.
+target_link_libraries(obj.OptTransforms PRIVATE cudaq-synth)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set_source_files_properties(CliffordTSynthesis.cpp PROPERTIES
     COMPILE_OPTIONS "-Wno-maybe-uninitialized")

--- a/cudaq/lib/Synthesis/CMakeLists.txt
+++ b/cudaq/lib/Synthesis/CMakeLists.txt
@@ -26,18 +26,8 @@ add_cudaq_library(cudaq-synth
   MPFR::mpfr
 )
 
-# The object library MLIR splits out for aggregation compiles the sources but
-# does not inherit the link interface of the library it belongs to, so the
-# GMP/MPFR include directories have to be attached to it directly.
-if(TARGET obj.cudaq-synth)
-  target_link_libraries(obj.cudaq-synth PRIVATE GMP::gmp MPFR::mpfr)
-endif()
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(cudaq-synth PUBLIC -Wno-psabi)
-  if(TARGET obj.cudaq-synth)
-    target_compile_options(obj.cudaq-synth PRIVATE -Wno-psabi)
-  endif()
 endif()
 
 target_include_directories(cudaq-synth PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/cudaq/lib/Synthesis/CMakeLists.txt
+++ b/cudaq/lib/Synthesis/CMakeLists.txt
@@ -6,24 +6,8 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-find_path(GMP_INCLUDE_DIR NAMES gmp.h HINTS "${GMP_ROOT}/include")
-find_path(MPFR_INCLUDE_DIR NAMES mpfr.h HINTS "${MPFR_ROOT}/include")
-
-set(_synth_saved_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
-find_library(GMP_LIBRARIES NAMES gmp libgmp HINTS "${GMP_ROOT}/lib")
-find_library(MPFR_LIBRARIES NAMES mpfr libmpfr HINTS "${MPFR_ROOT}/lib")
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_synth_saved_suffixes})
-
-if(NOT GMP_INCLUDE_DIR OR NOT GMP_LIBRARIES OR
-   NOT MPFR_INCLUDE_DIR OR NOT MPFR_LIBRARIES)
-  message(FATAL_ERROR
-    "The GMP/MPFR shared libraries were not found. They are required to "
-    "build CUDA-Q (Clifford+T rotation synthesis). Run "
-    "scripts/install_prerequisites.sh to build them from source, or install "
-    "them via your package manager (e.g. libgmp-dev and libmpfr-dev on apt) "
-    "and/or set GMP_INSTALL_PREFIX / MPFR_INSTALL_PREFIX.")
-endif()
+find_package(GMP REQUIRED COMPONENTS Headers)
+find_package(MPFR REQUIRED COMPONENTS Headers)
 
 add_cudaq_library(cudaq-synth
   Circuit/Circuit.cpp
@@ -37,10 +21,17 @@ add_cudaq_library(cudaq-synth
   Synthesis/Gridsynth.cpp
   Synthesis/KmmSynthesize.cpp
 
-  LINK_LIBS PRIVATE
-    ${GMP_LIBRARIES}
-    ${MPFR_LIBRARIES}
+  LINK_LIBS PUBLIC
+  GMP::gmp
+  MPFR::mpfr
 )
+
+# The object library MLIR splits out for aggregation compiles the sources but
+# does not inherit the link interface of the library it belongs to, so the
+# GMP/MPFR include directories have to be attached to it directly.
+if(TARGET obj.cudaq-synth)
+  target_link_libraries(obj.cudaq-synth PRIVATE GMP::gmp MPFR::mpfr)
+endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(cudaq-synth PUBLIC -Wno-psabi)
@@ -49,10 +40,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
-target_include_directories(cudaq-synth SYSTEM PUBLIC
-  $<BUILD_INTERFACE:${GMP_INCLUDE_DIR}>
-  $<BUILD_INTERFACE:${MPFR_INCLUDE_DIR}>
-)
 target_include_directories(cudaq-synth PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 foreach(_synth_dep IN LISTS GMP_LIBRARIES MPFR_LIBRARIES)

--- a/cudaq/lib/Synthesis/CMakeLists.txt
+++ b/cudaq/lib/Synthesis/CMakeLists.txt
@@ -32,15 +32,21 @@ endif()
 
 target_include_directories(cudaq-synth PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-foreach(_synth_dep IN LISTS GMP_LIBRARIES MPFR_LIBRARIES)
-  get_filename_component(_synth_dep_dir "${_synth_dep}" DIRECTORY)
-  get_filename_component(_synth_dep_name "${_synth_dep}" NAME_WE)
+foreach(_synth_dep IN ITEMS GMP::gmp MPFR::mpfr)
+  get_target_property(_synth_dep_file ${_synth_dep} IMPORTED_LOCATION)
+  get_filename_component(_synth_dep_dir "${_synth_dep_file}" DIRECTORY)
+  get_filename_component(_synth_dep_name "${_synth_dep_file}" NAME_WE)
   if(APPLE)
     file(GLOB _synth_dep_files
       "${_synth_dep_dir}/${_synth_dep_name}.dylib"
       "${_synth_dep_dir}/${_synth_dep_name}.*.dylib")
   else()
     file(GLOB _synth_dep_files "${_synth_dep_dir}/${_synth_dep_name}.so*")
+  endif()
+  if(NOT _synth_dep_files)
+    message(FATAL_ERROR "Found no shared library files to redistribute next to "
+      "${_synth_dep_file}; CUDA-Q must ship ${_synth_dep} to comply with the "
+      "LGPL v3.")
   endif()
   install(FILES ${_synth_dep_files} DESTINATION lib)
 endforeach()


### PR DESCRIPTION
full CI run: https://github.com/NVIDIA/cuda-quantum/actions/runs/32887500355.

This PR does the following minor tweaks to simplify downstream out-of-tree MLIR extensions:
- Previously, `add_cudaq_library` installed targets into a `CUDAQTargets` export group, but that group was never referred to elsewhere - this was effecitvely a no-op. Replaced that with a `cudaq-dev-targets` and a corresponding `CUDAQDevTargets.cmake` that can be ingested by downstream
- Ensures the `cudaq::MLIR` alias as well as the object libraries generated by LLVM and used for aggregation in the cudaqMLIR shared library properly re-expose dependencies and header locations
- defines dedicated `Find*.cmake` files for the GMP and MPFR dependencies that handle finding the dependencies for both in-tree builds and out-of-tree downstream builds
- Exposes the headers of `cudaq-synth` publicly. It seemed this was kept private on purpose, but doesn't work for some of our downstream consumers.
- Fixes an issue where some libraries were installed into `lib64` in the wheel build, which certain distros (e.g. ubuntu) don't find.

On the CI side, it enables building `cudaq-devel` wheels for `arm64` and adds an output to `.github/workflows/retrieve_python_wheels.yml`