### PR TITLE
Move `expand-measurements` into shared `prepare-for-wireset` pipeline

### DIFF
--- a/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -60,6 +60,7 @@ static void createPrepareForWiresetPipeline(
     OpPassManager &pm, const cudaq::opt::LoopUnrollOptions &loopUnrollOptions,
     bool addWireset) {
   auto &funcPM = pm.nest<func::FuncOp>();
+  funcPM.addPass(cudaq::opt::createExpandMeasurementsPass());
   funcPM.addPass(cudaq::opt::createAddDeallocs());
   funcPM.addPass(cudaq::opt::createEraseCompilerGeneratedLogOutput());
   funcPM.addPass(cudaq::opt::createExpandControlVeqs());

--- a/cudaq/test/Transforms/unroll_particular_wire_loops.qke
+++ b/cudaq/test/Transforms/unroll_particular_wire_loops.qke
@@ -256,6 +256,8 @@ module {
 // DEFAULT:         }
 }
 
+// Vector measurements must expand before loops are selectively unrolled.
+// PIPELINE: expand-measurements
 // The forwarded aliasing-quantum-access option must appear on cc-loop-unroll.
 // PIPELINE: cc-loop-unroll{allow-early-exit=false maximum-iterations=5 signal-failure-if-any-loop-cannot-be-completely-unrolled=false unroll-only-aliasing-quantum-access-loops=true unroll-only-index-use-loops=false}
 // PIPELINE: decomposition{{.*}}ExpPauliDecomposition

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-high-level-pipeline: "func.func(add-measurements),expand-measurements"
+  jit-high-level-pipeline: "func.func(add-measurements)"
   jit-mid-level-pipeline: "prepare-for-wireset{add-wireset=true unroll-only-aliasing-quantum-access-loops=true},qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "symbol-dce"
   # Tell the rest-qpu that the required output format is quake.

--- a/unittests/nvqpp/backends/quake_backend/quake_fake.yml
+++ b/unittests/nvqpp/backends/quake_backend/quake_fake.yml
@@ -22,7 +22,7 @@ config:
   # FakeQuakeServerHelper replaces %QUAKE_EMULATE_SUFFIX% with "" for remote
   # execution, yielding the exact low-level pipeline "symbol-dce". For local
   # emulation it replaces the suffix with the necessary emulation passes for local execution.
-  jit-high-level-pipeline: "func.func(add-measurements),expand-measurements"
+  jit-high-level-pipeline: "func.func(add-measurements)"
   jit-mid-level-pipeline: "prepare-for-wireset{add-wireset=true unroll-only-aliasing-quantum-access-loops=true},qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "symbol-dce%QUAKE_EMULATE_SUFFIX%"
   # Tell the rest-qpu that we are simply dumping CUDA-Q MLIR code.


### PR DESCRIPTION
This `expand-measurements` pass is common across targets that would use the `prepare-for-wireset` pipeline. Hence, added the pass to the pipeline.