### PR TITLE
[core] Canonicalize the allocation of empty veqs out of the way.

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -162,6 +162,8 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
   let assemblyFormat = [{
     $reference `:` qualified(type($reference)) attr-dict
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -406,6 +406,7 @@ def quake_ApplyOp : QuakeOp<"apply",
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::TypeRange":$retTy,
@@ -594,6 +595,7 @@ def quake_ApplyNoiseOp : QuakeOp<"apply_noise",
 
   let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
+  let hasCanonicalizer = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::StringRef":$noise_func,
@@ -1386,6 +1388,7 @@ class QuakeOperator<string mnemonic, list<Trait> traits = [],
   }];
 
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 
   code extraClassDeclaration = [{
     //===------------------------------------------------------------------===//
@@ -2081,6 +2084,7 @@ def quake_LogOutputOp : QuakeOp<"log_output"> {
   );
   let results = (outs Variadic<AnyQLinearType>:$outs);
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
   let builders = [
     OpBuilder<(ins "mlir::ValueRange":$args,
                    CArg<"bool", "false">:$compilerGenerated), [{

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -132,6 +132,186 @@ struct ForwardEmptyVeqSizePattern
   }
 };
 
+// %0 = quake.alloca !quake.veq<0>
+// ─────────────────────────────────
+// %0 = cc.poison !quake.veq<0>
+struct ReplaceZeroSizeAllocaPattern
+    : public OpRewritePattern<cudaq::quake::AllocaOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::AllocaOp alloc,
+                                PatternRewriter &rewriter) const override {
+    auto veqTy = dyn_cast<cudaq::quake::VeqType>(alloc.getType());
+    if (!veqTy || !veqTy.hasSpecifiedSize() || veqTy.getSize() != 0)
+      return failure();
+    rewriter.replaceOpWithNewOp<cudaq::cc::PoisonOp>(alloc, veqTy);
+    return success();
+  }
+};
+
+// `!quake.veq<0>` has no semantics of its own: it is only permitted because a
+// frontend may legitimately materialize an empty qubit vector. Once such an
+// operand shows up as a control (or an apply control), it is pure baggage --
+// there is nothing there to gate on -- so peel it out here rather than let
+// every later pass special-case a zero-size veq.
+static bool isEmptyVeqType(Value value) {
+  auto veqTy = dyn_cast<cudaq::quake::VeqType>(value.getType());
+  return veqTy && veqTy.hasSpecifiedSize() && veqTy.getSize() == 0;
+}
+
+// quake.x [%c, %empty] %t : (!quake.ref, !quake.veq<0>, !quake.ref) -> ()
+// ─────────────────────────────────────────────────────────────────────
+// quake.x [%c] %t : (!quake.ref, !quake.ref) -> ()
+//
+// Applies to any quantum operator (`quake.h`, `quake.x`, `quake.exp_pauli`,
+// etc.) that carries a `controls` operand segment together with a matching
+// `negated_qubit_controls` array.
+template <typename ConcreteOp>
+struct EraseEmptyVeqControlPattern : public OpRewritePattern<ConcreteOp> {
+  using OpRewritePattern<ConcreteOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConcreteOp op,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<unsigned> emptyIndices;
+    for (auto [index, control] : llvm::enumerate(op.getControls()))
+      if (isEmptyVeqType(control))
+        emptyIndices.push_back(index);
+    if (emptyIndices.empty())
+      return failure();
+
+    rewriter.modifyOpInPlace(op, [&] {
+      if (auto negated = op.getNegatedQubitControlsAttr()) {
+        SmallVector<bool> polarity(negated.asArrayRef());
+        for (unsigned index : llvm::reverse(emptyIndices))
+          polarity.erase(polarity.begin() + index);
+        op->setAttr("negated_qubit_controls",
+                    rewriter.getDenseBoolArrayAttr(polarity));
+      }
+      for (unsigned index : llvm::reverse(emptyIndices))
+        op.getControlsMutable().erase(index);
+    });
+    return success();
+  }
+};
+
+// quake.apply @callee [%c, %empty] (%args) : (...) -> ()
+// ────────────────────────────────────────────────────────
+// quake.apply @callee [%c] (%args) : (...) -> ()
+//
+// `quake.apply` has no `negated_qubit_controls` attribute to keep in sync, so
+// it gets its own (simpler) pattern rather than instantiating the templated
+// one above.
+struct EraseApplyEmptyVeqControlPattern
+    : public OpRewritePattern<cudaq::quake::ApplyOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::ApplyOp op,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<unsigned> emptyIndices;
+    for (auto [index, control] : llvm::enumerate(op.getControls()))
+      if (isEmptyVeqType(control))
+        emptyIndices.push_back(index);
+    if (emptyIndices.empty())
+      return failure();
+
+    rewriter.modifyOpInPlace(op, [&] {
+      for (unsigned index : llvm::reverse(emptyIndices))
+        op.getControlsMutable().erase(index);
+    });
+    return success();
+  }
+};
+
+// quake.apply_noise @chan (%p) %r, %empty : (..., !quake.ref,
+//     !quake.veq<0>) -> ()
+// ─────────────────────────────────────────────────────────────────────
+// quake.apply_noise @chan (%p) %r : (..., !quake.ref) -> ()
+//
+// A noise channel applied to an empty qubit register touches nothing, so the
+// empty operand is dropped just like an empty control operand. `apply_noise`
+// requires at least one qubit operand, so if every qubit is empty the whole
+// op is dead and is erased outright instead of being left with zero operands.
+struct EraseApplyNoiseEmptyVeqQubitPattern
+    : public OpRewritePattern<cudaq::quake::ApplyNoiseOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::ApplyNoiseOp op,
+                                PatternRewriter &rewriter) const override {
+    auto qubits = op.getQubits();
+    SmallVector<unsigned> emptyIndices;
+    for (auto [index, qubit] : llvm::enumerate(qubits))
+      if (isEmptyVeqType(qubit))
+        emptyIndices.push_back(index);
+    if (emptyIndices.empty())
+      return failure();
+
+    if (emptyIndices.size() == qubits.size()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    rewriter.modifyOpInPlace(op, [&] {
+      for (unsigned index : llvm::reverse(emptyIndices))
+        op.getQubitsMutable().erase(index);
+    });
+    return success();
+  }
+};
+
+// quake.log_output %r, %empty, %w : (..., !quake.veq<0>, ...) -> (...)
+// ───────────────────────────────────────────────────────────────────
+// quake.log_output %r, %w : (..., ...) -> (...)
+//
+// An empty veq has no observable qubit -- there is nothing there to log --
+// so it contributes nothing to what's being observed. A veq is never a
+// linear type, so dropping it never touches `outs`. If nothing observable
+// remains, the whole op is dead and is erased.
+struct DropEmptyVeqLogOutputArgsPattern
+    : public OpRewritePattern<cudaq::quake::LogOutputOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::LogOutputOp log,
+                                PatternRewriter &rewriter) const override {
+    auto args = log.getArgs();
+    SmallVector<Value> keep;
+    for (Value arg : args)
+      if (!isEmptyVeqType(arg))
+        keep.push_back(arg);
+    if (keep.size() == args.size())
+      return failure();
+
+    if (keep.empty()) {
+      rewriter.eraseOp(log);
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<cudaq::quake::LogOutputOp>(
+        log, keep, log.getCompilerGenerated());
+    return success();
+  }
+};
+
+// %3 = quake.extract_ref %v[%i] : (!quake.veq<0>, i64) -> !quake.ref
+// ────────────────────────────────────────────────────────────────────
+// %3 = cc.poison !quake.ref
+//
+// There is no valid index into an empty veq -- extracting from one is
+// already an out-of-bounds access -- so replace it with a poison ref rather
+// than let the invalid access linger in the IR.
+struct ReplaceEmptyVeqExtractRefPattern
+    : public OpRewritePattern<cudaq::quake::ExtractRefOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::ExtractRefOp extract,
+                                PatternRewriter &rewriter) const override {
+    if (!isEmptyVeqType(extract.getVeq()))
+      return failure();
+    rewriter.replaceOpWithNewOp<cudaq::cc::PoisonOp>(extract,
+                                                     extract.getType());
+    return success();
+  }
+};
+
 // %2 = constant 10 : i32
 // %3 = quake.alloca !quake.veq<?>[%2 : i32]
 // ─────────────────────────────────────────
