### PR TITLE
[CI] Skip NGC login in stitch job when credentials are absent

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -566,6 +566,10 @@ jobs:
 
     environment: ghcr-deployment
 
+    # The secrets context is unavailable in a step-level if, so mirror it to env.
+    env:
+      NGC_CREDENTIALS: ${{ secrets.NGC_CREDENTIALS }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -588,11 +592,12 @@ jobs:
           password: ${{ github.token }}
 
       - name: Log in to NGC
+        if: env.NGC_CREDENTIALS != ''
         uses: docker/login-action@v4
         with:
           registry: nvcr.io
           username: '$oauthtoken'
-          password: ${{ secrets.NGC_CREDENTIALS }}
+          password: ${{ env.NGC_CREDENTIALS }}
 
       - name: metadata for jobs
         id: metadata
@@ -678,7 +683,7 @@ jobs:
 
           is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
           has_continuous_deployment=${{ startsWith(github.ref_name, 'experimental/') || github.ref_name == 'main' }}
-          push_to_ngc=`($is_versioned || $has_continuous_deployment) && echo true || echo`
+          push_to_ngc=`${{ secrets.NGC_CREDENTIALS != '' }} && ($is_versioned || $has_continuous_deployment) && echo true || echo`
 
           echo "push to NGC? $push_to_ngc"
 


### PR DESCRIPTION
The stitch job logs in to nvcr.io unconditionally, so any repository or fork without an NGC_CREDENTIALS secret fails the job with "Password required" before a single image is stitched.

The job also derived push_to_ngc from the branch alone, so on main it would retag the release image to nvcr.io/nvidia/nightly even with no way to authenticate.

Gate both on the secret being non-empty, matching what docker_images.yml already does. Without credentials the images stay on ghcr.io, which is consistent with docker_images having suppressed its own NGC push for the same run. Behavior is unchanged wherever the secret is configured.

The credential is mirrored to a job-level env because the secrets context is not available in a step-level if.