### PR TITLE
[test] Add host architecture features for lit REQUIRES

### DIFF
--- a/cudaq/test/AST-Quake/calling_convention-aarch64.cpp
+++ b/cudaq/test/AST-Quake/calling_convention-aarch64.cpp
@@ -7,8 +7,8 @@
  ******************************************************************************/
 
 // This test is only valid for aarch64.
-// RUN: if [ `uname -m` = "aarch64" ] ; then \
-// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s ; fi
+// REQUIRES: host-aarch64
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
 
 #include <cudaq.h>
 #include <tuple>

--- a/cudaq/test/AST-Quake/calling_convention.cpp
+++ b/cudaq/test/AST-Quake/calling_convention.cpp
@@ -7,8 +7,8 @@
  ******************************************************************************/
 
 // This test is only valid for x86_64.
-// RUN: if [ `uname -m` = "x86_64" ] ; then \
-// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s ; fi
+// REQUIRES: host-x86_64
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
 
 #include <cudaq.h>
 #include <tuple>

--- a/cudaq/test/lit.cfg.py
+++ b/cudaq/test/lit.cfg.py
@@ -8,6 +8,7 @@
 
 import os
 import bisect
+import platform
 
 import lit.formats
 import lit.util
@@ -48,6 +49,14 @@ llvm_config.feature_config([('--assertion-mode', {'ON': 'asserts'})])
 config.targets = frozenset(config.targets_to_build.split())
 for arch in config.targets_to_build.split():
     config.available_features.add(arch.lower() + '-registered-target')
+
+# Host architecture, for tests that only run on one. Not the same as the
+# `<arch>-registered-target` features above, which name LLVM's codegen targets
+# rather than the host. arm64 (Apple silicon) is normalized to aarch64, so a
+# test needs only one REQUIRES line.
+host_arch = platform.machine().lower()
+host_arch = {'arm64': 'aarch64'}.get(host_arch, host_arch)
+config.available_features.add('host-' + host_arch)
 
 # Exclude a list of directories from the test suite:
 #   - 'Inputs' contain auxiliary inputs for various tests.

--- a/python/tests/mlir/lit.cfg.py
+++ b/python/tests/mlir/lit.cfg.py
@@ -7,6 +7,7 @@
 # ============================================================================ #
 
 import os
+import platform
 import subprocess
 import lit.formats
 import lit.util
@@ -41,6 +42,14 @@ llvm_config.feature_config([('--assertion-mode', {'ON': 'asserts'})])
 config.targets = frozenset(config.targets_to_build.split())
 for arch in config.targets_to_build.split():
     config.available_features.add(arch.lower() + '-registered-target')
+
+# Host architecture, for tests that only run on one. Not the same as the
+# `<arch>-registered-target` features above, which name LLVM's codegen targets
+# rather than the host. arm64 (Apple silicon) is normalized to aarch64, so a
+# test needs only one REQUIRES line.
+host_arch = platform.machine().lower()
+host_arch = {'arm64': 'aarch64'}.get(host_arch, host_arch)
+config.available_features.add('host-' + host_arch)
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent

--- a/targettests/lit.cfg.py
+++ b/targettests/lit.cfg.py
@@ -49,6 +49,14 @@ config.targets = frozenset(config.targets_to_build.split())
 for arch in config.targets_to_build.split():
     config.available_features.add(arch.lower() + '-registered-target')
 
+# Host architecture, for tests that only run on one. Not the same as the
+# `<arch>-registered-target` features above, which name LLVM's codegen targets
+# rather than the host. arm64 (Apple silicon) is normalized to aarch64, so a
+# test needs only one REQUIRES line.
+host_arch = platform.machine().lower()
+host_arch = {'arm64': 'aarch64'}.get(host_arch, host_arch)
+config.available_features.add('host-' + host_arch)
+
 # The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 


### PR DESCRIPTION
Closes #2276.

### What this does

