### PR TITLE
Add ascii draw regression test for mid-trace measurements

### DIFF
--- a/unittests/nvqpp/integration/draw_tester.cpp
+++ b/unittests/nvqpp/integration/draw_tester.cpp
@@ -132,3 +132,23 @@ CUDAQ_TEST(LatexDrawTester, skipsNonGateInstructions) {
 
   EXPECT_EQ(expected_str, cudaq::detail::getLaTeXString(trace));
 }
+
+CUDAQ_TEST(DrawTester, skipsNonGateInstructions) {
+  // Regression test: a measurement in the middle of the trace must not
+  // misalign the instruction indices used by the layers and the boxes.
+  cudaq::Trace trace;
+  trace.appendInstruction("h", {}, {}, {{2, 2}});
+  trace.appendMeasurement("mz", {{2, 2}});
+  trace.appendInstruction("x", {}, {}, {{2, 2}});
+
+  const std::string expected_str =
+      "               \n"
+      "q0 : ──────────\n"
+      "               \n"
+      "q1 : ──────────\n"
+      "     ╭───╮╭───╮\n"
+      "q2 : ┤ h ├┤ x ├\n"
+      "     ╰───╯╰───╯\n";
+
+  EXPECT_EQ(expected_str, cudaq::detail::draw(trace));
+}

--- a/unittests/nvqpp/integration/draw_tester.cpp
+++ b/unittests/nvqpp/integration/draw_tester.cpp
@@ -141,14 +141,16 @@ CUDAQ_TEST(DrawTester, skipsNonGateInstructions) {
   trace.appendMeasurement("mz", {{2, 2}});
   trace.appendInstruction("x", {}, {}, {{2, 2}});
 
-  const std::string expected_str =
-      "               \n"
-      "q0 : ──────────\n"
-      "               \n"
-      "q1 : ──────────\n"
-      "     ╭───╮╭───╮\n"
-      "q2 : ┤ h ├┤ x ├\n"
-      "     ╰───╯╰───╯\n";
+  // clang-format off
+  const std::string expected_str = R"(               
+q0 : ──────────
+               
+q1 : ──────────
+     ╭───╮╭───╮
+q2 : ┤ h ├┤ x ├
+     ╰───╯╰───╯
+)";
+  // clang-format on
 
   EXPECT_EQ(expected_str, cudaq::detail::draw(trace));
 }


### PR DESCRIPTION
Refs #5258

Test-only regression coverage for the mid-circuit-measurement draw bug reported in #5258. The renderer defect itself is already fixed on main by the trace rework in #4945 (included in `v0.15.2_base`); this adds an ascii-draw test so a gate that follows a measurement in the middle of a trace keeps its correct layer position.

The test builds a three-qubit trace with `h`, then `mz` on q2, then `x` on q2, and asserts the exact ascii output:

```
     ╭───╮╭───╮
q2 : ┤ h ├┤ x ├
     ╰───╯╰───╯
```

On 0.15.1 behavior this crashes instead of misrendering: `layers_from_trace` stored absolute instruction indices while `boxes_from_trace` pushed only gates, so a skipped measurement desynced the two and indexed out of bounds. Mirrors the existing `LatexDrawTester.skipsNonGateInstructions` case.

DCO: all commits signed off as required.

Test output (`ctest -R DrawTester -LE gpu_required` and friends, devcontainer cu12.6-gcc12, Release, no GPU in this environment):

```
 3/15 Test #299: qpp_DrawTester.skipsNonGateInstructions .........   Passed    0.02 sec
 5/15 Test #301: qpp_LatexDrawTester.skipsNonGateInstructions ....   Passed    0.02 sec
 8/15 Test #498: dm_DrawTester.skipsNonGateInstructions ..........   Passed    0.02 sec
10/15 Test #500: dm_LatexDrawTester.skipsNonGateInstructions .....   Passed    0.02 sec
13/15 Test #624: stim_DrawTester.skipsNonGateInstructions ........   Passed    0.02 sec
15/15 Test #626: stim_LatexDrawTester.skipsNonGateInstructions ...   Passed    0.02 sec
100% tests passed, 0 tests failed out of 15
```

`pre-commit run --all-files --hook-stage pre-push` passes on every hook except `markdown-link-check`, whose single failure is a pre-existing stale badge URL in the top-level `README.md` (untouched by this branch); all other checked files report OK.
