### PR TITLE
Update documentation for atomic quantum regions

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -2058,6 +2058,22 @@ def VariableCoalesce : Pass<"variable-coalesce", "mlir::func::FuncOp"> {
   ];
 }
 
+def VerifyAtomicQuantumRegions :
+    Pass<"verify-atomic-quantum-regions", "mlir::ModuleOp"> {
+  let summary =
+      "Check that an atomic quantum region denotes a unitary by rejecting "
+      "measurements and qubit allocations in the region";
+  let description = [{
+    This pass rejects measurement operations and qubit allocations in marked
+    `cc.scope` operations and in functions carrying the
+    `atomic_quantum_region` attribute.
+    This pass must run after aggressive inlining, so that operations reached
+    only through a callee are checked as well. It must also run before the
+    conversion to value semantics, where a qubit allocation stops being a
+    `quake.alloca`.
+  }];
+}
+
 def VerifyNoPhase : Pass<"verify-no-phase", "mlir::ModuleOp"> {
   let summary =
       "Verify that phase bookkeeping was eliminated before code generation";

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -2061,8 +2061,8 @@ def VariableCoalesce : Pass<"variable-coalesce", "mlir::func::FuncOp"> {
 def VerifyAtomicQuantumRegions :
     Pass<"verify-atomic-quantum-regions", "mlir::ModuleOp"> {
   let summary =
-      "Check that an atomic quantum region denotes a unitary by rejecting "
-      "measurements and qubit allocations in the region";
+      "Reject measurement operations and qubit allocations inside an atomic "
+      "quantum region";
   let description = [{
     This pass rejects measurement operations and qubit allocations in marked
     `cc.scope` operations and in functions carrying the

--- a/cudaq/lib/Optimizer/Transforms/AggressiveInlining.cpp
+++ b/cudaq/lib/Optimizer/Transforms/AggressiveInlining.cpp
@@ -9,6 +9,7 @@
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/Operation.h"
@@ -19,6 +20,7 @@
 namespace cudaq::opt {
 #define GEN_PASS_DEF_CONVERTTODIRECTCALLS
 #define GEN_PASS_DEF_CHECKKERNELCALLS
+#define GEN_PASS_DEF_VERIFYATOMICQUANTUMREGIONS
 #include "cudaq/Optimizer/Transforms/Passes.h.inc"
 } // namespace cudaq::opt
 
@@ -155,6 +157,129 @@ public:
   }
 };
 
+/// Reject qubit allocations and measurements in an atomic quantum region.
+/// A region is entered in two shapes and both are checked.
+/// `ConvertToDirectCalls` materializes a marked `cc.scope` at each call site of
+/// a marked kernel. A marked kernel launched directly as the entry point has no
+/// call site, so only the attribute on its `func.func` identifies it.
+class AtomicQuantumRegionVerifier {
+public:
+  explicit AtomicQuantumRegionVerifier(ModuleOp module) : module(module) {}
+
+  void verify() { verifyOperation(module, /*insideAtomicRegion=*/false); }
+
+  bool foundViolation() const { return passFailed; }
+
+private:
+  static bool startsAtomicRegion(Operation *op) {
+    if (auto function = dyn_cast<func::FuncOp>(op))
+      return function->hasAttr(cudaq::cc::atomicQuantumRegionAttrName);
+    if (auto scope = dyn_cast<cudaq::cc::ScopeOp>(op))
+      return scope.getAtomicQuantumRegionAttr() != nullptr;
+    return false;
+  }
+
+  /// Report an operation at most once, and report at most one operation per
+  /// source location. Inlining copies a violating callee into every marked
+  /// caller and leaves the original definition in place, so a single line of
+  /// user source becomes several violating operations.
+  bool shouldReport(Operation *op,
+                    llvm::SmallDenseSet<Location> &reportedSourceLocations) {
+    if (!reportedOperations.insert(op).second)
+      return false;
+    if (auto sourceLoc = op->getLoc()->findInstanceOf<FileLineColLoc>())
+      return reportedSourceLocations.insert(sourceLoc).second;
+    return true;
+  }
+
+  void verifyForbiddenOperation(Operation *op) {
+    if (isa<cudaq::quake::MeasurementInterface>(op)) {
+      if (!shouldReport(op, reportedMeasurementLocations))
+        return;
+      op->emitOpError(
+          "measurement operations are not supported inside an atomic quantum "
+          "region; measure outside the region");
+      passFailed = true;
+      return;
+    }
+
+    // Note: `quake.alloca` is the only qubit allocation form reachable here.
+    // This pass runs on reference semantics, before the conversion that turns
+    // allocations into `quake.null_wire` and `quake.borrow_wire`.
+    auto allocation = dyn_cast<cudaq::quake::AllocaOp>(op);
+    if (!allocation ||
+        !isa<cudaq::quake::RefType, cudaq::quake::VeqType>(
+            allocation.getType()) ||
+        !shouldReport(op, reportedAllocationLocations))
+      return;
+    allocation.emitOpError(
+        "qubit allocations are not supported inside an atomic quantum region; "
+        "allocate in the caller and pass the qubits as arguments");
+    passFailed = true;
+  }
+
+  /// Descend into a callee that the inliner left behind so a marked kernel
+  /// cannot hide a violation in an ordinary helper. `verifiedCallees` bounds
+  /// the traversal: a recursive or mutually recursive `cc.noinline_call` chain
+  /// would not terminate otherwise. A callee with no body is not checked. It
+  /// may be defined in another translation unit, and the link step runs this
+  /// pass again on the merged module.
+  void verifyCallee(Operation *call, FlatSymbolRefAttr calleeAttr) {
+    if (!calleeAttr)
+      return;
+    auto callee =
+        SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(call, calleeAttr);
+    if (!callee || callee.isDeclaration() ||
+        !verifiedCallees.insert(callee.getOperation()).second)
+      return;
+    verifyOperation(callee, /*insideAtomicRegion=*/true);
+  }
+
+  void verifyResidualCall(Operation *op) {
+    if (auto call = dyn_cast<func::CallOp>(op)) {
+      verifyCallee(op, call.getCalleeAttr());
+      return;
+    }
+    if (auto call = dyn_cast<cudaq::cc::NoInlineCallOp>(op))
+      verifyCallee(op, call.getCalleeAttr());
+  }
+
+  /// Regions nest but never reopen, so `insideAtomicRegion` only ever gets set.
+  void verifyOperation(Operation *op, bool insideAtomicRegion) {
+    insideAtomicRegion |= startsAtomicRegion(op);
+    if (insideAtomicRegion) {
+      verifyForbiddenOperation(op);
+      verifyResidualCall(op);
+    }
+
+    for (Region &region : op->getRegions())
+      for (Block &block : region)
+        for (Operation &nested : block)
+          verifyOperation(&nested, insideAtomicRegion);
+  }
+
+  ModuleOp module;
+  bool passFailed = false;
+  llvm::DenseSet<Operation *> reportedOperations;
+  llvm::DenseSet<Operation *> verifiedCallees;
+  llvm::SmallDenseSet<Location> reportedAllocationLocations;
+  llvm::SmallDenseSet<Location> reportedMeasurementLocations;
+};
+
+class VerifyAtomicQuantumRegions
+    : public cudaq::opt::impl::VerifyAtomicQuantumRegionsBase<
+          VerifyAtomicQuantumRegions> {
+public:
+  using VerifyAtomicQuantumRegionsBase::VerifyAtomicQuantumRegionsBase;
+
+  void runOnOperation() override {
+    AtomicQuantumRegionVerifier verifier(getOperation());
+    verifier.verify();
+    if (verifier.foundViolation())
+      signalPassFailure();
+  }
+};
+
 } // namespace
 
 static void defaultInlinerOptPipeline(OpPassManager &pm) {}
@@ -163,7 +288,8 @@ static void defaultInlinerOptPipeline(OpPassManager &pm) {}
 /// 1) Lower unwind control flow before creating call-site scopes.
 /// 2) Convert calls between kernels to direct calls (on the QPU).
 /// 3) Aggressively inline all calls.
-/// 4) Detect if kernel inlining has failed and left behind calls to kernels.
+/// 4) Reject measurements and qubit allocations in atomic quantum regions.
+/// 5) Detect if kernel inlining has failed and left behind calls to kernels.
 /// Such a failure is most likely a sign that there is a cycle in the call
 /// graph. [This check is a bad idea: this should be deferred to final codegen
 /// when translating the final Quake IR.]
@@ -172,6 +298,7 @@ void cudaq::opt::addAggressiveInlining(OpPassManager &pm, bool fatalChecks) {
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createUnwindLowering());
   pm.addPass(cudaq::opt::createConvertToDirectCalls());
   pm.addPass(createInlinerPass(opPipelines, defaultInlinerOptPipeline));
+  pm.addPass(cudaq::opt::createVerifyAtomicQuantumRegions());
   if (fatalChecks)
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createCheckKernelCalls());
   // Cleanup after inlining. We want to remove any copies between buffers for

--- a/cudaq/lib/Optimizer/Transforms/AggressiveInlining.cpp
+++ b/cudaq/lib/Optimizer/Transforms/AggressiveInlining.cpp
@@ -168,7 +168,7 @@ public:
 
   void verify() { verifyOperation(module, /*insideAtomicRegion=*/false); }
 
-  bool foundViolation() const { return passFailed; }
+  bool hasViolations() const { return passFailed; }
 
 private:
   static bool startsAtomicRegion(Operation *op) {
@@ -207,10 +207,7 @@ private:
     // This pass runs on reference semantics, before the conversion that turns
     // allocations into `quake.null_wire` and `quake.borrow_wire`.
     auto allocation = dyn_cast<cudaq::quake::AllocaOp>(op);
-    if (!allocation ||
-        !isa<cudaq::quake::RefType, cudaq::quake::VeqType>(
-            allocation.getType()) ||
-        !shouldReport(op, reportedAllocationLocations))
+    if (!allocation || !shouldReport(op, reportedAllocationLocations))
       return;
     allocation.emitOpError(
         "qubit allocations are not supported inside an atomic quantum region; "
@@ -275,7 +272,7 @@ public:
   void runOnOperation() override {
     AtomicQuantumRegionVerifier verifier(getOperation());
     verifier.verify();
-    if (verifier.foundViolation())
+    if (verifier.hasViolations())
       signalPassFailure();
   }
 };

--- a/cudaq/test/Transforms/atomic_quantum_region_errors.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_errors.qke
@@ -25,6 +25,8 @@ func.func @marked_allocations() attributes {atomic_quantum_region, "cudaq-entryp
   %q = quake.alloca !quake.ref
   // expected-error@+1 {{qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments}}
   %r = quake.alloca !quake.veq<2>
+  // expected-error@+1 {{qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments}}
+  %s = quake.alloca !quake.struq<!quake.ref, !quake.veq<2>>
   return
 }
 

--- a/cudaq/test/Transforms/atomic_quantum_region_errors.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_errors.qke
@@ -1,0 +1,97 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --aggressive-inlining --split-input-file --verify-diagnostics %s
+
+func.func @marked_measurements(%q: !quake.ref) attributes {atomic_quantum_region, "cudaq-entrypoint"} {
+  // expected-error@+1 {{measurement operations are not supported inside an atomic quantum region; measure outside the region}}
+  %x = quake.mx %q : (!quake.ref) -> !quake.measure
+  // expected-error@+1 {{measurement operations are not supported inside an atomic quantum region; measure outside the region}}
+  %y = quake.my %q : (!quake.ref) -> !quake.measure
+  // expected-error@+1 {{measurement operations are not supported inside an atomic quantum region; measure outside the region}}
+  %z = quake.mz %q : (!quake.ref) -> !quake.measure
+  return
+}
+
+// -----
+
+func.func @marked_allocations() attributes {atomic_quantum_region, "cudaq-entrypoint"} {
+  // expected-error@+1 {{qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments}}
+  %q = quake.alloca !quake.ref
+  // expected-error@+1 {{qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments}}
+  %r = quake.alloca !quake.veq<2>
+  return
+}
+
+// -----
+
+// Inlining copies the helper into the marked function and into the marked
+// scope at the call site. One diagnostic is expected because the copies share
+// this source location.
+func.func private @ordinary_measuring_helper(%q: !quake.ref) {
+  // expected-error@+1 {{measurement operations are not supported inside an atomic quantum region; measure outside the region}}
+  %m = quake.mz %q : (!quake.ref) -> !quake.measure
+  return
+}
+
+func.func @marked_transitive_measurement(%q: !quake.ref) attributes {atomic_quantum_region} {
+  call @ordinary_measuring_helper(%q) : (!quake.ref) -> ()
+  return
+}
+
+func.func @measurement_caller(%q: !quake.ref) {
+  call @marked_transitive_measurement(%q) : (!quake.ref) -> ()
+  return
+}
+
+// -----
+
+func.func private @ordinary_allocating_helper() {
+  // expected-error@+1 {{qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments}}
+  %q = quake.alloca !quake.ref
+  return
+}
+
+func.func @marked_transitive_allocation() attributes {atomic_quantum_region} {
+  call @ordinary_allocating_helper() : () -> ()
+  return
+}
+
+func.func @allocation_caller() {
+  call @marked_transitive_allocation() : () -> ()
+  return
+}
+
+// -----
+
+func.func @marked_scope(%q: !quake.ref) {
+  cc.scope {
+    // expected-error@+1 {{qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments}}
+    %local = quake.alloca !quake.ref
+    // expected-error@+1 {{measurement operations are not supported inside an atomic quantum region; measure outside the region}}
+    %m = quake.mz %q : (!quake.ref) -> !quake.measure
+    cc.continue
+  } {atomic_quantum_region}
+  return
+}
+
+// -----
+
+// `cc.noinline_call` survives the inliner, so the check walks the call graph
+// itself. This pair is mutually recursive and must still terminate.
+func.func private @noinline_cycle_helper(%q: !quake.ref) {
+  // expected-error@+1 {{measurement operations are not supported inside an atomic quantum region; measure outside the region}}
+  %m = quake.mz %q : (!quake.ref) -> !quake.measure
+  cc.noinline_call @marked_noinline_cycle(%q) : (!quake.ref) -> ()
+  return
+}
+
+func.func @marked_noinline_cycle(%q: !quake.ref) attributes {atomic_quantum_region} {
+  cc.noinline_call @noinline_cycle_helper(%q) : (!quake.ref) -> ()
+  return
+}

--- a/cudaq/test/Transforms/atomic_quantum_region_inlining.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_inlining.qke
@@ -26,19 +26,15 @@ module attributes {quake.mangled_name_map = {marked = "indirect_marked"}} {
     return
   }
 
-  func.func private @marked_feedback(%q: !quake.ref) attributes {atomic_quantum_region} {
-    %measurement = quake.mz %q : (!quake.ref) -> !quake.measure
-    %bit = quake.discriminate %measurement : (!quake.measure) -> i1
-    cc.if(%bit) {
+  func.func private @marked_conditional(%q: !quake.ref, %condition: i1) attributes {atomic_quantum_region} {
+    cc.if(%condition) {
       quake.z %q : (!quake.ref) -> ()
     }
     return
   }
 
-  func.func private @ordinary_feedback(%q: !quake.ref) {
-    %measurement = quake.mz %q : (!quake.ref) -> !quake.measure
-    %bit = quake.discriminate %measurement : (!quake.measure) -> i1
-    cc.if(%bit) {
+  func.func private @ordinary_conditional(%q: !quake.ref, %condition: i1) {
+    cc.if(%condition) {
       quake.z %q : (!quake.ref) -> ()
     }
     return
@@ -46,19 +42,22 @@ module attributes {quake.mangled_name_map = {marked = "indirect_marked"}} {
 
   func.func private @indirect_marked(!quake.ref)
 
-  func.func @caller(%q: !quake.ref) {
+  func.func @caller(%q: !quake.ref, %condition: i1) {
     func.call @marked(%q) : (!quake.ref) -> ()
     func.call @ordinary(%q) : (!quake.ref) -> ()
     func.call @nested(%q) : (!quake.ref) -> ()
-    func.call @marked_feedback(%q) : (!quake.ref) -> ()
-    func.call @ordinary_feedback(%q) : (!quake.ref) -> ()
+    func.call @marked_conditional(%q, %condition) : (!quake.ref, i1) -> ()
+    func.call @ordinary_conditional(%q, %condition) : (!quake.ref, i1) -> ()
     func.call @indirect_marked(%q) : (!quake.ref) -> ()
     return
   }
 }
 
+// CHECK-LABEL:   func.func private @indirect_marked(!quake.ref)
+
 // CHECK-LABEL:   func.func @caller(
-// CHECK-SAME:                      %[[ARG0:.*]]: !quake.ref) {
+// CHECK-SAME:                      %[[ARG0:.*]]: !quake.ref,
+// CHECK-SAME:                      %[[ARG1:.*]]: i1) {
 // CHECK:           cc.scope {
 // CHECK:             quake.h %[[ARG0]] : (!quake.ref) -> ()
 // CHECK:           } {atomic_quantum_region}
@@ -70,15 +69,11 @@ module attributes {quake.mangled_name_map = {marked = "indirect_marked"}} {
 // CHECK-NEXT:        quake.y %[[ARG0]] : (!quake.ref) -> ()
 // CHECK-NEXT:      } {atomic_quantum_region}
 // CHECK-NEXT:      cc.scope {
-// CHECK-NEXT:        %[[MZ_0:.*]] = quake.mz %[[ARG0]] : (!quake.ref) -> !quake.measure
-// CHECK-NEXT:        %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[MZ_0]] : (!quake.measure) -> i1
-// CHECK-NEXT:        cc.if(%[[DISCRIMINATE_0]]) {
+// CHECK-NEXT:        cc.if(%[[ARG1]]) {
 // CHECK-NEXT:          quake.z %[[ARG0]] : (!quake.ref) -> ()
 // CHECK-NEXT:        }
 // CHECK-NEXT:      } {atomic_quantum_region}
-// CHECK-NEXT:      %[[MZ_1:.*]] = quake.mz %[[ARG0]] : (!quake.ref) -> !quake.measure
-// CHECK-NEXT:      %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[MZ_1]] : (!quake.measure) -> i1
-// CHECK-NEXT:      cc.if(%[[DISCRIMINATE_1]]) {
+// CHECK-NEXT:      cc.if(%[[ARG1]]) {
 // CHECK-NEXT:        quake.z %[[ARG0]] : (!quake.ref) -> ()
 // CHECK-NEXT:      }
 // CHECK-NEXT:      cc.scope {

--- a/cudaq/tools/nvq++/nvq++.in
+++ b/cudaq/tools/nvq++/nvq++.in
@@ -1082,7 +1082,7 @@ if ${ENABLE_AGGRESSIVE_INLINE}; then
 	if ${DO_LINK}; then
 		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "aggressive-inlining")
 	else
-		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "indirect-to-direct-calls,inline")
+		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "indirect-to-direct-calls,inline,verify-atomic-quantum-regions")
 	fi
 fi
 if ${ENABLE_ARRAY_CONVERSION}; then

--- a/docs/sphinx/specification/cudaq/kernels.rst
+++ b/docs/sphinx/specification/cudaq/kernels.rst
@@ -54,10 +54,15 @@ can take quantum types as input.
 Atomic quantum regions
 ======================
 
-Mark a pure-device kernel as an atomic quantum region when each invocation
-must remain an optimization boundary. Quantum operations can be optimized
-within the invoked kernel and within its caller. An optimization must not
-combine, cancel, or move operations across the invocation boundary.
+An atomic quantum region denotes a single unitary operator on the qubits
+passed to it. Mark a pure-device kernel as an atomic quantum region when each
+invocation must remain an optimization boundary. Quantum operations can be
+optimized within the invoked kernel and within its caller. An optimization
+must not combine, cancel, or move operations across the invocation boundary.
+
+An atomic quantum region cannot allocate or measure qubits, including through
+kernels that it calls. Allocate qubits in the caller and pass them as
+arguments. Measure after the region returns.
 
 .. tab:: C++
 

--- a/docs/sphinx/using/extending/compiler/mlir_pass.rst
+++ b/docs/sphinx/using/extending/compiler/mlir_pass.rst
@@ -136,6 +136,11 @@ holds no allocations, so the marker reaches later passes. An optimization may
 rewrite quantum operations wholly inside or wholly outside a marked scope, but
 must not combine, cancel, or move operations across its boundary.
 
+The aggressive-inlining pipeline rejects Quake measurement operations and
+quantum allocations in a marked scope or marked function. Passes that run
+before this check must preserve the marker and call structure. Later passes
+must not move measurements or user qubit allocations into a marked scope.
+
 Tests should cover optimization within a block, across an ordinary scope, and
 conservative behavior at both a marked scope and an unsupported control-flow
 boundary.

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -6289,8 +6289,9 @@ def compile_to_mlir(uniqueId, astModule, signature: KernelSignature, defFrame,
     try:
         with trace.span("cudaq.pipeline.aot"):
             cudaq_runtime.runPassManager(pm, bridge.module)
-    except:
-        raise RuntimeError(f"could not compile code for '{bridge.name}'.")
+    except Exception as e:
+        raise RuntimeError(
+            f"could not compile code for '{bridge.name}'.\n{e}") from e
 
     bridge.module.operation.attributes.__setitem__(
         cudaq__unique_attr_name, StringAttr.get(bridge.name,

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -1756,9 +1756,9 @@ class PyKernel(object):
             try:
                 with trace.span("cudaq.pipeline.aot"):
                     cudaq_runtime.runPassManager(pm, self.qkeModule)
-            except:
+            except Exception as e:
                 raise RuntimeError("could not compile code for '" +
-                                   self.uniqName + "'.")
+                                   self.uniqName + "'.\n" + str(e)) from e
             self.qkeModule.operation.attributes.__setitem__(
                 cudaq__unique_attr_name,
                 StringAttr.get(self.uniqName, context=ctx))

--- a/python/extension/CUDAQuantumExtension.cpp
+++ b/python/extension/CUDAQuantumExtension.cpp
@@ -406,17 +406,23 @@ When using ``mpi4py``, keep the communicator object alive while CUDA-Q uses it.)
         // the pipeline failed. Returning success consumes the diagnostic, which
         // keeps the default handler from also printing it to `stderr`.
         std::string diagnostics;
+        llvm::raw_string_ostream os(diagnostics);
         mlir::ScopedDiagnosticHandler collect(
             module.getContext(), [&](mlir::Diagnostic &diag) {
               if (diag.getSeverity() != mlir::DiagnosticSeverity::Error)
                 return mlir::failure();
-              diagnostics += diag.str();
-              diagnostics += '\n';
+              os << diag.getLocation() << ": error: " << diag << '\n';
+              for (auto &note : diag.getNotes())
+                os << note.getLocation() << ": note: " << note << '\n';
               return mlir::success();
             });
         if (mlir::failed(cudaq_internal::compiler::runPassManager(
                 *unwrap(pm), module.getOperation())))
           throw std::runtime_error("pass pipeline failed\n" + diagnostics);
+        // A pass can emit an error and still report success, so the collected
+        // text would otherwise be dropped. Print it rather than lose it.
+        if (!diagnostics.empty())
+          llvm::errs() << diagnostics;
       },
       "Run an MLIR PassManager on a Module via the runtime helper that "
       "installs TracePassInstrumentation and releases the GIL. Used by "

--- a/python/extension/CUDAQuantumExtension.cpp
+++ b/python/extension/CUDAQuantumExtension.cpp
@@ -56,6 +56,7 @@
 #include "cudaq/runtime/logger/logger.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "mlir/CAPI/Pass.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include <nanobind/stl/complex.h>
@@ -400,9 +401,22 @@ When using ``mpi4py``, keep the communicator object alive while CUDA-Q uses it.)
   cudaqRuntime.def(
       "runPassManager",
       [](MlirPassManager pm, MlirModule mod) {
+        auto module = unwrap(mod);
+        // Collect error diagnostics so the Python exception carries the reason
+        // the pipeline failed. Returning success consumes the diagnostic, which
+        // keeps the default handler from also printing it to `stderr`.
+        std::string diagnostics;
+        mlir::ScopedDiagnosticHandler collect(
+            module.getContext(), [&](mlir::Diagnostic &diag) {
+              if (diag.getSeverity() != mlir::DiagnosticSeverity::Error)
+                return mlir::failure();
+              diagnostics += diag.str();
+              diagnostics += '\n';
+              return mlir::success();
+            });
         if (mlir::failed(cudaq_internal::compiler::runPassManager(
-                *unwrap(pm), unwrap(mod).getOperation())))
-          throw std::runtime_error("pass pipeline failed");
+                *unwrap(pm), module.getOperation())))
+          throw std::runtime_error("pass pipeline failed\n" + diagnostics);
       },
       "Run an MLIR PassManager on a Module via the runtime helper that "
       "installs TracePassInstrumentation and releases the GIL. Used by "

--- a/python/tests/kernel/test_atomic_quantum_region.py
+++ b/python/tests/kernel/test_atomic_quantum_region.py
@@ -10,6 +10,13 @@ import cudaq
 import numpy as np
 import pytest
 
+ALLOCATION_ERROR = (
+    "qubit allocations are not supported inside an atomic quantum region; "
+    "allocate in the caller and pass the qubits as arguments")
+MEASUREMENT_ERROR = (
+    "measurement operations are not supported inside an atomic quantum region; "
+    "measure outside the region")
+
 
 @cudaq.kernel(atomic_quantum_region=True)
 def atomic_h(q: cudaq.qubit):
@@ -54,9 +61,14 @@ def atomic_round_trip():
 
 
 @cudaq.kernel(atomic_quantum_region=True)
-def single_atomic_h():
-    q = cudaq.qubit()
+def single_atomic_h(q: cudaq.qubit):
     h(q)
+
+
+@cudaq.kernel
+def single_atomic_h_entry():
+    q = cudaq.qubit()
+    single_atomic_h(q)
 
 
 @cudaq.kernel
@@ -132,12 +144,12 @@ def test_atomic_quantum_region_state_apis():
     drawing = cudaq.draw(atomic_round_trip)
     assert drawing.count("┤ h ├") == 2
 
-    state = np.asarray(cudaq.get_state(single_atomic_h))
+    state = np.asarray(cudaq.get_state(single_atomic_h_entry))
     np.testing.assert_allclose(state,
                                np.array([1.0, 1.0]) / np.sqrt(2),
                                atol=1e-12)
 
-    unitary = cudaq.get_unitary(single_atomic_h)
+    unitary = cudaq.get_unitary(single_atomic_h_entry)
     np.testing.assert_allclose(unitary,
                                np.array([[1.0, 1.0], [1.0, -1.0]]) / np.sqrt(2),
                                atol=1e-12)
@@ -224,6 +236,134 @@ def test_atomic_quantum_region_builder_preserves_entangling_workload():
     assert ordinary_counts.count("000") == shots
     assert atomic_counts.count("011") == shots
     cudaq.reset_target()
+
+
+def test_atomic_quantum_region_decorator_rejects_local_operations():
+
+    @cudaq.kernel(atomic_quantum_region=True)
+    def measured(q: cudaq.qubit):
+        mz(q)
+
+    with pytest.raises(RuntimeError) as e:
+        measured.compile()
+    assert MEASUREMENT_ERROR in str(e.value)
+
+    @cudaq.kernel(atomic_quantum_region=True)
+    def allocated():
+        q = cudaq.qubit()
+        x(q)
+
+    with pytest.raises(RuntimeError) as e:
+        allocated.compile()
+    assert ALLOCATION_ERROR in str(e.value)
+
+
+def test_atomic_quantum_region_decorator_rejects_entry_point():
+
+    @cudaq.kernel(atomic_quantum_region=True)
+    def invalid_entry_point():
+        q = cudaq.qubit()
+        mz(q)
+
+    with pytest.raises(RuntimeError) as e:
+        cudaq.sample(invalid_entry_point)
+    diagnostics = str(e.value)
+    assert MEASUREMENT_ERROR in diagnostics
+    assert ALLOCATION_ERROR in diagnostics
+
+
+def test_atomic_quantum_region_decorator_rejects_transitive_measurement(capfd):
+
+    @cudaq.kernel
+    def measure_helper(q: cudaq.qubit):
+        mz(q)
+
+    @cudaq.kernel(atomic_quantum_region=True)
+    def marked(q: cudaq.qubit):
+        measure_helper(q)
+
+    @cudaq.kernel
+    def caller():
+        q = cudaq.qubit()
+        marked(q)
+
+    with pytest.raises(RuntimeError,
+                       match="Could not successfully apply kernel "
+                       "specialization"):
+        cudaq.sample(caller)
+    assert MEASUREMENT_ERROR in capfd.readouterr().err
+
+
+def test_atomic_quantum_region_positive_controls():
+
+    # Empty atomic regions are legal.
+    @cudaq.kernel(atomic_quantum_region=True)
+    def empty():
+        pass
+
+    @cudaq.kernel(atomic_quantum_region=True)
+    def unitary(q: cudaq.qubit):
+        x(q)
+
+    @cudaq.kernel
+    def caller():
+        q = cudaq.qubit()
+        unitary(q)
+        mz(q)
+
+    empty.compile()
+    counts = cudaq.sample(caller, shots_count=1)
+    assert counts.count("1") == 1
+
+
+@pytest.mark.parametrize("mark_first", [False, True])
+@pytest.mark.parametrize("operation", ["allocation", "measurement"])
+def test_atomic_quantum_region_builder_rejects_operations(
+        mark_first, operation):
+    if operation == "measurement":
+        kernel, q = cudaq.make_kernel(cudaq.qubit)
+    else:
+        kernel = cudaq.make_kernel()
+
+    if mark_first:
+        kernel.atomic_quantum_region()
+
+    if operation == "measurement":
+        kernel.mz(q)
+        expected_error = MEASUREMENT_ERROR
+    else:
+        kernel.qalloc()
+        expected_error = ALLOCATION_ERROR
+
+    if not mark_first:
+        kernel.atomic_quantum_region()
+
+    with pytest.raises(RuntimeError) as e:
+        kernel.compile()
+    assert expected_error in str(e.value)
+
+
+def test_atomic_quantum_region_builder_reports_each_violation():
+    # Builder operations carry no source location, so the verifier cannot
+    # collapse them by line the way it collapses the inlined copies of one
+    # decorated kernel. Each recorded operation is reported on its own.
+    allocating = cudaq.make_kernel()
+    allocating.qalloc()
+    allocating.qalloc()
+    allocating.atomic_quantum_region()
+
+    with pytest.raises(RuntimeError) as e:
+        allocating.compile()
+    assert str(e.value).count(ALLOCATION_ERROR) == 2
+
+    measuring, q0, q1 = cudaq.make_kernel(cudaq.qubit, cudaq.qubit)
+    measuring.mz(q0)
+    measuring.mz(q1)
+    measuring.atomic_quantum_region()
+
+    with pytest.raises(RuntimeError) as e:
+        measuring.compile()
+    assert str(e.value).count(MEASUREMENT_ERROR) == 2
 
 
 def test_atomic_quantum_region_sync_execution_apis():

--- a/python/tests/kernel/test_fixed_qref.py
+++ b/python/tests/kernel/test_fixed_qref.py
@@ -116,7 +116,7 @@ def test_dynamic_and_negative_qrefs_are_not_reused():
     assert len(counts) == 1
 
 
-def test_repeated_out_of_bounds_fixed_qrefs_still_diagnose(capfd):
+def test_repeated_out_of_bounds_fixed_qrefs_still_diagnose():
 
     @cudaq.kernel
     def direct():
@@ -131,10 +131,10 @@ def test_repeated_out_of_bounds_fixed_qrefs_still_diagnose(capfd):
         x(alias[2])
         x(alias[2])
 
-    with pytest.raises(RuntimeError, match="could not compile code"):
+    with pytest.raises(RuntimeError, match="could not compile code") as e:
         direct.compile()
-    assert "invalid index [2] because >= size [2]" in capfd.readouterr().err
+    assert "invalid index [2] because >= size [2]" in str(e.value)
 
-    with pytest.raises(RuntimeError, match="could not compile code"):
+    with pytest.raises(RuntimeError, match="could not compile code") as e:
         through_alias.compile()
-    assert "invalid index [2] because >= size [2]" in capfd.readouterr().err
+    assert "invalid index [2] because >= size [2]" in str(e.value)

--- a/targettests/execution/atomic_quantum_region_apis_errors.cpp
+++ b/targettests/execution/atomic_quantum_region_apis_errors.cpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: not nvq++ -DATOMIC_FREE_MEASUREMENT %s -o %t.free 2>&1 | FileCheck %s --check-prefix=MEASUREMENT
+// RUN: not nvq++ -DATOMIC_FUNCTOR_ALLOCATION %s -o %t.functor 2>&1 | FileCheck %s --check-prefix=ALLOCATION
+// RUN: not nvq++ -DATOMIC_LAMBDA_MEASUREMENT %s -o %t.lambda 2>&1 | FileCheck %s --check-prefix=MEASUREMENT
+// RUN: not nvq++ -DATOMIC_FREE_MEASUREMENT -c %s -o %t.o 2>&1 | FileCheck %s --check-prefix=MEASUREMENT
+// RUN: if %braket_avail; then not nvq++ --target braket --emulate -DATOMIC_FREE_MEASUREMENT %s -o %t.braket 2>&1 | FileCheck %s --check-prefix=MEASUREMENT; fi
+// RUN: if %oqc_avail; then not nvq++ --target oqc --emulate -DATOMIC_FREE_MEASUREMENT %s -o %t.oqc 2>&1 | FileCheck %s --check-prefix=MEASUREMENT; fi
+// RUN: not nvq++ --target quantinuum --emulate -DATOMIC_FREE_MEASUREMENT %s -o %t.quantinuum 2>&1 | FileCheck %s --check-prefix=MEASUREMENT
+//
+// MEASUREMENT-COUNT-1: error: 'quake.mz' op measurement operations are not supported inside an atomic quantum region; measure outside the region
+// MEASUREMENT-NOT: measurement operations are not supported inside an atomic quantum region
+//
+// ALLOCATION-COUNT-1: error: 'quake.alloca' op qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments
+// ALLOCATION-NOT: qubit allocations are not supported inside an atomic quantum region
+// clang-format on
+
+#include <cudaq.h>
+
+#if defined(ATOMIC_FREE_MEASUREMENT)
+
+__qpu__ void measure_helper(cudaq::qubit &q) { mz(q); }
+
+__qpu__ __atomic_quantum_region__ void invalid_region(cudaq::qubit &q) {
+  measure_helper(q);
+}
+
+struct test_kernel {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    h(q);
+    invalid_region(q);
+    x(q);
+  }
+};
+
+#elif defined(ATOMIC_FUNCTOR_ALLOCATION)
+
+struct test_kernel {
+  void operator()() __qpu__ __atomic_quantum_region__ {
+    cudaq::qubit q;
+    x(q);
+  }
+};
+
+#elif defined(ATOMIC_LAMBDA_MEASUREMENT)
+
+struct test_kernel {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    auto invalid_region = [](cudaq::qubit &target)
+                              __qpu__ __atomic_quantum_region__ { mz(target); };
+    invalid_region(q);
+  }
+};
+
+#endif
+
+int main() {
+  cudaq::sample(test_kernel{});
+  return 0;
+}


### PR DESCRIPTION
### Summary

* Reject qubit allocations and measurements in atomic quantum regions. 
* A new `verify-atomic-quantum-regions` pass runs after inlining, so it also catches violations reached only through a callee.

