### PR TITLE
Performance: Speed up phase-folding subcircuit discovery

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PhaseFolding.cpp
@@ -13,6 +13,7 @@
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -447,7 +448,8 @@ protected:
   // subcircuit; would be nice to turn them into local arguments instead
   SetVector<Value> termination_points;
   SetVector<Value> anchor_points;
-  SetVector<Value> seen;
+  // Only membership matters here. DenseSet avoids SetVector's linear erase.
+  DenseSet<Value> seen;
   DenseMap<Value, Value> scope_result_to_continue_operand;
 
   bool isTerminationPoint(Operation *op) {
@@ -574,8 +576,8 @@ protected:
       if (seen.contains(next))
         continue;
       calculateSubcircuitForQubitForward(next);
-      // Remove next from seen for working backwards
-      seen.remove(next);
+      // Revisit the anchor when walking backward.
+      seen.erase(next);
       calculateSubcircuitForQubitBackward(next);
     }
   }


### PR DESCRIPTION
Phase folding used `SetVector` to track visited wires. Removing anchors from this container repeatedly scanned a large vector. This changes the visited set to `DenseSet`.

On QSVT-12, total `PhaseFolding` time dropped from 24.0 to 5.3 seconds (78% reduction).