### PR TITLE
Performance: Speed up quantum allocation combining

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -425,6 +425,11 @@ def CombineQuantumAllocations :
     This pass will only process `quake.alloca` operations at the top-level of
     a function. It assumes all calls have been inlined, loops unrolled, etc.
 
+    To keep the greedy rewrite worklist small, the pass starts with only
+    existing `quake.alloca`, `quake.extract_ref`, `quake.get_member`,
+    `quake.subveq`, and `quake.concat` operations. It also considers any
+    operations created while rewriting them.
+
     If the function contains deallocations, these are combined as well. The
     combined deallocation will be added to each exit block.
   }];

--- a/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -194,9 +194,10 @@ public:
     if (analysis.empty())
       return true;
 
-    // Seed the greedy driver with only the operations that this rewrite owns.
-    // Include typed roots in nested regions because they may use an allocation
-    // from this region and must be revisited when that allocation is replaced.
+    // These patterns only apply to allocations and the operations that form
+    // views of them, so avoid adding the rest of the function to the rewrite
+    // worklist. Keep nested candidates because they may refer to an allocation
+    // from this region and need another rewrite after it is replaced.
     SmallVector<Operation *> candidates;
     region.walk<WalkOrder::PreOrder>([&](Operation *op) {
       if (isa<cudaq::quake::AllocaOp, cudaq::quake::ExtractRefOp,

--- a/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -194,6 +194,18 @@ public:
     if (analysis.empty())
       return true;
 
+    // Seed the greedy driver with only the operations that this rewrite owns.
+    // Include typed roots in nested regions because they may use an allocation
+    // from this region and must be revisited when that allocation is replaced.
+    SmallVector<Operation *> candidates;
+    region.walk<WalkOrder::PreOrder>([&](Operation *op) {
+      if (isa<cudaq::quake::AllocaOp, cudaq::quake::ExtractRefOp,
+              cudaq::quake::GetMemberOp, cudaq::quake::SubVeqOp,
+              cudaq::quake::ConcatOp>(op))
+        candidates.push_back(op);
+      return WalkResult::advance();
+    });
+
     // 2. Combine all the allocas into a single alloca at the top of the region.
     auto *entryBlock = &region.front();
     auto *ctx = &getContext();
@@ -206,14 +218,9 @@ public:
     // 3. Greedily replace the uses of the original alloca ops with uses of
     // partitions of the new alloca op. Replace subveq of subveq with a single
     // new subveq. Replace extract from subveq with extract from original
-    // veq. AllocaPat only matches ops literally in analysis.allocations (this
-    // call's own, region-scoped list), so it is harmless to always root the
-    // driver at the pass's own top-level function rather than region's
-    // owning op: a cc.scope/cc.create_lambda is not IsolatedFromAbove (it may
-    // reference values from its enclosing region), so applyPatternsGreedily
-    // cannot be rooted there directly, but the func::FuncOp always is and the
-    // driver already walks every nested region regardless of where it's
-    // rooted.
+    // veq. Generated extract, subveq, concat, and member operations remain
+    // eligible because they may enable further canonicalization. Unrelated
+    // existing operations in the region must not enter the worklist.
     {
       RewritePatternSet patterns(ctx);
       patterns.insert<AllocaPat>(ctx, analysis);
@@ -221,7 +228,11 @@ public:
       cudaq::quake::GetMemberOp::getCanonicalizationPatterns(patterns, ctx);
       cudaq::quake::SubVeqOp::getCanonicalizationPatterns(patterns, ctx);
       cudaq::quake::ConcatOp::getCanonicalizationPatterns(patterns, ctx);
-      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      GreedyRewriteConfig config;
+      config.setScope(&region).setStrictness(
+          GreedyRewriteStrictness::ExistingAndNewOps);
+      if (failed(applyOpPatternsGreedily(candidates, std::move(patterns),
+                                         config))) {
         region.getParentOp()->emitOpError(
             "combining alloca, subveq, and extract ops failed");
         signalPassFailure();


### PR DESCRIPTION
`CombineQuantumAllocations` currently adds every operation in a function to its
greedy rewrite worklist, even though its patterns only apply to quantum
allocations and the operations that form views of them.

This change builds the worklist from those operations instead. Newly created
operations remain eligible for rewriting, and nested candidates are included
because they can refer to an allocation from an enclosing region.

## Performance

Each generated kernel started with 16 single-qubit allocations, which the pass
combined into one allocation. The number of gates was much larger than the
number of allocations, which is why avoiding a rewrite-worklist entry for every
gate matters here:

- 16 allocations and 500,000 gates: 1.44 seconds to 0.19 seconds, about 7.5x
  faster.
- 16 allocations and 1,500,000 gates: 4.86 seconds to 0.51 seconds, about 9.5x
  faster.

Peak memory was also lower in both cases.