### PR TITLE
[realtime] Consolidate realtime builds around a new build_realtime.sh script.

### DIFF
--- a/.github/workflows/realtime_ci.yml
+++ b/.github/workflows/realtime_ci.yml
@@ -171,9 +171,7 @@ jobs:
             bash scripts/install_dev_prerequisites.sh
             # Build CUDA-Q Realtime
             cd /workspace/realtime
-            mkdir -p build && cd build
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DCUDAQ_REALTIME_BUILD_TESTS=ON -DCUDAQ_REALTIME_ENABLE_HSB_TOOLS=ON -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR=/workspace/holoscan-sensor-bridge -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR=/workspace/holoscan-sensor-bridge/build/ -DCMAKE_INSTALL_PREFIX=/workspace/installer
-            make -j$(nproc) install
+            CUDAQ_REALTIME_INSTALL_PREFIX=/workspace/installer bash scripts/build_realtime.sh 
 
       - name: 'Tar files'
         run: cd ${{ github.workspace }}/realtime/build && tar czf ${{ github.workspace }}/build_artifacts.tgz *

--- a/cmake/modules/Sanitizers.cmake
+++ b/cmake/modules/Sanitizers.cmake
@@ -18,6 +18,12 @@
 # -fno-omit-frame-pointer: Preserves frame pointers for better stack traces
 # -fno-optimize-sibling-calls: Disables tail call optimization for accurate stack traces
 # -fsanitize-address-use-after-scope: Detects use-after-scope bugs (Clang only)
+#
+# The flags are applied to C and C++ only. nvcc rejects them as its own options
+# and would need them forwarded with -Xcompiler, which instruments just the host
+# half of a .cu file; device code cannot be covered by ASan/UBSan at all (use
+# compute-sanitizer for that). Mixing instrumented and uninstrumented
+# translation units is supported by both sanitizers.
 
 include_guard()
 
@@ -46,15 +52,11 @@ function(cudaq_enable_sanitizers)
   # Sanitizer link flags
   set(SANITIZER_LINK_FLAGS -fsanitize=address,undefined)
 
-  # Convert list to space-separated string for CMAKE_*_FLAGS variables
-  # list(JOIN SANITIZER_COMPILE_FLAGS " " SANITIZER_COMPILE_FLAGS_STR)
-  # list(JOIN SANITIZER_LINK_FLAGS " " SANITIZER_LINK_FLAGS_STR)
-
   message(STATUS "  Sanitizer compile flags: ${SANITIZER_COMPILE_FLAGS}")
   message(STATUS "  Sanitizer link flags: ${SANITIZER_LINK_FLAGS}")
 
   # Apply flags globally using add_compile_options and add_link_options
   # These affect all targets defined after this point
-  add_compile_options(${SANITIZER_COMPILE_FLAGS})
-  add_link_options(${SANITIZER_LINK_FLAGS})
+  add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:${SANITIZER_COMPILE_FLAGS}>")
+  add_link_options("$<$<LINK_LANGUAGE:C,CXX>:${SANITIZER_LINK_FLAGS}>")
 endfunction()

