### PR TITLE
Ensure qubits in Python loops and ifs get freed

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5361,7 +5361,7 @@ class PyASTBridge(ast.NodeVisitor):
                 self.visit(assignNode)
             finally:
                 self.sinkAllocaNames = outerSink
-            [self.visit(b) for b in stmts]
+            self.buildScopedBlock(stmts)
             self.symbolTable.endBlock()
 
         self.createMonotonicForLoop(
@@ -5390,7 +5390,7 @@ class PyASTBridge(ast.NodeVisitor):
 
         def blockBuilder(iterVar):
             self.symbolTable.beginBlock()
-            [self.visit(b) for b in node.body]
+            self.buildScopedBlock(node.body)
             self.symbolTable.endBlock()
 
         self.createForLoop([], blockBuilder, [], evalCond, lambda _: [],

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5395,7 +5395,7 @@ class PyASTBridge(ast.NodeVisitor):
 
         self.createForLoop([], blockBuilder, [], evalCond, lambda _: [],
                            None if not node.orelse else
-                           lambda _: [self.visit(stmt) for stmt in node.orelse])
+                           lambda _: self.buildScopedBlock(node.orelse))
 
     def visit_BoolOp(self, node):
         """Convert boolean operations into equivalent MLIR operations using the

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -911,6 +911,23 @@ class PyASTBridge(ast.NodeVisitor):
         then or else block."""
         return self.inIfStmtBlockStack > 0
 
+    def buildScopedBlock(self, stmts):
+        """Emit `stmts` inside a `cc.scope`.
+
+        A qubit allocated in a compound statement must be freed when that
+        statement ends. `cc.scope` marks that point and `add-deallocs` puts the
+        `quake.dealloc` there. Scopes with nothing to free are removed by
+        canonicalization, so this costs nothing when there is no allocation.
+        """
+        scope = cc.ScopeOp([])
+        scopeBlock = Block.create_at_start(scope.initRegion, [])
+        with InsertionPoint(scopeBlock):
+            self.symbolTable.beginBlock()
+            [self.visit(b) for b in stmts]
+            if not self.hasTerminator(scopeBlock):
+                cc.ContinueOp([])
+            self.symbolTable.endBlock()
+
     def hasTerminator(self, block):
         """Return True if the given Block has a Terminator operation."""
         return cudaq_runtime.blockHasTerminator(block)
@@ -5638,24 +5655,20 @@ class PyASTBridge(ast.NodeVisitor):
         ifOp = cc.IfOp([], condition, [])
         thenBlock = Block.create_at_start(ifOp.thenRegion, [])
         with InsertionPoint(thenBlock):
-            self.symbolTable.beginBlock()
             self.pushIfStmtBlockStack()
-            [self.visit(b) for b in node.body]
+            self.buildScopedBlock(node.body)
             if not self.hasTerminator(thenBlock):
                 cc.ContinueOp([])
             self.popIfStmtBlockStack()
-            self.symbolTable.endBlock()
 
         if len(node.orelse) > 0:
             elseBlock = Block.create_at_start(ifOp.elseRegion, [])
             with InsertionPoint(elseBlock):
-                self.symbolTable.beginBlock()
                 self.pushIfStmtBlockStack()
-                [self.visit(b) for b in node.orelse]
+                self.buildScopedBlock(node.orelse)
                 if not self.hasTerminator(elseBlock):
                     cc.ContinueOp([])
                 self.popIfStmtBlockStack()
-                self.symbolTable.endBlock()
 
     def visit_Return(self, node):
 

--- a/python/tests/mlir/ast_decrementing_range.py
+++ b/python/tests/mlir/ast_decrementing_range.py
@@ -96,9 +96,7 @@ def test_should_we_really_support_this_in_cuda_q():
 # CHECK-SAME:      (%[[ARG0:.*]]: i64, %[[ARG1:.*]]: i64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 # CHECK-DAG:       %[[CONSTANT_0:.*]] = arith.constant 1 : i64
 # CHECK-DAG:       %[[CONSTANT_1:.*]] = arith.constant 0 : i64
-# CHECK-DAG:       %[[CONSTANT_2:.*]] = arith.constant 4 : i64
 # CHECK-DAG:       %[[CONSTANT_3:.*]] = arith.constant -1 : i64
-# CHECK-DAG:       %[[UNDEF_0:.*]] = cc.undef i64
 # CHECK-DAG:       %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<5>
 # CHECK:           %[[SUBI_0:.*]] = arith.subi %[[ARG1]], %[[CONSTANT_3]] : i64
 # CHECK:           %[[SUBI_1:.*]] = arith.subi %[[SUBI_0]], %[[ARG0]] : i64
@@ -106,17 +104,17 @@ def test_should_we_really_support_this_in_cuda_q():
 # CHECK:           %[[DIVSI_0:.*]] = arith.divsi %[[ADDI_0]], %[[CONSTANT_3]] : i64
 # CHECK:           %[[CMPI_0:.*]] = arith.cmpi sgt, %[[DIVSI_0]], %[[CONSTANT_1]] : i64
 # CHECK:           %[[SELECT_0:.*]] = arith.select %[[CMPI_0]], %[[DIVSI_0]], %[[CONSTANT_1]] : i64
-# CHECK:           %[[LOOP_0:.*]]:2 = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]], %[[VAL_1:.*]] = %[[UNDEF_0]]) -> (i64, i64)) {
+# CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]]) -> (i64)) {
 # CHECK:             %[[CMPI_1:.*]] = arith.cmpi ne, %[[VAL_0]], %[[SELECT_0]] : i64
-# CHECK:             cc.condition %[[CMPI_1]](%[[VAL_0]], %[[VAL_1]] : i64, i64)
+# CHECK:             cc.condition %[[CMPI_1]](%[[VAL_0]] : i64)
 # CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64):
+# CHECK:           ^bb0(%[[VAL_2:.*]]: i64):
 # CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_0]][4] : (!quake.veq<5>) -> !quake.ref
 # CHECK:             quake.h %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
-# CHECK:             cc.continue %[[VAL_2]], %[[CONSTANT_2]] : i64, i64
+# CHECK:             cc.continue %[[VAL_2]] : i64
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_4:.*]]: i64, %[[VAL_5:.*]]: i64):
+# CHECK:           ^bb0(%[[VAL_4:.*]]: i64):
 # CHECK:             %[[ADDI_1:.*]] = arith.addi %[[VAL_4]], %[[CONSTANT_0]] : i64
