### PR TITLE
[python] Add CustomTarget with set_target overload

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -262,7 +262,40 @@ OptimizationResult = cudaq_runtime.OptimizationResult
 # Runtime Functions
 __version__ = cudaq_runtime.__version__
 initialize_cudaq = cudaq_runtime.initialize_cudaq
-set_target = cudaq_runtime.set_target
+
+
+def set_target(target, **extra_config):
+    """Set the backend used for CUDA-Q kernel execution.
+
+    Can provide optional, target-specific configuration data via Python `kwargs`.
+
+    Args:
+      target: The CUDA-Q target, specified as a recognized target name (``str``)
+        or a :class:`cudaq.Target` instance. Support for
+        instances of :class:`cudaq._experimental.CustomTarget` is experimental.
+      **extra_config: Target-specific configuration for the named-target
+        overload.
+
+    Raises:
+      TypeError: For unsupported target types or keyword arguments.
+    """
+    from cudaq._experimental import CustomTarget
+    from cudaq._experimental import set_compile_target, set_runtime_endpoint
+
+    if isinstance(target, CustomTarget):
+        if extra_config:
+            raise TypeError(
+                "cudaq.set_target() does not accept keyword arguments when "
+                "target is a cudaq._experimental.CustomTarget.")
+        set_compile_target(target.compile_target)
+        set_runtime_endpoint(target.runtime_endpoint)
+        return target
+    elif isinstance(target, Target) or isinstance(target, str):
+        return cudaq_runtime.set_target(target, **extra_config)
+
+    raise TypeError(f"Unsupported target type: {type(target)}")
+
+
 reset_target = cudaq_runtime.reset_target
 has_target = cudaq_runtime.has_target
 get_target = cudaq_runtime.get_target

--- a/python/cudaq/_experimental/README.md
+++ b/python/cudaq/_experimental/README.md
@@ -16,6 +16,37 @@ WARNING: There are currently no checks in place to ensure that the compile targe
 and runtime endpoint are compatible. If mis-configured, the behavior is undefined
 and the user will most likely run into confusing runtime errors.
 
+### Custom targets
+
+A custom target pairs both halves and installs them together with
+`cudaq.set_target`. Build one by subclassing or instantiating
+`cudaq._experimental.CustomTarget` and pass it to `cudaq.set_target`:
+
+```python
+import cudaq
+from dataclasses import dataclass, field
+
+from cudaq._experimental import CompileTarget, CustomTarget, RuntimeEndpoint
+
+
+class MyEndpoint(RuntimeEndpoint):
+    def sample(self, module, args, **kwargs):
+        return cudaq.SampleResult({"00": kwargs["shots_count"]})
+
+
+@dataclass
+class MyCustomTarget(CustomTarget):
+    runtime_endpoint: RuntimeEndpoint = field(default_factory=MyEndpoint)
+    compile_target: CompileTarget = field(default_factory=CompileTarget)
+
+
+cudaq.set_target(MyCustomTarget())
+```
+
+Only instances of `cudaq._experimental.CustomTarget` (or a subclass) are
+accepted by this overload. Duck-typed objects with the same attributes are
+rejected so that using the experimental API is an explicit opt-in.
+
 ### Compile targets
 
 A compile target owns the MLIR pass pipelines, the code generation settings and

--- a/python/cudaq/_experimental/__init__.py
+++ b/python/cudaq/_experimental/__init__.py
@@ -13,9 +13,11 @@ may involve undocumented foot guns.
 
 from .runtime_endpoint import set_runtime_endpoint
 from .compile_target import CompileTarget, PipelineConfig, set_compile_target
