### PR TITLE
Performance: Avoid rewrite work in passes when no patterns can match

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/ConstantPropagation.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ConstantPropagation.cpp
@@ -223,6 +223,9 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     func::FuncOp func = getOperation();
+    if (!cudaq::opt::containsAnyOperation<cudaq::cc::LoadOp>(
+            func.getOperation()))
+      return;
     RewritePatternSet patterns(ctx);
     patterns.insert<ForwardSingleDimensionData, ForwardConstSubArray>(ctx);
 

--- a/cudaq/lib/Optimizer/Transforms/ConstantPropagation.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ConstantPropagation.cpp
@@ -223,7 +223,7 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     func::FuncOp func = getOperation();
-    if (!cudaq::opt::containsAnyOperation<cudaq::cc::LoadOp>(
+    if (!cudaq::opt::containsAnyOperationOfType<cudaq::cc::LoadOp>(
             func.getOperation()))
       return;
     RewritePatternSet patterns(ctx);

--- a/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
@@ -8,7 +8,8 @@
 
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace cudaq::opt {
@@ -21,72 +22,62 @@ namespace cudaq::opt {
 using namespace mlir;
 
 namespace {
-
-class CustomUnitaryPattern
-    : public OpRewritePattern<cudaq::quake::CustomUnitaryCallOp> {
-
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(cudaq::quake::CustomUnitaryCallOp customOp,
-                                PatternRewriter &rewriter) const override {
-
-    // Check if the generator associated with custom operation is a function. If
-    // not, it may already have been replaced.
-    auto generator = customOp.getGenerator();
-
-    auto parentModule = customOp->getParentOfType<ModuleOp>();
-    auto funcOp = parentModule.lookupSymbol<func::FuncOp>(generator);
-    if (!funcOp)
-      return failure();
-
-    funcOp.setPrivate();
-
-    // The generator function returns a concrete matrix. If prior passes have
-    // run to constant fold and lift array values, the generator function will
-    // have address of the global variable which holds the concrete matrix.
-    StringRef concreteMatrix;
-
-    funcOp.walk([&](cudaq::cc::AddressOfOp addrOp) {
-      concreteMatrix = addrOp.getGlobalName();
-    });
-
-    if (concreteMatrix.empty()) {
-      return customOp.emitError(
-          "Constant matrix corresponding to custom operation's generator "
-          "function not found in the module.");
-    }
-    // Modify the custom operation to use the global variable instead of the
-    // generator function.
-    auto ccGlobalOp =
-        parentModule.lookupSymbol<cudaq::cc::GlobalOp>(concreteMatrix);
-
-    if (ccGlobalOp) {
-      rewriter.replaceOpWithNewOp<cudaq::quake::CustomUnitaryConstantOp>(
-          customOp,
-          FlatSymbolRefAttr::get(parentModule.getContext(), concreteMatrix),
-          customOp.getIsAdj(), customOp.getParameters(), customOp.getControls(),
-          customOp.getTargets(), customOp.getNegatedQubitControlsAttr());
-      return success();
-    }
-    return failure();
-  }
-};
-
 class GetConcreteMatrixPass
     : public cudaq::opt::impl::GetConcreteMatrixBase<GetConcreteMatrixPass> {
 public:
   using GetConcreteMatrixBase::GetConcreteMatrixBase;
 
   void runOnOperation() override {
-    if (!cudaq::opt::containsAnyOperationOfType<
-            cudaq::quake::CustomUnitaryCallOp>(getOperation().getOperation()))
+    auto module = getOperation();
+    SmallVector<Operation *> candidates;
+    module.walk<WalkOrder::PreOrder>(
+        [&](cudaq::quake::CustomUnitaryCallOp customOp) {
+          candidates.push_back(customOp.getOperation());
+        });
+    if (candidates.empty())
       return;
-    auto *ctx = &getContext();
-    RewritePatternSet patterns(ctx);
-    patterns.insert<CustomUnitaryPattern>(ctx);
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
-      signalPassFailure();
+
+    IRRewriter rewriter(&getContext());
+    llvm::SmallPtrSet<Operation *, 4> convertedGenerators;
+    for (Operation *candidate : candidates) {
+      auto customOp = cast<cudaq::quake::CustomUnitaryCallOp>(candidate);
+      auto parentModule = customOp->getParentOfType<ModuleOp>();
+      auto generator =
+          parentModule.lookupSymbol<func::FuncOp>(customOp.getGenerator());
+      if (!generator)
+        continue;
+
+      rewriter.modifyOpInPlace(generator, [&] { generator.setPrivate(); });
+      StringRef concreteMatrix;
+      generator.walk([&](cudaq::cc::AddressOfOp address) {
+        concreteMatrix = address.getGlobalName();
+      });
+      if (concreteMatrix.empty()) {
+        customOp.emitError(
+            "Constant matrix corresponding to custom operation's generator "
+            "function not found in the module.");
+        continue;
+      }
+      if (!parentModule.lookupSymbol<cudaq::cc::GlobalOp>(concreteMatrix))
+        continue;
+
+      rewriter.setInsertionPoint(customOp);
+      rewriter.replaceOpWithNewOp<cudaq::quake::CustomUnitaryConstantOp>(
+          customOp,
+          FlatSymbolRefAttr::get(parentModule.getContext(), concreteMatrix),
+          customOp.getIsAdj(), customOp.getParameters(), customOp.getControls(),
+          customOp.getTargets(), customOp.getNegatedQubitControlsAttr());
+      convertedGenerators.insert(generator.getOperation());
+    }
+
+    SmallVector<Operation *> deadAddresses;
+    for (Operation *generator : convertedGenerators)
+      generator->walk([&](cudaq::cc::AddressOfOp address) {
+        if (address->use_empty())
+          deadAddresses.push_back(address.getOperation());
+      });
+    for (Operation *address : deadAddresses)
+      rewriter.eraseOp(address);
   }
 };
 

--- a/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
@@ -79,6 +79,9 @@ public:
   using GetConcreteMatrixBase::GetConcreteMatrixBase;
 
   void runOnOperation() override {
+    if (!cudaq::opt::containsAnyOperation<cudaq::quake::CustomUnitaryCallOp>(
+            getOperation().getOperation()))
+      return;
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.insert<CustomUnitaryPattern>(ctx);

--- a/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
@@ -29,6 +29,8 @@ public:
 
   void runOnOperation() override {
     auto module = getOperation();
+    // Replacing one of these calls never creates another, so the calls already
+    // present in the module are the complete worklist.
     SmallVector<Operation *> candidates;
     module.walk<WalkOrder::PreOrder>(
         [&](cudaq::quake::CustomUnitaryCallOp customOp) {
@@ -41,6 +43,8 @@ public:
     llvm::SmallPtrSet<Operation *, 4> convertedGenerators;
     for (Operation *candidate : candidates) {
       auto customOp = cast<cudaq::quake::CustomUnitaryCallOp>(candidate);
+      // Look up the generator from the call's nearest module. This matters when
+      // the pass root contains nested modules with their own symbol tables.
       auto parentModule = customOp->getParentOfType<ModuleOp>();
       auto generator =
           parentModule.lookupSymbol<func::FuncOp>(customOp.getGenerator());
@@ -70,6 +74,8 @@ public:
       convertedGenerators.insert(generator.getOperation());
     }
 
+    // A generator may be shared by several calls. Wait until every call has
+    // been handled before removing matrix addresses that no longer have users.
     SmallVector<Operation *> deadAddresses;
     for (Operation *generator : convertedGenerators)
       generator->walk([&](cudaq::cc::AddressOfOp address) {

--- a/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
@@ -79,8 +79,8 @@ public:
   using GetConcreteMatrixBase::GetConcreteMatrixBase;
 
   void runOnOperation() override {
-    if (!cudaq::opt::containsAnyOperation<cudaq::quake::CustomUnitaryCallOp>(
-            getOperation().getOperation()))
+    if (!cudaq::opt::containsAnyOperationOfType<
+            cudaq::quake::CustomUnitaryCallOp>(getOperation().getOperation()))
       return;
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);

--- a/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
-#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/MapVector.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -29,61 +29,68 @@ public:
 
   void runOnOperation() override {
     auto module = getOperation();
-    // Replacing one of these calls never creates another, so the calls already
-    // present in the module are the complete worklist.
-    SmallVector<Operation *> candidates;
+    // Collect all calls before walking any generator body. Replacing a call
+    // cannot create another candidate, so this snapshot is complete.
+    llvm::SmallMapVector<func::FuncOp,
+                         SmallVector<cudaq::quake::CustomUnitaryCallOp>, 4>
+        generatorWorklist;
     module.walk<WalkOrder::PreOrder>(
         [&](cudaq::quake::CustomUnitaryCallOp customOp) {
-          candidates.push_back(customOp.getOperation());
+          // Resolve the generator from the call's nearest module. This matters
+          // when the pass root contains nested modules with their own symbol
+          // tables.
+          auto parentModule = customOp->getParentOfType<ModuleOp>();
+          auto generator =
+              parentModule.lookupSymbol<func::FuncOp>(customOp.getGenerator());
+          if (!generator)
+            return;
+
+          generatorWorklist[generator].push_back(customOp);
         });
-    if (candidates.empty())
+    if (generatorWorklist.empty())
       return;
 
     IRRewriter rewriter(&getContext());
-    llvm::SmallPtrSet<Operation *, 4> convertedGenerators;
-    for (Operation *candidate : candidates) {
-      auto customOp = cast<cudaq::quake::CustomUnitaryCallOp>(candidate);
-      // Look up the generator from the call's nearest module. This matters when
-      // the pass root contains nested modules with their own symbol tables.
-      auto parentModule = customOp->getParentOfType<ModuleOp>();
-      auto generator =
-          parentModule.lookupSymbol<func::FuncOp>(customOp.getGenerator());
-      if (!generator)
-        continue;
-
+    for (auto &[generator, calls] : generatorWorklist) {
       rewriter.modifyOpInPlace(generator, [&] { generator.setPrivate(); });
       StringRef concreteMatrix;
+      SmallVector<cudaq::cc::AddressOfOp> addresses;
       generator.walk([&](cudaq::cc::AddressOfOp address) {
         concreteMatrix = address.getGlobalName();
+        addresses.push_back(address);
       });
-      if (concreteMatrix.empty()) {
-        customOp.emitError(
-            "Constant matrix corresponding to custom operation's generator "
-            "function not found in the module.");
-        continue;
+
+      bool hasConvertedCall = false;
+      for (cudaq::quake::CustomUnitaryCallOp customOp : calls) {
+        if (concreteMatrix.empty()) {
+          customOp.emitError(
+              "Constant matrix corresponding to custom operation's generator "
+              "function not found in the module.");
+          continue;
+        }
+
+        auto parentModule = customOp->getParentOfType<ModuleOp>();
+        if (!parentModule.lookupSymbol<cudaq::cc::GlobalOp>(concreteMatrix))
+          continue;
+
+        rewriter.setInsertionPoint(customOp);
+        rewriter.replaceOpWithNewOp<cudaq::quake::CustomUnitaryConstantOp>(
+            customOp,
+            FlatSymbolRefAttr::get(parentModule.getContext(), concreteMatrix),
+            customOp.getIsAdj(), customOp.getParameters(),
+            customOp.getControls(), customOp.getTargets(),
+            customOp.getNegatedQubitControlsAttr());
+        hasConvertedCall = true;
       }
-      if (!parentModule.lookupSymbol<cudaq::cc::GlobalOp>(concreteMatrix))
-        continue;
 
-      rewriter.setInsertionPoint(customOp);
-      rewriter.replaceOpWithNewOp<cudaq::quake::CustomUnitaryConstantOp>(
-          customOp,
-          FlatSymbolRefAttr::get(parentModule.getContext(), concreteMatrix),
-          customOp.getIsAdj(), customOp.getParameters(), customOp.getControls(),
-          customOp.getTargets(), customOp.getNegatedQubitControlsAttr());
-      convertedGenerators.insert(generator.getOperation());
+      // A generator may be shared by several calls. Wait until every call has
+      // been handled before removing matrix addresses that no longer have
+      // users.
+      if (hasConvertedCall)
+        for (cudaq::cc::AddressOfOp address : addresses)
+          if (address->use_empty())
+            rewriter.eraseOp(address);
     }
-
-    // A generator may be shared by several calls. Wait until every call has
-    // been handled before removing matrix addresses that no longer have users.
-    SmallVector<Operation *> deadAddresses;
-    for (Operation *generator : convertedGenerators)
-      generator->walk([&](cudaq::cc::AddressOfOp address) {
-        if (address->use_empty())
-          deadAddresses.push_back(address.getOperation());
-      });
-    for (Operation *address : deadAddresses)
-      rewriter.eraseOp(address);
   }
 };
 

--- a/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -337,16 +337,37 @@ public:
     // Make the unchecked assumption that a ConstArrayOp was added by the
     // LiftArrayAlloc pass. This assumption means that the backing store of the
     // ConstArrayOp has been checked that it is never written to.
-    RewritePatternSet patterns(ctx);
     unsigned counter = 0;
-    patterns.insert<ReifySpanPattern, ConstantArrayPattern>(ctx, module,
-                                                            counter);
     LLVM_DEBUG(llvm::dbgs() << "Before globalizing array values:\n"
                             << module << '\n');
-    if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
+
+    SmallVector<Operation *> reifyRoots;
+    module.walk<WalkOrder::PreOrder>([&](cudaq::cc::ReifySpanOp reify) {
+      reifyRoots.push_back(reify.getOperation());
+    });
+    GreedyRewriteConfig config;
+    config.setScope(&module.getBodyRegion())
+        .setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
+    RewritePatternSet reifyPatterns(ctx);
+    reifyPatterns.insert<ReifySpanPattern>(ctx, module, counter);
+    if (failed(applyOpPatternsGreedily(reifyRoots, std::move(reifyPatterns),
+                                       config))) {
       signalPassFailure();
       return;
     }
+
+    SmallVector<Operation *> constantArrayRoots;
+    module.walk<WalkOrder::PreOrder>([&](cudaq::cc::ConstantArrayOp array) {
+      constantArrayRoots.push_back(array.getOperation());
+    });
+    RewritePatternSet constantArrayPatterns(ctx);
+    constantArrayPatterns.insert<ConstantArrayPattern>(ctx, module, counter);
+    if (failed(applyOpPatternsGreedily(
+            constantArrayRoots, std::move(constantArrayPatterns), config))) {
+      signalPassFailure();
+      return;
+    }
+
     LLVM_DEBUG(llvm::dbgs() << "After globalizing array values:\n"
                             << module << '\n');
   }

--- a/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -329,6 +329,10 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     ModuleOp module = getOperation();
+    if (!cudaq::opt::containsAnyOperation<cudaq::cc::ConstantArrayOp,
+                                          cudaq::cc::ReifySpanOp>(
+            module.getOperation()))
+      return;
 
     // Make the unchecked assumption that a ConstArrayOp was added by the
     // LiftArrayAlloc pass. This assumption means that the backing store of the

--- a/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -334,18 +334,22 @@ public:
             module.getOperation()))
       return;
 
-    // Make the unchecked assumption that a ConstArrayOp was added by the
-    // LiftArrayAlloc pass. This assumption means that the backing store of the
-    // ConstArrayOp has been checked that it is never written to.
+    // LiftArrayAlloc has already checked that these constant arrays are not
+    // modified, so this pass does not repeat the write analysis.
     unsigned counter = 0;
     LLVM_DEBUG(llvm::dbgs() << "Before globalizing array values:\n"
                             << module << '\n');
 
+    // Rewrite spans first because a constant array used by cc.reify_span is not
+    // yet eligible for ConstantArrayPattern. Recollect the arrays afterward,
+    // since removing a span can make its source array eligible.
     SmallVector<Operation *> reifyRoots;
     module.walk<WalkOrder::PreOrder>([&](cudaq::cc::ReifySpanOp reify) {
       reifyRoots.push_back(reify.getOperation());
     });
     GreedyRewriteConfig config;
+    // Keep operations created by these roots on the worklist without adding
+    // unrelated operations that were already in the module.
     config.setScope(&module.getBodyRegion())
         .setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
     RewritePatternSet reifyPatterns(ctx);

--- a/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -329,8 +329,8 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     ModuleOp module = getOperation();
-    if (!cudaq::opt::containsAnyOperation<cudaq::cc::ConstantArrayOp,
-                                          cudaq::cc::ReifySpanOp>(
+    if (!cudaq::opt::containsAnyOperationOfType<cudaq::cc::ConstantArrayOp,
+                                                cudaq::cc::ReifySpanOp>(
             module.getOperation()))
       return;
 

--- a/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
@@ -9,6 +9,8 @@
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
@@ -27,6 +29,61 @@ using namespace mlir;
 #include "LiftArrayAllocPatterns.inc"
 
 namespace {
+static void collectDefiningOps(Value value,
+                               llvm::SmallPtrSetImpl<Operation *> &seen,
+                               SmallVectorImpl<Operation *> &candidates) {
+  Operation *definingOp = value.getDefiningOp();
+  if (!definingOp || seen.contains(definingOp))
+    return;
+
+  SmallVector<std::pair<Operation *, bool>, 16> worklist;
+  worklist.emplace_back(definingOp, false);
+  while (!worklist.empty()) {
+    auto [op, expanded] = worklist.pop_back_val();
+    if (expanded) {
+      candidates.push_back(op);
+      continue;
+    }
+    if (!seen.insert(op).second)
+      continue;
+    worklist.emplace_back(op, true);
+    for (Value operand : llvm::reverse(op->getOperands()))
+      if (Operation *producer = operand.getDefiningOp())
+        if (!seen.contains(producer))
+          worklist.emplace_back(producer, false);
+  }
+}
+
+static SmallVector<Operation *>
+collectAllocationCandidates(func::FuncOp func, bool includeMemoryOps) {
+  SmallVector<Operation *> candidates;
+  llvm::SmallPtrSet<Operation *, 16> seen;
+  auto addCandidate = [&](Operation *op) {
+    if (seen.insert(op).second)
+      candidates.push_back(op);
+  };
+
+  func.walk([&](cudaq::cc::AllocaOp alloc) {
+    for (Operation *pointerOp : alloc->getUsers()) {
+      if (!isa<cudaq::cc::CastOp, cudaq::cc::ComputePtrOp>(pointerOp))
+        continue;
+      if (includeMemoryOps)
+        addCandidate(pointerOp);
+      for (Operation *user : pointerOp->getUsers()) {
+        auto store = dyn_cast<cudaq::cc::StoreOp>(user);
+        if (!store)
+          continue;
+        collectDefiningOps(store.getValue(), seen, candidates);
+        if (includeMemoryOps)
+          addCandidate(store);
+      }
+    }
+    if (includeMemoryOps)
+      addCandidate(alloc);
+  });
+  return candidates;
+}
+
 class LiftArrayAllocPass
     : public cudaq::opt::impl::LiftArrayAllocBase<LiftArrayAllocPass> {
 public:
@@ -35,9 +92,30 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     auto func = getOperation();
-    if (!cudaq::opt::containsAnyOperationOfType<cudaq::cc::AllocaOp>(
-            func.getOperation()))
+    SmallVector<Operation *> initializerOps =
+        collectAllocationCandidates(func, false);
+    SmallVector<Operation *> candidates =
+        collectAllocationCandidates(func, true);
+    if (candidates.empty())
       return;
+
+    GreedyRewriteConfig config;
+    config.setScope(&func.getBody())
+        .setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
+
+    // The region driver folded initializer expressions before retrying the
+    // allocation pattern. Preserve that phase ordering without scanning ops
+    // unrelated to an allocation.
+    if (!initializerOps.empty()) {
+      RewritePatternSet foldingPatterns(ctx);
+      if (failed(applyOpPatternsGreedily(initializerOps,
+                                         std::move(foldingPatterns), config))) {
+        signalPassFailure();
+        return;
+      }
+      candidates = collectAllocationCandidates(func, true);
+    }
+
     DominanceInfo domInfo(func);
     StringRef funcName = func.getName();
     RewritePatternSet patterns(ctx);
@@ -46,7 +124,8 @@ public:
     LLVM_DEBUG(llvm::dbgs()
                << "Before lifting constant array: " << func << '\n');
 
-    if (failed(applyPatternsGreedily(func, std::move(patterns))))
+    if (failed(
+            applyOpPatternsGreedily(candidates, std::move(patterns), config)))
       signalPassFailure();
 
     LLVM_DEBUG(llvm::dbgs()

--- a/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
@@ -35,7 +35,7 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     auto func = getOperation();
-    if (!cudaq::opt::containsAnyOperation<cudaq::cc::AllocaOp>(
+    if (!cudaq::opt::containsAnyOperationOfType<cudaq::cc::AllocaOp>(
             func.getOperation()))
       return;
     DominanceInfo domInfo(func);

--- a/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
@@ -35,6 +35,9 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     auto func = getOperation();
+    if (!cudaq::opt::containsAnyOperation<cudaq::cc::AllocaOp>(
+            func.getOperation()))
+      return;
     DominanceInfo domInfo(func);
     StringRef funcName = func.getName();
     RewritePatternSet patterns(ctx);

--- a/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
@@ -29,6 +29,9 @@ using namespace mlir;
 #include "LiftArrayAllocPatterns.inc"
 
 namespace {
+// Collect the initializer slice in producer-before-consumer order so each
+// stored value can be folded. Use an explicit stack because generated
+// initializer chains can be very deep.
 static void collectDefiningOps(Value value,
                                llvm::SmallPtrSetImpl<Operation *> &seen,
                                SmallVectorImpl<Operation *> &candidates) {
@@ -103,9 +106,9 @@ public:
     config.setScope(&func.getBody())
         .setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
 
-    // The region driver folded initializer expressions before retrying the
-    // allocation pattern. Preserve that phase ordering without scanning ops
-    // unrelated to an allocation.
+    // AllocaPattern requires each stored value to be a direct constant. Fold
+    // the initializer slices first, then rebuild the candidate set because
+    // folding may replace or erase operations collected above.
     if (!initializerOps.empty()) {
       RewritePatternSet foldingPatterns(ctx);
       if (failed(applyOpPatternsGreedily(initializerOps,

--- a/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
@@ -57,8 +57,8 @@ static void collectDefiningOps(Value value,
   }
 }
 
-static SmallVector<Operation *>
-collectAllocationCandidates(func::FuncOp func, bool includeMemoryOps) {
+template <bool includeMemoryOps>
+static SmallVector<Operation *> collectAllocationCandidates(func::FuncOp func) {
   SmallVector<Operation *> candidates;
   llvm::SmallPtrSet<Operation *, 16> seen;
   auto addCandidate = [&](Operation *op) {
@@ -70,18 +70,18 @@ collectAllocationCandidates(func::FuncOp func, bool includeMemoryOps) {
     for (Operation *pointerOp : alloc->getUsers()) {
       if (!isa<cudaq::cc::CastOp, cudaq::cc::ComputePtrOp>(pointerOp))
         continue;
-      if (includeMemoryOps)
+      if constexpr (includeMemoryOps)
         addCandidate(pointerOp);
       for (Operation *user : pointerOp->getUsers()) {
         auto store = dyn_cast<cudaq::cc::StoreOp>(user);
         if (!store)
           continue;
         collectDefiningOps(store.getValue(), seen, candidates);
-        if (includeMemoryOps)
+        if constexpr (includeMemoryOps)
           addCandidate(store);
       }
     }
-    if (includeMemoryOps)
+    if constexpr (includeMemoryOps)
       addCandidate(alloc);
   });
   return candidates;
@@ -96,9 +96,9 @@ public:
     auto *ctx = &getContext();
     auto func = getOperation();
     SmallVector<Operation *> initializerOps =
-        collectAllocationCandidates(func, false);
+        collectAllocationCandidates<false>(func);
     SmallVector<Operation *> candidates =
-        collectAllocationCandidates(func, true);
+        collectAllocationCandidates<true>(func);
     if (candidates.empty())
       return;
 
@@ -116,7 +116,7 @@ public:
         signalPassFailure();
         return;
       }
-      candidates = collectAllocationCandidates(func, true);
+      candidates = collectAllocationCandidates<true>(func);
     }
 
     DominanceInfo domInfo(func);

--- a/cudaq/lib/Optimizer/Transforms/PassDetails.h
+++ b/cudaq/lib/Optimizer/Transforms/PassDetails.h
@@ -12,6 +12,7 @@
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "llvm/Support/Casting.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
@@ -19,8 +20,21 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/Visitors.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
+
+namespace cudaq::opt {
+template <typename... OpTypes>
+bool containsAnyOperation(mlir::Operation *root) {
+  return root
+      ->walk([](mlir::Operation *operation) {
+        return llvm::isa<OpTypes...>(operation) ? mlir::WalkResult::interrupt()
+                                                : mlir::WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+} // namespace cudaq::opt
 
 #define GATE_OPS(MACRO)                                                        \
   MACRO(XOp), MACRO(YOp), MACRO(ZOp), MACRO(HOp), MACRO(SOp), MACRO(TOp),      \

--- a/cudaq/lib/Optimizer/Transforms/PassDetails.h
+++ b/cudaq/lib/Optimizer/Transforms/PassDetails.h
@@ -25,6 +25,8 @@
 #include "mlir/Pass/PassRegistry.h"
 
 namespace cudaq::opt {
+/// \returns true when \p root or a nested operation has one of the types in
+/// `OpTypes`. The walk stops after the first matching operation.
 template <typename... OpTypes>
 bool containsAnyOperationOfType(mlir::Operation *root) {
   return root

--- a/cudaq/lib/Optimizer/Transforms/PassDetails.h
+++ b/cudaq/lib/Optimizer/Transforms/PassDetails.h
@@ -26,7 +26,7 @@
 
 namespace cudaq::opt {
 template <typename... OpTypes>
-bool containsAnyOperation(mlir::Operation *root) {
+bool containsAnyOperationOfType(mlir::Operation *root) {
   return root
       ->walk([](mlir::Operation *operation) {
         return llvm::isa<OpTypes...>(operation) ? mlir::WalkResult::interrupt()

--- a/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
@@ -140,13 +140,24 @@ public:
   using PyFrontendCleanupBase::PyFrontendCleanupBase;
 
   void runOnOperation() override {
-    if (!cudaq::opt::containsAnyOperationOfType<cudaq::quake::VeqSizeOp>(
-            getOperation().getOperation()))
+    auto func = getOperation();
+    SmallVector<Operation *> candidates;
+    func.walk([&](cudaq::quake::VeqSizeOp op) {
+      candidates.push_back(op.getOperation());
+    });
+    if (candidates.empty())
       return;
+
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<HoistVeqSizeThroughIfPattern>(ctx);
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+    // Hoisting can only expose another match by creating a branch-local
+    // `quake.veq_size`, so existing and newly created roots close the worklist.
+    GreedyRewriteConfig config;
+    config.setScope(&func.getBody())
+        .setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
+    if (failed(
+            applyOpPatternsGreedily(candidates, std::move(patterns), config)))
       signalPassFailure();
   }
 };

--- a/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
@@ -151,8 +151,10 @@ public:
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<HoistVeqSizeThroughIfPattern>(ctx);
-    // Hoisting can only expose another match by creating a branch-local
-    // `quake.veq_size`, so existing and newly created roots close the worklist.
+    // Hoisting an outer size query creates new size queries inside its
+    // branches. Keep those new operations on the worklist so nested
+    // conditionals are handled without scanning unrelated operations in the
+    // function.
     GreedyRewriteConfig config;
     config.setScope(&func.getBody())
         .setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);

--- a/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
@@ -140,6 +140,9 @@ public:
   using PyFrontendCleanupBase::PyFrontendCleanupBase;
 
   void runOnOperation() override {
+    if (!cudaq::opt::containsAnyOperation<cudaq::quake::VeqSizeOp>(
+            getOperation().getOperation()))
+      return;
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<HoistVeqSizeThroughIfPattern>(ctx);

--- a/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
+++ b/cudaq/lib/Optimizer/Transforms/PyFrontendCleanup.cpp
@@ -140,7 +140,7 @@ public:
   using PyFrontendCleanupBase::PyFrontendCleanupBase;
 
   void runOnOperation() override {
-    if (!cudaq::opt::containsAnyOperation<cudaq::quake::VeqSizeOp>(
+    if (!cudaq::opt::containsAnyOperationOfType<cudaq::quake::VeqSizeOp>(
             getOperation().getOperation()))
       return;
     auto *ctx = &getContext();

--- a/cudaq/lib/Optimizer/Transforms/StatePreparation.cpp
+++ b/cudaq/lib/Optimizer/Transforms/StatePreparation.cpp
@@ -444,6 +444,11 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     func::FuncOp func = getOperation();
+    if (!cudaq::opt::containsAnyOperation<cudaq::quake::InitializeStateOp,
+                                          cudaq::quake::GetNumberOfQubitsOp,
+                                          cudaq::quake::DeleteStateOp>(
+            func.getOperation()))
+      return;
 
     LLVM_DEBUG(llvm::dbgs() << "Function before state preparation:\n"
                             << func << "\n\n");

--- a/cudaq/lib/Optimizer/Transforms/StatePreparation.cpp
+++ b/cudaq/lib/Optimizer/Transforms/StatePreparation.cpp
@@ -444,10 +444,9 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     func::FuncOp func = getOperation();
-    if (!cudaq::opt::containsAnyOperation<cudaq::quake::InitializeStateOp,
-                                          cudaq::quake::GetNumberOfQubitsOp,
-                                          cudaq::quake::DeleteStateOp>(
-            func.getOperation()))
+    if (!cudaq::opt::containsAnyOperationOfType<
+            cudaq::quake::InitializeStateOp, cudaq::quake::GetNumberOfQubitsOp,
+            cudaq::quake::DeleteStateOp>(func.getOperation()))
       return;
 
     LLVM_DEBUG(llvm::dbgs() << "Function before state preparation:\n"

--- a/docs/sphinx/using/extending/compiler/mlir_pass.rst
+++ b/docs/sphinx/using/extending/compiler/mlir_pass.rst
@@ -206,6 +206,9 @@ conditions.
 Choose the MLIR transformation mechanism
 ========================================
 
+Return early when a pass can cheaply determine that it has no work to do,
+especially on large circuits.
+
 Use an operation's fold hook or canonicalization patterns for a local canonical
 form that is valid whenever the operation appears. For example, the
 ``cc.cast`` canonicalizer removes a cast when its operand and result have the

--- a/docs/sphinx/using/extending/compiler/mlir_pass.rst
+++ b/docs/sphinx/using/extending/compiler/mlir_pass.rst
@@ -241,10 +241,12 @@ how its run time scales. Measure the pass on its own and in the compiler
 pipelines that use it. The following practices can help keep pass time under
 control:
 
-- **Avoid unnecessary work.** For example, ``Operation::walk`` with
-  ``WalkResult::interrupt`` can stop when it finds a known root operation.
-  ``applyOpPatternsGreedily`` can limit the initial ``worklist`` to candidate
-  operations when doing so preserves the required rewrite behavior.
+- **Avoid unnecessary greedy rewrite work.** If a pass uses
+  ``applyPatternsGreedily`` across an entire region, consider passing an
+  initial ``worklist`` of matching operations to ``applyOpPatternsGreedily``. Do
+  this only when it preserves the required folding and newly exposed matches.
+  Otherwise, keep the region-wide driver and use
+  ``containsAnyOperationOfType`` to skip it when no patterns can match.
 
 - **Choose a rewrite driver that matches the transformation.**
   ``walkAndApplyPatterns`` can suit independent rewrites that need only one
@@ -260,7 +262,8 @@ control:
 Use ``--mlir-timing`` and CUDA-Q compiler traces to identify slow passes. If a
 pass has several stages, add focused trace spans to find where time is spent.
 Test inputs with different sizes and numbers of matching operations, verify that
-the output is unchanged, and check the effect on full compiler time.
+the required transformation behavior is preserved, and check the effect on
+full compiler time.
 
 Implement and register a built-in pass
 ======================================

--- a/docs/sphinx/using/extending/compiler/mlir_pass.rst
+++ b/docs/sphinx/using/extending/compiler/mlir_pass.rst
@@ -206,9 +206,6 @@ conditions.
 Choose the MLIR transformation mechanism
 ========================================
 
-Return early when a pass can cheaply determine that it has no work to do,
-especially on large circuits.
-
 Use an operation's fold hook or canonicalization patterns for a local canonical
 form that is valid whenever the operation appears. For example, the
 ``cc.cast`` canonicalizer removes a cast when its operand and result have the
@@ -235,6 +232,35 @@ central type switch. Use a dedicated operation pass when the work must be
 scheduled in a pipeline, expose options, emit diagnostics, or coordinate a
 bounded set of rewrites, conversions, and analyses. These mechanisms are often
 components of the pass rather than alternatives to it.
+
+Pass performance
+================
+
+When developing a pass, benchmark it on inputs of increasing size to understand
+how its run time scales. Measure the pass on its own and in the compiler
+pipelines that use it. The following practices can help keep pass time under
+control:
+
+- **Avoid unnecessary work.** For example, ``Operation::walk`` with
+  ``WalkResult::interrupt`` can stop when it finds a known root operation.
+  ``applyOpPatternsGreedily`` can limit the initial ``worklist`` to candidate
+  operations when doing so preserves the required rewrite behavior.
+
+- **Choose a rewrite driver that matches the transformation.**
+  ``walkAndApplyPatterns`` can suit independent rewrites that need only one
+  visit. ``applyPatternsGreedily`` is appropriate when rewrites expose further
+  matches or the pass relies on folding or region simplification.
+
+- **Reduce repeated traversal and bookkeeping.** Use SSA use-def chains, local
+  indexes, or batched analysis when a pass would otherwise scan the same IR for
+  each candidate. When mutation invalidates information needed by later
+  queries, collect decisions before applying rewrites. Use data structures that
+  make the pass's common operations inexpensive.
+
+Use ``--mlir-timing`` and CUDA-Q compiler traces to identify slow passes. If a
+pass has several stages, add focused trace spans to find where time is spent.
+Test inputs with different sizes and numbers of matching operations, verify that
+the output is unchanged, and check the effect on full compiler time.
 
 Implement and register a built-in pass
 ======================================


### PR DESCRIPTION
Six passes currently invoke MLIR's greedy rewrite driver
even when the IR contains none of the operation types their patterns can
match. On large modules, that turns a pass with no relevant work into a full IR
traversal.

This change gives those passes a small typed check. It walks the IR
once, stops at the first relevant operation, and returns early when there is no
possible pattern root. If a matching op is present, the pass runs exactly as it did
before.

I've applied this to:

- `LiftArrayAlloc`
- `GlobalizeArrayValues`
- `PyFrontendCleanup`
- `GetConcreteMatrix`
- `ConstantPropagation`
- `StatePreparation`

## Performance

Benchmarking results a fixed number of operations:

| Gates | Baseline pass time | New pass time | Time saved | Reduction | Speedup | Baseline process wall | New process wall |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 500,000 | 5.7525 s | 1.7238 s | 4.0287 s | 70.0% | 3.34x | 8.73 s | 4.42 s |
| 1,000,000 | 12.8370 s | 2.9031 s | 9.9339 s | 77.4% | 4.42x | 18.83 s | 8.03 s |
| 1,500,000 | 20.4164 s | 7.5225 s | 12.8939 s | 63.2% | 2.71x | 31.29 s | 20.50 s |

At 1.5 million gates, every individual pass spent substantially less time:

| Pass | Baseline | New | Time saved | Reduction | Speedup |
|---|---:|---:|---:|---:|---:|
| `LiftArrayAlloc` | 2.1607 s | 0.5827 s | 1.5780 s | 73.0% | 3.71x |
| `GlobalizeArrayValues` | 2.3258 s | 0.5546 s | 1.7712 s | 76.2% | 4.19x |
| `PyFrontendCleanup` | 2.1621 s | 0.4843 s | 1.6778 s | 77.6% | 4.46x |
| `GetConcreteMatrix` | 2.5007 s | 0.7070 s | 1.7937 s | 71.7% | 3.54x |
| `ConstantPropagation` | 2.6656 s | 0.7523 s | 1.9133 s | 71.8% | 3.54x |
| `StatePreparation` | 3.2388 s | 1.1060 s | 2.1328 s | 65.9% | 2.93x |
