### PR TITLE
Make the compile error from `const qubit&` argument more explicit

### DIFF
--- a/cudaq/test/AST-error/const_qubit.cpp
+++ b/cudaq/test/AST-error/const_qubit.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: ( cudaq-quake %s || true ) 2>&1 | FileCheck %s --implicit-check-not="Cannot operate on a qudit with Levels != 2" --implicit-check-not="no matching function for call to 'qubitToQuditInfo'" --implicit-check-not="no matching function for call to 'qubitIsNegative'"
+
+// CHECK-COUNT-8: static assertion failed{{.*}}Cannot apply a quantum operation to a const qubit.
+// CHECK: C++ source has errors. nvq++ cannot proceed.
+// clang-format on
+
+#include <cudaq.h>
+
+struct for_in_vector {
+  auto operator()() __qpu__ {
+    cudaq::qvector q(2);
+    for (const auto &qubit : q) {
+      x(qubit);
+      x(qubit);
+    }
+  }
+};
+
+struct parameterized_gate {
+  auto operator()() __qpu__ {
+    cudaq::qvector q(1);
+    for (const auto &qubit : q)
+      rx(0.5, qubit);
+  }
+};
+
+struct u3_gate {
+  auto operator()() __qpu__ {
+    cudaq::qvector q(1);
+    for (const auto &qubit : q)
+      u3(0.1, 0.2, 0.3, qubit);
+  }
+};
+
+struct swap_gate {
+  auto operator()() __qpu__ {
+    cudaq::qubit target;
+    cudaq::qvector q(1);
+    for (const auto &qubit : q)
+      swap(qubit, target);
+  }
+};
+
+struct controlled_gate {
+  auto operator()() __qpu__ {
+    cudaq::qubit target;
+    cudaq::qvector q(1);
+    for (const auto &qubit : q)
+      x<cudaq::ctrl>(qubit, target);
+  }
+};
+
+struct controlled_parameterized_gate {
+  auto operator()() __qpu__ {
+    cudaq::qubit control;
+    cudaq::qvector q(1);
+    for (const auto &qubit : q)
+      rx<cudaq::ctrl>(0.5, control, qubit);
+  }
+};
+
+struct controlled_u3_gate {
+  auto operator()() __qpu__ {
+    cudaq::qubit control;
+    cudaq::qubit target;
+    cudaq::qvector q(1);
+    for (const auto &qubit : q)
+      u3<cudaq::ctrl>(0.1, 0.2, 0.3, control, qubit, target);
+  }
+};
+
+struct controlled_swap_gate {
+  auto operator()() __qpu__ {
+    cudaq::qubit control;
+    cudaq::qubit target;
+    cudaq::qvector q(1);
+    for (const auto &qubit : q)
+      swap<cudaq::ctrl>(control, qubit, target);
+  }
+};

--- a/cudaq/test/AST-error/const_qubit.cpp
+++ b/cudaq/test/AST-error/const_qubit.cpp
@@ -6,12 +6,11 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
-// RUN: ( cudaq-quake %s || true ) 2>&1 | FileCheck %s --implicit-check-not="Cannot operate on a qudit with Levels != 2" --implicit-check-not="no matching function for call to 'qubitToQuditInfo'" --implicit-check-not="no matching function for call to 'qubitIsNegative'"
-
-// CHECK-COUNT-8: static assertion failed{{.*}}Cannot apply a quantum operation to a const qubit.
-// CHECK: C++ source has errors. nvq++ cannot proceed.
-// clang-format on
+// Diagnostic verification treats the expected Clang errors as success, so
+// cudaq-quake continues Quake AST traversal on the invalid AST. Ignore the
+// resulting secondary traversal errors.
+// RUN: cudaq-quake -verify -Xcudaq -Xclang \
+// RUN:   -Xcudaq -verify-ignore-unexpected=error %s -o /dev/null
 
 #include <cudaq.h>
 
