### PR TITLE
Fix quadratic scaling in loop unrolling

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
+++ b/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
@@ -384,14 +384,9 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
     LLVM_DEBUG(llvm::dbgs() << "after unrolling a loop:\n";
                lastBranch->getParentOfType<func::FuncOp>().dump());
 
-    // Merge the chain of blocks just created back into the block the loop was
-    // in. Done here, head-first, this is linear in the trip count: every step
-    // inlines exactly one iteration's worth of ops. Leaving the chain for the
-    // canonicalizer to collapse is quadratic instead, because the greedy
-    // driver pops newly created blocks in reverse and so merges tail-first,
-    // re-inlining a block that grew on the previous merge. Blocks with more
-    // than one predecessor (break edges, the exit block) stop the merge and
-    // are left to the canonicalizer.
+    // Merge the chain of blocks here head-first, as the greedy pattern
+    // rewriter exhibits quadratic slowdown merging into canonical form.
+    // Stop at any blocks with multiple predecessors for later processing.
     while (auto br = dyn_cast<cf::BranchOp>(startBlock->getTerminator())) {
       Block *succ = br.getDest();
       if (succ == endBlock || !succ->getSinglePredecessor())

--- a/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
+++ b/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
@@ -385,7 +385,7 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
                lastBranch->getParentOfType<func::FuncOp>().dump());
 
     // Merge the chain of blocks here head-first, as the greedy pattern
-    // rewriter exhibits quadratic slowdown merging into canonical form.
+    // rewriter exhibits quadratic slowdown when it does the merging.
     // Stop at any blocks with multiple predecessors for later processing.
     while (auto br = dyn_cast<cf::BranchOp>(startBlock->getTerminator())) {
       Block *succ = br.getDest();

--- a/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
+++ b/cudaq/lib/Optimizer/Transforms/LoopUnrollPatterns.inc
@@ -268,6 +268,7 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
     auto *insBlock = rewriter.getInsertionBlock();
     auto insPos = rewriter.getInsertionPoint();
     auto *endBlock = rewriter.splitBlock(insBlock, insPos);
+    auto *startBlock = insBlock;
     auto argTys = loop.getResultTypes();
     SmallVector<Location> argLocs(argTys.size(), loop.getLoc());
     endBlock->addArguments(argTys, argLocs);
@@ -382,6 +383,24 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
 
     LLVM_DEBUG(llvm::dbgs() << "after unrolling a loop:\n";
                lastBranch->getParentOfType<func::FuncOp>().dump());
+
+    // Merge the chain of blocks just created back into the block the loop was
+    // in. Done here, head-first, this is linear in the trip count: every step
+    // inlines exactly one iteration's worth of ops. Leaving the chain for the
+    // canonicalizer to collapse is quadratic instead, because the greedy
+    // driver pops newly created blocks in reverse and so merges tail-first,
+    // re-inlining a block that grew on the previous merge. Blocks with more
+    // than one predecessor (break edges, the exit block) stop the merge and
+    // are left to the canonicalizer.
+    while (auto br = dyn_cast<cf::BranchOp>(startBlock->getTerminator())) {
+      Block *succ = br.getDest();
+      if (succ == endBlock || !succ->getSinglePredecessor())
+        break;
+      SmallVector<Value> brArgs(br.getDestOperands());
+      rewriter.eraseOp(br);
+      rewriter.mergeBlocks(succ, startBlock, brArgs);
+    }
+
     progress++;
     return success();
   }


### PR DESCRIPTION
Unrolling emits one block per iteration, chained by `cf.br`, and leaves the chain for `cf::BranchOp::canonicalize` to collapse. The greedy driver pops newly-created ops in reverse, so it merges the chain tail-first — and each merge re-inlines a block that grew during the previous merge, resulting in O(N²) op moves where every moved op gets re-enqueued and re-folded.

Fix: the unroll pattern now collapses its own chain head-first before returning, where each step inlines exactly one iteration.

Claude-generated benchmarking:

| Trip count | Before | After | Speedup |
| ---------: | -----: | ----: | ------: |
| 250 | 0.326s | 0.018s | 18× |
| 500 | 1.265s | 0.029s | 44× |
| 1,000 | 4.499s | 0.054s | 83× |
| 2,000 | 19.741s | 0.103s | 192× |
| 4,000 | 75.408s | 0.203s | 371× |

Growth per doubling of the trip count, confirming the complexity change:

| N → 2N | Before | After |
| ------ | -----: | ----: |
| 250 → 500 | 3.88× | 1.61× |
| 500 → 1,000 | 3.56× | 1.86× |
| 1,000 → 2,000 | 4.39× | 1.91× |
| 2,000 → 4,000 | 3.82× | 1.97× |