### PR TITLE
[core] Fix loop normalization with linear induction expressions

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/LoopAnalysis.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LoopAnalysis.cpp
@@ -184,6 +184,7 @@ static BlockArgument getLinearExpr(Value expr,
     auto vl = peelCastOps(va);
     if (auto ba = dyn_cast<BlockArgument>(vl);
         ba && isLoopInvariant(vb, loop)) {
+      result.linearInduction = va;
       saved = vb;
       return ba;
     }
@@ -763,11 +764,23 @@ cudaq::opt::getLoopComponents(cudaq::cc::LoopOp loop) {
   // TODO: A possible extension is to detect \em{conditionally iterated} loops
   // and open those up to further analysis and transformations such as loop
   // unrolling.
-  if (getLinearExpr(cmpOp.getLhs(), result, loop) ==
-      whileEntry.getArgument(*result.induction))
+  auto matchAndSetLinearExpr = [&](Value value) {
+    auto candidate = result;
+    candidate.negatedAddend = false;
+    candidate.reciprocalScale = false;
+    candidate.minusOneMult = false;
+    candidate.linearInduction = {};
+    candidate.addendValue = {};
+    candidate.scaleValue = {};
+    if (getLinearExpr(value, candidate, loop) !=
+        whileEntry.getArgument(*result.induction))
+      return false;
+    result = candidate;
+    return true;
+  };
+  if (matchAndSetLinearExpr(cmpOp.getLhs()))
     result.compareValue = cmpOp.getRhs();
-  else if (getLinearExpr(cmpOp.getRhs(), result, loop) ==
-           whileEntry.getArgument(*result.induction))
+  else if (matchAndSetLinearExpr(cmpOp.getRhs()))
     result.compareValue = cmpOp.getLhs();
   else
     return {};

--- a/cudaq/lib/Optimizer/Transforms/LoopAnalysis.h
+++ b/cudaq/lib/Optimizer/Transforms/LoopAnalysis.h
@@ -55,6 +55,7 @@ struct LoopComponents {
   bool negatedAddend = false;   // b is -b; b is subtracted.
   bool reciprocalScale = false; // m is 1/m; m is a divisor.
   bool minusOneMult = false;    // -1 * m; from b - m * i
+  mlir::Value linearInduction;  // i after casts, before m and b
   mlir::Value addendValue;      // b value
   mlir::Value scaleValue;       // m value
 };

--- a/cudaq/lib/Optimizer/Transforms/LoopNormalizePatterns.inc
+++ b/cudaq/lib/Optimizer/Transforms/LoopNormalizePatterns.inc
@@ -171,13 +171,12 @@ public:
                                          newUpper, wideZero);
     }
     // 3) Rewrite the comparison (!=) and step operations (+1).
-    // getCompareInduction() returns the *other* operand of the original
-    // comparison (i.e. whatever `compareValue`, now folded into newUpper,
-    // was being compared against). That operand may itself be a widened
-    // (cast) copy of the induction rather than the induction's own `ty`, so
-    // promote whichever of v1/newUpper is narrower to match the other
-    // instead of assuming either one's type.
-    Value v1 = c.getCompareInduction();
+    // The addend and scale from a linear comparison expression have already
+    // been folded into newUpper. Compare the normalized induction directly
+    // with that iteration count. Reusing the original expression here would
+    // apply its addend or scale twice.
+    rewriter.setInsertionPoint(cmpOp);
+    Value v1 = c.isLinearExpr() ? c.linearInduction : c.getCompareInduction();
     if (v1.getType() != newUpper.getType()) {
       if (widerOf(v1.getType(), newUpper.getType()) == v1.getType())
         newUpper = promote(newUpper);
@@ -185,7 +184,6 @@ public:
         v1 = cudaq::cc::CastOp::create(rewriter, loc, newUpper.getType(), v1,
                                        cudaq::cc::CastOpMode::Signed);
     }
-    rewriter.setInsertionPoint(cmpOp);
     Value newCmp = arith::CmpIOp::create(
         rewriter, cmpOp.getLoc(), arith::CmpIPredicate::ne, v1, newUpper);
     cmpOp->replaceAllUsesWith(ValueRange{newCmp});

