### PR TITLE
[core] Retain atomic quantum regions through REST target pipelines

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/CombineMeasurements.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineMeasurements.cpp
@@ -227,6 +227,19 @@ public:
     func::FuncOp func = getOperation();
     OpBuilder builder(func);
 
+    auto nestedMeasurement = func.walk([&](cudaq::quake::MzOp measure) {
+      if (measure->getParentOp() == func.getOperation())
+        return WalkResult::advance();
+      measure.emitError(
+          "combine-measurements requires measurements to be top-level in the "
+          "function");
+      return WalkResult::interrupt();
+    });
+    if (nestedMeasurement.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
     LLVM_DEBUG(llvm::dbgs() << "Function before combining measurements:\n"
                             << func << "\n\n");
 

--- a/cudaq/test/Transforms/atomic_quantum_region_target_codegen.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_target_codegen.qke
@@ -1,0 +1,77 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-each --pass-pipeline='builtin.module(decomposition{basis=h,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements))' %s | cudaq-translate --convert-to=openqasm2 | FileCheck --check-prefix=QASM %s
+// RUN: cudaq-opt --verify-each --pass-pipeline='builtin.module(func.func(erase-implicit-output),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=path(3)},func.func(regtomem),lower-wireset-to-profile-qir{convert-to=qir-base})' %s | FileCheck --check-prefix=QIR %s
+// RUN: cudaq-opt --verify-each --pass-pipeline='builtin.module(func.func(erase-implicit-output),anyon-cgate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=path(3)},func.func(regtomem),lower-wireset-to-profile-qir{convert-to=qir-adaptive})' %s | FileCheck --check-prefix=QIR %s
+// RUN: cudaq-opt --verify-each --pass-pipeline='builtin.module(func.func(erase-implicit-output),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=path(3)},func.func(delay-measurements),func.func(cse,normalize-phase-placement,lower-phase,canonicalize),iqm-gate-set-mapping,lower-to-cfg,func.func(regtomem))' %s | cudaq-translate --convert-to=iqm | FileCheck --check-prefix=IQM %s
+// RUN: FileCheck --check-prefix=NO-EARLY-CFG %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/anyon/anyon.yml
+// RUN: FileCheck --check-prefix=QASM-YAML %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
+// RUN: FileCheck --check-prefix=NO-EARLY-CFG %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
+// RUN: FileCheck --check-prefix=NO-EARLY-CFG %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
+// RUN: FileCheck --check-prefix=QASM-YAML %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/qbraid/qbraid.yml
+// RUN: FileCheck --check-prefix=QASM-YAML %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/scaleway/scaleway.yml
+// RUN: FileCheck --check-prefix=NO-EARLY-CFG %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/tii/tii.yml
+// RUN: FileCheck --check-prefix=IQM-YAML %s --input-file=%cudaq_src_dir/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
+
+func.func @atomic_round_trip() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %q = quake.alloca !quake.veq<3>
+  %q0 = quake.extract_ref %q[0] : (!quake.veq<3>) -> !quake.ref
+  %q1 = quake.extract_ref %q[1] : (!quake.veq<3>) -> !quake.ref
+  %q2 = quake.extract_ref %q[2] : (!quake.veq<3>) -> !quake.ref
+  cc.scope {
+    quake.h %q0 : (!quake.ref) -> ()
+    quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%q1] %q2 : (!quake.ref, !quake.ref) -> ()
+  } {atomic_quantum_region}
+  cc.scope {
+    quake.x [%q1] %q2 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.h %q0 : (!quake.ref) -> ()
+  } {atomic_quantum_region}
+  %m0 = quake.mz %q0 : (!quake.ref) -> !cc.measure_handle
+  %m1 = quake.mz %q1 : (!quake.ref) -> !cc.measure_handle
+  %m2 = quake.mz %q2 : (!quake.ref) -> !cc.measure_handle
+  return
+}
+
+// QASM:      qreg var0[3];
+// QASM-NEXT: h var0[0];
+// QASM-NEXT: cx var0[0], var0[1];
+// QASM-NEXT: cx var0[1], var0[2];
+// QASM-NEXT: cx var0[1], var0[2];
+// QASM-NEXT: cx var0[0], var0[1];
+// QASM-NEXT: h var0[0];
+// QASM:      measure var0
+
+// QIR-LABEL: llvm.func @atomic_round_trip()
+// QIR:       llvm.call @__quantum__qis__h__body
+// QIR-COUNT-4: llvm.call @__quantum__qis__cnot__body
+// QIR:       llvm.call @__quantum__qis__h__body
+// QIR-COUNT-3: llvm.call @__quantum__qis__mz__body
+
+// IQM-DAG: "name": "prx"
+// IQM-DAG: "name": "prx"
+// IQM-DAG: "name": "cz"
+// IQM-DAG: "name": "cz"
+// IQM-DAG: "name": "cz"
+// IQM-DAG: "name": "cz"
+// IQM-DAG: "name": "measure"
+// IQM-DAG: "name": "measure"
+// IQM-DAG: "name": "measure"
+// IQM:     "name": "atomic_round_trip"
+
+// NO-EARLY-CFG:     jit-mid-level-pipeline:
+// NO-EARLY-CFG-NOT: lower-to-cfg
+
+// QASM-YAML:      jit-mid-level-pipeline: "decomposition
+// QASM-YAML-SAME: canonicalize,combine-measurements)"
+// QASM-YAML-NOT:  lower-to-cfg
+
+// IQM-YAML:      jit-mid-level-pipeline: "func.func(erase-implicit-output),iqm-gate-set-mapping
+// IQM-YAML-SAME: iqm-gate-set-mapping,lower-to-cfg,func.func(regtomem)"