@@ -19,6 +18,8 @@ struct for_in_vector {
   auto operator()() __qpu__ {
     cudaq::qvector q(2);
     for (const auto &qubit : q) {
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       x(qubit);
       x(qubit);
     }
@@ -29,6 +30,8 @@ struct parameterized_gate {
   auto operator()() __qpu__ {
     cudaq::qvector q(1);
     for (const auto &qubit : q)
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       rx(0.5, qubit);
   }
 };
@@ -37,6 +40,8 @@ struct u3_gate {
   auto operator()() __qpu__ {
     cudaq::qvector q(1);
     for (const auto &qubit : q)
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       u3(0.1, 0.2, 0.3, qubit);
   }
 };
@@ -46,6 +51,8 @@ struct swap_gate {
     cudaq::qubit target;
     cudaq::qvector q(1);
     for (const auto &qubit : q)
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       swap(qubit, target);
   }
 };
@@ -55,6 +62,8 @@ struct controlled_gate {
     cudaq::qubit target;
     cudaq::qvector q(1);
     for (const auto &qubit : q)
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       x<cudaq::ctrl>(qubit, target);
   }
 };
@@ -64,6 +73,8 @@ struct controlled_parameterized_gate {
     cudaq::qubit control;
     cudaq::qvector q(1);
     for (const auto &qubit : q)
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       rx<cudaq::ctrl>(0.5, control, qubit);
   }
 };
@@ -74,6 +85,8 @@ struct controlled_u3_gate {
     cudaq::qubit target;
     cudaq::qvector q(1);
     for (const auto &qubit : q)
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       u3<cudaq::ctrl>(0.1, 0.2, 0.3, control, qubit, target);
   }
 };
@@ -84,6 +97,8 @@ struct controlled_swap_gate {
     cudaq::qubit target;
     cudaq::qvector q(1);
     for (const auto &qubit : q)
+      // expected-error@* {{Cannot apply a quantum operation to a const qubit.}}
+      // expected-note@+1 {{in instantiation of function template}}
       swap<cudaq::ctrl>(control, qubit, target);
   }
 };

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -144,6 +144,14 @@ void oneQubitApplyControlledRange(QubitRange &ctrls, qubit &target) {
   };                                                                           \
   }                                                                            \
   template <typename mod = base, typename... QubitArgs>                        \
+    requires(std::conjunction_v<                                               \
+                 std::is_same<qubit, std::remove_cv_t<QubitArgs>>...> &&       \
+             std::disjunction_v<std::is_const<QubitArgs>...>)                  \
+  void NAME(QubitArgs &...) {                                                  \
+    static_assert(!std::disjunction_v<std::is_const<QubitArgs>...>,            \
+                  "Cannot apply a quantum operation to a const qubit.");       \
+  }                                                                            \
+  template <typename mod = base, typename... QubitArgs>                        \
   void NAME(QubitArgs &...args) {                                              \
     oneQubitApply<qubit_op::NAME##Op, mod>(args...);                           \
   }                                                                            \
@@ -232,6 +240,14 @@ void oneQubitSingleParameterControlledRange(ScalarAngle angle,
   };                                                                           \
   }                                                                            \
   template <typename mod = base, typename ScalarAngle, typename... QubitArgs>  \
+    requires(std::conjunction_v<                                               \
+                 std::is_same<qubit, std::remove_cv_t<QubitArgs>>...> &&       \
+             std::disjunction_v<std::is_const<QubitArgs>...>)                  \
+  void NAME(ScalarAngle, QubitArgs &...) {                                     \
+    static_assert(!std::disjunction_v<std::is_const<QubitArgs>...>,            \
+                  "Cannot apply a quantum operation to a const qubit.");       \
+  }                                                                            \
+  template <typename mod = base, typename ScalarAngle, typename... QubitArgs>  \
   void NAME(ScalarAngle angle, QubitArgs &...args) {                           \
     oneQubitSingleParameterApply<qubit_op::NAME##Op, mod>(angle, args...);     \
   }                                                                            \
@@ -255,6 +271,15 @@ struct u3 {
   static constexpr std::string_view name{"u3"};
 };
 } // namespace types
+
+template <typename mod = base, typename ScalarAngle, typename... QubitArgs>
+  requires(
+      std::conjunction_v<std::is_same<qubit, std::remove_cv_t<QubitArgs>>...> &&
+      std::disjunction_v<std::is_const<QubitArgs>...>)
+void u3(ScalarAngle, ScalarAngle, ScalarAngle, QubitArgs &...) {
+  static_assert(!std::disjunction_v<std::is_const<QubitArgs>...>,
+                "Cannot apply a quantum operation to a const qubit.");
+}
 
 template <typename mod = base, typename ScalarAngle, typename... QubitArgs>
 void u3(ScalarAngle theta, ScalarAngle phi, ScalarAngle lambda,
@@ -305,6 +330,15 @@ struct swap {
   static constexpr std::string_view name{"swap"};
 };
 } // namespace types