@@ -300,6 +480,31 @@ public:
     }
     rewriter.replaceOpWithNewOp<cudaq::quake::ExtractRefOp>(
         extract, subveq.getVeq(), offset);
+    return success();
+  }
+};
+
+// %0 = quake.concat %r0, %empty, %r1 : (!quake.ref, !quake.veq<0>,
+//          !quake.ref) -> !quake.veq<2>
+// ──────────────────────────────────────────────────────────────────────
+// %0 = quake.concat %r0, %r1 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+//
+// An empty veq contributes zero qubits to the concatenation, so dropping it
+// changes nothing about the result.
+struct DropEmptyVeqConcatOperandsPattern
+    : public OpRewritePattern<cudaq::quake::ConcatOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::ConcatOp concat,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Value> keep;
+    for (Value target : concat.getTargets())
+      if (!isEmptyVeqType(target))
+        keep.push_back(target);
+    if (keep.empty() || keep.size() == concat.getTargets().size())
+      return failure();
+    rewriter.replaceOpWithNewOp<cudaq::quake::ConcatOp>(concat,
+                                                        concat.getType(), keep);
     return success();
   }
 };
@@ -485,6 +690,27 @@ struct UselessConcatOpPattern
   }
 };
 
+// %3 = quake.get_member %s[0] : (!quake.struq<!quake.veq<0>, ...>) ->
+//                                !quake.veq<0>
+// ──────────────────────────────────────────────────────────────────
+// %3 = cc.poison !quake.veq<0>
+//
+// A struq member that is statically empty carries no qubits, so extracting
+// it is just as meaningless as allocating it. Canonicalize to the same
+// poison placeholder used for a zero-size alloca.
+struct ReplaceEmptyVeqGetMemberPattern
+    : public OpRewritePattern<cudaq::quake::GetMemberOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::GetMemberOp getMem,
+                                PatternRewriter &rewriter) const override {
+    if (!isEmptyVeqType(getMem.getResult()))
+      return failure();
+    rewriter.replaceOpWithNewOp<cudaq::cc::PoisonOp>(getMem, getMem.getType());
+    return success();
+  }
+};
+
 // %7 = quake.make_struq %5, %6 : (!quake.veq<A>, !quake.veq<N>) ->
 //                    !quake.struq<!quake.veq<A>, !quake.veq<N>>
 // %8 = quake.get_member %7[1] : (!quake.struq<!quake.veq<A>,
@@ -509,6 +735,31 @@ struct BypassMakeStruq : public OpRewritePattern<cudaq::quake::GetMemberOp> {
                                                              from);
     else
       rewriter.replaceOp(getMem, from);
+    return success();
+  }
+};
+
+// %0 = quake.init_state %targets, %state : (!quake.veq<0>, T) -> !quake.veq<?>
+// ────────────────────────────────────────────────────────────────────────────
+// %0 = quake.relax_size %targets : (!quake.veq<0>) -> !quake.veq<?>
+//
+// An empty state vector has nothing to initialize -- there are no qubits to
+// carry the amplitude -- so the op is a no-op. Erase it and forward its
+// `targets` operand directly to its uses.
+struct ForwardEmptyVeqInitStatePattern
+    : public OpRewritePattern<cudaq::quake::InitializeStateOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::InitializeStateOp initState,
+                                PatternRewriter &rewriter) const override {
+    if (!isEmptyVeqType(initState.getTargets()))
+      return failure();
+    Value targets = initState.getTargets();
+    if (targets.getType() != initState.getType())
+      targets = cudaq::quake::RelaxSizeOp::create(rewriter, initState.getLoc(),
+                                                  initState.getType(), targets)
+                    .getResult();
+    rewriter.replaceOp(initState, targets);
     return success();
   }
 };
@@ -551,6 +802,31 @@ struct ForwardAllocaTypePattern
           }
       }
     return failure();