--- a/cudaq/test/Transforms/combine_measurements_nested.qke
+++ b/cudaq/test/Transforms/combine_measurements_nested.qke
@@ -1,0 +1,25 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -combine-measurements -verify-diagnostics %s
+
+// combine-measurements analyzes top-level measurements. Reject nested
+// measurements until the pass supports them rather than assigning incorrect
+// output offsets during its recursive rewrite.
+func.func @nested_measurement() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %q = quake.alloca !quake.veq<2>
+  %q0 = quake.extract_ref %q[0] : (!quake.veq<2>) -> !quake.ref
+  %q1 = quake.extract_ref %q[1] : (!quake.veq<2>) -> !quake.ref
+  cc.scope {
+    %local = cc.alloca i64
+    // expected-error@+1 {{combine-measurements requires measurements to be top-level in the function}}
+    %m0 = quake.mz %q0 : (!quake.ref) -> !cc.measure_handle
+  }
+  %m1 = quake.mz %q1 : (!quake.ref) -> !cc.measure_handle
+  return
+}

--- a/python/tests/backends/test_OQC.py
+++ b/python/tests/backends/test_OQC.py
@@ -58,6 +58,29 @@ def startUpMockServer():
     cudaq.reset_target()
 
 
+@cudaq.kernel(atomic_quantum_region=True)
+def oqc_atomic_workload(q: cudaq.qview):
+    h(q[0])
+    x.ctrl(q[0], q[1])
+    x.ctrl(q[1], q[2])
+
+
+@cudaq.kernel
+def oqc_atomic_round_trip():
+    q = cudaq.qvector(3)
+    oqc_atomic_workload(q)
+    cudaq.adjoint(oqc_atomic_workload, q)
+    mz(q)
+
+
+def test_OQC_atomic_quantum_region_resources():
+    resources = cudaq.estimate_resources(oqc_atomic_round_trip)
+    assert resources.to_dict() == {"cx": 4, "h": 2, "mz": 3}
+    assert resources.num_qubits == 3
+    assert resources.depth == 7
+    assert resources.multi_qubit_depth == 4
+
+
 def test_OQC_sample():
     # Create the kernel we'd like to execute on OQC
     kernel = cudaq.make_kernel()

--- a/python/tests/backends/test_resource_counter.py
+++ b/python/tests/backends/test_resource_counter.py
@@ -91,6 +91,53 @@ def test_control_gates_resources():
     assert d["ch"] == 1
 
 