+
+template <typename mod = base, typename... QubitArgs>
+  requires(
+      std::conjunction_v<std::is_same<qubit, std::remove_cv_t<QubitArgs>>...> &&
+      std::disjunction_v<std::is_const<QubitArgs>...>)
+void swap(QubitArgs &...) {
+  static_assert(!std::disjunction_v<std::is_const<QubitArgs>...>,
+                "Cannot apply a quantum operation to a const qubit.");
+}
 
 template <typename mod = base, typename... QubitArgs>
 void swap(QubitArgs &...args) {


### PR DESCRIPTION
Our quantum gates are declared to support `qubit &` (non-const type).

However, this check is performed rather late, e.g., in the implementation (`oneQubitApply`).

This generated an unwieldy error message, which didn't really point to the fact that user has a `const` qualifier.

For example, a reported case was

```
struct for_in_vector {
  auto operator()() __qpu__ {
    cudaq::qvector q(2);
    for (auto const& qubit : q) {
      x(qubit);
      x(qubit);
    }
  }
};
```

which resulted in a complex compile error chain, including `Cannot operate on a qudit with Levels != 2`, etc., 

```
E           In file included from for_in_vector.cpp:12:
E           In file included from /opt/nvidia/cudaq/include/cudaq.h:14:
E           /opt/nvidia/cudaq/include/cudaq/qis/qubit_qis.h:69:17: error: static assertion failed due to requirement 'std::conjunction<std::is_same<cudaq::qudit<2>, const cudaq::qudit<2>>>::value': Cannot operate on a qudit with Levels != 2
E              69 |   static_assert(std::conjunction<std::is_same<qubit, QubitArgs>...>::value,
E                 |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
E           /opt/nvidia/cudaq/include/cudaq/qis/qubit_qis.h:172:1: note: in instantiation of function template specialization 'cudaq::oneQubitApply<cudaq::qubit_op::xOp, cudaq::base, const cudaq::qudit<2>>' requested here
E             172 | CUDAQ_QIS_ONE_TARGET_QUBIT_(x)
E                 | ^
E           /opt/nvidia/cudaq/include/cudaq/qis/qubit_qis.h:148:5: note: expanded from macro 'CUDAQ_QIS_ONE_TARGET_QUBIT_'
E             148 |     oneQubitApply<qubit_op::NAME##Op, mod>(args...);                           \
E                 |     ^
E           for_in_vector.cpp:20:7: note: in instantiation of function template specialization 'cudaq::x<cudaq::base, const cudaq::qudit<2>>' requested here
E              20 |       x(qubit);
E                 |       ^
E           In file included from for_in_vector.cpp:12:
E           In file included from /opt/nvidia/cudaq/include/cudaq.h:14:
E           /opt/nvidia/cudaq/include/cudaq/qis/qubit_qis.h:76:37: error: no matching function for call to 'qubitToQuditInfo'
E              76 |   std::vector<QuditInfo> quditInfos{qubitToQuditInfo(args)...};
E                 |                                     ^~~~~~~~~~~~~~~~
E           /opt/nvidia/cudaq/include/cudaq/qis/qubit_qis.h:56:18: note: candidate function not viable: 1st argument ('const cudaq::qudit<2>') would lose const qualifier
E              56 | inline QuditInfo qubitToQuditInfo(qubit &q) { return {q.n_levels(), q.id()}; }
E                 |                  ^                ~~~~~~~~
E           /opt/nvidia/cudaq/include/cudaq/qis/qubit_qis.h:77:36: error: no matching function for call to 'qubitIsNegative'
E              77 |   std::vector<bool> qubitIsNegated{qubitIsNegative(args)...};
E                 |                                    ^~~~~~~~~~~~~~~
E           /opt/nvidia/cudaq/include/cudaq/qis/qubit_qis.h:57:13: note: candidate function not viable: 1st argument ('const cudaq::qudit<2>') would lose const qualifier
E              57 | inline bool qubitIsNegative(qubit &q) { return q.is_negative(); }
E                 |             ^               ~~~~~~~~
E           error: C++ source has errors. nvq++ cannot proceed.
```

This PR adds an early catch for this case to output a proper compiler error message.