### PR TITLE
[docs] Fix set_target docstring reference to CustomTarget

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -305,7 +305,7 @@ def set_target(target, **extra_config):
     Args:
       target: The CUDA-Q target, specified as a recognized target name (``str``)
         or a :class:`cudaq.Target` instance. Support for
-        instances of :class:`cudaq._experimental.CustomTarget` is experimental.
+        instances of ``cudaq._experimental.CustomTarget`` is experimental.
       **extra_config: Target-specific configuration for the named-target
         overload.
 


### PR DESCRIPTION
Introduced by 209af4330f ("[python] Add CustomTarget with set_target overload (#5281)").

cudaq._experimental is not autodoc'd, so the :class: cross-reference had no target. build_docs.sh runs sphinx-build with -n -W, which turned that single warning into a failure and broke Deployments on main.

Use a literal instead. The class is private and will not be documented.