+def test_atomic_quantum_region_resources():
+
+    @cudaq.kernel(atomic_quantum_region=True)
+    def atomic_workload(q: cudaq.qview):
+        h(q[0])
+        x.ctrl(q[0], q[1])
+        x.ctrl(q[1], q[2])
+
+    @cudaq.kernel
+    def round_trip():
+        q = cudaq.qvector(3)
+        atomic_workload(q)
+        cudaq.adjoint(atomic_workload, q)
+        mz(q)
+
+    def check_resources(resources):
+        assert resources.to_dict() == {"cx": 4, "h": 2, "mz": 3}
+        assert resources.num_qubits == 3
+        assert resources.depth == 7
+        assert resources.multi_qubit_depth == 4
+
+    check_resources(cudaq.estimate_resources(round_trip))
+
+    cudaq.set_target("quantinuum", emulate=True)
+    check_resources(cudaq.estimate_resources(round_trip))
+
+
+def test_atomic_quantum_region_builder_resources():
+    workload, q0, q1, q2 = cudaq.make_kernel(cudaq.qubit, cudaq.qubit,
+                                             cudaq.qubit)
+    workload.atomic_quantum_region()
+    workload.h(q0)
+    workload.cx(q0, q1)
+    workload.cx(q1, q2)
+
+    round_trip = cudaq.make_kernel()
+    qubits = round_trip.qalloc(3)
+    round_trip.apply_call(workload, qubits[0], qubits[1], qubits[2])
+    round_trip.adjoint(workload, qubits[0], qubits[1], qubits[2])
+
+    resources = cudaq.estimate_resources(round_trip)
+    assert resources.to_dict() == {"cx": 4, "h": 2}
+    assert resources.num_qubits == 3
+    assert resources.depth == 6
+    assert resources.multi_qubit_depth == 4
+
+
 def test_choice_function_1():
 
     @cudaq.kernel

--- a/python/tests/kernel/test_atomic_quantum_region.py
+++ b/python/tests/kernel/test_atomic_quantum_region.py
@@ -182,6 +182,50 @@ def test_atomic_quantum_region_builder_contract():
     assert "atomic_quantum_region" in str(marked_after_compile.qkeModule)
 
 
+def test_atomic_quantum_region_builder_preserves_entangling_workload():
+
+    def make_workload(atomic):
+        workload, q0, q1, q2 = cudaq.make_kernel(cudaq.qubit, cudaq.qubit,
+                                                 cudaq.qubit)
+        if atomic:
+            workload.atomic_quantum_region()
+        workload.h(q0)
+        workload.cx(q0, q1)
+        workload.cx(q1, q2)
+        return workload
+
+    def make_round_trip(workload):
+        round_trip = cudaq.make_kernel()
+        qubits = round_trip.qalloc(3)
+        round_trip.apply_call(workload, qubits[0], qubits[1], qubits[2])
+        round_trip.adjoint(workload, qubits[0], qubits[1], qubits[2])
+        return round_trip
+
+    ordinary = make_round_trip(make_workload(False))
+    atomic = make_round_trip(make_workload(True))
+
+    assert cudaq.draw(ordinary) == ""
+    atomic_drawing = cudaq.draw(atomic)
+    assert atomic_drawing.count("┤ h ├") == 2
+    assert atomic_drawing.count("┤ x ├") == 4
+
+    pauli_x = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.complex128)
+    noise = cudaq.NoiseModel()
+    noise.add_all_qubit_channel("x",
+                                cudaq.KrausChannel([np.kron(pauli_x, pauli_x)]),
+                                num_controls=1)
+
+    cudaq.set_target("density-matrix-cpu")
+    shots = 8
+    ordinary_counts = cudaq.sample(ordinary,
+                                   shots_count=shots,
+                                   noise_model=noise)
+    atomic_counts = cudaq.sample(atomic, shots_count=shots, noise_model=noise)
+    assert ordinary_counts.count("000") == shots
+    assert atomic_counts.count("011") == shots
+    cudaq.reset_target()
+
+
 def test_atomic_quantum_region_sync_execution_apis():
     shots = 8
     counts = cudaq.sample(atomic_round_trip, shots_count=shots)

--- a/runtime/cudaq/platform/default/rest/helpers/anyon/anyon.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/anyon/anyon.yml
@@ -19,7 +19,7 @@ config:
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "expand-measurements"
-  jit-mid-level-pipeline: "func.func(erase-implicit-output),lower-to-cfg,anyon-%Q_GATE%-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)"
+  jit-mid-level-pipeline: "func.func(erase-implicit-output),anyon-%Q_GATE%-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)"
   # Tell the rest-qpu that we are generating Adaptive QIR.
   codegen-emission: qir-adaptive
 

--- a/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "decomposition{basis=h,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
 

--- a/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
@@ -20,7 +20,7 @@ config:
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "expand-measurements"
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(memtoreg{quantum=0})"
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(memtoreg{quantum=0})"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
 

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
@@ -21,7 +21,9 @@ config:
   jit-high-level-pipeline: "expand-measurements"
   # The first mapping can emit phase bookkeeping. Lower it before the final
   # mapping, which converts LowerPhase's R1/Rz output to IQM native gates.
