### PR TITLE
[realtime] Adding unified "kernel" support for UDP.

### DIFF
--- a/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
+++ b/realtime/include/cudaq/realtime/cpu_transport/udp_wrapper.h
@@ -30,6 +30,33 @@
 /// drained).
 ///
 /// Deliberately no `ibverbs`, no CUDA: buildable and runnable anywhere.
+///
+/// UNIFIED MODE
+/// ============
+///
+/// By default this transceiver is an active agent: it moves bytes wire<->ring
+/// on its own two threads and a consumer only ever touches the rings.
+/// cpu_udp_set_unified inverts that. No threads are started, and the consumer's
+/// single thread drives the wire itself through cpu_udp_rx_poll and
+/// cpu_udp_tx_publish. It exists for consumers that already own a dispatch loop
+/// and would otherwise be running two -- in-tree, the library's unified host
+/// dispatcher, reached through the `udp` bridge provider's `--unified` mode.
+///
+/// The ring contract above then changes in two ways that are not optional:
+///
+///   * rx_flags is UNUSED. cpu_udp_rx_poll reports a slot by return value
+///     instead of publishing an address, and a consumer of this shape never
+///     clears an rx flag -- so a flag set here would wedge that slot for good.
+///     Slot occupancy is tracked through tx_flags alone.
+///
+///   * Slot addresses are DERIVED, not carried. The consumer computes
+///     rx_data + slot * page_size itself, and cpu_udp_rx_poll places the
+///     datagram at exactly that address.
+///
+/// Every unified call must come from that one thread, which is what licenses
+/// the absence of locking on the peer address and the RX cursor. Mixing the two
+/// shapes is refused rather than raced: the hooks fail unless unified mode is
+/// set, and setting it is refused once running.
 
 #pragma once
 
@@ -86,11 +113,38 @@ int cpu_udp_connect(cpu_udp_transceiver_t handle, const char *host,
 /// Bound local UDP port (valid after cpu_udp_bind / cpu_udp_connect).
 uint16_t cpu_udp_get_port(cpu_udp_transceiver_t handle);
 
-/// Start the RX and TX pump threads. Returns 1 on success.
+/// Switch to unified (thread-free) mode; see "Unified mode" above. MUST precede
+/// cpu_udp_start, which is what it changes; returns 0 if already running. Once
+/// set, cpu_udp_start starts no pump threads and the two hooks below are the
+/// only data path.
+int cpu_udp_set_unified(cpu_udp_transceiver_t handle, int unified);
+
+/// Start the RX and TX pump threads. Returns 1 on success. Under unified mode
+/// there are no such threads: this only marks the transceiver running.
 int cpu_udp_start(cpu_udp_transceiver_t handle);
 
-/// Stop the pump threads and close the socket. Idempotent.
+/// Stop the pump threads and close the socket. Idempotent. Under unified mode
+/// the consumer MUST stop driving the hooks first -- they use this socket.
 void cpu_udp_close(cpu_udp_transceiver_t handle);
+
+//==============================================================================
+// Unified-mode data plane (see "Unified mode" above; both refused unless
+// cpu_udp_set_unified succeeded)
+//==============================================================================
+
+/// Non-blocking RX. Returns 1 and sets *out_slot when a datagram has been
+/// placed in that RX slot (at rx_data + slot * page_size, zero-filled past the
+/// received bytes). Returns 0 when nothing was ready, when the in-order slot is
+/// still occupied (tx_flags[slot] != 0, i.e. a response still in flight), or
+/// when the datagram exceeded this end's page_size (dropped, warned once).
+/// Never touches rx_flags.
+int cpu_udp_rx_poll(cpu_udp_transceiver_t handle, uint32_t *out_slot);
+
+/// Ship TX slot `slot` to the most recent inbound peer as one full-stride
+/// datagram. Returns 1 on success. Slot-addressed rather than FIFO, so
+/// responses may be published in any order. Does NOT touch tx_flags: the
+/// consumer owns them in this shape.
+int cpu_udp_tx_publish(cpu_udp_transceiver_t handle, uint32_t slot);
 
 //==============================================================================
 // Ring access (addresses are host pointers, same contract as roce_wrapper.h)

--- a/realtime/include/cudaq/realtime/daemon/bridge/bridge_interface.h
+++ b/realtime/include/cudaq/realtime/daemon/bridge/bridge_interface.h
@@ -37,9 +37,14 @@ typedef enum {
 
 } cudaq_realtime_transport_provider_t;
 
+/// Transport shapes a provider may serve.  A provider answers
+/// `get_transport_context` for the one it is configured for and refuses the
+/// other; see cudaq_bridge_get_transport_context for that contract.
 typedef enum {
-  RING_BUFFER = 0, // Ring buffer context (for GpuRoceTransceiver provider)
-  UNIFIED = 1,     /// Unified transport context  for unified dispatch
+  RING_BUFFER = 0, /// Rings the consumer polls, filled by the transport's own
+                   /// RX/TX path (threads or kernels)
+  UNIFIED = 1,     /// One loop does RX, dispatch and TX; the context says whose
+                   /// loop it is
 } cudaq_realtime_transport_context_t;
 
 /// Result of a non-blocking RX poll on the ringbuffer dataplane.
@@ -148,8 +153,9 @@ cudaq_bridge_create(cudaq_realtime_bridge_handle_t *out_bridge_handle,
 /// @brief Destroy the transport bridge and release all associated resources.
 cudaq_status_t cudaq_bridge_destroy(cudaq_realtime_bridge_handle_t bridge);
 
-/// @brief Retrieve the transport context for the given bridge.
-/// This could be a ring buffer or unified context.
+/// @brief Retrieve the transport context for the given bridge: a
+/// `cudaq_ringbuffer_t` for RING_BUFFER, a `cudaq_unified_dispatch_ctx_t` for
+/// UNIFIED.
 cudaq_status_t cudaq_bridge_get_transport_context(
     cudaq_realtime_bridge_handle_t bridge,
     cudaq_realtime_transport_context_t context_type, void *out_context);

--- a/realtime/lib/cpu_transport/udp_transceiver.cpp
+++ b/realtime/lib/cpu_transport/udp_transceiver.cpp
@@ -15,6 +15,13 @@
 /// ordering the RoCE recv-WQE path provides); the TX thread ships any
 /// published TX slot (tx_flag[slot] == slot data address) to the peer as one
 /// full-stride datagram and clears the flag.
+///
+/// Unified mode (cpu_udp_set_unified) replaces both threads with two hooks the
+/// caller pumps from its own thread -- rxPoll/txPublish below -- for consumers
+/// that already own a dispatch loop and do not want a second one. Everything
+/// else is shared with the threaded shape: the same rings, the same socket, the
+/// same peer learning, the same oversize policy. See udp_wrapper.h's "Unified
+/// mode" section for the two ways the ring contract differs.
 
 #include "cudaq/realtime/cpu_transport/udp_wrapper.h"
 #include "cudaq/realtime/daemon/dispatcher/cpu_relax.h"
@@ -134,13 +141,91 @@ public:
     return true;
   }
 
+  // Must precede start(), which is what it changes. Refused once running: the
+  // pump threads and the hooks would then be contending for the same socket
+  // and the same slots.
+  bool setUnified(bool enable) {
+    if (running)
+      return false;
+    unified = enable;
+    return true;
+  }
+
   bool start() {
     if (fd < 0 || running)
       return false;
     running = true;
+    // Unified: the caller's thread is the data plane, so there is nothing to
+    // spawn. Still marked running, so close() and the misuse guards below
+    // behave identically in both shapes.
+    if (unified)
+      return true;
     rx_thread = std::thread([this] { rxLoop(); });
     tx_thread = std::thread([this] { txLoop(); });
     return true;
+  }
+
+  // Non-blocking RX for the unified shape. Returns true and sets *out_slot when
+  // a datagram has been placed at rx_data + slot * page_size -- the exact
+  // address the consumer derives for itself, since this shape carries no
+  // address in a flag.
+  //
+  // rx_flags is deliberately untouched: in this shape nothing ever clears an rx
+  // flag, so setting one would wedge that slot permanently. Occupancy is
+  // tracked through tx_flags alone.
+  bool rxPoll(std::uint32_t *out_slot) {
+    if (!unified || !out_slot || fd < 0)
+      return false;
+
+    // Back-pressure: a response is still in flight for this slot (a running
+    // GRAPH_LAUNCH graph), so its RX half cannot be reused yet. Checked before
+    // the recv so the datagram stays queued in the socket rather than being
+    // consumed with nowhere to put it.
+    if (load_flag(&tx_flags[next_rx_slot]) != 0)
+      return false;
+
+    std::uint8_t *rx_slot = rx_data + next_rx_slot * page_size;
+    sockaddr_in from{};
+    socklen_t fromlen = sizeof(from);
+    // Straight into the slot, no staging copy. MSG_TRUNC still reports the
+    // datagram's true length even though at most page_size bytes were copied,
+    // which is what keeps the oversize check below honest.
+    const ssize_t got =
+        ::recvfrom(fd, rx_slot, page_size, MSG_DONTWAIT | MSG_TRUNC,
+                   reinterpret_cast<sockaddr *>(&from), &fromlen);
+    if (got <= 0)
+      return false; // EAGAIN: nothing ready
+    if (static_cast<std::size_t>(got) > page_size) {
+      warnOversizeOnce(got);
+      // The slot keeps a truncated prefix, which is harmless: it was never
+      // reported, so nothing can read it, and the next poll on this slot
+      // overwrites it.
+      return false;
+    }
+    std::memset(rx_slot + got, 0, page_size - static_cast<std::size_t>(got));
+
+    // No peer_mutex here, and none needed: in this shape there are no pump
+    // threads, and both hooks run on the consumer's one dispatch thread.
+    peer_addr = from;
+    have_peer = true;
+    *out_slot = next_rx_slot;
+    next_rx_slot = (next_rx_slot + 1) % num_pages;
+    return true;
+  }
+
+  // Ship one TX slot to the most recent inbound peer as one full-stride
+  // datagram. Slot-addressed rather than FIFO, so responses may be published in
+  // any order -- unlike txLoop, whose cursor imposes publish order.
+  //
+  // Does NOT touch tx_flags: in this shape the consumer (dispatcher and graph
+  // engine) owns them, and txLoop's clear-after-send has no counterpart here.
+  bool txPublish(std::uint32_t slot) {
+    if (!unified || fd < 0 || slot >= num_pages || !have_peer)
+      return false;
+    const std::uint8_t *tx_slot = tx_data + slot * page_size;
+    return ::sendto(fd, tx_slot, page_size, 0,
+                    reinterpret_cast<const sockaddr *>(&peer_addr),
+                    sizeof(peer_addr)) == static_cast<ssize_t>(page_size);
   }
 
   void close() {
@@ -168,11 +253,24 @@ private:
     fd = ::socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0)
       return false;
-    // Bounded recv wait so rxLoop can observe shutdown.
+    // Bounded recv wait so rxLoop can observe shutdown. Irrelevant in unified
+    // mode, whose recv is MSG_DONTWAIT.
     const timeval rx_poll_interval{0, 100000}; // 100 ms
     ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rx_poll_interval,
                  sizeof(rx_poll_interval));
     return true;
