### PR TITLE
[Quantinuum] Installing curl and jq in provider test container

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -287,17 +287,6 @@ jobs:
             echo "testlist=$filelist" >> $GITHUB_OUTPUT
           fi
 
-      # The nightly CUDA-Q image does not ship curl or jq, which the provider
-      # setup steps below need.
-      - name: Install CLI prerequisites
-        run: |
-          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
-          if ! command -v curl > /dev/null || ! command -v jq > /dev/null; then
-            retry apt-get update
-            retry apt-get install -y --no-install-recommends curl jq
-          fi
-        shell: bash
-
       # Provider-specific setup steps
       - name: Setup ${{ matrix.provider }} account
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -287,6 +287,17 @@ jobs:
             echo "testlist=$filelist" >> $GITHUB_OUTPUT
           fi
 
+      # The nightly CUDA-Q image does not ship curl or jq, which the provider
+      # setup steps below need.
+      - name: Install CLI prerequisites
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          if ! command -v curl > /dev/null || ! command -v jq > /dev/null; then
+            retry apt-get update
+            retry apt-get install -y --no-install-recommends curl jq
+          fi
+        shell: bash
+
       # Provider-specific setup steps
       - name: Setup ${{ matrix.provider }} account
         run: |

--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -51,6 +51,8 @@ ENV UCX_LOG_LEVEL=error
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates wget git sudo vim \
+        # needed to follow the backend credential setup in our documentation:
+        curl jq \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 # Install CUDA-Q runtime dependencies.

--- a/docs/sphinx/using/backends/hardware/iontrap.rst
+++ b/docs/sphinx/using/backends/hardware/iontrap.rst
@@ -112,7 +112,8 @@ account details.
 
 .. code:: bash
 
-    # You may need to run: `apt-get update && apt-get install curl`
+    # curl is preinstalled in the CUDA-Q container. Elsewhere, you may need to
+    # run: `apt-get update && apt-get install curl`
     curl -c $HOME/.quantinuum_cookies.txt -X POST https://nexus.quantinuum.com/auth/login \
     -H "Content-Type: application/json" -d '{ "email":"<your_alias>@email.com","password":"<your_password>" }' >/dev/null
     awk '$6 == "myqos_oat" {refresh=$7} $6 == "myqos_id" {key=$7} END {print "key: " key "\nrefresh: " refresh}' $HOME/.quantinuum_cookies.txt > $HOME/.quantinuum_config

--- a/docs/sphinx/using/backends/hardware/superconducting.rst
+++ b/docs/sphinx/using/backends/hardware/superconducting.rst
@@ -25,7 +25,8 @@ Users can also login and get the keys manually using the following commands:
 
 .. code:: bash
 
-    # You may need to run: `apt-get update && apt-get install curl jq`
+    # curl and jq are preinstalled in the CUDA-Q container. Elsewhere, you may
+    # need to run: `apt-get update && apt-get install curl jq`
     curl -X POST --user "<username>:<password>"  -H "Content-Type: application/json" \
     https://api.anyon.cloud:5000/login > credentials.json
     id_token=`cat credentials.json | jq -r '."id_token"'`


### PR DESCRIPTION
The nightly integration test job runs in the CUDA-Q image, which does not ship `curl` or `jq` (only the ext image does). The Quantinuum account setup step failed with
```
curl: command not found
Error: Quantinuum login request failed (curl error)
```

Here we are adding a step that installs both before the provider setup steps run.

Fixes https://github.com/NVIDIA/cuda-quantum/actions/runs/32804781345/job/97916018838#step:5:160