-  jit-mid-level-pipeline: "func.func(erase-implicit-output),lower-to-cfg,iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),func.func(cse,normalize-phase-placement,lower-phase,canonicalize),iqm-gate-set-mapping"
+  # Keep atomic regions structured through that final quantum rewrite, then
+  # lower to CFG and return to memory semantics for IQM JSON emission.
+  jit-mid-level-pipeline: "func.func(erase-implicit-output),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements),func.func(cse,normalize-phase-placement,lower-phase,canonicalize),iqm-gate-set-mapping,lower-to-cfg,func.func(regtomem)"
   # Tell the rest-qpu that we are generating IQM JSON.
   codegen-emission: iqm
 

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
@@ -19,7 +19,7 @@ config:
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "expand-measurements"
-  jit-mid-level-pipeline: "func.func(erase-implicit-output),lower-to-cfg,oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)"
+  jit-mid-level-pipeline: "func.func(erase-implicit-output),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,dqe,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem)"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
 

--- a/runtime/cudaq/platform/default/rest/helpers/qbraid/qbraid.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/qbraid/qbraid.yml
@@ -21,7 +21,7 @@ config:
   # `outputNames[jobId]` in the helper. Without that pass the default register
   # would contain compiler-generated ancillae and named sub-registers would be
   # unreachable (see QbraidServerHelper::processResults).
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM.
   codegen-emission: qasm2
 

--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/scaleway.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/scaleway.yml
@@ -19,7 +19,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qasm2
 

--- a/runtime/cudaq/platform/default/rest/helpers/tii/tii.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/tii/tii.yml
@@ -20,7 +20,7 @@ config:
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipelines
   jit-high-level-pipeline: "expand-measurements"
-  jit-mid-level-pipeline: "lower-to-cfg,func.func(canonicalize,multicontrol-decomposition),decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,canonicalize),symbol-dce"
+  jit-mid-level-pipeline: "func.func(canonicalize,multicontrol-decomposition),decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,canonicalize),symbol-dce"
   codegen-emission: qasm2
 
 target-arguments:

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -12,6 +12,7 @@
 #include "common/AnalysisScope.h"
 #include "common/PluginUtils.h"
 #include "common/Trace.h"
+#include "resourcecounter/ResourceCounterScope.h"
 #include "cudaq/qis/qudit.h"
 #include "cudaq/qis/state.h"
 #include "cudaq/runtime/logger/logger.h"
@@ -787,6 +788,12 @@ void __quantum__rt__result_record_output(Result *r, int8_t *name) {
     quantumRTGenericRecordOutput("RESULT", (b ? 1 : 0), regName.c_str());
     return;
   }
+
+  // QIR codegen records a result after its measurement call. Resource
+  // estimation has already counted that call and does not need the recording
+  // path to measure the same qubit again.
+  if (nvqir::resource_counter::is_active())
+    return;
 
   if (name && qubitPtrIsIndex)
     __quantum__qis__mz__to__register(measRes2QB[r],

--- a/runtime/nvqir/resourcecounter/ResourceCounter.cpp
+++ b/runtime/nvqir/resourcecounter/ResourceCounter.cpp
@@ -39,6 +39,12 @@ cudaq::detail::AnalysisScope make_scope(std::function<bool()> choice) {
        .on_exit = [rc](CircuitSimulator &) { rc->setToZeroState(); }}};
 }
 