+  }
+};
+
+// %0 = quake.subveq %v, %lo, %hi : (!quake.veq<0>, i64, i64) -> !quake.veq<?>
+// ────────────────────────────────────────────────────────────────────────────
+// %0 = quake.relax_size %v : (!quake.veq<0>) -> !quake.veq<?>
+//
+// The only valid subrange of an empty veq is itself: the op is dead weight.
+// Forward the input directly rather than let a canonically out-of-bounds
+// range linger in the IR.
+struct ForwardEmptyVeqSubVeqPattern
+    : public OpRewritePattern<cudaq::quake::SubVeqOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::SubVeqOp subveq,
+                                PatternRewriter &rewriter) const override {
+    if (!isEmptyVeqType(subveq.getVeq()))
+      return failure();
+    Value veq = subveq.getVeq();
+    if (veq.getType() != subveq.getType())
+      veq = cudaq::quake::RelaxSizeOp::create(rewriter, subveq.getLoc(),
+                                              subveq.getType(), veq)
+                .getResult();
+    rewriter.replaceOp(subveq, veq);
+    return success();
   }
 };
 

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -159,6 +159,24 @@ static bool isEmptyVeqType(Value value) {
   return veqTy && veqTy.hasSpecifiedSize() && veqTy.getSize() == 0;
 }
 
+// quake.dealloc %empty : !quake.veq<0>
+// ─────────────────────────────────────
+// removed
+//
+// There are no qubits to free, so the op is dead.
+struct EraseEmptyVeqDeallocPattern
+    : public OpRewritePattern<cudaq::quake::DeallocOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::quake::DeallocOp dealloc,
+                                PatternRewriter &rewriter) const override {
+    if (!isEmptyVeqType(dealloc.getReference()))
+      return failure();
+    rewriter.eraseOp(dealloc);
+    return success();
+  }
+};
+
 // quake.x [%c, %empty] %t : (!quake.ref, !quake.veq<0>, !quake.ref) -> ()
 // ─────────────────────────────────────────────────────────────────────
 // quake.x [%c] %t : (!quake.ref, !quake.ref) -> ()

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -825,12 +825,12 @@ struct ForwardAllocaTypePattern
 
 // %0 = quake.subveq %v, %lo, %hi : (!quake.veq<0>, i64, i64) -> !quake.veq<?>
 // ────────────────────────────────────────────────────────────────────────────
-// %0 = quake.relax_size %v : (!quake.veq<0>) -> !quake.veq<?>
+// %0 = cc.poison !quake.veq<?>
 //
-// The only valid subrange of an empty veq is itself: the op is dead weight.
-// Forward the input directly rather than let a canonically out-of-bounds
-// range linger in the IR.
-struct ForwardEmptyVeqSubVeqPattern
+// There is no valid subrange of an empty veq -- any requested range is
+// inherently out of bounds -- so replace it with a poison value instead of
+// letting the invalid access linger in the IR.
+struct ReplaceEmptyVeqSubVeqPattern
     : public OpRewritePattern<cudaq::quake::SubVeqOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -838,12 +838,8 @@ struct ForwardEmptyVeqSubVeqPattern
                                 PatternRewriter &rewriter) const override {
     if (!isEmptyVeqType(subveq.getVeq()))
       return failure();
-    Value veq = subveq.getVeq();
-    if (veq.getType() != subveq.getType())
-      veq = cudaq::quake::RelaxSizeOp::create(rewriter, subveq.getLoc(),
-                                              subveq.getType(), veq)
-                .getResult();
-    rewriter.replaceOp(subveq, veq);
+    rewriter.replaceOpWithNewOp<cudaq::cc::PoisonOp>(subveq,
+                                                     subveq.getType());
     return success();
   }
 };

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -966,7 +966,7 @@ LogicalResult cudaq::quake::SubVeqOp::verify() {
 
 void cudaq::quake::SubVeqOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<ForwardEmptyVeqSubVeqPattern, FixUnspecifiedSubveqPattern,
+  patterns.add<ReplaceEmptyVeqSubVeqPattern, FixUnspecifiedSubveqPattern,
                FuseConstantToSubveqPattern, RemoveSubVeqNoOpPattern,
                CombineSubVeqsPattern>(context);
 }

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -332,6 +332,11 @@ cudaq::quake::InitializeStateOp cudaq::quake::AllocaOp::getInitializedState() {
   return {};
 }
 
+void cudaq::quake::DeallocOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<EraseEmptyVeqDeallocPattern>(context);
+}
+
 //===----------------------------------------------------------------------===//
 // Apply
 //===----------------------------------------------------------------------===//

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -319,7 +319,8 @@ void cudaq::quake::AllocaOp::getCanonicalizationPatterns(
   // Use a canonicalization pattern as folding the constant into the veq type
   // changes the type. Uses may still expect a veq with unspecified size.
   // Folding is strictly reductive and doesn't allow the creation of ops.
-  patterns.add<FuseConstantToAllocaPattern>(context);
+  patterns.add<ReplaceZeroSizeAllocaPattern, FuseConstantToAllocaPattern>(
+      context);
 }
 
 cudaq::quake::InitializeStateOp cudaq::quake::AllocaOp::getInitializedState() {
@@ -464,6 +465,11 @@ LogicalResult cudaq::quake::ApplyOp::verify() {
           "appended result types must match linear-type actuals in order");
 
   return success();
+}
+
+void cudaq::quake::ApplyOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<EraseApplyEmptyVeqControlPattern>(context);
 }
 
 void cudaq::quake::ApplyOp::print(OpAsmPrinter &p) {
@@ -659,6 +665,11 @@ LogicalResult cudaq::quake::ApplyNoiseOp::verify() {
   return success();
 }
 
+void cudaq::quake::ApplyNoiseOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<EraseApplyNoiseEmptyVeqQubitPattern>(context);
+}
+
 //===----------------------------------------------------------------------===//
 // BorrowWire
 //===----------------------------------------------------------------------===//
