### PR TITLE
[IQM nightly test] Getting counts from the job status response

### DIFF
--- a/.github/actions/setup-precommit/action.yml
+++ b/.github/actions/setup-precommit/action.yml
@@ -89,7 +89,7 @@ runs:
       if: inputs.install-go == 'true'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25.3'
         cache: false
 
     - name: Cache Go modules

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -286,23 +286,11 @@ bool IQMServerHelper::jobIsDone(ServerMessage &getJobResponse) {
                                ", reason: " + jobMessage);
     }
 
-    // retrieve the counts artifact
+    // The counts are already part of the status response, so there is no need
+    // to fetch them separately.
     ServerMessage counts_batch;
     try {
-      RestClient client;
-      std::string iqmServerBaseUrl(iqmServerUrl);
-
-      auto pos = iqmServerBaseUrl.find("://cocos.");
-      if (pos != std::string::npos) {
-        iqmServerBaseUrl.erase(pos + 3, 6); // skip anchor and erase "cocos."
-        pos = iqmServerBaseUrl.find_first_of('/', pos + 3); // start of the path
-        iqmServerBaseUrl.erase(pos + 1);                    // erase the path
-      }
-
-      auto headers = generateRequestHeader();
-      counts_batch = client.get(
-          iqmServerBaseUrl,
-          "api/v1/jobs/" + jobId + "/artifacts/measurement_counts", headers);
+      counts_batch = getJobResponse["counts_batch"];
       if (counts_batch.is_null() || counts_batch.empty() ||
           counts_batch.type() != nlohmann::json::value_t::array ||
           counts_batch[0].type() != nlohmann::json::value_t::object) {

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -290,6 +290,9 @@ bool IQMServerHelper::jobIsDone(ServerMessage &getJobResponse) {
     // to fetch them separately.
     ServerMessage counts_batch;
     try {
+      if (!getJobResponse.contains("counts_batch")) {
+        throw std::runtime_error("counts_batch field missing in results");
+      }
       counts_batch = getJobResponse["counts_batch"];
       if (counts_batch.is_null() || counts_batch.empty() ||
           counts_batch.type() != nlohmann::json::value_t::array ||

--- a/scripts/run_header_checks.sh
+++ b/scripts/run_header_checks.sh
@@ -43,7 +43,17 @@ for file in $cmakelists; do
   cp "$file"{,.tmp}
 done
 
-go install github.com/apache/skywalking-eyes/cmd/license-eye@latest
+# Pin the license-eye version. Using @latest means a new upstream release can
+# raise the required Go toolchain version and break the check without warning.
+license_eye_version=v0.9.0
+if ! go install github.com/apache/skywalking-eyes/cmd/license-eye@$license_eye_version; then
+  echo "Failed to install license-eye $license_eye_version." >&2
+  echo "It requires Go 1.25.3 or newer; installed: $(go version 2>/dev/null || echo none)." >&2
+  for file in $cmakelists; do
+    rm "$file".tmp
+  done
+  exit 1
+fi
 # Use GOPATH if set, otherwise default to ~/go (Go's default)
 "${GOPATH:-$HOME/go}/bin/license-eye" header $command
 status=$?


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/33040669400/job/98413636048#step:6:432

The counts artifact was fetched from a second host derived by stripping the "cocos." label out of IQM_SERVER_URL. That apex host serves no TLS certificate, so the nightly died with a handshake failure. 

The status response already contains counts_batch, so read it directly instead. Removes a round-trip per job.

Output
```
[2026-08-28 04:06:23.379] [info] [Future.cpp:34] Future got job retrieval path as https://cocos.resonance.meetiqm.com/pyrite:test/circuits/01a0468c-1f0c-7da2-8bee-ef87f204c47b/counts.
[2026-08-28 04:06:26.711] [info] [IQMServerHelper.cpp:324] Artifacts: [{"counts":{"0":491,"1":509},"measurement_keys":["m_QB1"],"mkeys2qubit":{"m_QB1":"QB1"}}]
[2026-08-28 04:06:26.711] [info] [IQMServerHelper.cpp:336] postJobResponse: [{"counts":{"0":491,"1":509},"measurement_keys":["m_QB1"],"mkeys2qubit":{"m_QB1":"QB1"}}]
```