+bool is_active() noexcept {
+  return resource_counter_simulator &&
+         cudaq::detail::AnalysisScope::active_simulator() ==
+             resource_counter_simulator;
+}
+
 cudaq::Resources get_counts() {
   auto *sim = cudaq::detail::AnalysisScope::active_simulator();
   auto *rc = getResourceCounterSimulator();

--- a/runtime/nvqir/resourcecounter/ResourceCounterScope.h
+++ b/runtime/nvqir/resourcecounter/ResourceCounterScope.h
@@ -25,6 +25,10 @@ namespace nvqir::resource_counter {
 /// current thread.
 cudaq::detail::AnalysisScope make_scope(std::function<bool()> choice);
 
+/// @brief Return true when the current thread is inside a resource-counter
+/// scope.
+bool is_active() noexcept;
+
 /// @brief Snapshot of the resource counts accumulated so far.
 ///
 /// Must be called while a resource-counter scope is active. The result

--- a/targettests/execution/estimate_resources_tracer.cpp
+++ b/targettests/execution/estimate_resources_tracer.cpp
@@ -15,10 +15,15 @@
 // RUN:   FileCheck %s --check-prefixes=CHECK,AOT
 // RUN: nvq++ -DCASE3 %s -o %t && CUDAQ_LOG_LEVEL=info %t | \
 // RUN:   FileCheck %s --check-prefixes=CHECK,AOT
+// RUN: nvq++ -DCASE4 %s -o %t && CUDAQ_LOG_LEVEL=info %t | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,AOT
 // RUN: nvq++ --target quantinuum --emulate -DCASE1 %s -o %t && \
 // RUN:   CUDAQ_LOG_LEVEL=info %t | FileCheck %s --check-prefixes=CHECK,EMULATE
 // RUN: nvq++ --target quantinuum --emulate -DCASE2 %s -o %t && \
 // RUN:   CUDAQ_LOG_LEVEL=info %t | FileCheck %s --check-prefixes=CHECK,EMULATE
+// RUN: nvq++ --target quantinuum --emulate -DCASE4 %s -o %t && \
+// RUN:   CUDAQ_LOG_LEVEL=info %t | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,EMULATE-ATOMIC
 
 // We don't run CASE3 with emulation on because compilation takes several
 // minutes
@@ -39,6 +44,11 @@
 // EMULATE: JIT high level:
 // EMULATE: Pass pipeline for
 // EMULATE-NOT: Applying x with 1 controls
+
+// EMULATE-ATOMIC: JIT high level:
+// EMULATE-ATOMIC: Pass pipeline for
+// EMULATE-ATOMIC: Applying h with 0 controls
+// EMULATE-ATOMIC: Applying x with 1 controls
 
 #include <cassert>
 #include <cudaq.h>
@@ -122,6 +132,36 @@ int main() {
   auto totalOps = resources.count();
   assert(totalOps == numLayers * numQubits * 1.5);
 
+  return 0;
+}
+
+#elif CASE4
+
+struct atomic_workload {
+  void operator()(cudaq::qview<> q) __qpu__ __atomic_quantum_region__ {
+    h(q[0]);
+    x<cudaq::ctrl>(q[0], q[1]);
+    x<cudaq::ctrl>(q[1], q[2]);
+  }
+};
+
+struct atomic_round_trip {
+  void operator()() __qpu__ {
+    cudaq::qvector q(3);
+    atomic_workload{}(q);
+    cudaq::adjoint(atomic_workload{}, q);
+    mz(q);
+  }
+};
+
+int main() {
+  auto resources = cudaq::estimate_resources(atomic_round_trip{});
+  assert(resources.count("h") == 2);
+  assert(resources.count_controls("x", /*controls*/ 1) == 4);
+  assert(resources.count("mz") == 3);
+  assert(resources.getNumQubits() == 3);
+  assert(resources.getCircuitDepth() == 7);
+  assert(resources.getMultiQubitDepth() == 4);
   return 0;
 }
 

--- a/unittests/nvqpp/integration/analysis_scope_tester.cpp
+++ b/unittests/nvqpp/integration/analysis_scope_tester.cpp
@@ -23,12 +23,15 @@ bool alwaysFalse() { return false; }
 
 CUDAQ_TEST(AnalysisScopeTester, isActiveDuringLifetime) {
   EXPECT_FALSE(AnalysisScope::is_active());
+  EXPECT_FALSE(nvqir::resource_counter::is_active());
   {
     auto s = nvqir::resource_counter::make_scope(alwaysFalse);
     EXPECT_TRUE(AnalysisScope::is_active());
+    EXPECT_TRUE(nvqir::resource_counter::is_active());
     EXPECT_EQ(s.name(), "resource_counter");
   }
   EXPECT_FALSE(AnalysisScope::is_active());
+  EXPECT_FALSE(nvqir::resource_counter::is_active());
 }
 
 CUDAQ_TEST(AnalysisScopeTester, nestedThrows) {
@@ -80,6 +83,7 @@ CUDAQ_TEST(AnalysisScopeTester, prepopulateRejectsForeignScope) {
   ASSERT_NE(backendSim, nvqir::getResourceCounterSimulator());
 
   AnalysisScope s{"backend_scope", *backendSim, {}};
+  EXPECT_FALSE(nvqir::resource_counter::is_active());
   cudaq::Resources counts;
   counts.appendInstruction("h", 0);
   EXPECT_ANY_THROW(nvqir::resource_counter::prepopulate(std::move(counts)));


### PR DESCRIPTION
### Summary

Preserve atomic quantum regions through hardware optimization and correct QIR resource counting.

### What Changed

- Remove early CFG lowering from eight hardware targets.
- Reject nested measurements instead of corrupting output mappings in `combine-measurements` pass
- Prevent duplicate measurement resource counts.

### Integration testing

- [x] Braket - manual
```27 passed```
- [x] Run nightly integration CI pipeline
   https://github.com/NVIDIA/cuda-quantum/actions/runs/33131507021