@@ -683,8 +694,9 @@ LogicalResult cudaq::quake::BorrowWireOp::verify() {
 
 void cudaq::quake::ConcatOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<ConcatSizePattern, ConcatNoOpPattern, UselessConcatOpPattern,
-               ConcatFlattenPattern>(context);
+  patterns.add<DropEmptyVeqConcatOperandsPattern, ConcatSizePattern,
+               ConcatNoOpPattern, UselessConcatOpPattern, ConcatFlattenPattern>(
+      context);
 }
 
 LogicalResult cudaq::quake::ConcatOp::verify() {
@@ -748,7 +760,8 @@ void printRawString(OpAsmPrinter &printer, OP refOp, Value stringVal,
 
 void cudaq::quake::ExpPauliOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<BindExpPauliWord, AdjustAdjointExpPauliPattern>(context);
+  patterns.add<BindExpPauliWord, AdjustAdjointExpPauliPattern,
+               EraseEmptyVeqControlPattern<ExpPauliOp>>(context);
 }
 
 LogicalResult cudaq::quake::ExpPauliOp::verify() {
@@ -807,7 +820,8 @@ void printRawIndex(OpAsmPrinter &printer, OP refOp, Value index,
 
 void cudaq::quake::ExtractRefOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<FuseConstantToExtractRefPattern, ForwardConcatExtractSingleton,
+  patterns.add<ReplaceEmptyVeqExtractRefPattern,
+               FuseConstantToExtractRefPattern, ForwardConcatExtractSingleton,
                ForwardConcatExtractPattern, ExtractRefFromSubVeqPattern>(
       context);
 }
@@ -850,7 +864,7 @@ LogicalResult cudaq::quake::GetMemberOp::verify() {
 
 void cudaq::quake::GetMemberOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<BypassMakeStruq>(context);
+  patterns.add<ReplaceEmptyVeqGetMemberPattern, BypassMakeStruq>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -878,7 +892,8 @@ LogicalResult cudaq::quake::InitializeStateOp::verify() {
 
 void cudaq::quake::InitializeStateOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<ForwardAllocaTypePattern>(context);
+  patterns.add<ForwardEmptyVeqInitStatePattern, ForwardAllocaTypePattern>(
+      context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -946,8 +961,9 @@ LogicalResult cudaq::quake::SubVeqOp::verify() {
 
 void cudaq::quake::SubVeqOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<FixUnspecifiedSubveqPattern, FuseConstantToSubveqPattern,
-               RemoveSubVeqNoOpPattern, CombineSubVeqsPattern>(context);
+  patterns.add<ForwardEmptyVeqSubVeqPattern, FixUnspecifiedSubveqPattern,
+               FuseConstantToSubveqPattern, RemoveSubVeqNoOpPattern,
+               CombineSubVeqsPattern>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1282,7 +1298,8 @@ void cudaq::quake::PhaseOp::getOperatorMatrix(Matrix &matrix) {
 
 void cudaq::quake::PhaseOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<EraseZeroPhasePattern, MergeAdjacentPhasePattern>(context);
+  patterns.add<EraseZeroPhasePattern, MergeAdjacentPhasePattern,
+               EraseEmptyVeqControlPattern<PhaseOp>>(context);
 }
 
 void cudaq::quake::PhasedRxOp::getOperatorMatrix(Matrix &matrix) {
@@ -1441,6 +1458,11 @@ LogicalResult cudaq::quake::CustomUnitaryCallOp::verify() {
   return verifyOperator(cast<cudaq::quake::OperatorInterface>(getOperation()));
 }
 
+void cudaq::quake::CustomUnitaryCallOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<EraseEmptyVeqControlPattern<CustomUnitaryCallOp>>(context);
+}
+
 void cudaq::quake::CustomUnitaryConstantOp::getOperatorMatrix(Matrix &matrix) {
   matrix.clear();
   // The unitary is held in a `cc.global` constant referenced by this op. Read
@@ -1528,6 +1550,11 @@ LogicalResult cudaq::quake::CustomUnitaryConstantOp::verify() {
   }
 
   return verifyOperator(cast<cudaq::quake::OperatorInterface>(getOperation()));
+}
+
+void cudaq::quake::CustomUnitaryConstantOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<EraseEmptyVeqControlPattern<CustomUnitaryConstantOp>>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1656,6 +1683,14 @@ INSTANTIATE_CALLBACKS(PhaseOp)
 BUILTIN_GATE_OPS(INSTANTIATE_OPERATOR_VERIFY)
 WIRE_OPS(INSTANTIATE_LINEAR_TYPE_VERIFY)
 
+#define INSTANTIATE_OPERATOR_CANONICALIZATION(Op)                              \
+  void cudaq::quake::Op::getCanonicalizationPatterns(                          \
+      RewritePatternSet &patterns, MLIRContext *context) {                     \
+    patterns.add<EraseEmptyVeqControlPattern<Op>>(context);                    \
+  }
+
+BUILTIN_GATE_OPS(INSTANTIATE_OPERATOR_CANONICALIZATION)
+
 //===----------------------------------------------------------------------===//
 // LogOutputOp
 //===----------------------------------------------------------------------===//
@@ -1670,6 +1705,11 @@ LogicalResult cudaq::quake::LogOutputOp::verify() {
     return emitOpError("result types must mirror wire/cable operand types "
                        "in left-to-right order");
   return success();
+}
+
+void cudaq::quake::LogOutputOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<DropEmptyVeqLogOutputArgsPattern>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/cudaq/test/Transforms/veq0_canonicalize.qke
+++ b/cudaq/test/Transforms/veq0_canonicalize.qke
@@ -100,17 +100,16 @@ func.func @extract_ref_empty_veq(%v: !quake.veq<0>, %i: i64) -> !quake.ref {
 // CHECK-NOT:     quake.extract_ref
 // CHECK:         return %[[R]] : !quake.ref
 
-// The only valid subrange of an empty veq is itself, so `quake.subveq` is
-// erased and its input forwarded (relaxed to the result type).
-func.func @forward_empty_veq_subveq(%v: !quake.veq<0>, %lo: i64,
+// There is no valid subrange of an empty veq, so `quake.subveq` is replaced
+// with a poison value of the result type.
+func.func @replace_empty_veq_subveq(%v: !quake.veq<0>, %lo: i64,
                                     %hi: i64) -> !quake.veq<?> {
   %0 = quake.subveq %v, %lo, %hi : (!quake.veq<0>, i64, i64) -> !quake.veq<?>
   return %0 : !quake.veq<?>
 }
 
-// CHECK-LABEL: func.func @forward_empty_veq_subveq(
-// CHECK-SAME:    %[[V:[a-zA-Z0-9_.$-]+]]: !quake.veq<0>
-// CHECK:         %[[R:.*]] = quake.relax_size %[[V]] : (!quake.veq<0>) -> !quake.veq<?>
+// CHECK-LABEL: func.func @replace_empty_veq_subveq(
+// CHECK:         %[[R:.*]] = cc.poison !quake.veq<?>
 // CHECK-NOT:     quake.subveq
 // CHECK:         return %[[R]] : !quake.veq<?>
 

--- a/cudaq/test/Transforms/veq0_canonicalize.qke
+++ b/cudaq/test/Transforms/veq0_canonicalize.qke
@@ -172,3 +172,13 @@ func.func @log_output_erase_all_empty_veq_args(%e0: !quake.veq<0>,
 // CHECK-LABEL: func.func @log_output_erase_all_empty_veq_args(
 // CHECK-NOT:     quake.log_output
 // CHECK:         return
+
+// There are no qubits to free in an empty veq, so the dealloc is dead.
+func.func @erase_empty_veq_dealloc(%e: !quake.veq<0>) {
+  quake.dealloc %e : !quake.veq<0>
+  return
+}
+
+// CHECK-LABEL: func.func @erase_empty_veq_dealloc(
+// CHECK-NOT:     quake.dealloc
+// CHECK:         return

--- a/cudaq/test/Transforms/veq0_canonicalize.qke
+++ b/cudaq/test/Transforms/veq0_canonicalize.qke
@@ -1,0 +1,174 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --canonicalize %s | FileCheck %s
+
+// `!quake.veq<0>` has no semantics of its own. These tests exercise the
+// canonicalization patterns that treat it as baggage to be erased, dropped,
+// or forwarded through, rather than special-cased downstream.
+
+// A zero-size alloca has no useful semantics; it is replaced with an explicit
+// poison value of the same type.
+func.func @erase_zero_size_alloca() -> !quake.veq<0> {
+  %0 = quake.alloca !quake.veq<0>
+  return %0 : !quake.veq<0>
+}
+
+// CHECK-LABEL: func.func @erase_zero_size_alloca
+// CHECK:         %[[V:.*]] = cc.poison !quake.veq<0>
+
+// An empty control register can never gate an operator, so it is dropped
+// and the polarity array is shrunk to match the remaining control.
+func.func @erase_empty_veq_control(%c0: !quake.ref, %c1: !quake.veq<0>,
+                                   %t: !quake.ref) {
+  quake.x [%c0, %c1 neg [true, false]] %t
+      : (!quake.ref, !quake.veq<0>, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @erase_empty_veq_control(
+// CHECK-SAME:    %[[C0:[a-zA-Z0-9_.$-]+]]: !quake.ref, %[[C1:[a-zA-Z0-9_.$-]+]]: !quake.veq<0>, %[[T:[a-zA-Z0-9_.$-]+]]: !quake.ref
+// CHECK:         quake.x {{\[}}%[[C0]] neg [true]{{\]}} %[[T]] : (!quake.ref, !quake.ref) -> ()
+
+func.func @erase_empty_veq_control_exp_pauli(%theta: f64, %c0: !quake.ref,
+                                             %c1: !quake.veq<0>,
+                                             %t: !quake.ref) {
+  quake.exp_pauli (%theta) [%c0, %c1] %t to "X"
+      : (f64, !quake.ref, !quake.veq<0>, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @erase_empty_veq_control_exp_pauli(
+// CHECK-SAME:    %[[THETA:[a-zA-Z0-9_.$-]+]]: f64, %[[C0:[a-zA-Z0-9_.$-]+]]: !quake.ref, %[[C1:[a-zA-Z0-9_.$-]+]]: !quake.veq<0>, %[[T:[a-zA-Z0-9_.$-]+]]: !quake.ref
+// CHECK:         quake.exp_pauli (%[[THETA]]) {{\[}}%[[C0]]{{\]}} %[[T]] to "X"
+
+func.func private @apply_callee(!quake.ref)
+
+func.func @erase_apply_empty_veq_control(%c: !quake.ref, %e: !quake.veq<0>,
+                                         %t: !quake.ref) {
+  quake.apply @apply_callee [%c, %e] (%t)
+      : (!quake.ref, !quake.veq<0>, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @erase_apply_empty_veq_control(
+// CHECK-SAME:    %[[C:[a-zA-Z0-9_.$-]+]]: !quake.ref, %[[E:[a-zA-Z0-9_.$-]+]]: !quake.veq<0>, %[[T:[a-zA-Z0-9_.$-]+]]: !quake.ref
+// CHECK:         quake.apply @apply_callee {{\[}}%[[C]]{{\]}} (%[[T]]) : (!quake.ref, !quake.ref) -> ()
+
+// An empty state vector has nothing to initialize, so `quake.init_state` is
+// erased and its `targets` operand forwarded (relaxed to the result type).
+func.func @forward_empty_veq_init_state(
+    %t: !quake.veq<0>, %s: !cc.ptr<!cc.array<f64 x 1>>) -> !quake.veq<?> {
+  %0 = quake.init_state %t, %s
+      : (!quake.veq<0>, !cc.ptr<!cc.array<f64 x 1>>) -> !quake.veq<?>
+  return %0 : !quake.veq<?>
+}
+
+// CHECK-LABEL: func.func @forward_empty_veq_init_state(
+// CHECK-SAME:    %[[T:[a-zA-Z0-9_.$-]+]]: !quake.veq<0>
+// CHECK:         %[[R:.*]] = quake.relax_size %[[T]] : (!quake.veq<0>) -> !quake.veq<?>
+// CHECK-NOT:     quake.init_state
+// CHECK:         return %[[R]] : !quake.veq<?>
+
+// An empty veq contributes zero qubits to a concatenation.
+func.func @drop_empty_veq_concat_operand(
+    %r0: !quake.ref, %e: !quake.veq<0>, %r1: !quake.ref) -> !quake.veq<2> {
+  %0 = quake.concat %r0, %e, %r1
+      : (!quake.ref, !quake.veq<0>, !quake.ref) -> !quake.veq<2>
+  return %0 : !quake.veq<2>
+}
+
+// CHECK-LABEL: func.func @drop_empty_veq_concat_operand(
+// CHECK-SAME:    %[[R0:[a-zA-Z0-9_.$-]+]]: !quake.ref, %[[E:[a-zA-Z0-9_.$-]+]]: !quake.veq<0>, %[[R1:[a-zA-Z0-9_.$-]+]]: !quake.ref
+// CHECK:         %[[V:.*]] = quake.concat %[[R0]], %[[R1]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
+// CHECK:         return %[[V]] : !quake.veq<2>
+
+// There is no valid index into an empty veq, so extracting from one is replaced
+// with a poison ref instead of generating an out-of-bounds access.
+func.func @extract_ref_empty_veq(%v: !quake.veq<0>, %i: i64) -> !quake.ref {
+  %0 = quake.extract_ref %v[%i] : (!quake.veq<0>, i64) -> !quake.ref
+  return %0 : !quake.ref
+}
+
+// CHECK-LABEL: func.func @extract_ref_empty_veq(
+// CHECK:         %[[R:.*]] = cc.poison !quake.ref
+// CHECK-NOT:     quake.extract_ref
+// CHECK:         return %[[R]] : !quake.ref
+
+// The only valid subrange of an empty veq is itself, so `quake.subveq` is
+// erased and its input forwarded (relaxed to the result type).
+func.func @forward_empty_veq_subveq(%v: !quake.veq<0>, %lo: i64,
+                                    %hi: i64) -> !quake.veq<?> {
+  %0 = quake.subveq %v, %lo, %hi : (!quake.veq<0>, i64, i64) -> !quake.veq<?>
+  return %0 : !quake.veq<?>
+}
+
+// CHECK-LABEL: func.func @forward_empty_veq_subveq(
+// CHECK-SAME:    %[[V:[a-zA-Z0-9_.$-]+]]: !quake.veq<0>
+// CHECK:         %[[R:.*]] = quake.relax_size %[[V]] : (!quake.veq<0>) -> !quake.veq<?>
+// CHECK-NOT:     quake.subveq
+// CHECK:         return %[[R]] : !quake.veq<?>
+
+// A noise channel applied to an empty qubit register touches nothing, so the
+// empty operand is dropped.
+func.func @apply_noise_drop_empty_veq_qubit(%r: !quake.ref,
+                                            %e: !quake.veq<0>) {
+  quake.apply_noise @noise_chan() %r, %e
+      : (!quake.ref, !quake.veq<0>) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @apply_noise_drop_empty_veq_qubit(
+// CHECK-SAME:    %[[R:[a-zA-Z0-9_.$-]+]]: !quake.ref
+// CHECK:         quake.apply_noise @noise_chan() %[[R]] : (!quake.ref) -> ()
+
+// `apply_noise` requires at least one qubit operand, so if every qubit is empty
+// the whole op is dead and erased outright.
+func.func @apply_noise_erase_all_empty_veq_qubits(%e0: !quake.veq<0>,
+                                                  %e1: !quake.veq<0>) {
+  quake.apply_noise @noise_chan() %e0, %e1
+      : (!quake.veq<0>, !quake.veq<0>) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @apply_noise_erase_all_empty_veq_qubits(
+// CHECK-NOT:     quake.apply_noise
+// CHECK:         return
+
+// A struq member that is statically empty carries no qubits, so extracting
+// it is replaced with a poison value, just like a zero-size alloca.
+func.func @get_member_empty_veq(%s: !quake.struq<!quake.veq<0>, !quake.ref>) -> !quake.veq<0> {
+  %0 = quake.get_member %s[0] : (!quake.struq<!quake.veq<0>, !quake.ref>) -> !quake.veq<0>
+  return %0 : !quake.veq<0>
+}
+
+// CHECK-LABEL: func.func @get_member_empty_veq(
+// CHECK:         %[[R:.*]] = cc.poison !quake.veq<0>
+// CHECK-NOT:     quake.get_member
+// CHECK:         return %[[R]] : !quake.veq<0>
+
+// An empty veq has no observable qubit, so it contributes nothing to what's
+// being logged and is dropped from the IR. We can't observe nothing.
+func.func @log_output_drop_empty_veq_arg(%r: !quake.ref, %e: !quake.veq<0>) {
+  quake.log_output %r, %e : (!quake.ref, !quake.veq<0>) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @log_output_drop_empty_veq_arg(
+// CHECK-SAME:    %[[R:[a-zA-Z0-9_.$-]+]]: !quake.ref
+// CHECK:         quake.log_output %[[R]] : (!quake.ref) -> ()
+
+func.func @log_output_erase_all_empty_veq_args(%e0: !quake.veq<0>,
+                                               %e1: !quake.veq<0>) {
+  quake.log_output %e0, %e1 : (!quake.veq<0>, !quake.veq<0>) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @log_output_erase_all_empty_veq_args(
+// CHECK-NOT:     quake.log_output
+// CHECK:         return

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4741,8 +4741,8 @@ class PyASTBridge(ast.NodeVisitor):
                     cc.ContinueOp([i, new_veq])
 
                 # Check if the source iterable is empty. If so, return a
-                # poison veq<0>. Otherwise peel the first element to form a
-                # veq<1> seed so the loop never starts from a veq<0> alloca
+                # poison `veq<0>`. Otherwise peel the first element to form a
+                # `veq<1>` seed so the loop never starts from a `veq<0> alloca`
                 # (which has no valid semantics).
                 isEmpty = arith.CmpIOp(IntegerAttr.get(i64Ty, 0), iterableSize,
                                        c0).result

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4755,7 +4755,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                 nonEmptyBlock = Block.create_at_start(ifEmptyOp.elseRegion, [])
                 with InsertionPoint(nonEmptyBlock):
-                    # Peel element 0 to form the initial veq<1> seed.
+                    # Peel element 0 to form the initial `veq<1>` seed.
                     idx_val_0 = extractElem(c0)
                     self.symbolTable.beginBlock()
                     self.__deconstructAssignment(node.generators[0].target,

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4697,9 +4697,11 @@ class PyASTBridge(ast.NodeVisitor):
             if (cc.SequenceType.isinstance(orig_iterable_type) or
                     quake.VeqType.isinstance(orig_iterable_type)):
                 i64Ty = self.getIntegerType()
+                i1Ty = self.getIntegerType(1)
                 veqTy = self.getVeqType()
-                c0 = self.getConstantInt(0)
                 c1 = self.getConstantInt(1)
+                falseVal = self.getConstantInt(0, 1)
+                trueVal = self.getConstantInt(1, 1)
                 empty_veq_ty = quake.VeqType.get(0, context=self.ctx)
                 veq1_ty = quake.VeqType.get(1, context=self.ctx)
 
@@ -4714,86 +4716,68 @@ class PyASTBridge(ast.NodeVisitor):
                     return cc.LoadOp(elem_addr).result
 
                 def bodyBuilder(args):
-                    i, curr_veq = args[0], args[1]
+                    # `found` tracks whether a real qubit has been placed in
+                    # the accumulator yet. Until it has, `curr_veq` is just
+                    # the initial poison seed and is *never read* by this
+                    # body: a matching element always *replaces* it (a
+                    # fresh `veq<1>`), never concatenates onto it. Only once
+                    # `found` is true does a later match grow the (now
+                    # real) accumulator via `quake.concat`. A `!quake.veq<0>`
+                    # has no valid semantics, so it must never be an operand
+                    # to a concat -- it may only ever be the final, unread
+                    # result of a search that found nothing at all.
+                    i, found, curr_veq = args[0], args[1], args[2]
                     idx_val = extractElem(i)
                     self.symbolTable.beginBlock()
                     self.__deconstructAssignment(node.generators[0].target,
                                                  idx_val)
-                    if hasFilter:
-                        cond = evalFilter()
-                        ifOp = cc.IfOp([veqTy], cond, [])
-                        thenBlock = Block.create_at_start(ifOp.thenRegion, [])
-                        with InsertionPoint(thenBlock):
-                            self.visit(node.elt)
-                            ref = self.popValue()
-                            appended = quake.ConcatOp(veqTy,
-                                                      [curr_veq, ref]).result
-                            cc.ContinueOp([appended])
-                        elseBlock = Block.create_at_start(ifOp.elseRegion, [])
-                        with InsertionPoint(elseBlock):
-                            cc.ContinueOp([curr_veq])
-                        new_veq = ifOp.result
-                    else:
+                    cond = evalFilter() if hasFilter else trueVal
+                    ifCond = cc.IfOp([i1Ty, veqTy], cond, [])
+                    condThen = Block.create_at_start(ifCond.thenRegion, [])
+                    with InsertionPoint(condThen):
                         self.visit(node.elt)
                         ref = self.popValue()
-                        new_veq = quake.ConcatOp(veqTy, [curr_veq, ref]).result
-                    self.symbolTable.endBlock()
-                    cc.ContinueOp([i, new_veq])
-
-                # Check if the source iterable is empty. If so, return a
-                # poison `veq<0>`. Otherwise peel the first element to form a
-                # `veq<1>` seed so the loop never starts from a `veq<0> alloca`
-                # (which has no valid semantics).
-                isEmpty = arith.CmpIOp(IntegerAttr.get(i64Ty, 0), iterableSize,
-                                       c0).result
-                ifEmptyOp = cc.IfOp([veqTy], isEmpty, [])
-                emptyBlock = Block.create_at_start(ifEmptyOp.thenRegion, [])
-                with InsertionPoint(emptyBlock):
-                    poison = cc.PoisonOp(empty_veq_ty)
-                    cc.ContinueOp(
-                        [quake.RelaxSizeOp(veqTy, poison.result).result])
-
-                nonEmptyBlock = Block.create_at_start(ifEmptyOp.elseRegion, [])
-                with InsertionPoint(nonEmptyBlock):
-                    # Peel element 0 to form the initial `veq<1>` seed.
-                    idx_val_0 = extractElem(c0)
-                    self.symbolTable.beginBlock()
-                    self.__deconstructAssignment(node.generators[0].target,
-                                                 idx_val_0)
-                    if hasFilter:
-                        cond0 = evalFilter()
-                        ifFilter0 = cc.IfOp([veqTy], cond0, [])
-                        thenBlock0 = Block.create_at_start(
-                            ifFilter0.thenRegion, [])
-                        with InsertionPoint(thenBlock0):
-                            self.visit(node.elt)
-                            ref0 = self.popValue()
-                            veq1 = quake.ConcatOp(veq1_ty, [ref0]).result
+                        ifFound = cc.IfOp([veqTy], found, [])
+                        foundThen = Block.create_at_start(
+                            ifFound.thenRegion, [])
+                        with InsertionPoint(foundThen):
+                            grown = quake.ConcatOp(veqTy,
+                                                   [curr_veq, ref]).result
+                            cc.ContinueOp([grown])
+                        foundElse = Block.create_at_start(
+                            ifFound.elseRegion, [])
+                        with InsertionPoint(foundElse):
+                            veq1 = quake.ConcatOp(veq1_ty, [ref]).result
                             cc.ContinueOp(
                                 [quake.RelaxSizeOp(veqTy, veq1).result])
-                        elseBlock0 = Block.create_at_start(
-                            ifFilter0.elseRegion, [])
-                        with InsertionPoint(elseBlock0):
-                            poison0 = cc.PoisonOp(empty_veq_ty)
-                            cc.ContinueOp([
-                                quake.RelaxSizeOp(veqTy, poison0.result).result
-                            ])
-                        init_seed = ifFilter0.result
-                    else:
-                        self.visit(node.elt)
-                        ref0 = self.popValue()
-                        veq1 = quake.ConcatOp(veq1_ty, [ref0]).result
-                        init_seed = quake.RelaxSizeOp(veqTy, veq1).result
+                        cc.ContinueOp([trueVal, ifFound.result])
+                    condElse = Block.create_at_start(ifCond.elseRegion, [])
+                    with InsertionPoint(condElse):
+                        cc.ContinueOp([found, curr_veq])
                     self.symbolTable.endBlock()
+                    cc.ContinueOp([i, ifCond.results[0], ifCond.results[1]])
 
-                    loop = self.createForLoop(
-                        [i64Ty, veqTy], bodyBuilder, [c1, init_seed],
-                        lambda args: arith.CmpIOp(IntegerAttr.get(
-                            i64Ty, 2), args[0], iterableSize).result, lambda
-                        args: [arith.AddIOp(args[0], c1).result, args[1]])
-                    cc.ContinueOp([loop.results[1]])
+                # Seed the accumulator with poison: there is no sound
+                # zero-length `!quake.veq` to allocate and grow. The loop
+                # above only ever *replaces* this seed (with a real
+                # `veq<1>`) the first time a matching element is found; it
+                # is never grown from. If no element ever matches -- an
+                # empty source iterable, or a filter that rejects every
+                # element -- the poison seed survives as the final,
+                # unread-by-this-lowering result. Using that result (e.g.
+                # applying a gate to it) is then a bug in the user's kernel,
+                # not something this lowering can paper over.
+                poison = cc.PoisonOp(empty_veq_ty)
+                init_seed = quake.RelaxSizeOp(veqTy, poison.result).result
 
-                self.pushValue(ifEmptyOp.result)
+                loop = self.createForLoop(
+                    [i64Ty, i1Ty, veqTy], bodyBuilder,
+                    [self.getConstantInt(0), falseVal, init_seed],
+                    lambda args: arith.CmpIOp(IntegerAttr.get(i64Ty, 2), args[
+                        0], iterableSize).result, lambda args:
+                    [arith.AddIOp(args[0], c1).result, args[1], args[2]])
+
+                self.pushValue(loop.results[2])
                 return
             self.emitFatalError(
                 "unsupported list comprehension producing qubit references",

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4716,7 +4716,7 @@ class PyASTBridge(ast.NodeVisitor):
                     return cc.LoadOp(elem_addr).result
 
                 def bodyBuilder(args):
-                    # `found` tracks whether a real qubit has been placed in
+                    # `found` tracks whether a real `qubit` has been placed in
                     # the accumulator yet. Until it has, `curr_veq` is just
                     # the initial poison seed and is *never read* by this
                     # body: a matching element always *replaces* it (a
@@ -4724,7 +4724,7 @@ class PyASTBridge(ast.NodeVisitor):
                     # `found` is true does a later match grow the (now
                     # real) accumulator via `quake.concat`. A `!quake.veq<0>`
                     # has no valid semantics, so it must never be an operand
-                    # to a concat -- it may only ever be the final, unread
+                    # to a `concat` -- it may only ever be the final, unread
                     # result of a search that found nothing at all.
                     i, found, curr_veq = args[0], args[1], args[2]
                     idx_val = extractElem(i)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4700,25 +4700,22 @@ class PyASTBridge(ast.NodeVisitor):
                 veqTy = self.getVeqType()
                 c0 = self.getConstantInt(0)
                 c1 = self.getConstantInt(1)
-
                 empty_veq_ty = quake.VeqType.get(0, context=self.ctx)
-                init_veq = quake.RelaxSizeOp(
-                    veqTy,
-                    quake.AllocaOp(empty_veq_ty).result).result
+                veq1_ty = quake.VeqType.get(1, context=self.ctx)
+
+                def extractElem(i):
+                    if quake.VeqType.isinstance(iterable.type):
+                        return quake.ExtractRefOp(iterTy, iterable, -1,
+                                                  index=i).result
+                    elem_addr = cc.ComputePtrOp(
+                        cc.PointerType.get(iterTy), iterable, [i],
+                        DenseI32ArrayAttr.get([kDynamicPtrIndex],
+                                              context=self.ctx))
+                    return cc.LoadOp(elem_addr).result
 
                 def bodyBuilder(args):
                     i, curr_veq = args[0], args[1]
-                    if quake.VeqType.isinstance(iterable.type):
-                        idx_val = quake.ExtractRefOp(iterTy,
-                                                     iterable,
-                                                     -1,
-                                                     index=i).result
-                    else:
-                        elem_addr = cc.ComputePtrOp(
-                            cc.PointerType.get(iterTy), iterable, [i],
-                            DenseI32ArrayAttr.get([kDynamicPtrIndex],
-                                                  context=self.ctx))
-                        idx_val = cc.LoadOp(elem_addr).result
+                    idx_val = extractElem(i)
                     self.symbolTable.beginBlock()
                     self.__deconstructAssignment(node.generators[0].target,
                                                  idx_val)
@@ -4743,12 +4740,60 @@ class PyASTBridge(ast.NodeVisitor):
                     self.symbolTable.endBlock()
                     cc.ContinueOp([i, new_veq])
 
-                loop = self.createForLoop(
-                    [i64Ty, veqTy], bodyBuilder, [c0, init_veq],
-                    lambda args: arith.CmpIOp(IntegerAttr.get(i64Ty, 2), args[
-                        0], iterableSize).result,
-                    lambda args: [arith.AddIOp(args[0], c1).result, args[1]])
-                self.pushValue(loop.results[1])
+                # Check if the source iterable is empty. If so, return a
+                # poison veq<0>. Otherwise peel the first element to form a
+                # veq<1> seed so the loop never starts from a veq<0> alloca
+                # (which has no valid semantics).
+                isEmpty = arith.CmpIOp(IntegerAttr.get(i64Ty, 0), iterableSize,
+                                       c0).result
+                ifEmptyOp = cc.IfOp([veqTy], isEmpty, [])
+                emptyBlock = Block.create_at_start(ifEmptyOp.thenRegion, [])
+                with InsertionPoint(emptyBlock):
+                    poison = cc.PoisonOp(empty_veq_ty)
+                    cc.ContinueOp(
+                        [quake.RelaxSizeOp(veqTy, poison.result).result])
+
+                nonEmptyBlock = Block.create_at_start(ifEmptyOp.elseRegion, [])
+                with InsertionPoint(nonEmptyBlock):
+                    # Peel element 0 to form the initial veq<1> seed.
+                    idx_val_0 = extractElem(c0)
+                    self.symbolTable.beginBlock()
+                    self.__deconstructAssignment(node.generators[0].target,
+                                                 idx_val_0)
+                    if hasFilter:
+                        cond0 = evalFilter()
+                        ifFilter0 = cc.IfOp([veqTy], cond0, [])
+                        thenBlock0 = Block.create_at_start(
+                            ifFilter0.thenRegion, [])
+                        with InsertionPoint(thenBlock0):
+                            self.visit(node.elt)
+                            ref0 = self.popValue()
+                            veq1 = quake.ConcatOp(veq1_ty, [ref0]).result
+                            cc.ContinueOp(
+                                [quake.RelaxSizeOp(veqTy, veq1).result])
+                        elseBlock0 = Block.create_at_start(
+                            ifFilter0.elseRegion, [])
+                        with InsertionPoint(elseBlock0):
+                            poison0 = cc.PoisonOp(empty_veq_ty)
+                            cc.ContinueOp([
+                                quake.RelaxSizeOp(veqTy, poison0.result).result
+                            ])
+                        init_seed = ifFilter0.result
+                    else:
+                        self.visit(node.elt)
+                        ref0 = self.popValue()
+                        veq1 = quake.ConcatOp(veq1_ty, [ref0]).result
+                        init_seed = quake.RelaxSizeOp(veqTy, veq1).result
+                    self.symbolTable.endBlock()
+
+                    loop = self.createForLoop(
+                        [i64Ty, veqTy], bodyBuilder, [c1, init_seed],
+                        lambda args: arith.CmpIOp(IntegerAttr.get(
+                            i64Ty, 2), args[0], iterableSize).result, lambda
+                        args: [arith.AddIOp(args[0], c1).result, args[1]])
+                    cc.ContinueOp([loop.results[1]])
+
+                self.pushValue(ifEmptyOp.result)
                 return
             self.emitFatalError(
                 "unsupported list comprehension producing qubit references",


### PR DESCRIPTION
Fixes a semantics bug in the Python bridge.