### PR TITLE
[CI] Run the CMake integration test and the dynamics test suite

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -253,6 +253,8 @@ jobs:
           retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # build-essential is needed for nbconvert (jupyter/nbconvert#1742).
           retry sudo apt-get update && retry sudo apt-get install -y build-essential python3-dev python3-venv python3-pip
+          # pip, not apt: test_cmake_find_package.sh needs cmake >= 4.0.
+          retry sudo pip3 install --break-system-packages cmake
 
           backends_to_test=`\
               for file in $(ls $CUDA_QUANTUM_PATH/targets/*.yml); \
@@ -780,8 +782,10 @@ jobs:
           retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           retry apt-get update
           # binutils (nm) is needed by the license compliance validation.
+          # make and pip cmake (>= 4.0) are needed by test_cmake_find_package.sh.
           retry apt-get install -y --no-install-recommends \
-            wget ca-certificates libc6-dev libopenmpi-dev binutils
+            wget ca-certificates libc6-dev libopenmpi-dev binutils make python3-pip
+          retry pip3 install --break-system-packages cmake
           distro=`echo ${{ matrix.os_image }} | tr -d . | tr -d :`
           CUDA_DOWNLOAD_URL=https://developer.download.nvidia.com/compute/cuda/repos
           retry wget "${CUDA_DOWNLOAD_URL}/$distro/x86_64/cuda-keyring_1.1-1_all.deb"
@@ -805,8 +809,10 @@ jobs:
           # dnf-specific retry: clears cached metadata between attempts so that
           # a stale 404 from a CDN mirror doesn't poison the cache for retry #2.
           retry_dnf() { local pre=""; [ "$(id -u)" -ne 0 ] && pre=sudo; for n in 1 2 3; do $pre dnf "$@" && return 0; [ $n -lt 3 ] && { $pre dnf clean metadata >/dev/null 2>&1 || true; sleep $((15*n*n)); }; done; return 1; }
+          # make is needed by test_cmake_find_package.sh; cmake comes from conda
+          # below, since ubi8 ships Python 3.6 and pip cannot install cmake 4.x.
           retry_dnf install -y --nobest --setopt=install_weak_deps=False \
-            'dnf-command(config-manager)' glibc-devel openssh-clients binutils
+            'dnf-command(config-manager)' glibc-devel openssh-clients binutils make
           CUDA_VERSION=${{ matrix.cuda_version }}
           DISTRIBUTION=rhel8
           . scripts/configure_build.sh install-cudart
@@ -820,7 +826,7 @@ jobs:
           rm -f /tmp/miniconda.sh
           eval "$($conda_prefix/bin/conda shell.bash hook)"
           export CONDA_OVERRIDE_CUDA="$CUDA_VERSION"
-          retry conda install -y --override-channels -c conda-forge openmpi">=5.0.7"
+          retry conda install -y --override-channels -c conda-forge openmpi">=5.0.7" cmake">=4.0"
           chmod -R a+rX "$conda_prefix"
 
       - name: Install and run sanity checks
@@ -854,6 +860,8 @@ jobs:
           rm -rf "$workdir/examples/python" "$workdir/applications/python" "$workdir/targets/python"
           cp scripts/validate_installation.sh "$workdir/"
           cp scripts/validate_license_compliance.sh "$workdir/"
+          # Without this the CMake integration test silently skips itself.
+          cp scripts/test_cmake_find_package.sh "$workdir/"
           chown -R cudaqtest "$workdir"
 
           touch "$GITHUB_STEP_SUMMARY"
@@ -962,43 +970,11 @@ jobs:
               fi
           done
 
-          # Also need to test dynamics; the example script became notebooks in #2900.
+          # Also need to test dynamics. The example script became notebooks in
+          # #2900, so exercise the repo's dynamics suite against the wheel.
           echo "Running with target dynamics"
-          cat > /tmp/dynamics_validation.py <<'PYEOF'
-          import numpy as np
-          import cupy as cp
-          import cudaq
-          from cudaq import spin, Schedule, RungeKuttaIntegrator
-
-          cudaq.set_target("dynamics")
-
-          # Single qubit under H = omega * sigma_x, so <sigma_z>(t) = cos(2*omega*t).
-          omega = 2 * np.pi * 0.1
-          hamiltonian = omega * spin.x(0)
-          dimensions = {0: 2}
-          rho0 = cudaq.State.from_data(
-              cp.array([[1.0, 0.0], [0.0, 0.0]], dtype=cp.complex128))
-          steps = np.linspace(0, 10, 101)
-
-          result = cudaq.evolve(
-              hamiltonian,
-              dimensions,
-              Schedule(steps, ["time"]),
-              rho0,
-              observables=[spin.y(0), spin.z(0)],
-              collapse_operators=[],
-              store_intermediate_results=cudaq.IntermediateResultSave.EXPECTATION_VALUE,
-              integrator=RungeKuttaIntegrator())
-
-          z = np.array([ev[1].expectation() for ev in result.expectation_values()])
-          expected = np.cos(2 * omega * steps)
-          err = np.max(np.abs(z - expected))
-          print(f"steps={len(z)} max|<z>-cos(2*omega*t)|={err:.3e}")
-          assert len(z) == len(steps), "unexpected number of intermediate results"
-          assert err < 1e-3, f"dynamics evolution deviates from analytic solution: {err}"
-          print("dynamics smoke test PASSED")
-          PYEOF
-          python3 /tmp/dynamics_validation.py
+          retry python3 -m pip install pytest
+          python3 -m pytest python/tests/dynamics -q
           if [ $? -ne 0 ]; then
               echo -e "\e[01;31mPython trivial test for dynamics failed.\e[0m" >&2
               status_sum=$((status_sum+1))


### PR DESCRIPTION
Two more validation gaps found while auditing for checks that report success without testing anything.

test_cmake_find_package.sh never ran in any of the six jobs that invoke it. Installer validation did not copy the script into the test user's workdir, so validate_installation.sh reported "script not found" and skipped it. Release image validation found the script but had no cmake, so it skipped via the other branch of the same guard. Copy the script, and install cmake where it is missing. The script requires cmake 4.0, so it comes from pip on Ubuntu and from conda on ubi8, whose Python 3.6 cannot install a current cmake wheel.

The dynamics wheel check was a smoke test written inline in this workflow. Replace it with the repo's own dynamics suite, which is 95 tests rather than one assertion, is maintained alongside the code, and keeps test logic out of CI YAML.

Verified against the artifacts of validation run 33139965314. The CMake test passes in the release image, in an Ubuntu installer environment, and in a ubi8 installer environment. The dynamics suite reports 94 passed and 1 skipped, the skip being a torch integrator test that the wheel does not depend on.