### PR TITLE
Pinning lit<23 to fix the Build assets job

### DIFF
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -342,8 +342,9 @@ RUN gcc_packages=$(dnf list installed "gcc*" | sed '/Installed Packages/d' | cut
     dnf install -y --nobest --setopt=install_weak_deps=False glibc-devel
 
 ## [Python MLIR tests]
+# lit 23+ rejects the external shell our lit configs use. Pin to LLVM 22.x.
 RUN cd /cuda-quantum && source scripts/configure_build.sh && \
-    python3 -m pip install lit pytest scipy && \
+    python3 -m pip install 'lit<23' pytest scipy && \
     "${LLVM_INSTALL_PREFIX}/bin/llvm-lit" -v _skbuild/python/tests/mlir \
         --param cudaq_site_config=_skbuild/python/tests/mlir/lit.site.cfg.py
 # The other tests for the Python wheel are run post-installation.
@@ -375,7 +376,8 @@ RUN if [ -x "$(command -v nvidia-smi)" ] && [ -n "$(nvidia-smi | egrep -o "CUDA 
             cuda-cudart-devel-$(echo ${CUDA_VERSION} | tr . -); \
     fi
 
-RUN python3 -m ensurepip --upgrade && python3 -m pip install lit && \
+# lit 23+ rejects the external shell our lit configs use. Pin to LLVM 22.x.
+RUN python3 -m ensurepip --upgrade && python3 -m pip install 'lit<23' && \
     dnf install -y --nobest --setopt=install_weak_deps=False file which
 RUN cd /cuda-quantum && source scripts/configure_build.sh && \
     if [ ! -x "$(command -v nvcc)" ]; then \


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/32919408280/job/98036566499#step:15:61665

The Build assets job started failing even without code changes

```
ValueError: execute_external=True is deprected as of LLVM-23
```

The Dockerfile installs lit with plain `pip install lit`, so it picks up whatever is newest (lit 23.1.0), released a few days ago.
`llvm-lit` uses that pip installed lit, and lit 23 turns `ShTest(execute_external=True)` into a hard error.

All four of our lit configs use that setting, so the test config fails to load and the build stops. We build against LLVM 22.1.4, so pulling in lit 23 was a mismatch.

Pinning lit to the matching generation (`lit<23`) at both install sites.

