### PR TITLE
[CI] Add labeler rules for the new CI label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -92,3 +92,10 @@ build:
       - docker/**
       - scripts/**
       - CMakeLists.txt
+
+CI:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/**
+      - .pre-commit-config.yaml
+      - .licenserc.yaml


### PR DESCRIPTION
PRs that only touch CI plumbing currently land with no label, or with `build` when they happen to also touch `docker/` or `scripts/`. Now that a `CI` label exists in the repo, wire it up in the labeler config so it gets applied automatically.

The rule matches all of `.github/**`, which covers workflows, composite actions, `workflows/config/`, the `pre-commit/` configs, and the top-level CI configuration files (`required-checks.yml`, `codecov.yml`, `wheel_sources.yml`, `research-preview-paths.txt`). Using the directory glob rather than enumerating paths means new CI files are labeled without another change here. The root `.pre-commit-config.yaml` and `.licenserc.yaml` are included as well, since both drive repo checks.

Labels are additive, so a PR touching both CI and build files still receives `build` alongside `CI`.