--- a/realtime/CMakeLists.txt
+++ b/realtime/CMakeLists.txt
@@ -75,6 +75,19 @@ option(CUDAQ_REALTIME_BUILD_EXAMPLES
 option(CUDAQ_REALTIME_ENABLE_HSB_TOOLS
        "Build HSB bridge/emulator/playback tools (requires the holoscan-sensor-bridge libraries)."
        OFF)
+option(CUDAQ_REALTIME_ENABLE_SANITIZERS
+       "Enable Address Sanitizer (ASan) and Undefined Behavior Sanitizer (UBSan)."
+       OFF)
+
+# Enable sanitizers if requested (must be done early to affect all targets).
+# Integrated CUDA-Q builds inherit whatever the top-level CUDAQ_ENABLE_SANITIZERS
+# applied, so this only covers the standalone realtime build. The realtime tree
+# always ships inside the CUDA-Q repository, so reuse the CUDA-Q module.
+if(CUDAQ_REALTIME_STANDALONE_BUILD AND CUDAQ_REALTIME_ENABLE_SANITIZERS)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules")
+  include(Sanitizers)
+  cudaq_enable_sanitizers()
+endif()
 
 set(_host_compiler_opts_list "")
 if(CUDAQ_REALTIME_STANDALONE_BUILD)

--- a/realtime/docker/assets.Dockerfile
+++ b/realtime/docker/assets.Dockerfile
@@ -88,6 +88,7 @@ ADD cmake/modules/CUDAQGtestDiscovery.cmake /cuda-quantum/cmake/modules/CUDAQGte
 # [HSB]
 ARG cuda_native_arg="80-real;90"
 ENV CUDA_NATIVE_ARCH=${cuda_native_arg}
+ENV HSB_ROOT=/holoscan-sensor-bridge
 ARG hsb_version="2.6.0-EA2"
 # Build HSB
 RUN cd / && git clone -b ${hsb_version} https://github.com/nvidia-holoscan/holoscan-sensor-bridge.git && cd holoscan-sensor-bridge && \
@@ -95,10 +96,10 @@ RUN cd / && git clone -b ${hsb_version} https://github.com/nvidia-holoscan/holos
     cmake --build build --target roce_receiver gpu_roce_transceiver hololink_core
 
 # [CUDAQ Realtime]
+# Set install prefix to match where build_installer.sh expects it
+ENV CUDAQ_REALTIME_INSTALL_PREFIX=/realtime_assets
 RUN cd /cuda-quantum/realtime && \
-    mkdir -p build && cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCUDAQ_REALTIME_BUILD_TESTS=ON -DCUDAQ_REALTIME_ENABLE_HSB_TOOLS=ON -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR=/holoscan-sensor-bridge -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR=/holoscan-sensor-bridge/build/ -DCMAKE_INSTALL_PREFIX=/realtime_assets && \
-    make -j$(nproc) install
+    bash scripts/build_realtime.sh
 
 # [Install makeself]
 RUN git clone --filter=tree:0 https://github.com/megastep/makeself /makeself && \
@@ -107,9 +108,6 @@ RUN git clone --filter=tree:0 https://github.com/megastep/makeself /makeself && 
     ln -s /makeself/makeself-header.sh /usr/local/bin/makeself-header.sh
 
 # [Build realtime installer]
-# Set install prefix to match where build_installer.sh expects it
-ENV CUDAQ_REALTIME_INSTALL_PREFIX=/realtime_assets
-# Run installer build script
 RUN bash /cuda-quantum/realtime/scripts/build_installer.sh -c $(echo $CUDA_VERSION | cut -d . -f1)   
 
 FROM scratch

--- a/realtime/docs/building.md
+++ b/realtime/docs/building.md
@@ -34,6 +34,20 @@ for more information about these tests.
 the basic CUDA-Q Realtime library, e.g., the dispatch library
 and host API; no networking transport layer is included.
 
+## Using the build script
+
+`realtime/scripts/build_realtime.sh` wraps the steps above: it configures,
+builds and installs CUDA-Q Realtime, mirroring the options of the top-level
+`scripts/build_cudaq.sh`. Run it from anywhere in the CUDA-Q source tree:
+
+```bash
+# Release build, installed into $HOME/.cudaq_realtime
+bash realtime/scripts/build_realtime.sh
+
+# Debug build with Address and Undefined Behavior Sanitizers
+bash realtime/scripts/build_realtime.sh -c Debug -s
+```
+
 ## Enable Holoscan Sensor Bridge Support
 
 [Holoscan Sensor Bridge](https://www.nvidia.com/en-us/technologies/holoscan-sensor-bridge/)

--- a/realtime/scripts/build_realtime.sh
+++ b/realtime/scripts/build_realtime.sh
@@ -43,7 +43,7 @@
 #                                   given after -- overrides both.
 #   CUDAQ_REALTIME_BUILD_TESTS      Build the unit tests. Defaults to ON.
 #   CUDAQ_REALTIME_BUILD_EXAMPLES   Build the examples. Defaults to OFF.
-#   HSB_ROOT                     Holoscan Sensor Bridge source checkout.
+#   HSB_ROOT                        Holoscan Sensor Bridge source checkout.
 #                                   HSB tools are enabled when it exists.
 #                                   Defaults to $HOME/cudaq/holoscan-sensor-bridge;
 #                                   set it to the empty string to never enable them.
@@ -123,8 +123,8 @@ OPTIND=$__optind__
 install_prefix=${CUDAQ_REALTIME_INSTALL_PREFIX:-${CUDAQ_INSTALL_PREFIX:-$HOME/.cudaq_realtime}}
 
 # HSB tools need a built holoscan-sensor-bridge tree; enable them if we find one.
-# An explicitly empty HSB_SRC_DIR opts out of the search.
-hsb_src_dir=${HSB_SRC_DIR-/tmp/holoscan-sensor-bridge}
+# An explicitly empty HSB_ROOT opts out of the search.
+hsb_src_dir=${HSB_ROOT-/tmp/holoscan-sensor-bridge}
 hsb_cmake_args=(-DCUDAQ_REALTIME_ENABLE_HSB_TOOLS=OFF)
 if [ -n "$hsb_src_dir" ] && [ -d "$hsb_src_dir" ]; then
   echo "Holoscan Sensor Bridge detected in $hsb_src_dir. Enabling HSB tools."

--- a/realtime/scripts/build_realtime.sh
+++ b/realtime/scripts/build_realtime.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Configure, build and install the standalone cudaq-realtime libraries.
+#
+# Usage:
+# bash realtime/scripts/build_realtime.sh
+# -or-
+# bash realtime/scripts/build_realtime.sh -c Debug -s
+# -or-
+# CUDAQ_REALTIME_INSTALL_PREFIX=/path/for/installing bash realtime/scripts/build_realtime.sh
+# -or-
+# bash realtime/scripts/build_realtime.sh -- -DCMAKE_CUDA_FLAGS=-D_SOME_GUARD
+#
+# Options:
+# -c <build_configuration>: The build configuration to use. Defaults to Release.
+# -B <build_dir>: The build directory to use. Defaults to realtime/build.
+# -i: Whether to build incrementally. Defaults to False.
+# -s: Enable sanitizers (ASan, UBSan) for memory error detection. Defaults to
+#     False. Intended to be combined with -c Debug.
+# -j <num_jobs>: The number of jobs to use. Defaults to all available cores.
+# -h: Print this help text.
+# --: Arguments after -- are passed directly to cmake (e.g., -DVAR=value).
+#     They are appended last, so they take precedence over the defaults set
+#     by this script.
+#
+# Environment:
+#   CUDAQ_REALTIME_INSTALL_PREFIX   Install prefix. Falls back to
+#                                   CUDAQ_INSTALL_PREFIX, then
+#                                   $HOME/.cudaq_realtime. Point a subsequent
+#                                   CUDA-Q build at it with
+#                                   -DCUDAQ_REALTIME_DIR=<prefix>.
+#   CC / CXX                        Host compilers.
+#   CMAKE_CUDA_FLAGS                Extra nvcc flags, appended to the flags this
+#                                   script sets itself. A -DCMAKE_CUDA_FLAGS
+#                                   given after -- overrides both.
+#   CUDAQ_REALTIME_BUILD_TESTS      Build the unit tests. Defaults to ON.
+#   CUDAQ_REALTIME_BUILD_EXAMPLES   Build the examples. Defaults to OFF.
+#   HSB_ROOT                     Holoscan Sensor Bridge source checkout.
+#                                   HSB tools are enabled when it exists.
+#                                   Defaults to $HOME/cudaq/holoscan-sensor-bridge;
+#                                   set it to the empty string to never enable them.
+#
+# Prerequisites:
+# - CMake 4.0+, ninja-build
+# - CUDA toolkit (12+); a CUDA-less configure builds only the UDP transport.
+# - For HSB tools: DOCA with gpunetio and a built holoscan-sensor-bridge tree,
+#   see isntall_dev_prerequisites.sh
+
+set -euo pipefail
+
+this_file_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+realtime_src="$(cd "$this_file_dir/.." && pwd -P)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash realtime/scripts/build_realtime.sh [options] [-- <extra cmake args>]
+
+Options:
+  -c <build_configuration>  Build configuration (default: Release)
+  -B <build_dir>            Build directory (default: realtime/build)
+  -i                        Build incrementally (default: clean build)
+  -s                        Enable sanitizers (ASan, UBSan)
+  -j <num_jobs>             Number of build jobs (default: all cores)
+  -h                        Print this help text
+EOF
+}
+
+build_configuration=${CMAKE_BUILD_TYPE:-Release}
+build_dir="$realtime_src/build"
+clean_build=true
+enable_sanitizers=false
+parallel_args=(--parallel)
+
+# Extract extra cmake args after the -- separator.
+extra_cmake_args=()
+args_before_sep=()
+found_sep=false
+for arg in "$@"; do
+  if [ "$arg" = "--" ] && ! $found_sep; then
+    found_sep=true
+  elif $found_sep; then
+    extra_cmake_args+=("$arg")
+  else
+    args_before_sep+=("$arg")
+  fi
+done
+set -- ${args_before_sep[@]+"${args_before_sep[@]}"}
+
+__optind__=$OPTIND
+OPTIND=1
+while getopts ":c:B:isj:h" opt; do
+  case $opt in
+    c) build_configuration="$OPTARG"
+    ;;
+    B) build_dir="$OPTARG"
+    ;;
+    i) clean_build=false
+    ;;
+    s) enable_sanitizers=true
+    ;;
+    j) parallel_args=(--parallel "$OPTARG")
+    ;;
+    h) usage
+    exit 0
+    ;;
+    \?) echo "Invalid command line option -$OPTARG" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+done
+OPTIND=$__optind__
+
+install_prefix=${CUDAQ_REALTIME_INSTALL_PREFIX:-${CUDAQ_INSTALL_PREFIX:-$HOME/.cudaq_realtime}}
+
+# HSB tools need a built holoscan-sensor-bridge tree; enable them if we find one.
+# An explicitly empty HSB_SRC_DIR opts out of the search.
+hsb_src_dir=${HSB_SRC_DIR-/tmp/holoscan-sensor-bridge}
+hsb_cmake_args=(-DCUDAQ_REALTIME_ENABLE_HSB_TOOLS=OFF)
+if [ -n "$hsb_src_dir" ] && [ -d "$hsb_src_dir" ]; then
+  echo "Holoscan Sensor Bridge detected in $hsb_src_dir. Enabling HSB tools."
+  hsb_cmake_args=(
+    -DCUDAQ_REALTIME_ENABLE_HSB_TOOLS=ON
+    "-DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR=$hsb_src_dir"
+    "-DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR=$hsb_src_dir/build"
+  )
+fi
+
+ccache_args=()
+if [ -x "$(command -v ccache)" ]; then
+  echo "ccache detected. Configuring build to use ccache for faster recompilation."
+  ccache_args=(
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+  )
+else
+  echo "ccache not found. To speed up recompilation, consider installing ccache."
+fi
+
+sanitizer_args=()
+if $enable_sanitizers; then
+  echo "Enabling Address Sanitizer (ASan) and Undefined Behavior Sanitizer (UBSan)..."
+  sanitizer_args=(-DCUDAQ_REALTIME_ENABLE_SANITIZERS=ON)
+fi
+
+# The caller's CMAKE_CUDA_FLAGS is appended to the flags this script needs
+# itself (none so far), so callers never have to repeat the script's own.
+cuda_flags="${CMAKE_CUDA_FLAGS:-}"
+
+echo "Build directory: $build_dir"
+if $clean_build && [ -d "$build_dir" ]; then
+  echo "Removing existing build directory for a clean build..."
+  rm -rf "$build_dir"
+fi
+mkdir -p "$build_dir"
+
+echo "Preparing cudaq-realtime build from $realtime_src..."
+cmake_args=(
+  -G Ninja
+  -S "$realtime_src"
+  -B "$build_dir"
+  "-DCMAKE_BUILD_TYPE=$build_configuration"
+  "-DCMAKE_INSTALL_PREFIX=$install_prefix"
+  "-DCUDAQ_REALTIME_BUILD_TESTS=${CUDAQ_REALTIME_BUILD_TESTS:-ON}"
+  "-DCUDAQ_REALTIME_BUILD_EXAMPLES=${CUDAQ_REALTIME_BUILD_EXAMPLES:-OFF}"
+  "${hsb_cmake_args[@]}"
+  ${ccache_args[@]+"${ccache_args[@]}"}
+  ${sanitizer_args[@]+"${sanitizer_args[@]}"}
+  ${cuda_flags:+"-DCMAKE_CUDA_FLAGS=$cuda_flags"}
+  ${extra_cmake_args[@]+"${extra_cmake_args[@]}"}
+)
+cmake "${cmake_args[@]}"
+
+echo "Building cudaq-realtime with configuration $build_configuration..."
+cmake --build "$build_dir" --target install "${parallel_args[@]}"
+
+echo "Installed cudaq-realtime in directory: $install_prefix"


### PR DESCRIPTION
Along the same idea as https://github.com/NVIDIA/cuda-quantum/pull/5227, I would like to consolidate the realtime builds around a script. I would like cudaqx, CI, docker and development to use the same scripts that will take care of checking for the HSB_ROOT and build accordingly.

