### PR TITLE
Performance: Speed up noise and QEC erasure passes

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/EraseNoise.cpp
+++ b/cudaq/lib/Optimizer/Transforms/EraseNoise.cpp
@@ -10,8 +10,8 @@
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 namespace cudaq::opt {
 #define GEN_PASS_DEF_ERASENOISE
@@ -48,8 +48,9 @@ public:
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.insert<EraseApplyNoisePattern>(ctx);
-    if (failed(applyPatternsGreedily(op, std::move(patterns))))
-      signalPassFailure();
+    PatternRewriter rewriter(ctx);
+    (void)eraseUnreachableBlocks(rewriter, op->getRegions());
+    walkAndApplyPatterns(op, FrozenRewritePatternSet(std::move(patterns)));
     LLVM_DEBUG(llvm::dbgs() << "After erasure:\n" << *op << "\n\n");
   }
 };

--- a/cudaq/lib/Optimizer/Transforms/EraseQEC.cpp
+++ b/cudaq/lib/Optimizer/Transforms/EraseQEC.cpp
@@ -10,7 +10,8 @@
 #include "cudaq/Optimizer/Dialect/QEC/QECOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 namespace cudaq::opt {
 #define GEN_PASS_DEF_ERASEQEC
@@ -51,8 +52,9 @@ public:
     patterns.insert<EraseQECOpPattern<cudaq::qec::DetectorOp>,
                     EraseQECOpPattern<cudaq::qec::ObservableOp>,
                     EraseQECOpPattern<cudaq::qec::DetectorsOp>>(ctx);
-    if (failed(applyPatternsGreedily(op, std::move(patterns))))
-      signalPassFailure();
+    PatternRewriter rewriter(ctx);
+    (void)eraseUnreachableBlocks(rewriter, op->getRegions());
+    walkAndApplyPatterns(op, FrozenRewritePatternSet(std::move(patterns)));
     LLVM_DEBUG(llvm::dbgs() << "After QEC erasure:\n" << *op << "\n\n");
   }
 };


### PR DESCRIPTION
Replace the greedy rewrite driver in EraseNoise and EraseQEC with MLIR's linear `walkAndApplyPatterns` driver. The existing erase-only patterns remain unchanged.

The greedy rewrite driver is designed for transformations where one rewrite can expose another. It maintains a worklist, performs folding and region cleanup, and continues until the IR stops changing. These passes are simpler because deleting a noise or QEC marker cannot make another operation match. A single walk can therefore erase every marker without repeatedly revisiting the IR. 

Unreachable blocks are removed first because the walk skips them, preserving the previous cleanup behavior.


## Performance

Median subprocess wall time after one warmup and three measured runs. For a benchmark sweeping the number of quantum operations in the kernel. 

| Gates | Pass | Before | After | Reduction | Speedup |
|---:|---|---:|---:|---:|---:|
| 100,000 | EraseNoise | 0.37 s | 0.32 s | 13.5% | 1.16x |
| 100,000 | EraseQEC | 0.58 s | 0.46 s | 20.7% | 1.26x |
| 500,000 | EraseNoise | 3.21 s | 2.49 s | 22.4% | 1.29x |
| 500,000 | EraseQEC | 2.87 s | 1.64 s | 42.9% | 1.75x |
| 1,000,000 | EraseNoise | 6.18 s | 5.14 s | 16.8% | 1.20x |
| 1,000,000 | EraseQEC | 6.49 s | 3.48 s | 46.4% | 1.86x |
| 1,500,000 | EraseNoise | 6.31 s | 6.29 s | 0.3% | 1.00x |
| 1,500,000 | EraseQEC | 13.38 s | 9.61 s | 28.2% | 1.39x |