+  }
+
+  // Shared by both shapes: a stride mismatch drops EVERY request, which
+  // otherwise looks like a silent hang upstream, so it is worth one loud line -
+  // but only one.
+  void warnOversizeOnce(ssize_t got) {
+    if (!oversize_warned.exchange(true))
+      std::fprintf(stderr,
+                   "[cudaq-udp-transport] dropping %zd-byte datagram: "
+                   "exceeds this end's page_size (%zu); both ends must "
+                   "use the same slot stride (further drops not logged)\n",
+                   got, page_size);
   }
 
   // One inbound datagram -> one RX slot, in strict ring order. Back-pressure
@@ -190,14 +288,7 @@ private:
       if (got <= 0)
         continue; // timeout/EINTR: re-check `running`
       if (static_cast<std::size_t>(got) > page_size) {
-        // Stride mismatch with the peer; drop. Warn once -- a mismatch drops
-        // EVERY request, which otherwise looks like a silent hang upstream.
-        if (!oversize_warned.exchange(true))
-          std::fprintf(stderr,
-                       "[cudaq-udp-transport] dropping %zd-byte datagram: "
-                       "exceeds this end's page_size (%zu); both ends must "
-                       "use the same slot stride (further drops not logged)\n",
-                       got, page_size);
+        warnOversizeOnce(got); // stride mismatch with the peer; drop
         continue;
       }
 
@@ -269,6 +360,12 @@ private:
   std::uint16_t local_port = 0;
   std::atomic<bool> running{false};
   std::atomic<bool> oversize_warned{false};
+  // Set before start() and never written again, so the hot paths can read it
+  // without synchronization.
+  bool unified = false;
+  // rxPoll's ring cursor -- rxLoop's equivalent is a local, since only one of
+  // the two shapes ever runs. Plain unsigned: the one dispatch thread owns it.
+  unsigned next_rx_slot = 0;
   std::thread rx_thread;
   std::thread tx_thread;
   std::mutex peer_mutex;
@@ -333,8 +430,20 @@ uint16_t cpu_udp_get_port(cpu_udp_transceiver_t handle) {
   return handle ? cast(handle)->port() : 0;
 }
 
