### PR TITLE
test: cover the control on a controlled swap through openqasm2

### DIFF
--- a/python/tests/builder/test_translate.py
+++ b/python/tests/builder/test_translate.py
@@ -172,3 +172,30 @@ def test_translate_builder_adjoint_t_openqasm():
     assert "OPENQASM 2.0;" in asm
     body = asm[asm.index('qreg'):]
     assert "tdg var0[0];" in body
+
+
+def test_translate_controlled_swap_keeps_control():
+    """A controlled swap must not lower to an unconditional swap.
+
+    Reported in #5192: the SwapToCX decomposition read only the two targets and
+    emitted three CNOTs between them, so the control was dropped and the
+    exported circuit swapped unconditionally.
+
+    The control has to be |0> for this to be visible. With the control set, a
+    controlled swap and a plain swap agree, which is why the existing
+    SwapToCX.qke test does not catch it: it only covers the uncontrolled case.
+    """
+    kernel = cudaq.make_kernel()
+    q = kernel.qalloc(3)
+    kernel.x(q[1])
+    kernel.cswap(q[0], q[1], q[2])
+    asm = cudaq.translate(kernel, format="openqasm2")
+
+    body = "\n".join(
+        line for line in asm.splitlines()
+        if line.strip() and not line.strip().startswith(
+            ("//", "OPENQASM", "include", "qreg", "creg"))
+    )
+    assert "var0[0]" in body, (
+        "the control qubit appears in no gate, so the controlled swap was "
+        f"lowered as an unconditional one:\n{body}")


### PR DESCRIPTION
Regression test for #5192, which I reported: a controlled swap lowers to three CNOTs between the two targets, so the control is dropped and the exported OpenQASM 2 swaps unconditionally while the simulator does not.

This only adds the test. The lowering itself is still open, and there is a discussion on the issue about which form to use.

Two things about how it is written:

The control is `|0>` on purpose. With the control set, a controlled swap and a plain swap agree, so a test with the control on passes either way. That is why `test/Transforms/DecompositionPatterns/SwapToCX.qke` does not catch this: it only covers the uncontrolled swap.

It asserts that the control qubit appears in some gate, rather than pinning a particular decomposition. Whether the fix emits a Fredkin, bails out for controlled swaps, or does something else, the control has to survive, and I did not want the test to constrain that choice.

Verified against 0.15.1 from `pip install cudaq`: it fails there with the control absent, and the assertion prints the emitted body so the failure explains itself. Two unrelated tests in this file (`test_translate_builder_qir` and `test_translate_builder_with_params_qir`) already fail for me on the released wheel, in `kernel_builder.py`, so I could not run the whole file green. The rest passes.