--- a/cudaq/test/AST-Quake/loop_normal.cpp
+++ b/cudaq/test/AST-Quake/loop_normal.cpp
@@ -232,8 +232,7 @@ __qpu__ void linear_expr0() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr0
 // CHECK:           %[[VAL_2:.*]] = arith.constant 9 : i32
 // CHECK:           cc.loop while ((%[[VAL_5:.*]] = %{{.*}}) -> (i32)) {
-// CHECK:             %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %{{.*}} : i32
-// CHECK:             %[[VAL_7:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_7:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_5]] : i32)
 // CHECK:           } do {
 // CHECK:           } {normalized}
@@ -249,10 +248,8 @@ __qpu__ void linear_expr1a() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr1a
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 6 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_6:.*]] = %
-// CHECK:             %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %
-// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_8]](%[[VAL_6]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
@@ -267,10 +264,8 @@ __qpu__ void linear_expr1b() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr1b
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 5 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_6:.*]] = %
-// CHECK:             %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_8]](%[[VAL_6]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
@@ -285,12 +280,8 @@ __qpu__ void linear_expr2() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr2
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 7 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 3 : i32
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_7:.*]] = %
-// CHECK:             %[[VAL_8:.*]] = arith.muli %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:             %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_4]] : i32
-// CHECK:             %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_9]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_10]](%[[VAL_7]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
@@ -305,10 +296,8 @@ __qpu__ void linear_expr3a() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr3a
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 6 : i32
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_7:.*]] = %
-// CHECK:             %[[VAL_9:.*]] = arith.subi %[[VAL_4]], %[[VAL_7]] : i32
-// CHECK:             %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_9]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_10]](%[[VAL_7]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
@@ -324,10 +313,8 @@ __qpu__ void linear_expr3b() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr3b
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %
-// CHECK:             %[[VAL_8:.*]] = arith.subi %[[VAL_3]], %[[VAL_6]] : i32
-// CHECK:             %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_8]], %[[VAL_0]] : i32
+// CHECK:             %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           } {normalized}
 // clang-format on
 