+int cpu_udp_set_unified(cpu_udp_transceiver_t handle, int unified) {
+  return handle && cast(handle)->setUnified(unified != 0) ? 1 : 0;
+}
+
 int cpu_udp_start(cpu_udp_transceiver_t handle) {
   return handle && cast(handle)->start() ? 1 : 0;
+}
+
+int cpu_udp_rx_poll(cpu_udp_transceiver_t handle, uint32_t *out_slot) {
+  return handle && cast(handle)->rxPoll(out_slot) ? 1 : 0;
+}
+
+int cpu_udp_tx_publish(cpu_udp_transceiver_t handle, uint32_t slot) {
+  return handle && cast(handle)->txPublish(slot) ? 1 : 0;
 }
 
 void cpu_udp_close(cpu_udp_transceiver_t handle) {

--- a/realtime/lib/daemon/bridge/gpu_roce/bridge_impl.cpp
+++ b/realtime/lib/daemon/bridge/gpu_roce/bridge_impl.cpp
@@ -156,6 +156,20 @@ static cudaq_status_t gpu_roce_bridge_get_transport_context(
   if (!ctx->transceiver)
     return CUDAQ_ERR_INTERNAL;
 
+  // This provider implements both shapes, and create() has already committed
+  // to one of them: config.unified decides whether the transceiver was built
+  // with the 3-kernel path (use_3kernel above) and whether launch() starts a
+  // monitor thread.  So report only the configured shape, per the contract on
+  // cudaq_bridge_get_transport_context.  Describing the other one on request
+  // was worse than useless: a consumer that selected unified but forgot this
+  // bridge's --unified could take the launch_fn anyway, then watch launch()
+  // start the 3-kernel monitor underneath its unified dispatcher.  Refusing
+  // makes that a wiring error at the consumer instead.
+  if (context_type == UNIFIED && !ctx->config.unified)
+    return CUDAQ_ERR_UNSUPPORTED;
+  if (context_type == RING_BUFFER && ctx->config.unified)
+    return CUDAQ_ERR_UNSUPPORTED;
+
   auto &transceiver = ctx->transceiver;
   if (context_type == RING_BUFFER) {
     cudaq_ringbuffer_t *ringbuffer =

--- a/realtime/lib/daemon/bridge/udp/bridge_impl.cpp
+++ b/realtime/lib/daemon/bridge/udp/bridge_impl.cpp
@@ -27,13 +27,34 @@
 ///                     so a GPU consumer (e.g. a device-resident dispatch
 ///                     scheduler) can poll them directly; requires a CUDA
 ///                     device at create()
+///   --unified         serve the single-thread unified shape instead of the
+///                     3-thread ring shape: the transceiver starts no pump
+///                     threads and the consumer's dispatch thread drives the
+///                     wire through the rx_poll/tx_publish hooks returned by
+///                     get_cpu_dataplane.  get_transport_context(UNIFIED) then
+///                     answers OK with a NULL launch_fn -- "unified, but the
+///                     loop is yours" -- which is what sends a consumer on to
+///                     get_cpu_dataplane.  The two shapes are exclusive, so
+///                     RING_BUFFER is refused in this mode, and UNIFIED plus
+///                     get_cpu_dataplane are refused without it.
+///
+/// This file stays a thin adapter in both shapes: the transceiver owns the
+/// socket, the rings, the peer address, and both data planes (udp_wrapper.h,
+/// "Unified mode"), and the hooks below only translate its 1/0 returns into the
+/// interface's status enums.
 ///
 /// Lifecycle mapping:
 ///   create      transceiver construction + bind (port is known after this,
 ///               so get_endpoint_info is valid before connect/launch)
 ///   connect     no-op (connectionless)
-///   launch      start the RX/TX ring threads
-///   disconnect  close the socket and stop the threads
+///   launch      start the RX/TX ring threads.  Under --unified there are no
+///               such threads, so this is harmless but unnecessary; a unified
+///               consumer normally skips it (starting a second loop that
+///               raced the data-plane hooks is precisely what that shape
+///               forbids).
+///   disconnect  close the socket and stop the threads.  Under --unified the
+///               consumer MUST stop its dispatcher first: the hooks touch the
+///               socket this closes.
 ///   destroy     free the transceiver
 
 #include "cudaq/realtime/cpu_transport/udp_wrapper.h"
@@ -54,6 +75,7 @@ struct UdpBridgeContext {
   uint32_t num_slots = 8;
   uint32_t slot_size = 256;
   bool pinned_rings = false;
+  bool unified = false;
   // Owned pinned+mapped buffers when pinned_rings is set (freed AFTER the
   // transceiver is destroyed).
   void *pinned[4] = {nullptr, nullptr, nullptr, nullptr};
@@ -70,6 +92,37 @@ void free_pinned(UdpBridgeContext *ctx) {
 bool starts_with(const std::string &s, const char *prefix) {
   const size_t n = std::strlen(prefix);
   return s.size() >= n && std::memcmp(s.data(), prefix, n) == 0;
+}
+
+// Describe the transceiver's four rings.  Shared by both shapes: the ring
+// shape hands this out as the transport context, the unified shape embeds it
+// in the data-plane alongside the hooks.
+cudaq_status_t fill_ring(UdpBridgeContext *ctx, cudaq_ringbuffer_t *ring) {
+  auto *rx_flags = reinterpret_cast<volatile uint64_t *>(
+      cpu_udp_get_rx_ring_flag_addr(ctx->transceiver));
+  auto *tx_flags = reinterpret_cast<volatile uint64_t *>(
+      cpu_udp_get_tx_ring_flag_addr(ctx->transceiver));
+  auto *rx_data = reinterpret_cast<uint8_t *>(
+      cpu_udp_get_rx_ring_data_addr(ctx->transceiver));
+  auto *tx_data = reinterpret_cast<uint8_t *>(
+      cpu_udp_get_tx_ring_data_addr(ctx->transceiver));
+  if (!rx_flags || !tx_flags || !rx_data || !tx_data)
+    return CUDAQ_ERR_INTERNAL;
+
+  // Plain host memory: the device-pointer and host-view fields are the same
+  // addresses (consumers running CUDAQ_DISPATCH_PATH_HOST read the _host
+  // fields; nothing dereferences these as device pointers).
+  ring->rx_flags = rx_flags;
+  ring->tx_flags = tx_flags;
+  ring->rx_data = rx_data;
+  ring->tx_data = tx_data;
+  ring->rx_stride_sz = ctx->slot_size;
+  ring->tx_stride_sz = ctx->slot_size;
+  ring->rx_flags_host = rx_flags;
+  ring->tx_flags_host = tx_flags;
+  ring->rx_data_host = rx_data;
+  ring->tx_data_host = tx_data;
+  return CUDAQ_OK;
 }
 
 } // namespace
@@ -93,6 +146,8 @@ static cudaq_status_t udp_bridge_create(cudaq_realtime_bridge_handle_t *handle,
         ctx->slot_size = static_cast<uint32_t>(std::stoul(a.substr(12)));
       else if (a == "--pinned-rings")
         ctx->pinned_rings = true;
+      else if (a == "--unified")
+        ctx->unified = true;
       // Unrecognized arguments are ignored (callers forward their full
       // transport argument list).
     } catch (const std::exception &) {
@@ -139,6 +194,15 @@ static cudaq_status_t udp_bridge_create(cudaq_realtime_bridge_handle_t *handle,
     delete ctx;
     return CUDAQ_ERR_INTERNAL;
   }
+  // Before the transceiver is started, which is what the mode changes.
+  if (ctx->unified && !cpu_udp_set_unified(ctx->transceiver, 1)) {
+    std::cerr << "ERROR: udp bridge: could not select unified mode"
+              << std::endl;
+    cpu_udp_destroy_transceiver(ctx->transceiver);
+    free_pinned(ctx);
+    delete ctx;
+    return CUDAQ_ERR_INTERNAL;
+  }
   if (!cpu_udp_bind(ctx->transceiver, ctx->requested_port)) {
     std::cerr << "ERROR: udp bridge: bind(port=" << ctx->requested_port
               << ") failed" << std::endl;
@@ -172,34 +236,68 @@ static cudaq_status_t udp_bridge_get_transport_context(
   auto *ctx = reinterpret_cast<UdpBridgeContext *>(handle);
   if (!ctx->transceiver)
     return CUDAQ_ERR_INTERNAL;
+
+  // A consumer asks here for whichever shape it means to serve, so both are
+  // answerable.  Under --unified the answer is "unified, but the loop is
+  // yours": no dispatcher override, and the hooks that drive it come from
+  // get_cpu_dataplane.  Both fields are written rather than left alone, so a
+  // caller that did not zero-initialize reads "no override" and not stack
+  // garbage it would then try to call.
+  if (context_type == UNIFIED) {
+    if (!ctx->unified)
+      return CUDAQ_ERR_UNSUPPORTED;
+    auto *unified_ctx =
+        reinterpret_cast<cudaq_unified_dispatch_ctx_t *>(out_context);
+    unified_ctx->launch_fn = nullptr;
+    unified_ctx->transport_ctx = nullptr;
+    return CUDAQ_OK;
+  }
   if (context_type != RING_BUFFER)
     return CUDAQ_ERR_UNSUPPORTED;
+  // Report the rings only in the shape that uses them.  Handing them out under
+  // --unified would let a consumer poll rx_flags that the unified data path
+  // never sets, which looks like a transport silently dropping every request;
+  // refusing turns that into a consumer-side wiring error naming the shape.
+  if (ctx->unified)
+    return CUDAQ_ERR_UNSUPPORTED;
 
-  auto *ring = reinterpret_cast<cudaq_ringbuffer_t *>(out_context);
-  auto *rx_flags = reinterpret_cast<volatile uint64_t *>(
-      cpu_udp_get_rx_ring_flag_addr(ctx->transceiver));
-  auto *tx_flags = reinterpret_cast<volatile uint64_t *>(
-      cpu_udp_get_tx_ring_flag_addr(ctx->transceiver));
-  auto *rx_data = reinterpret_cast<uint8_t *>(
-      cpu_udp_get_rx_ring_data_addr(ctx->transceiver));
-  auto *tx_data = reinterpret_cast<uint8_t *>(
-      cpu_udp_get_tx_ring_data_addr(ctx->transceiver));
-  if (!rx_flags || !tx_flags || !rx_data || !tx_data)
+  return fill_ring(ctx, reinterpret_cast<cudaq_ringbuffer_t *>(out_context));
+}
+
+// The unified data plane's two hooks, translating the transceiver's 1/0
+// returns into the interface's status enums.  `ctx` is the transceiver handle
+// itself, so they carry no state of their own -- the socket, the rings, the
+// peer address and the RX cursor all live one layer down, shared with the
+// threaded shape rather than duplicated here.
+static cudaq_rx_status_t udp_dp_rx_poll(void *ctx, uint32_t *out_slot) {
+  return cpu_udp_rx_poll(ctx, out_slot) ? CUDAQ_RX_READY : CUDAQ_RX_EMPTY;
+}
+
+static cudaq_status_t udp_dp_tx_publish(void *ctx, uint32_t slot) {
+  return cpu_udp_tx_publish(ctx, slot) ? CUDAQ_OK : CUDAQ_ERR_INTERNAL;
+}
+
+// Serve the single-thread unified shape: the ring plus the two hooks that
+// drive it.  Refused unless --unified was passed, so a consumer that asks for
+// this shape against a ring-mode bridge gets a clean UNSUPPORTED rather than
+// hooks that race the pump threads.
+static cudaq_status_t
+udp_bridge_get_cpu_dataplane(cudaq_realtime_bridge_handle_t handle,
+                             cudaq_cpu_dataplane_t *out_dataplane) {
+  if (!handle || !out_dataplane)
+    return CUDAQ_ERR_INVALID_ARG;
+  auto *ctx = reinterpret_cast<UdpBridgeContext *>(handle);
+  if (!ctx->transceiver)
     return CUDAQ_ERR_INTERNAL;
+  if (!ctx->unified)
+    return CUDAQ_ERR_UNSUPPORTED;
 
-  // Plain host memory: the device-pointer and host-view fields are the same
-  // addresses (consumers running CUDAQ_DISPATCH_PATH_HOST read the _host
-  // fields; nothing dereferences these as device pointers).
-  ring->rx_flags = rx_flags;
-  ring->tx_flags = tx_flags;
-  ring->rx_data = rx_data;
-  ring->tx_data = tx_data;
-  ring->rx_stride_sz = ctx->slot_size;
-  ring->tx_stride_sz = ctx->slot_size;
-  ring->rx_flags_host = rx_flags;
-  ring->tx_flags_host = tx_flags;
-  ring->rx_data_host = rx_data;
-  ring->tx_data_host = tx_data;
+  const cudaq_status_t status = fill_ring(ctx, &out_dataplane->ring);
+  if (status != CUDAQ_OK)
+    return status;
+  out_dataplane->ctx = ctx->transceiver;
+  out_dataplane->rx_poll = udp_dp_rx_poll;
+  out_dataplane->tx_publish = udp_dp_tx_publish;
   return CUDAQ_OK;
 }
 
@@ -215,6 +313,8 @@ static cudaq_status_t udp_bridge_launch(cudaq_realtime_bridge_handle_t handle) {
   auto *ctx = reinterpret_cast<UdpBridgeContext *>(handle);
   if (!ctx->transceiver)
     return CUDAQ_ERR_INTERNAL;
+  // No special case for --unified: cpu_udp_start starts no pump threads in
+  // that mode, so there is nothing here that could race the hooks.
   if (!cpu_udp_start(ctx->transceiver)) {
     std::cerr << "ERROR: udp bridge: transceiver start failed" << std::endl;
     return CUDAQ_ERR_INTERNAL;
@@ -267,9 +367,7 @@ cudaq_realtime_bridge_interface_t *cudaq_realtime_get_bridge_interface() {
       udp_bridge_connect,
       udp_bridge_launch,
       udp_bridge_disconnect,
-      /*get_cpu_dataplane=*/nullptr, // ring path only (unified shape is a
-                                     // follow-up; see udp_wrapper.h ring
-                                     // contract)
+      udp_bridge_get_cpu_dataplane,
       udp_bridge_get_endpoint_info,
       udp_bridge_get_ring_geometry,
       /*set_function_table=*/nullptr, // no function table needed

--- a/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
+++ b/realtime/unittests/bridge_interface/udp/test_udp_bridge_provider.cpp
@@ -16,12 +16,27 @@
 /// absolute path.  If the provider .so regresses to a dynamic dependency on
 /// libcudart, its dlopen fails here on a host without a CUDA runtime, and
 /// cudaq_bridge_create_from_library returns an error instead of CUDAQ_OK.
+///
+/// The dispatch-shape cases below are contract-and-wiring only: this binary
+/// links no transport, so it asserts which shapes the provider offers and that
+/// the data plane it hands out is connected to a real socket and the rings it
+/// advertised -- but not how that data plane behaves.  The behavior of the
+/// hooks belongs to the transceiver that implements them and is covered by
+/// test_udp_transceiver's `UdpUnifiedServiceTest`; both shapes under a real
+/// dispatcher are covered by test_udp_two_process.  A plain UDP socket is
+/// enough to stand in for the far end here, needing no library at all.
 
 #include "cudaq/realtime/daemon/bridge/bridge_interface.h"
 
 #include <gtest/gtest.h>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -30,6 +45,24 @@
 #error                                                                         \
     "UDP_BRIDGE_PROVIDER_PATH must be defined (path to the built udp provider .so)"
 #endif
+
+namespace {
+
+// Create a bridge from the built provider with `args`, which the provider
+// parses in create().
+cudaq_realtime_bridge_handle_t make_bridge(std::vector<std::string> args) {
+  std::vector<char *> argv;
+  for (auto &a : args)
+    argv.push_back(a.data());
+  cudaq_realtime_bridge_handle_t bridge = nullptr;
+  EXPECT_EQ(cudaq_bridge_create_from_library(&bridge, UDP_BRIDGE_PROVIDER_PATH,
+                                             static_cast<int>(argv.size()),
+                                             argv.data()),
+            CUDAQ_OK);
+  return bridge;
+}
+
+} // namespace
 
 TEST(UdpBridgeProvider, LoadsAndCreatesPlainBridgeWithoutCudaRuntime) {
   std::vector<std::string> args = {"--port=0", "--num-slots=8",
@@ -85,4 +118,229 @@ TEST(UdpBridgeProvider, LoadsAndCreatesPlainBridgeWithoutCudaRuntime) {
   // An unknown handle (here: the destroyed one) is rejected.
   EXPECT_EQ(cudaq_bridge_set_function_table(bridge, &table),
             CUDAQ_ERR_INVALID_ARG);
+}
+
+// The 3-thread ring shape and the single-thread unified shape are mutually
+// exclusive, and each is refused in the other's mode.  Refusing is the point:
+// silently serving the wrong one produces a transport that appears to drop
+// every request.
+TEST(UdpBridgeProvider, RefusesCpuDataplaneWithoutUnified) {
+  cudaq_realtime_bridge_handle_t bridge =
+      make_bridge({"--port=0", "--num-slots=8", "--slot-size=256"});
+  ASSERT_NE(bridge, nullptr);
+
+  cudaq_cpu_dataplane_t dataplane = {};
+  EXPECT_EQ(cudaq_bridge_get_cpu_dataplane(bridge, &dataplane),
+            CUDAQ_ERR_UNSUPPORTED);
+
+  // ... while the ring shape is served, as it always has been.
+  cudaq_ringbuffer_t ring = {};
+  EXPECT_EQ(cudaq_bridge_get_transport_context(bridge, RING_BUFFER, &ring),
+            CUDAQ_OK);
+
+  EXPECT_EQ(cudaq_bridge_destroy(bridge), CUDAQ_OK);
+}
+
+TEST(UdpBridgeProvider, ExposesCpuDataplaneWithUnified) {
+  cudaq_realtime_bridge_handle_t bridge = make_bridge(
+      {"--unified", "--port=0", "--num-slots=8", "--slot-size=256"});
+  ASSERT_NE(bridge, nullptr);
+
+  cudaq_cpu_dataplane_t dataplane = {};
+  ASSERT_EQ(cudaq_bridge_get_cpu_dataplane(bridge, &dataplane), CUDAQ_OK);
+
+  // Both hooks are required, and the unified loop derives every slot address
+  // from the host-view pointers and the strides, so those must be populated
+  // too.  rx_flags is deliberately not asserted on: this shape does not use it.
+  EXPECT_NE(dataplane.ctx, nullptr);
+  EXPECT_NE(dataplane.rx_poll, nullptr);
+  EXPECT_NE(dataplane.tx_publish, nullptr);
+  EXPECT_NE(dataplane.ring.rx_data_host, nullptr);
+  EXPECT_NE(dataplane.ring.tx_data_host, nullptr);
+  EXPECT_NE(dataplane.ring.tx_flags_host, nullptr);
+  EXPECT_EQ(dataplane.ring.rx_stride_sz, size_t{256});
+  EXPECT_EQ(dataplane.ring.tx_stride_sz, size_t{256});
+
+  // Refusing the other shape is what turns a caller's `--dispatch=` mismatch
+  // into a named wiring error rather than a transport that appears to drop
+  // every request.
+  cudaq_ringbuffer_t ring = {};
+  EXPECT_EQ(cudaq_bridge_get_transport_context(bridge, RING_BUFFER, &ring),
+            CUDAQ_ERR_UNSUPPORTED);
+
+  EXPECT_EQ(cudaq_bridge_destroy(bridge), CUDAQ_OK);
+}
+
+// A consumer that means to serve unified asks get_transport_context first, the
+// same call it would make for the ring shape, and keys off launch_fn to learn
+// which flavor of unified it got.  Both configurations are asserted, because
+// the whole mechanism rests on a provider refusing the shape it is NOT running.
+TEST(UdpBridgeProvider, AnswersUnifiedWithNoDispatcherOverride) {
+  cudaq_realtime_bridge_handle_t ring_bridge =
+      make_bridge({"--port=0", "--num-slots=8", "--slot-size=256"});
+  ASSERT_NE(ring_bridge, nullptr);
+  cudaq_unified_dispatch_ctx_t unified_ctx = {};
+  EXPECT_EQ(
+      cudaq_bridge_get_transport_context(ring_bridge, UNIFIED, &unified_ctx),
+      CUDAQ_ERR_UNSUPPORTED);
+  EXPECT_EQ(cudaq_bridge_destroy(ring_bridge), CUDAQ_OK);
+
+  cudaq_realtime_bridge_handle_t unified_bridge = make_bridge(
+      {"--unified", "--port=0", "--num-slots=8", "--slot-size=256"});
+  ASSERT_NE(unified_bridge, nullptr);
+  // Deliberately dirty: the provider must write both fields, not merely leave
+  // them alone, or a caller reusing a struct reads stale bytes as an override
+  // and calls into them.
+  cudaq_unified_dispatch_ctx_t dirty;
+  dirty.launch_fn = reinterpret_cast<cudaq_unified_launch_fn_t>(0xdeadbeef);
+  dirty.transport_ctx = reinterpret_cast<void *>(0xfeedface);
+  ASSERT_EQ(cudaq_bridge_get_transport_context(unified_bridge, UNIFIED, &dirty),
+            CUDAQ_OK);
+
+  // Null means "unified, but the loop is yours": this transport supplies no
+  // dispatcher override, so the consumer goes on to get_cpu_dataplane.  A stray
+  // non-null here would send it down the set_unified_launch path instead and
+  // the data plane would never be installed.
+  EXPECT_EQ(dirty.launch_fn, nullptr);
+  EXPECT_EQ(dirty.transport_ctx, nullptr);
+
+  EXPECT_EQ(cudaq_bridge_destroy(unified_bridge), CUDAQ_OK);
+}
+
+//==============================================================================
+// Is the data plane we hand out actually wired to anything?
+//==============================================================================
+
+/// A unified bridge plus a plain UDP socket standing in for the far end.  The
+/// tests call the two hooks the way `cudaq_host_unified_loop` does, so nothing
+/// here needs a dispatcher.
+///
+/// The point is the wiring, not the behavior: `dataplane.ctx` must be the
+/// transceiver handle (passing the bridge context instead would compile and
+/// then corrupt memory), and `dataplane.ring` must describe the same rings
+/// those hooks read and write.  Both are the kind of mistake that only a real
+/// datagram catches.
+class UdpUnifiedWiringTest : public ::testing::Test {
+protected:
+  static constexpr uint32_t kNumSlots = 4;
+  static constexpr uint32_t kSlotSize = 256;
+
+  void SetUp() override {
+    bridge = make_bridge({"--unified", "--port=0",
+                          "--num-slots=" + std::to_string(kNumSlots),
+                          "--slot-size=" + std::to_string(kSlotSize)});
+    ASSERT_NE(bridge, nullptr);
+    ASSERT_EQ(cudaq_bridge_get_cpu_dataplane(bridge, &dp), CUDAQ_OK);
+
+    // The provider binds loopback and reports the port it landed on, which is
+    // the only way to find an ephemeral one.
+    char endpoint[256] = {};
+    ASSERT_EQ(
+        cudaq_bridge_get_endpoint_info(bridge, endpoint, sizeof(endpoint)),
+        CUDAQ_OK);
+    // Anchored on the space: "port=" also occurs inside "transport=".
+    const char *port = std::strstr(endpoint, " port=");
+    ASSERT_NE(port, nullptr) << endpoint;
+    const int port_number = std::atoi(port + 6);
+    ASSERT_GT(port_number, 0) << endpoint;
+    service.sin_family = AF_INET;
+    service.sin_addr.s_addr = ::htonl(INADDR_LOOPBACK);
+    service.sin_port = ::htons(static_cast<uint16_t>(port_number));
+
+    peer_fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_GE(peer_fd, 0);
+    // Bounded, so a missing response fails this test rather than hanging it.
+    const timeval reply_timeout{1, 0};
+    ::setsockopt(peer_fd, SOL_SOCKET, SO_RCVTIMEO, &reply_timeout,
+                 sizeof(reply_timeout));
+  }
+
+  void TearDown() override {
+    if (peer_fd >= 0)
+      ::close(peer_fd);
+    EXPECT_EQ(cudaq_bridge_destroy(bridge), CUDAQ_OK);
+  }
+
+  void sendFromPeer(const std::string &payload) {
+    ASSERT_EQ(::sendto(peer_fd, payload.data(), payload.size(), 0,
+                       reinterpret_cast<const sockaddr *>(&service),
+                       sizeof(service)),
+              static_cast<ssize_t>(payload.size()));
+  }
+
+  // rx_poll is non-blocking, so spin the way the dispatch loop does.
+  bool pollUntilReady(uint32_t *slot, unsigned budget_ms = 2000) {
+    for (unsigned i = 0; i < budget_ms * 2; ++i) {
+      if (dp.rx_poll(dp.ctx, slot) == CUDAQ_RX_READY)
+        return true;
+      ::usleep(500);
+    }
+    return false;
+  }
+
+  const char *rxSlot(uint32_t slot) const {
+    return reinterpret_cast<const char *>(
+        dp.ring.rx_data_host + static_cast<size_t>(slot) * kSlotSize);
+  }
+
+  void writeTxSlot(uint32_t slot, const std::string &payload) {
+    uint8_t *tx = dp.ring.tx_data_host + static_cast<size_t>(slot) * kSlotSize;
+    std::memset(tx, 0, kSlotSize);
+    std::memcpy(tx, payload.data(), payload.size());
+  }
+
+  cudaq_realtime_bridge_handle_t bridge = nullptr;
+  cudaq_cpu_dataplane_t dp = {};
+  sockaddr_in service = {};
+  int peer_fd = -1;
+};
+
+TEST_F(UdpUnifiedWiringTest, HooksRoundTripThroughTheAdvertisedRings) {
+  sendFromPeer("ping");
+
+  uint32_t slot = 42;
+  ASSERT_TRUE(pollUntilReady(&slot));
+  EXPECT_EQ(slot, 0u);
+  // Read through the advertised ring base and stride, which is the wiring
+  // under test: rx_poll put the datagram where the dispatch loop will look.
+  EXPECT_STREQ(rxSlot(slot), "ping");
+
+  // Answer from the TX half of the slot the request arrived in, as the
+  // dispatcher does.
+  writeTxSlot(slot, "pong");
+  ASSERT_EQ(dp.tx_publish(dp.ctx, slot), CUDAQ_OK);
+
+  char reply[kSlotSize] = {};
+  const ssize_t got = ::recv(peer_fd, reply, sizeof(reply), 0);
+  ASSERT_EQ(got, static_cast<ssize_t>(kSlotSize))
+      << "one full stride per frame";
+  EXPECT_STREQ(reply, "pong");
+}
+
+TEST_F(UdpUnifiedWiringTest, LaunchDoesNotStartAPumpThatRacesTheHooks) {
+  // The provider deliberately does not special-case launch() for this shape,
+  // on the grounds that the transceiver starts no pump threads once unified.
+  // That is the whole safety argument, so it is worth pinning: an arriving
+  // datagram must still be sitting on the socket afterwards.
+  ASSERT_EQ(cudaq_bridge_launch(bridge), CUDAQ_OK);
+  sendFromPeer("still-queued");
+
+  // A pump thread would have consumed it into slot 0 and published the flag.
+  ::usleep(250000);
+  EXPECT_EQ(dp.ring.rx_flags_host[0], 0u);
+
+  uint32_t slot = 0;
+  ASSERT_TRUE(pollUntilReady(&slot));
+  EXPECT_STREQ(rxSlot(slot), "still-queued");
+}
+
+TEST_F(UdpUnifiedWiringTest, HookFailuresReachTheCallerAsErrors) {
+  // The hooks translate the transceiver's 1/0 into status enums, and 0 is all
+  // they get -- so every failure arrives as ERR_INTERNAL, without the
+  // resolution to say INVALID_ARG. That is acceptable because the unified loop
+  // only ever publishes a slot rx_poll just handed it, making these
+  // unreachable in production; but the translation must not report success.
+  EXPECT_EQ(dp.tx_publish(dp.ctx, kNumSlots), CUDAQ_ERR_INTERNAL);
+  // Nothing has arrived, so no peer address has been learned yet.
+  EXPECT_EQ(dp.tx_publish(dp.ctx, 0), CUDAQ_ERR_INTERNAL);
 }

--- a/realtime/unittests/bridge_interface/udp/test_udp_two_process.cpp
+++ b/realtime/unittests/bridge_interface/udp/test_udp_two_process.cpp
@@ -40,11 +40,19 @@
 /// verify is that a refused frame produces no response and is not counted as
 /// dispatched, measured against a round trip that is known to work.
 ///
-/// Parameterized on the dispatch shape, which crosses the process boundary as a
-/// command-line token.  Only "ring" is instantiated today; the client half of
-/// the wire is byte-identical under "unified" (that shape changes only how the
-/// server services its own rings), so adding it is one value in the
-/// instantiation list once the provider exposes a CPU data-plane.
+/// That gap is the ring shape's alone: the unified shape publishes by slot
+/// index rather than through a FIFO cursor, so a skipped slot costs it
+/// nothing.  The tests are written to the stricter of the two anyway, which is
+/// what lets one body serve both.
+///
+/// Parameterized on the dispatch shape, which crosses the process boundary as
+/// command-line tokens -- one for the server, one for the bridge.  Every case
+/// runs under both: the client half of the wire
+/// is byte-identical, since the shape changes only how the server services its
+/// own rings -- 3 threads moving bytes between the wire and the ring buffer, or
+/// one dispatcher thread driving the wire itself through the provider's
+/// rx_poll/tx_publish hooks.  That is the property worth testing here, and the
+/// only way to test it is to assert the two are indistinguishable from outside.
 
 #include "cudaq/realtime/cpu_transport/udp_wrapper.h"
 #include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
@@ -92,18 +100,27 @@ constexpr auto kNoResponseWindow = std::chrono::milliseconds(500);
 class UdpTwoProcess : public ::testing::TestWithParam<const char *> {
 protected:
   void SetUp() override {
-    const std::vector<std::string> argv = {
-        CUDAQ_REALTIME_TEST_SERVER_PATH, "--transport=udp",
-        std::string("--dispatch=") + GetParam(), "--port=0",
-        "--num-slots=" + std::to_string(kNumSlots),
-        "--slot-size=" + std::to_string(kSlotSize),
-        // Backstop in case a failing test leaves the child unreaped.
-        "--timeout=120"};
+    const bool unified = std::string(GetParam()) == "unified";
+    std::vector<std::string> argv = {
+        CUDAQ_REALTIME_TEST_SERVER_PATH,
+        // Server options: how this end is wired, plus a backstop in case a
+        // failing test leaves the child unreaped.
+        "--transport=udp", std::string("--dispatch=") + GetParam(),
+        "--timeout=120",
+        // Bridge options from here on, forwarded verbatim by the server.
+        "--", "--port=0", "--num-slots=" + std::to_string(kNumSlots),
+        "--slot-size=" + std::to_string(kSlotSize)};
+    // The shape's second token, this one for the bridge: --dispatch= wires the
+    // server, this puts the provider in the matching mode. Deliberately not
+    // synthesized by the server -- see the shape note in its header.
+    if (unified)
+      argv.push_back("--unified");
     ASSERT_TRUE(server.start(argv, kReadyPrefix))
         << "server did not become ready; output:\n"
         << server.output();
 
-    // The shape the server actually brought up, not the one we asked for.
+    // The shape the server actually brought up. Both tokens agreeing is what
+    // gets us here at all: a mismatch fails the server's wiring step.
     EXPECT_EQ(std::string(GetParam()), field("dispatch")) << server.output();
     ASSERT_EQ("udp", field("transport")) << server.output();
 
@@ -287,7 +304,7 @@ TEST_P(UdpTwoProcess, ReportsProcessedCount) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    Shapes, UdpTwoProcess, ::testing::Values("ring"),
+    Shapes, UdpTwoProcess, ::testing::Values("ring", "unified"),
     [](const ::testing::TestParamInfo<const char *> &info) {
       return std::string(info.param);
     });

--- a/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
+++ b/realtime/unittests/cpu_transport/test_udp_transceiver.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <gtest/gtest.h>
 #include <string>
+#include <thread>
 
 using cudaq::realtime::testing::load_flag;
 using cudaq::realtime::testing::slot_data;
@@ -85,6 +86,81 @@ protected:
         reinterpret_cast<const char *>(slotData(serviceRxData, slot)));
     store_flag(serviceRxFlags, slot, 0);
     return payload;
+  }
+
+  cpu_udp_transceiver_t service = nullptr;
+  cpu_udp_transceiver_t caller = nullptr;
+  std::uint64_t serviceRxFlags = 0, serviceRxData = 0;
+  std::uint64_t serviceTxFlags = 0, serviceTxData = 0;
+  std::uint64_t callerRxFlags = 0, callerRxData = 0;
+  std::uint64_t callerTxFlags = 0, callerTxData = 0;
+};
+
+// A UNIFIED (thread-free) service paired with an ordinary pumping caller. This
+// test thread drives the service's data plane through the two hooks, standing
+// in for the consumer's dispatch loop. The caller is deliberately unchanged:
+// only one end opts into this shape, and the wire between them is identical.
+class UdpUnifiedServiceTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    service = cpu_udp_create_transceiver(kPageSize, kNumPages);
+    ASSERT_NE(nullptr, service);
+    ASSERT_EQ(1, cpu_udp_set_unified(service, 1));
+    ASSERT_EQ(1, cpu_udp_bind(service, /*port=*/0));
+    ASSERT_NE(0, cpu_udp_get_port(service));
+    ASSERT_EQ(1, cpu_udp_start(service)); // starts no threads in this mode
+
+    caller = cpu_udp_create_transceiver(kPageSize, kNumPages);
+    ASSERT_NE(nullptr, caller);
+    ASSERT_EQ(1,
+              cpu_udp_connect(caller, "127.0.0.1", cpu_udp_get_port(service)));
+    ASSERT_EQ(1, cpu_udp_start(caller));
+
+    serviceRxFlags = cpu_udp_get_rx_ring_flag_addr(service);
+    serviceRxData = cpu_udp_get_rx_ring_data_addr(service);
+    serviceTxFlags = cpu_udp_get_tx_ring_flag_addr(service);
+    serviceTxData = cpu_udp_get_tx_ring_data_addr(service);
+    callerRxFlags = cpu_udp_get_rx_ring_flag_addr(caller);
+    callerTxFlags = cpu_udp_get_tx_ring_flag_addr(caller);
+    callerRxData = cpu_udp_get_rx_ring_data_addr(caller);
+    callerTxData = cpu_udp_get_tx_ring_data_addr(caller);
+  }
+
+  void TearDown() override {
+    cpu_udp_destroy_transceiver(caller);
+    cpu_udp_destroy_transceiver(service);
+  }
+
+  void publishFromCaller(unsigned slot, const std::string &payload) {
+    ASSERT_LT(payload.size(), kPageSize);
+    std::uint8_t *tx = slotData(callerTxData, slot);
+    std::memset(tx, 0, kPageSize);
+    std::memcpy(tx, payload.data(), payload.size());
+    store_flag(callerTxFlags, slot, reinterpret_cast<std::uint64_t>(tx));
+  }
+
+  // cpu_udp_rx_poll is non-blocking, so spin the way a dispatch loop does.
+  bool pollService(std::uint32_t *slot, std::chrono::milliseconds budget =
+                                            std::chrono::milliseconds(2000)) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    do {
+      if (cpu_udp_rx_poll(service, slot))
+        return true;
+      std::this_thread::sleep_for(std::chrono::microseconds(200));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return false;
+  }
+
+  // For the cases where the *absence* of delivery is the property under test.
+  bool serviceStaysEmpty(
+      std::chrono::milliseconds window = std::chrono::milliseconds(250)) {
+    std::uint32_t slot = 0;
+    return !pollService(&slot, window);
+  }
+
+  std::string serviceSlotPayload(std::uint32_t slot) const {
+    return std::string(
+        reinterpret_cast<const char *>(slotData(serviceRxData, slot)));
   }
 
   cpu_udp_transceiver_t service = nullptr;
@@ -264,6 +340,171 @@ TEST_F(UdpTransceiverPairTest, DropsDatagramsLargerThanOwnStride) {
       wait_for_flag(serviceRxFlags, 0, std::chrono::milliseconds(250)));
 
   cpu_udp_destroy_transceiver(bigCaller);
+}
+
+//==============================================================================
+// Unified (thread-free) mode
+//==============================================================================
+
+TEST_F(UdpUnifiedServiceTest, StartSpawnsNoPumpThreads) {
+  publishFromCaller(0, "queued");
+  // The caller's TX pump ships it, so it really is on the wire ...
+  ASSERT_TRUE(wait_for_flag_clear(callerTxFlags, 0));
+
+  // ... but no RX pump exists at the service to move it into a slot. A pump
+  // would have published the flag well inside this window.
+  EXPECT_FALSE(
+      wait_for_flag(serviceRxFlags, 0, std::chrono::milliseconds(250)));
+
+  // The datagram was queued, not lost: the hook still finds it.
+  std::uint32_t slot = 42;
+  ASSERT_TRUE(pollService(&slot));
+  EXPECT_EQ(0u, slot);
+  EXPECT_EQ("queued", serviceSlotPayload(slot));
+}
+
+TEST_F(UdpUnifiedServiceTest, RxPollReportsSlotByValueAndLeavesRxFlagsAlone) {
+  publishFromCaller(0, "request-0");
+
+  std::uint32_t slot = 42;
+  ASSERT_TRUE(pollService(&slot));
+  EXPECT_EQ(0u, slot);
+  // The payload is at the address the consumer derives for itself, since this
+  // shape carries no address in a flag.
+  EXPECT_EQ("request-0", serviceSlotPayload(slot));
+  // Nothing in this shape ever clears an rx flag, so the hook must not set
+  // one -- that slot would be occupied forever.
+  EXPECT_EQ(0u, load_flag(serviceRxFlags, slot));
+}
+
+TEST_F(UdpUnifiedServiceTest, HooksRoundTripToCaller) {
+  publishFromCaller(0, "ping");
+  std::uint32_t slot = 0;
+  ASSERT_TRUE(pollService(&slot));
+  EXPECT_EQ("ping", serviceSlotPayload(slot));
+
+  // Answer from the TX half of the same slot, as the dispatcher does. The
+  // response goes to the source of the most recent inbound datagram.
+  std::uint8_t *tx = slotData(serviceTxData, slot);
+  std::memset(tx, 0, kPageSize);
+  std::memcpy(tx, "pong", 4);
+  ASSERT_EQ(1, cpu_udp_tx_publish(service, slot));
+
+  // The caller is an ordinary pumping transceiver, so its RX ring behaves
+  // normally: publishing from the unified end is invisible on the wire.
+  ASSERT_TRUE(wait_for_flag(callerRxFlags, 0));
+  EXPECT_EQ(0, std::memcmp(slotData(callerRxData, 0), "pong", 4));
+  store_flag(callerRxFlags, 0, 0);
+
+  // tx_publish does not touch tx_flags: the consumer owns them here, and
+  // there is no TX pump to recycle them.
+  EXPECT_EQ(0u, load_flag(serviceTxFlags, slot));
+}
+
+TEST_F(UdpUnifiedServiceTest, RxPollBackPressuresOnPendingTxFlag) {
+  // tx_flags is the only occupancy marker in this shape: non-zero means a
+  // response is still in flight for that slot (in production, a running
+  // GRAPH_LAUNCH graph), so its RX half must not be handed out again.
+  store_flag(serviceTxFlags, 0, 1);
+  publishFromCaller(0, "blocked");
+  ASSERT_TRUE(wait_for_flag_clear(callerTxFlags, 0));
+
+  EXPECT_TRUE(serviceStaysEmpty());
+
+  // Back-pressure without consuming: releasing the slot releases the datagram
+  // that was waiting behind it.
+  store_flag(serviceTxFlags, 0, 0);
+  std::uint32_t slot = 42;
+  ASSERT_TRUE(pollService(&slot));
+  EXPECT_EQ(0u, slot);
+  EXPECT_EQ("blocked", serviceSlotPayload(slot));
+}
+
+TEST_F(UdpUnifiedServiceTest, RxPollFillsSlotsInStrictRingOrder) {
+  // Two laps of the ring: a cursor that failed to wrap or a slot that failed
+  // to recycle would stall this.
+  for (unsigned i = 0; i < 2 * kNumPages; ++i) {
+    const unsigned callerSlot = i % kNumPages;
+    const std::string payload = "msg-" + std::to_string(i);
+    publishFromCaller(callerSlot, payload);
+    ASSERT_TRUE(wait_for_flag_clear(callerTxFlags, callerSlot))
+        << "message " << i;
+
+    std::uint32_t slot = 42;
+    ASSERT_TRUE(pollService(&slot)) << "message " << i;
+    EXPECT_EQ(i % kNumPages, slot) << "message " << i;
+    EXPECT_EQ(payload, serviceSlotPayload(slot)) << "message " << i;
+  }
+}
+
+TEST_F(UdpUnifiedServiceTest, DropsOversizeDatagramInUnifiedMode) {
+  // Same policy as the RX pump (both ends must agree on page_size), reached
+  // through the hook instead: MSG_TRUNC reports the true length even though
+  // only page_size bytes were copied.
+  cpu_udp_transceiver_t bigCaller =
+      cpu_udp_create_transceiver(2 * kPageSize, kNumPages);
+  ASSERT_NE(nullptr, bigCaller);
+  ASSERT_EQ(1,
+            cpu_udp_connect(bigCaller, "127.0.0.1", cpu_udp_get_port(service)));
+  ASSERT_EQ(1, cpu_udp_start(bigCaller));
+
+  const std::uint64_t bigTxFlags = cpu_udp_get_tx_ring_flag_addr(bigCaller);
+  const std::uint64_t bigTxData = cpu_udp_get_tx_ring_data_addr(bigCaller);
+  std::uint8_t *tx = slotData(bigTxData, 0, 2 * kPageSize);
+  std::memset(tx, 0xAB, 2 * kPageSize);
+  store_flag(bigTxFlags, 0, reinterpret_cast<std::uint64_t>(tx));
+
+  ASSERT_TRUE(wait_for_flag_clear(bigTxFlags, 0)); // shipped ...
+  EXPECT_TRUE(serviceStaysEmpty());                // ... and dropped
+
+  // The drop consumed no slot, so a well-sized datagram still lands in slot 0.
+  publishFromCaller(0, "after-drop");
+  std::uint32_t slot = 42;
+  ASSERT_TRUE(pollService(&slot));
+  EXPECT_EQ(0u, slot);
+  EXPECT_EQ("after-drop", serviceSlotPayload(slot));
+
+  cpu_udp_destroy_transceiver(bigCaller);
+}
+
+TEST_F(UdpUnifiedServiceTest, RejectsMisuse) {
+  // The shape cannot be changed under a running transceiver: the pump threads
+  // and the hooks would contend for the same socket and slots.
+  EXPECT_EQ(0, cpu_udp_set_unified(service, 0));
+
+  // Out of range rather than reading past the end of the ring.
+  EXPECT_EQ(0, cpu_udp_tx_publish(service, kNumPages));
+
+  // The hooks are refused on a threaded transceiver, so a consumer that wires
+  // the wrong shape gets a failure rather than a race with the pumps. (The
+  // caller here is connected and pumping, hence has a peer to answer.)
+  std::uint32_t slot = 0;
+  EXPECT_EQ(0, cpu_udp_rx_poll(caller, &slot));
+  EXPECT_EQ(0, cpu_udp_tx_publish(caller, 0));
+
+  EXPECT_EQ(0, cpu_udp_set_unified(nullptr, 1));
+  EXPECT_EQ(0, cpu_udp_rx_poll(nullptr, &slot));
+  EXPECT_EQ(0, cpu_udp_rx_poll(service, nullptr));
+  EXPECT_EQ(0, cpu_udp_tx_publish(nullptr, 0));
+}
+
+TEST(UdpUnifiedLifecycle, PublishNeedsAPeerAndSetUnifiedPrecedesStart) {
+  cpu_udp_transceiver_t xcvr = cpu_udp_create_transceiver(kPageSize, kNumPages);
+  ASSERT_NE(nullptr, xcvr);
+  ASSERT_EQ(1, cpu_udp_set_unified(xcvr, 1));
+  // Unified mode does not remove the need for a socket.
+  EXPECT_EQ(0, cpu_udp_start(xcvr));
+  ASSERT_EQ(1, cpu_udp_bind(xcvr, /*port=*/0));
+  ASSERT_EQ(1, cpu_udp_start(xcvr));
+
+  // Nothing has arrived, so no peer has been learned and there is nowhere to
+  // send a response.
+  EXPECT_EQ(0, cpu_udp_tx_publish(xcvr, 0));
+  // And the mode is now frozen.
+  EXPECT_EQ(0, cpu_udp_set_unified(xcvr, 1));
+
+  cpu_udp_close(xcvr);
+  cpu_udp_destroy_transceiver(xcvr);
 }
 
 } // namespace

--- a/realtime/unittests/test_server/CMakeLists.txt
+++ b/realtime/unittests/test_server/CMakeLists.txt
@@ -38,6 +38,7 @@ target_compile_definitions(cudaq-realtime-test-server PRIVATE
 
 target_link_libraries(cudaq-realtime-test-server PRIVATE
   cudaq-realtime
+  cudaq-realtime-dispatch
   Threads::Threads
 )
 

--- a/realtime/unittests/test_server/cudaq_realtime_test_server.cpp
+++ b/realtime/unittests/test_server/cudaq_realtime_test_server.cpp
@@ -10,31 +10,48 @@
 /// @brief Service half of the realtime two-process tests: a dispatcher serving
 ///        the `rpc_increment` HOST_CALL handler over any bridge provider.
 ///
+/// Also meant to be read.  This is the shortest complete path from "I have a
+/// bridge provider" to "I am serving RPCs", so the numbered steps in `main` are
+/// the reference: they are the whole API sequence, in order, with nothing
+/// hidden behind a helper.  Copy them.
+///
 /// Transport-agnostic by construction.  Every transport is reached through the
 /// same bridge vtable (bridge_interface.h), and each provider owns its own
 /// bring-up -- udp binds a socket in create(), cpu_roce does the full TCP
 /// rendezvous plus QP/rkey swap across create()/connect() -- so there is no
-/// per-transport code here.  `--transport=` names the provider library and
-/// every unrecognized argument is forwarded to it verbatim, which is how
-/// `--port=`, `--device=`, `--local-ip=`, `--qp_config=`, `--peer-ip=`,
-/// `--remote-qp=`, `--num-slots=` and `--slot-size=` reach the provider that
-/// understands them.  Providers ignore arguments they do not recognize, by
-/// contract, so forwarding the whole command line is safe.
+/// per-transport code here.
+///
+/// TWO COMMAND LINES, ONE ARGV
+///
+///     cudaq-realtime-test-server [server options] [-- bridge options]
+///
+/// `--` is the boundary: before it are this server's options, after it are the
+/// bridge's, forwarded verbatim and never read here.  That is how `--port=`,
+/// `--device=`, `--local-ip=`, `--qp_config=`, `--peer-ip=`, `--remote-qp=`,
+/// `--num-slots=`, `--slot-size=`, `--unified` and `--pinned-rings` reach the
+/// provider that understands them, without this file knowing any of them exist.
+/// Sharing one namespace was tried: everything unrecognized was forwarded and
+/// providers ignore what they do not know, so a misspelled option of OURS was
+/// swallowed and served the default.  The split is what lets this server reject
+/// its own typos.
+///
+/// THE SHAPE TAKES A TOKEN ON EACH SIDE OF THE `--`
+///
+///     --dispatch=ring                          (and no --unified)
+///     --dispatch=unified  --  ... --unified
+///
+/// `--dispatch=` wires THIS SERVER: `ring` means the dispatcher polls the
+/// provider's ring buffer while the provider moves bytes to the wire on its own
+/// threads; `unified` means one loop does RX, dispatch and TX, driving the
+/// transport through the provider's rx_poll/tx_publish hooks.  A provider
+/// parses its own arguments in create() and cannot see this flag, so it needs
+/// its own for the same shape.
 ///
 /// ORDERING RULE: the READY line is printed BEFORE cudaq_bridge_connect().
 /// A rendezvous transport blocks in connect() until the caller dials in, while
 /// the caller waits for READY before dialing -- announcing after connecting
 /// would deadlock the pair.  Providers are built for this order: endpoint info
 /// is valid as soon as create() returns.
-///
-/// Two dispatch shapes are wired through the three functions below, so a shape
-/// is one command-line token rather than a second binary:
-///   --dispatch=ring     dispatcher polls the provider's ring buffer while the
-///                       provider's own pump threads move bytes to the wire.
-///   --dispatch=unified  dispatcher drives the transport itself through the
-///                       provider's rx_poll/tx_publish hooks and the provider
-///                       starts no threads.  Fails cleanly with UNSUPPORTED
-///                       against a provider whose get_cpu_dataplane is NULL.
 ///
 /// Handshake, both parsed by cudaq::realtime::testing::ServerProcess:
 ///   CUDAQ_REALTIME_SERVER_READY <provider key=value...> dispatch=<shape>
@@ -63,16 +80,15 @@ setup_rpc_increment_function_table_host(cudaq_function_entry_t *h_entries);
 
 namespace {
 
-enum class Shape { Ring, Unified };
-
-const char *shape_name(Shape shape) {
-  return shape == Shape::Unified ? "unified" : "ring";
-}
-
 struct ServerConfig {
   std::string transport = "udp";
-  Shape shape = Shape::Ring;
+  bool unified = false;
   int timeout_sec = 60;
+  // The bridge's own command line: the tokens after `--`, forwarded verbatim
+  // and never interpreted here.  Points into main's argv, which outlives
+  // create().
+  int bridge_argc = 0;
+  char **bridge_argv = nullptr;
 };
 
 std::atomic<int> g_shutdown{0};
@@ -85,19 +101,26 @@ bool starts_with(const std::string &s, const char *prefix) {
 
 void print_usage(const char *program) {
   std::cout
-      << "Usage: " << program << " [options] [provider options]\n\n"
+      << "Usage: " << program << " [server options] [-- bridge options]\n\n"
       << "Serves the rpc_increment HOST_CALL handler over any bridge "
          "provider.\n\n"
-      << "Options:\n"
+      << "Server options (before --):\n"
       << "  --transport=NAME    provider to load: a bare name resolved to\n"
       << "                      libcudaq-realtime-bridge-<name>.so (udp,\n"
       << "                      cpu_roce, ...) or a path to a provider .so\n"
       << "                      [default udp]\n"
       << "  --dispatch=SHAPE    ring | unified            [default ring]\n"
+      << "                      wires THIS SERVER only; the bridge needs its\n"
+      << "                      own flag for the same shape (udp: --unified)\n"
       << "  --timeout=N         run timeout in seconds    [default 60]\n\n"
-      << "All other options are forwarded to the provider, e.g. --port=N,\n"
-      << "--num-slots=N, --slot-size=N, --device=NAME, --local-ip=ADDR,\n"
-      << "--qp_config=MODE, --peer-ip=ADDR, --remote-qp=N.\n";
+      << "Bridge options (after --) are forwarded verbatim and never read\n"
+      << "here, e.g. --port=N, --num-slots=N, --slot-size=N, --unified,\n"
+      << "--pinned-rings, --device=NAME, --local-ip=ADDR, --qp_config=MODE,\n"
+      << "--peer-ip=ADDR, --remote-qp=N.\n\n"
+      << "Examples:\n"
+      << "  " << program << " --transport=udp --dispatch=ring -- --port=0\n"
+      << "  " << program
+      << " --transport=udp --dispatch=unified -- --port=0 --unified\n";
 }
 
 // Ring geometry is queried from the provider rather than parsed here, so the
@@ -109,23 +132,27 @@ bool parse_args(int argc, char **argv, ServerConfig &cfg, bool &help) {
       help = true;
       return false;
     }
+    // `--` ends our options; the rest is the bridge's, untouched, including
+    // tokens that look like ours.
+    if (a == "--") {
+      cfg.bridge_argv = argv + i + 1;
+      cfg.bridge_argc = argc - i - 1;
+      return true;
+    }
     try {
       if (starts_with(a, "--transport="))
         cfg.transport = a.substr(12);
-      else if (starts_with(a, "--dispatch=")) {
-        const std::string shape = a.substr(11);
-        if (shape == "ring")
-          cfg.shape = Shape::Ring;
-        else if (shape == "unified")
-          cfg.shape = Shape::Unified;
-        else {
-          std::cerr << "ERROR: unknown --dispatch=" << shape
-                    << " (expected ring or unified)" << std::endl;
-          return false;
-        }
-      } else if (starts_with(a, "--timeout="))
+      else if (a == "--dispatch=ring")
+        cfg.unified = false;
+      else if (a == "--dispatch=unified")
+        cfg.unified = true;
+      else if (starts_with(a, "--timeout="))
         cfg.timeout_sec = std::stoi(a.substr(10));
-      // Everything else belongs to the provider; forwarded untouched.
+      else {
+        std::cerr << "ERROR: unknown server option '" << a
+                  << "'; bridge options go after '--'" << std::endl;
+        return false;
+      }
     } catch (const std::exception &) {
       std::cerr << "ERROR: bad numeric value in '" << a << "'" << std::endl;
       return false;
@@ -157,56 +184,6 @@ std::string resolve_provider_lib(const std::string &transport) {
 #endif
   return soname; // fall back to the dynamic loader's search path
 }
-
-//===----------------------------------------------------------------------===//
-// The shape seam: the only three shape-aware functions in this file.
-//===----------------------------------------------------------------------===//
-
-// Transport context the dispatcher is wired to.  The unified data-plane is
-// held by pointer inside the dispatcher, so this must outlive it (declared
-// before the dispatcher in main, destroyed after).
-struct ShapeState {
-  cudaq_ringbuffer_t ring{};
-  cudaq_cpu_dataplane_t dataplane{};
-};
-
-// (1) Read at cudaq_dispatcher_create time.
-void configure_shape(Shape shape, cudaq_dispatcher_config_t &dcfg) {
-  if (shape == Shape::Unified) {
-    // The unified loop keeps the per-slot TX markers (its publish hook reads
-    // them to tell a running graph from a finished one), so skip_tx_markers
-    // stays 0; the dispatcher overrides it regardless.
-    dcfg.kernel_type = CUDAQ_KERNEL_UNIFIED;
-    return;
-  }
-  dcfg.kernel_type = CUDAQ_KERNEL_REGULAR;
-  // The provider's TX pump owns the wire and treats any non-zero flag as a
-  // slot address, so the in-flight sentinel must not be written.
-  dcfg.skip_tx_markers = 1;
-}
-
-// (2) Called after create, before start.
-cudaq_status_t wire_shape(Shape shape, cudaq_realtime_bridge_handle_t bridge,
-                          cudaq_dispatcher_t *dispatcher, ShapeState &state) {
-  if (shape == Shape::Unified) {
-    const cudaq_status_t status =
-        cudaq_bridge_get_cpu_dataplane(bridge, &state.dataplane);
-    if (status != CUDAQ_OK)
-      return status;
-    return cudaq_dispatcher_set_cpu_dataplane(dispatcher, &state.dataplane);
-  }
-  const cudaq_status_t status =
-      cudaq_bridge_get_transport_context(bridge, RING_BUFFER, &state.ring);
-  if (status != CUDAQ_OK)
-    return status;
-  return cudaq_dispatcher_set_ringbuffer(dispatcher, &state.ring);
-}
-
-// (3) Unified drives the transport from the dispatcher's own thread; starting
-// the provider's pump threads as well would race its hooks for the rings.
-bool needs_bridge_launch(Shape shape) { return shape != Shape::Unified; }
-
-//===----------------------------------------------------------------------===//
 
 // Reverse-order teardown, so any early `return 1` releases the transport too.
 // The dispatcher goes first: its loop reads the provider's rings (and under
@@ -245,19 +222,26 @@ int main(int argc, char **argv) {
     }
     return 1;
   }
+  const char *shape = cfg.unified ? "unified" : "ring";
 
   std::signal(SIGINT, on_signal);
   std::signal(SIGTERM, on_signal);
 
-  // Declared before the resources so it outlives the dispatcher that points
-  // into it (see ShapeState).
-  ShapeState state;
+  // Declared up here, and not down at [4] where it is filled, because
+  // cudaq_dispatcher_set_cpu_dataplane RETAINS THIS POINTER -- the loop
+  // dereferences it on every iteration.  Before `res` for the same reason: its
+  // destructor stops the dispatcher, which has to happen while the struct the
+  // dispatcher is reading is still alive.  The ring buffer needs none of this
+  // and stays local to its branch: set_ringbuffer copies.
+  cudaq_cpu_dataplane_t dataplane{};
   ServerResources res;
 
-  // [1] Load the provider and let it parse our whole command line.
+  // [1] Load the provider and hand it its own command line -- the tokens after
+  //     `--`, verbatim, and nothing of ours.
   const std::string library = resolve_provider_lib(cfg.transport);
-  if (cudaq_bridge_create_from_library(&res.bridge, library.c_str(), argc,
-                                       argv) != CUDAQ_OK) {
+  if (cudaq_bridge_create_from_library(&res.bridge, library.c_str(),
+                                       cfg.bridge_argc,
+                                       cfg.bridge_argv) != CUDAQ_OK) {
     std::cerr << "ERROR: cannot create a bridge from '" << library
               << "' (--transport=" << cfg.transport << ")" << std::endl;
     return 1;
@@ -285,6 +269,7 @@ int main(int argc, char **argv) {
   }
 
   // [3] Dispatcher: HOST path, HOST_CALL mode, geometry from the transport.
+  //     One of the two places the shape appears.
   if (cudaq_dispatch_manager_create(&res.manager) != CUDAQ_OK) {
     std::cerr << "ERROR: cudaq_dispatch_manager_create failed" << std::endl;
     return 1;
@@ -294,24 +279,71 @@ int main(int argc, char **argv) {
   dcfg.dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
   dcfg.num_slots = num_slots;
   dcfg.slot_size = slot_size;
-  configure_shape(cfg.shape, dcfg);
+  dcfg.kernel_type = cfg.unified ? CUDAQ_KERNEL_UNIFIED : CUDAQ_KERNEL_REGULAR;
+  // Ring shape only: the provider's TX pump owns the wire and treats any
+  // non-zero flag as a slot address, so the in-flight sentinel must not be
+  // written.  The unified loop needs that sentinel (its publish hook reads it
+  // to tell a running graph from a finished one) and forces this to 0 anyway.
+  dcfg.skip_tx_markers = cfg.unified ? 0 : 1;
   if (cudaq_dispatcher_create(res.manager, &dcfg, &res.dispatcher) !=
       CUDAQ_OK) {
     std::cerr << "ERROR: cudaq_dispatcher_create failed" << std::endl;
     return 1;
   }
 
-  // [4] Wire the transport to the dispatcher (shape-dependent).
-  const cudaq_status_t wired =
-      wire_shape(cfg.shape, res.bridge, res.dispatcher, state);
-  if (wired != CUDAQ_OK) {
-    std::cerr << "ERROR: cannot wire --dispatch=" << shape_name(cfg.shape)
-              << " to provider '" << library << "': "
-              << (wired == CUDAQ_ERR_UNSUPPORTED
-                      ? "the provider does not support this shape"
-                      : "wiring failed")
-              << std::endl;
-    return 1;
+  // [4] Wire the transport to the dispatcher: a ring the dispatcher polls, or
+  //     the two hooks it drives itself.  The other place the shape appears, and
+  //     the one that catches a shape the provider is not serving.
+  if (cfg.unified) {
+    cudaq_unified_dispatch_ctx_t unified_dispatch{};
+    if (cudaq_bridge_get_transport_context(res.bridge, UNIFIED,
+                                           &unified_dispatch) != CUDAQ_OK) {
+      std::cerr << "ERROR: Failed to get unified dispatch context" << std::endl;
+      return 1;
+    }
+    if (unified_dispatch.launch_fn != nullptr &&
+        unified_dispatch.transport_ctx != nullptr &&
+        dcfg.dispatch_path == CUDAQ_DISPATCH_PATH_DEVICE) {
+      // Legacy path: the bridge provides the dispatch call.
+      if (cudaq_dispatcher_set_unified_launch(
+              res.dispatcher, unified_dispatch.launch_fn,
+              unified_dispatch.transport_ctx) != CUDAQ_OK) {
+        std::cerr << "ERROR: Failed to set unified launch function"
+                  << std::endl;
+        return 1;
+      }
+    } else {
+      if (cudaq_bridge_get_cpu_dataplane(res.bridge, &dataplane) != CUDAQ_OK) {
+        std::cerr << "ERROR: Failed to get CPU dataplane" << std::endl;
+        return 1;
+      }
+      if (cudaq_dispatcher_set_cpu_dataplane(res.dispatcher, &dataplane) !=
+          CUDAQ_OK) {
+        std::cerr << "ERROR: Failed to set CPU dataplane" << std::endl;
+        return 1;
+      }
+    }
+  } else {
+    cudaq_ringbuffer_t ring{};
+    if (cudaq_bridge_get_transport_context(res.bridge, RING_BUFFER, &ring) !=
+        CUDAQ_OK) {
+      std::cerr << "ERROR: Failed to get ring buffer context" << std::endl;
+      return 1;
+    }
+    if (cudaq_dispatcher_set_ringbuffer(res.dispatcher, &ring) != CUDAQ_OK) {
+      std::cerr << "ERROR: Failed to set ring buffer" << std::endl;
+      return 1;
+    }
+
+    // Legacy path: the dispatching call is provided externally.
+    if (dcfg.dispatch_path == CUDAQ_DISPATCH_PATH_DEVICE) {
+      if (cudaq_dispatcher_set_launch_fn(
+              res.dispatcher, &cudaq_launch_dispatch_kernel_regular) !=
+          CUDAQ_OK) {
+        std::cerr << "ERROR: Failed to set launch function" << std::endl;
+        return 1;
+      }
+    }
   }
 
   // [5] Function table: the single host-side increment handler.
@@ -345,7 +377,7 @@ int main(int argc, char **argv) {
   //     through so the harness needs no per-transport parsing.  std::endl
   //     flushes, which matters because stdout is a pipe here.
   std::cout << "CUDAQ_REALTIME_SERVER_READY " << endpoint
-            << " dispatch=" << shape_name(cfg.shape) << " slots=" << num_slots
+            << " dispatch=" << shape << " slots=" << num_slots
             << " slot_size=" << slot_size << std::endl;
 
   // [8] Connect: a no-op for connectionless transports, a blocking wait for
@@ -355,10 +387,11 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  // [9] Start the provider's pump threads last, once the dispatcher is
-  //     already polling.
-  if (needs_bridge_launch(cfg.shape) &&
-      cudaq_bridge_launch(res.bridge) != CUDAQ_OK) {
+  // [9] Hand the provider its go-ahead, last, once the dispatcher is already
+  //     polling.  Unconditional: a transport with nothing to start under this
+  //     shape (udp under --unified, whose loop is ours) does nothing here,
+  //     which is its business rather than ours to predict.
+  if (cudaq_bridge_launch(res.bridge) != CUDAQ_OK) {
     std::cerr << "ERROR: cudaq_bridge_launch failed" << std::endl;
     return 1;
   }


### PR DESCRIPTION
## Summary

`cudaq_host_unified_loop` (HOST + `CUDAQ_KERNEL_UNIFIED`) had no transport behind
it: every provider hardcoded `get_cpu_dataplane = nullptr`. This gives UDP a
unified data plane and runs the two-process UDP tests under both shapes.

## Changes by file

**`udp_wrapper.h` + `udp_transceiver.cpp`** — unified (thread-free) mode:
`cpu_udp_set_unified`, `cpu_udp_rx_poll`, `cpu_udp_tx_publish`. No pump threads;
the consumer's dispatch thread drives the wire. `rx_poll` recvs `MSG_DONTWAIT`
into the in-order slot and back-pressures on `tx_flags[slot]`; `tx_publish` is
slot-addressed. Header documents the ring-contract changes: `rx_flags` unused,
slot addresses derived.

**`bridge_interface.h`** — docs: a provider serves the one shape it was
configured for and refuses the other.

**`udp/bridge_impl.cpp`** — adds `--unified`, implements `get_cpu_dataplane`.
`get_transport_context(UNIFIED)` returns OK with a NULL `launch_fn`. Shapes are
exclusive both ways, so mis-wiring gets `UNSUPPORTED`.

**`gpu_roce/bridge_impl.cpp`** — same rule; previously a consumer that forgot
`--unified` could take the `launch_fn` and race the 3-kernel monitor.

**`cudaq_realtime_test_server.cpp`** — argv split at `--` (server options before,
bridge options after). Adds support for the legacy `cudaq_dispatcher_set_launch_fn` and
`cudaq_dispatcher_set_unified_launch_fn`.  

**Tests** — +8 transceiver cases, +6 provider cases, and
`test_udp_two_process.cpp` now instantiated over `{"ring", "unified"}`.