-# CHECK:             cc.continue %[[ADDI_1]], %[[VAL_5]] : i64, i64
+# CHECK:             cc.continue %[[ADDI_1]] : i64
 # CHECK:           } {normalized}
 # CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<5>

--- a/python/tests/mlir/qalloc_scope_if.py
+++ b/python/tests/mlir/qalloc_scope_if.py
@@ -1,0 +1,38 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# RUN: PYTHONPATH=../../ pytest -rP  %s | FileCheck %s
+
+import cudaq
+
+
+def test_qalloc_freed_at_end_of_if():
+    """A qubit allocated in an `if` branch is freed when the branch ends."""
+
+    @cudaq.kernel
+    def kernel(b: bool):
+        r = cudaq.qubit()
+        if b:
+            q = cudaq.qvector(2)
+            h(q[0])
+            x.ctrl(q[0], r)
+        mz(r)
+
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel..
+# CHECK-SAME:      (%[[VAL_0:.*]]: i1)
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           cc.if(%[[VAL_0]]) {
+# CHECK:             cc.scope {
+# CHECK:               %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+# CHECK:               quake.dealloc %[[VAL_2]] : !quake.veq<2>
+# CHECK:             }
+# CHECK:           }
+# CHECK:           quake.dealloc %[[VAL_1]] : !quake.ref

--- a/python/tests/mlir/qalloc_scope_loop.py
+++ b/python/tests/mlir/qalloc_scope_loop.py
@@ -1,0 +1,66 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# RUN: PYTHONPATH=../../ pytest -rP  %s | FileCheck %s
+
+import cudaq
+
+
+def test_qalloc_freed_each_for_iteration():
+    """A qubit allocated in a `for` body is freed at the end of each pass."""
+
+    @cudaq.kernel
+    def for_kernel():
+        r = cudaq.qubit()
+        for i in range(3):
+            q = cudaq.qvector(2)
+            h(q[0])
+            x.ctrl(q[0], r)
+        mz(r)
+
+    print(for_kernel)
+
+
+def test_qalloc_freed_each_while_iteration():
+    """A qubit allocated in a `while` body is freed at the end of each pass."""
+
+    @cudaq.kernel
+    def while_kernel(n: int):
+        r = cudaq.qubit()
+        i = 0
+        while i < n:
+            q = cudaq.qvector(2)
+            h(q[0])
+            x.ctrl(q[0], r)
+            i = i + 1
+        mz(r)
+
+    print(while_kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__for_kernel..
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           cc.loop while
+# CHECK:           } do {
+# CHECK:             cc.scope {
+# CHECK:               %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
+# CHECK:               quake.dealloc %[[VAL_1]] : !quake.veq<2>
+# CHECK:             }
+# CHECK:           } step {
+# CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__while_kernel..
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           cc.loop while
+# CHECK:           } do {
+# CHECK:             %[[VAL_1:.*]] = cc.scope -> (i64) {
+# CHECK:               %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+# CHECK:               quake.dealloc %[[VAL_2]] : !quake.veq<2>
+# CHECK:             }
+# CHECK:           } step {
+# CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref

--- a/python/tests/mlir/qalloc_scope_loop.py
+++ b/python/tests/mlir/qalloc_scope_loop.py
@@ -43,6 +43,43 @@ def test_qalloc_freed_each_while_iteration():
     print(while_kernel)
 
 
+def test_qalloc_freed_at_end_of_loop_else():
+    """A qubit allocated in a `while` loop's `else` block is freed when it
+    ends."""
+
+    @cudaq.kernel
+    def else_kernel(n: int):
+        r = cudaq.qubit()
+        i = 0
+        while i < n:
+            h(r)
+            i = i + 1
+        else:
+            q = cudaq.qvector(2)
+            h(q[0])
+            x.ctrl(q[0], r)
+        mz(r)
+
+    print(else_kernel)
+
+
+def test_qalloc_freed_at_end_of_for_else():
+    """A qubit allocated in a `for` loop's `else` block is freed when it ends."""
+
+    @cudaq.kernel
+    def for_else_kernel(n: int):
+        r = cudaq.qubit()
+        for i in range(n):
+            h(r)
+        else:
+            q = cudaq.qvector(2)
+            h(q[0])
+            x.ctrl(q[0], r)
+        mz(r)
+
+    print(for_else_kernel)
+
+
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__for_kernel..
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           cc.loop while
@@ -63,4 +100,26 @@ def test_qalloc_freed_each_while_iteration():
 # CHECK:               quake.dealloc %[[VAL_2]] : !quake.veq<2>
 # CHECK:             }
 # CHECK:           } step {
+# CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__else_kernel..
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           cc.loop while
+# CHECK:           } else {
+# CHECK:             cc.scope {
+# CHECK:               %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
+# CHECK:               quake.dealloc %[[VAL_1]] : !quake.veq<2>
+# CHECK:             }
+# CHECK:           }
+# CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__for_else_kernel..
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           cc.loop while
+# CHECK:           } else {
+# CHECK:             cc.scope {
+# CHECK:               %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
+# CHECK:               quake.dealloc %[[VAL_1]] : !quake.veq<2>
+# CHECK:             }
+# CHECK:           }
 # CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref


### PR DESCRIPTION
The Python bridge never emitted `cc.scope`, so compound statements had no lifetime structure. The `add-deallocs` pass had nothing to attach to, and a qubit allocated inside a loop body or an `if` branch was never deallocated.

```
r = cudaq.qubit()
for i in range(3):
    # allocated every iteration, never freed
    q = cudaq.qvector(2)
```

Before
- one `quake.dealloc` for r, none for the per iteration veq<2>.

After
- a `quake.dealloc` at scope exit, every iteration (the same shape cudaq-quake already produces for the equivalent C++ kernel).

The fix adds buildScopedBlock, which wraps if/else branches, loop bodies, and the loop else block in a cc.scope. Python locals stay in the function entry block, since they are function-scoped and not block-scoped as in C++. The scope is only for allocation lifetime.

Split out of #5251.