@@ -342,10 +329,8 @@ __qpu__ void linear_expr3c() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr3c
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_6:.*]] = %[[VAL_0]]) -> (i32)) {
-// CHECK:             %[[VAL_8:.*]] = arith.subi %[[VAL_3]], %[[VAL_6]] : i32
-// CHECK:             %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_8]], %[[VAL_0]] : i32
+// CHECK:             %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           } {normalized}
 // clang-format on
 
@@ -359,10 +344,8 @@ __qpu__ void linear_expr4() {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr4
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 5 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_6:.*]] = %
-// CHECK:             %[[VAL_7:.*]] = arith.subi %[[VAL_3]], %[[VAL_6]] : i32
-// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_8]](%[[VAL_6]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
@@ -376,14 +359,9 @@ __qpu__ void linear_expr5a() {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr5a
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 0 : i32
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 5 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 4 : i32
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_7:.*]] = %
-// CHECK:             %[[VAL_8:.*]] = arith.muli %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:             %[[VAL_9:.*]] = arith.subi %[[VAL_4]], %[[VAL_8]] : i32
-// CHECK:             %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_9]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_10]](%[[VAL_7]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
@@ -397,13 +375,9 @@ __qpu__ void linear_expr5b() {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr5b
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 4 : i32
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:           cc.loop while ((%[[VAL_6:.*]] = %
-// CHECK:             %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[VAL_2]] : i32
-// CHECK:             %[[VAL_8:.*]] = arith.subi %[[VAL_3]], %[[VAL_7]] : i32
-// CHECK:             %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_8]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_2]] : i32
 // CHECK:             cc.condition %[[VAL_9]](%[[VAL_6]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
@@ -421,10 +395,8 @@ __qpu__ void linear_expr6() {
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_0]]) -> (i32)) {
-// CHECK:             %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : i32
-// CHECK:             %[[VAL_7:.*]] = arith.addi %[[VAL_6]], %[[VAL_1]] : i32
-// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_2]] : i32
-// CHECK:             cc.condition %[[VAL_8]](%[[VAL_5]] : i32)
+// CHECK:             %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : i32)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_9:.*]]: i32):
 // CHECK:             %[[VAL_10:.*]] = arith.muli %[[VAL_9]], %[[VAL_2]] : i32
@@ -436,6 +408,55 @@ __qpu__ void linear_expr6() {
 // CHECK:           ^bb0(%[[VAL_14:.*]]: i32):
 // CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_1]] : i32
 // CHECK:             cc.continue %[[VAL_15]] : i32
+// CHECK:           } {normalized}
+// clang-format on
+
+__qpu__ void linear_expr_dynamic(int bound) {
+  cudaq::qubit q;
+  for (int i = 1; i + 2 < bound; i += 2)
+    x(q);
+}
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr_dynamic
+// CHECK:           %[[COUNT:.*]] = arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+// CHECK:           cc.loop while ((%[[IV:.*]] = %{{.*}}) -> (i32)) {
+// CHECK:             %[[COND:.*]] = arith.cmpi ne, %[[IV]], %[[COUNT]] : i32
+// CHECK:             cc.condition %[[COND]](%[[IV]] : i32)
+// CHECK:           } {normalized}
+// clang-format on
+
+__qpu__ void linear_expr_unsigned(int bound) {
+  cudaq::qubit q;
+  for (std::uint8_t i = 0; i + 1 < bound; ++i)
+    x(q);
+}
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr_unsigned
+// CHECK:           %[[ZERO8:.*]] = arith.constant 0 : i8
+// CHECK:           %[[COUNT8:.*]] = arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+// CHECK:           cc.loop while ((%[[IV8:.*]] = %[[ZERO8]]) -> (i8)) {
+// CHECK:             %[[WIDE_IV:.*]] = cc.cast unsigned %[[IV8]] : (i8) -> i32
+// CHECK:             %[[COND8:.*]] = arith.cmpi ne, %[[WIDE_IV]], %[[COUNT8]] : i32
+// CHECK:             cc.condition %[[COND8]](%[[IV8]] : i8)
+// CHECK:           } {normalized}
+// clang-format on
+
+__qpu__ void linear_expr_invariant_side(int bound) {
+  cudaq::qubit q;
+  for (int i = 1; bound + 1 > i; ++i)
+    x(q);
+}
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr_invariant_side
+// CHECK-SAME:    (%[[BOUND:.*]]: i32)
+// CHECK:           %[[ZERO:.*]] = arith.constant 0 : i32
+// CHECK:           %[[COUNT_SIDE:.*]] = arith.select %{{.*}}, %[[BOUND]], %[[ZERO]] : i32
+// CHECK:           cc.loop while ((%[[IV_SIDE:.*]] = %[[ZERO]]) -> (i32)) {
+// CHECK:             %[[COND_SIDE:.*]] = arith.cmpi ne, %[[IV_SIDE]], %[[COUNT_SIDE]] : i32
+// CHECK:             cc.condition %[[COND_SIDE]](%[[IV_SIDE]] : i32)
 // CHECK:           } {normalized}
 // clang-format on
 

--- a/cudaq/test/Transforms/loop_induction_fuse_forms.qke
+++ b/cudaq/test/Transforms/loop_induction_fuse_forms.qke
@@ -321,7 +321,7 @@ func.func @while_coincident_secondary(%n: i64) -> (i64, i64) {
 // CHECK:           %[[SELECT_0:.*]] = arith.select %[[CMPI_0]], %[[DIVSI_0]], %[[CONSTANT_0]] : i64
 // CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_0]]) -> (i64)) {
 // CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_0]], %[[CONSTANT_1]] : i64
-// CHECK:             %[[CMPI_1:.*]] = arith.cmpi ne, %[[ADDI_0]], %[[SELECT_0]] : i64
+// CHECK:             %[[CMPI_1:.*]] = arith.cmpi ne, %[[VAL_0]], %[[SELECT_0]] : i64
 // CHECK:             cc.condition %[[CMPI_1]](%[[ADDI_0]] : i64)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_1:.*]]: i64):


### PR DESCRIPTION
### Summary

* Fix linear-expression loop normalization when structured loops reach the code-generation pipeline.

* The normalized guard now compares the canonical induction value directly with the computed trip count. The change also reuses the widening cast already present on the comparison operand and prevents metadata from the invariant comparison operand from leaking into the induction expression.

* This fixes `nvqpp_VQEH2` after delaying `lower-to-cfg`.