Registers a `host-<arch>` lit feature in the three lit configurations
(`cudaq/test`, `targettests`, `python/tests/mlir`) so that a test which is only
valid on one architecture can say so with `REQUIRES:`, and converts the two
existing calling convention tests to use such.

The feature comes from `platform.machine()`, normalized so that Apple silicon
(`arm64`) and Linux (`aarch64`) produce the same spelling and a test only needs
one `REQUIRES` line.

### Why

The two calling convention tests currently gate themselves with a shell
conditional in the RUN line:

```
// RUN: if [ `uname -m` = "aarch64" ] ; then \
// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s ; fi
```

When architecture does not match, test is not skipped, but passed.
Running the aarch64 test on an x86_64 host with `llvm-lit -a`:

```
RUN: at line 10: if [ `uname -m` = "aarch64" ] ; then  cudaq-quake ... | FileCheck ... ; fi
++ uname -m
+ '[' x86_64 = aarch64 ']'
```

Bracket is false, the block exits 0, FileCheck never runs, and lit reports
PASS. So each of these two tests pass while checking nothing on the
runner for the other architecture, thus a calling convention regression is
invisible there. That is also the `if` referenced from the CI link in the
issue.

### Before and after

On an x86_64 host, running just these two tests:

```
# before
PASS: CUDAQ :: AST-Quake/calling_convention-aarch64.cpp
PASS: CUDAQ :: AST-Quake/calling_convention.cpp

# after
UNSUPPORTED: CUDAQ :: AST-Quake/calling_convention-aarch64.cpp
PASS: CUDAQ :: AST-Quake/calling_convention.cpp
```

### Testing

Full `ctest` run on x86_64 (Ubuntu 24.04, gcc 13.3, CUDA 12.9, single GPU):
2268 passed, 2 failed, out of 2270. Both failures are
`CuStateVecEx.HostMigrationLarge` and `CuStateVecEx.HostMigrationExpectation`,
which carry the `large_memory_required` label and fail with "State vector
exceeds configured GPU and CPU memory." on this machine. They fail identically
on an unmodified checkout, so they are unrelated to this change. Excluding that
label the run is clean. The suite numbers above were collected at 28e8434; this
branch rebases onto current main without touching any file changed since, so the
diff CI sees is the diff those numbers describe.

To confirm the new feature actually gates rather than being ignored, I checked
both directions in all three suites: a test requiring the host architecture
runs, and a test requiring the other architecture is reported unsupported
rather than executed. For the two suites that have no arch-specific test yet, I
did this with temporary probe files whose RUN line was `false`, so they would
have failed loudly if the gate had not held. I also confirmed the surviving
x86_64 test is not vacuous by corrupting one of its CHECK lines and seeing it
fail.

What I could not test: I only have x86_64 hardware, so I cannot verify that
`calling_convention-aarch64.cpp` passes on aarch64. It is now reported
unsupported off-aarch64 instead of silently passing, which is the behavior the
issue asks for, but the arm64 CI leg is the first thing that will actually
execute its CHECK lines. Given the test has been vacuous since it was added,
that run is worth watching.

### Notes

The naming (`host-x86_64`, `host-aarch64`) is the one open question. The tree
already has three partial spellings. `<arch>-registered-target` is in all three
configs, but it describes the code generation targets LLVM was built with rather
than the host. `darwin-arm64` is in `targettests` only. LLVM's own
`host=<triple>` is nominally available, since all three site configs call
`lit.llvm.initialize`. It evaluates to the literal string `host=None` today,
because `config.host_triple` is never set. I picked `host-<arch>` because it
reads well in a REQUIRES line and does not tie the architecture to an OS. It is
a one line change, so pick one and I will match it.

I left `darwin-arm64` and its one XFAIL consumer alone rather than folding them
into the new feature, since that is a behavior change to an existing test and
not what this issue asks for; it is a follow-up if you want the spellings
unified.
