### PR TITLE
[CI] Fix validation steps that passed without running anything

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -281,15 +281,23 @@ jobs:
         shell: bash
         run: |
           status_sum=0 && set +e # Allow script to keep going through errors
-          for ex in `find /home/cudaq/examples/other/distributed/ -name '*.cpp'`; do
+          # C++ examples keep their cpp/ prefix under /home/cudaq/examples.
+          mpi_examples=/home/cudaq/examples/cpp/other/distributed
+          if [ ! -d "$mpi_examples" ]; then
+            echo "::error::MPI examples directory not found: $mpi_examples"
+            exit 1
+          fi
+          found=0
+          for ex in `find "$mpi_examples" -name '*.cpp'`; do
+            found=$((found+1))
+            filename=$(basename -- "$ex")
             # Set CUDAQ_ENABLE_MPI_EXAMPLE to activate these examples.
             nvq++ -DCUDAQ_ENABLE_MPI_EXAMPLE=1 $ex
             status=$?
             if [ $status -eq 0 ]; then
-              # Run with mpiexec
-              mpiexec --allow-run-as-root -np 4 ./a.out
+              # --oversubscribe: OpenMPI sizes slots by physical cores.
+              mpiexec --allow-run-as-root --oversubscribe -np 4 ./a.out
               status=$?
-              filename=$(basename -- "$ex")
               if [ $status -eq 0 ]; then
                 echo ":white_check_mark: Successfully ran $filename." >> $GITHUB_STEP_SUMMARY
               else
@@ -301,6 +309,11 @@ jobs:
               status_sum=$((status_sum+1))
             fi
           done
+          # An empty sweep used to pass silently; treat it as a failure.
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No MPI examples found under $mpi_examples"
+            exit 1
+          fi
           set -e # Re-enable exit code error checking
           if [ ! $status_sum -eq 0 ]; then
             echo "::error::$status_sum examples failed; see step summary for a list of failures."
@@ -949,10 +962,47 @@ jobs:
               fi
           done
 
-          # Also need to test dynamics
+          # Also need to test dynamics; the example script became notebooks in #2900.
           echo "Running with target dynamics"
-          retry python3 -m pip install matplotlib
-          python3 docs/sphinx/examples/python/dynamics/qubit_dynamics.py
+          cat > /tmp/dynamics_validation.py <<'PYEOF'
+          import numpy as np
+          import cupy as cp
+          import cudaq
+          from cudaq import spin, Schedule, RungeKuttaIntegrator
+
+          cudaq.set_target("dynamics")
+
+          # Single qubit under H = omega * sigma_x, so <sigma_z>(t) = cos(2*omega*t).
+          omega = 2 * np.pi * 0.1
+          hamiltonian = omega * spin.x(0)
+          dimensions = {0: 2}
+          rho0 = cudaq.State.from_data(
+              cp.array([[1.0, 0.0], [0.0, 0.0]], dtype=cp.complex128))
+          steps = np.linspace(0, 10, 101)
+
+          result = cudaq.evolve(
+              hamiltonian,
+              dimensions,
+              Schedule(steps, ["time"]),
+              rho0,
+              observables=[spin.y(0), spin.z(0)],
+              collapse_operators=[],
+              store_intermediate_results=cudaq.IntermediateResultSave.EXPECTATION_VALUE,
+              integrator=RungeKuttaIntegrator())
+
+          z = np.array([ev[1].expectation() for ev in result.expectation_values()])
+          expected = np.cos(2 * omega * steps)
+          err = np.max(np.abs(z - expected))
+          print(f"steps={len(z)} max|<z>-cos(2*omega*t)|={err:.3e}")
+          assert len(z) == len(steps), "unexpected number of intermediate results"
+          assert err < 1e-3, f"dynamics evolution deviates from analytic solution: {err}"
+          print("dynamics smoke test PASSED")
+          PYEOF
+          python3 /tmp/dynamics_validation.py
+          if [ $? -ne 0 ]; then
+              echo -e "\e[01;31mPython trivial test for dynamics failed.\e[0m" >&2
+              status_sum=$((status_sum+1))
+          fi
 
           set -e # Re-enable exit code error checking
           if [ "$status_sum" -ne "0" ]; then


### PR DESCRIPTION
Two checks in the Validation workflow reported success without executing the thing they were meant to test.

The wheel validation dynamics test invoked
docs/sphinx/examples/python/dynamics/qubit_dynamics.py, which was removed in #2900 when the dynamics examples became notebooks. Python exited with "No such file or directory" on all six matrix jobs, but its exit code was never added to status_sum, so the step stayed green. No Python dynamics example remains, so replace the invocation with a self-contained smoke test that evolves a single qubit under H = omega * sigma_x and checks the result against the analytic cos(2*omega*t) solution. Drop the matplotlib install because nothing else in the step needs it.

The release image MPI validation globbed
/home/cudaq/examples/other/distributed/. cudaq.Dockerfile copies docs/sphinx/examples to /home/cudaq/examples, so the C++ examples keep a cpp/ prefix and the real path is
/home/cudaq/examples/cpp/other/distributed/. find failed, the loop body never ran, and status_sum stayed 0. A missing directory or an empty sweep is now an error rather than a silent pass.

mpiexec also needs --oversubscribe. OpenMPI sizes slots by physical cores, so -np 4 fails on a runner with fewer than four.

Verified against the artifacts of validation run 33139965314. The dynamics test passes on the cu12 and cu13 wheels for Python 3.12 and 3.14. The MPI step runs four ranks successfully in both the cu12 and cu13 release images.