+from .custom_target import CustomTarget
 
 __all__ = [
     "CompileTarget",
+    "CustomTarget",
     "PipelineConfig",
     "set_compile_target",
     "set_runtime_endpoint",

--- a/python/cudaq/_experimental/custom_target.py
+++ b/python/cudaq/_experimental/custom_target.py
@@ -1,0 +1,68 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Pair a compile target with a runtime endpoint.
+
+A custom target combines the two halves of a target config in one definition: a
+compile target that defines how kernels are compiled and a runtime endpoint that
+defines where they run. Install one with :func:`cudaq.set_target`:
+
+```python
+import cudaq
+from dataclasses import dataclass, field
+
+from cudaq._experimental import CompileTarget, CustomTarget, RuntimeEndpoint
+
+
+class MyEndpoint(RuntimeEndpoint):
+
+    def sample(self, module, args, **kwargs):
+        return cudaq.SampleResult({"00": kwargs["shots_count"]})
+
+
+@dataclass
+class MyCustomTarget(CustomTarget):
+    runtime_endpoint: RuntimeEndpoint = field(default_factory=MyEndpoint)
+    compile_target: CompileTarget = field(default_factory=CompileTarget)
+
+
+cudaq.set_target(MyCustomTarget())
+cudaq.sample(my_kernel)
+```
+
+You must currently mark any custom class explicitly as a valid target by
+inheriting from :class:`CustomTarget`. Otherwise, :func:`cudaq.set_target`
+will throw an error.
+
+.. warning::
+
+   This API is experimental. There is currently no check that the compile target
+   and runtime endpoint are compatible; mismatches surface as hard to diagnose
+   compilation or execution errors.
+"""
+
+from dataclasses import dataclass
+
+from .compile_target import CompileTarget
+from .runtime_endpoint import RuntimeEndpoint
+
+__all__ = [
+    "CustomTarget",
+]
+
+
+@dataclass
+class CustomTarget:
+    """A compile target and runtime endpoint installed together.
+
+    Args:
+      runtime_endpoint: The endpoint that receives compiled kernels.
+      compile_target: The machine model kernels are compiled against.
+    """
+
+    runtime_endpoint: RuntimeEndpoint
+    compile_target: CompileTarget

--- a/python/tests/backends/test_experimental_custom_target.py
+++ b/python/tests/backends/test_experimental_custom_target.py
@@ -66,7 +66,7 @@ def compiled_quake_ops(kernel, target):
 
     def walk(op):
         ops.append((op.name, len(op.operands)))
-        return WalkResult.ADVANCE()
+        return WalkResult.ADVANCE
 
     cudaq.set_target(target)
     cudaq.sample(kernel, shots_count=1)
@@ -84,7 +84,10 @@ def test_set_target_accepts_custom_target_subclass():
 
     assert result["00"] == 7
     assert len(target.runtime_endpoint.calls) == 1
-    assert target.runtime_endpoint.calls[0] == ("sample", {"shots_count": 7})
+    assert target.runtime_endpoint.calls[0] == ("sample", {
+        "shots_count": 7,
+        "explicit_measurements": False
+    })
 
 
 def test_set_target_accepts_direct_custom_target_instance():

--- a/python/tests/backends/test_experimental_custom_target.py
+++ b/python/tests/backends/test_experimental_custom_target.py
@@ -1,0 +1,139 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Tests for the experimental `CustomTarget` type and the `cudaq.set_target`
+# overload that installs a compile target and runtime endpoint together.
+
+import pytest
+from dataclasses import dataclass, field
+
+import cudaq
+from cudaq._experimental import CompileTarget, CustomTarget
+from cudaq._experimental.runtime_endpoint import RuntimeEndpoint
+from cudaq.mlir.ir import WalkResult
+
+SWAP_TO_CX_PIPELINE = (
+    "canonicalize,decomposition{enable-patterns=SwapToCX},canonicalize")
+
+
+@pytest.fixture(autouse=True)
+def reset_target():
+    cudaq.set_target("qpp-cpu")
+    yield
+    cudaq.reset_target()
+
+
+@cudaq.kernel
+def swap_kernel():
+    q = cudaq.qvector(2)
+    x(q[0])
+    swap(q[0], q[1])
+    mz(q)
+
+
+class DemoEndpoint(RuntimeEndpoint):
+    """Records launches and returns a canned result."""
+
+    def __init__(self):
+        self.calls = []
+        self.mlir_module = None
+
+    def sample(self, module, args, **kwargs):
+        self.calls.append(("sample", kwargs))
+        self.mlir_module = module.mlir_module
+        return cudaq.SampleResult({"00": kwargs["shots_count"]})
+
+
+@dataclass
+class DemoCustomTarget(CustomTarget):
+    runtime_endpoint: RuntimeEndpoint = field(default_factory=DemoEndpoint)
+    compile_target: CompileTarget = field(default_factory=CompileTarget)
+
+
+def swap_pipeline_target():
+    ct = CompileTarget()
+    ct.pipeline_config.override_pass_pipeline = SWAP_TO_CX_PIPELINE
+    return ct
+
+
+def compiled_quake_ops(kernel, target):
+    ops = []
+
+    def walk(op):
+        ops.append((op.name, len(op.operands)))
+        return WalkResult.ADVANCE()
+
+    cudaq.set_target(target)
+    cudaq.sample(kernel, shots_count=1)
+    endpoint = target.runtime_endpoint
+    assert endpoint.mlir_module is not None
+    endpoint.mlir_module.operation.walk(walk)
+    return ops
+
+
+def test_set_target_accepts_custom_target_subclass():
+    target = DemoCustomTarget()
+    cudaq.set_target(target)
+
+    result = cudaq.sample(swap_kernel, shots_count=7)
+
+    assert result["00"] == 7
+    assert len(target.runtime_endpoint.calls) == 1
+    assert target.runtime_endpoint.calls[0] == ("sample", {"shots_count": 7})
+
+
+def test_set_target_accepts_direct_custom_target_instance():
+    endpoint = DemoEndpoint()
+    target = CustomTarget(
+        runtime_endpoint=endpoint,
+        compile_target=CompileTarget(),
+    )
+    cudaq.set_target(target)
+
+    cudaq.sample(swap_kernel, shots_count=3)
+
+    assert len(endpoint.calls) == 1
+
+
+def test_set_target_with_custom_target_uses_custom_compile_target():
+    target = DemoCustomTarget(compile_target=swap_pipeline_target())
+    ops = compiled_quake_ops(swap_kernel, target)
+
+    assert all(name != "quake.swap" for name, _ in ops)
+    controlled_x = [
+        name for name, num_operands in ops
+        if name == "quake.x" and num_operands > 1
+    ]
+    assert len(controlled_x) == 3
+
+
+def test_duck_typed_object_is_not_accepted_as_custom_target():
+
+    class DuckTarget:
+        runtime_endpoint = DemoEndpoint()
+        compile_target = CompileTarget()
+
+    with pytest.raises(TypeError):
+        cudaq.set_target(DuckTarget())
+
+
+def test_set_target_rejects_kwargs_for_custom_target():
+    target = DemoCustomTarget()
+
+    with pytest.raises(
+            TypeError,
+            match="does not accept keyword arguments when target is a "
+            "cudaq._experimental.CustomTarget",
+    ):
+        cudaq.set_target(target, option="fp64")
+
+
+def test_named_set_target_still_works_after_wrapper():
+    cudaq.set_target("qpp-cpu")
+    counts = cudaq.sample(swap_kernel, shots_count=10)
+    assert sum(counts.values()) == 10


### PR DESCRIPTION
This PR introduces a `cudaq._experimental.CustomTarget` type, which can be passed to `cudaq.set_target`. The following are equivalent:

```python
import cudaq
from cudaq._experimental import CustomTarget

target = CustomTarget(runtime_endpoint=some_endpoint, compile_target=some_target)
cudaq.set_target(target)
```

and 

```python
import cudaq
from cudaq._experimental import set_compile_target, set_runtime_endpoint

set_compile_target(some_target)
set_runtime_endpoint(some_endpoint)
```