### PR TITLE
[CI] Point release-pipeline badge and Slack alert at Validation

### DIFF
--- a/.github/nv-slack-bot.yaml
+++ b/.github/nv-slack-bot.yaml
@@ -1,16 +1,16 @@
 $schema: https://public.gha-runners.nvidia.com/nv-slack-bot/schemas/config-v1.json
 enabled: true
 notifications:
-  - name: "Publishing workflow failed"
+  - name: "Validation workflow failed"
     event: workflow_run
     slack:
       nvidia:
         channels:
           - id: C0AT93CK1B9 # nvqpp-cudaq-notifications
-    match: workflow_run.name = "Publishing" and workflow_run.conclusion = "failure"
+    match: workflow_run.name = "Validation" and workflow_run.conclusion = "failure"
     message:
       body: |
-        <{{url}}|Publishing workflow> failed on `{{branch}}` (commit <{{commitUrl}}|{{sha}}>)
+        <{{url}}|Validation workflow> failed on `{{branch}}` (commit <{{commitUrl}}|{{sha}}>)
       vars:
         url: workflow_run.html_url
         branch: workflow_run.head_branch

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ src="https://github.com/NVIDIA/cuda-quantum/actions/workflows/deployments.yml/ba
 />
 
 <img align="left"
-src="https://github.com/NVIDIA/cuda-quantum/actions/workflows/publishing.yml/badge.svg?branch=main"
+src="https://github.com/NVIDIA/cuda-quantum/actions/workflows/validation.yml/badge.svg?branch=main"
 />
 
 <img align="left"


### PR DESCRIPTION
The Publishing workflow was replaced by Validation, but the README badge and the nv-slack-bot rule still referenced it. The badge 404'd and a failing Validation run alerted nobody.