### PR TITLE
Ability to reject CFG IR from unwind ops for some targets

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -2005,6 +2005,15 @@ def UnwindLowering : Pass<"unwind-lowering", "mlir::func::FuncOp"> {
     "cudaq::quake::QuakeDialect", "cudaq::cc::CCDialect"];
 }
 
+def VerifyNoCFG : Pass<"verify-no-cfg", "mlir::func::FuncOp"> {
+  let summary = "Reject functions that contain CFG branch operations.";
+  let description = [{
+    Reject a function if it contains `cf.br` or `cf.cond_br`. Targets that
+    require structured control flow can add this pass to their pipeline after
+    argument synthesis and canonicalization have removed dead branches.
+  }];
+}
+
 def UnwindByDataFlow : Pass<"unwind-by-dataflow", "mlir::func::FuncOp"> {
   let summary = "Lower unwind control-flow macros to data-flow flag variables.";
   let description = [{

--- a/cudaq/lib/Optimizer/Transforms/LowerUnwind.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LowerUnwind.cpp
@@ -17,6 +17,7 @@
 
 namespace cudaq::opt {
 #define GEN_PASS_DEF_UNWINDLOWERING
+#define GEN_PASS_DEF_VERIFYNOCFG
 #include "cudaq/Optimizer/Transforms/Passes.h.inc"
 } // namespace cudaq::opt
 
@@ -25,6 +26,34 @@ namespace cudaq::opt {
 using namespace mlir;
 
 namespace {
+
+class VerifyNoCFGPass
+    : public cudaq::opt::impl::VerifyNoCFGBase<VerifyNoCFGPass> {
+public:
+  using VerifyNoCFGBase::VerifyNoCFGBase;
+
+  void runOnOperation() override {
+    // This pass runs in target-specific pipelines after argument synthesis and
+    // canonicalization. Only reject CFG branches that remain in the program;
+    // branches folded from concrete runtime arguments are therefore accepted.
+    Operation *branch = nullptr;
+    getOperation().walk([&](Operation *op) {
+      if (isa<cf::BranchOp, cf::CondBranchOp>(op)) {
+        branch = op;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (!branch)
+      return;
+
+    emitError(branch->getLoc(),
+              "the selected target does not support control-flow graph "
+              "operations; an early return, break, or continue may have "
+              "produced unsupported control flow in the kernel");
+    signalPassFailure();
+  }
+};
 
 // A cc.scope may have break, continue, and return landing pads. A func.func may
 // have a return landing pad. This struture tracks the landing pads associated

--- a/cudaq/test/Transforms/verify_no_cfg.qke
+++ b/cudaq/test/Transforms/verify_no_cfg.qke
@@ -1,0 +1,27 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --verify-no-cfg %s -split-input-file -verify-diagnostics
+
+func.func @conditional_branch(%condition: i1) {
+  // expected-error@+1 {{the selected target does not support control-flow graph operations; an early return, break, or continue may have produced unsupported control flow in the kernel}}
+  cf.cond_br %condition, ^then, ^else
+^then:
+  return
+^else:
+  return
+}
+
+// -----
+
+func.func @branch() {
+  // expected-error@+1 {{the selected target does not support control-flow graph operations; an early return, break, or continue may have produced unsupported control flow in the kernel}}
+  cf.br ^exit
+^exit:
+  return
+}

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-high-level-pipeline: "func.func(add-measurements)"
+  jit-high-level-pipeline: "func.func(verify-no-cfg,add-measurements)"
   jit-mid-level-pipeline: "prepare-for-wireset{add-wireset=true unroll-only-aliasing-quantum-access-loops=true},qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "symbol-dce"
   # Tell the rest-qpu that the required output format is quake.

--- a/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
+++ b/unittests/nvqpp/backends/quake_backend/QuakeStartServerAndTest.sh.in
@@ -150,6 +150,63 @@ else
   echo ":white_check_mark: Successfully ran Python test_app.py"
 fi
 
+# Concrete boolean arguments fold the control flow introduced by early return,
+# break, and continue. The mock server verifies that these successful requests
+# contain no CFG operations.
+PATH=@CMAKE_BINARY_DIR@/bin:$PATH nvq++ --target quake_fake @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_unwind_app.cpp -o test_unwind_app
+if [ $? -ne 0 ]; then
+  echo ":x: nvq++ compilation failed for test_unwind_app"
+  test_err_sum=$((test_err_sum+1))
+else
+  for unwind_case in early-return break continue; do
+    unwind_output=$(./test_unwind_app "$unwind_case" 2>&1)
+    unwind_status=$?
+    if [ "$unwind_status" -ne 0 ]; then
+      echo ":x: C++ synthesized $unwind_case failed"
+      echo "$unwind_output"
+      test_err_sum=$((test_err_sum+1))
+    else
+      echo ":white_check_mark: C++ synthesized $unwind_case contains no CFG"
+    fi
+  done
+
+  for cfg_case in measurement-return measurement-break measurement-continue; do
+    cfg_output=$(./test_unwind_app "$cfg_case" 2>&1)
+    cfg_status=$?
+    if [ "$cfg_status" -eq 0 ] || [[ "$cfg_output" != *'the selected target does not support control-flow graph operations; an early return, break, or continue may have produced unsupported control flow in the kernel'* ]]; then
+      echo ":x: C++ $cfg_case rejection did not produce the expected diagnostic"
+      echo "$cfg_output"
+      test_err_sum=$((test_err_sum+1))
+    else
+      echo ":white_check_mark: C++ $cfg_case rejected by quake_fake"
+    fi
+  done
+fi
+
+for unwind_case in early-return break continue; do
+  unwind_output=$(PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_unwind_app.py "$unwind_case" 2>&1)
+  unwind_status=$?
+  if [ "$unwind_status" -ne 0 ]; then
+    echo ":x: Python synthesized $unwind_case failed"
+    echo "$unwind_output"
+    test_err_sum=$((test_err_sum+1))
+  else
+    echo ":white_check_mark: Python synthesized $unwind_case contains no CFG"
+  fi
+done
+
+for cfg_case in measurement-return measurement-break measurement-continue; do
+  cfg_output=$(PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_unwind_app.py "$cfg_case" 2>&1)
+  cfg_status=$?
+  if [ "$cfg_status" -eq 0 ] || [[ "$cfg_output" != *'the selected target does not support control-flow graph operations; an early return, break, or continue may have produced unsupported control flow in the kernel'* ]]; then
+    echo ":x: Python $cfg_case rejection did not produce the expected diagnostic"
+    echo "$cfg_output"
+    test_err_sum=$((test_err_sum+1))
+  else
+    echo ":white_check_mark: Python $cfg_case rejected by quake_fake"
+  fi
+done
+
 # Python loop remote execution test. CUDAQ_DUMP_JIT_IR validates that the Python
 # client preserves cc.loop operations for the nop codegen path.
 CUDAQ_DUMP_JIT_IR=1 PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/nvqpp/backends/quake_backend/test_loop_app.py > test_loop_app.py.out 2>&1

--- a/unittests/nvqpp/backends/quake_backend/mock_server.py
+++ b/unittests/nvqpp/backends/quake_backend/mock_server.py
@@ -73,6 +73,13 @@ def verifyValueSemanticsPayload(decoded_payload):
                 f" `{token}`. The server must receive wireset MLIR.")
 
 
+def verifyNoCFG(decoded_payload):
+    for token in ["cf.br", "cf.cond_br"]:
+        if token in decoded_payload:
+            raise RuntimeError(
+                f"Remote payload contains unsupported CFG operation `{token}`.")
+
+
 def verifyExpectedMapping(decoded_payload, entry_func_name):
     if "mapping" not in entry_func_name:
         return
@@ -166,6 +173,7 @@ async def postJob(request: Request):
             " eliminated by the eliminate-dead-heap-copy pass.")
 
     verifyValueSemanticsPayload(decoded_payload)
+    verifyNoCFG(decoded_payload)
 
     ctx = getMLIRContext()
     recovered_mod = Module.parse(decoded_payload, context=ctx)

--- a/unittests/nvqpp/backends/quake_backend/quake_fake.yml
+++ b/unittests/nvqpp/backends/quake_backend/quake_fake.yml
@@ -22,7 +22,7 @@ config:
   # FakeQuakeServerHelper replaces %QUAKE_EMULATE_SUFFIX% with "" for remote
   # execution, yielding the exact low-level pipeline "symbol-dce". For local
   # emulation it replaces the suffix with the necessary emulation passes for local execution.
-  jit-high-level-pipeline: "func.func(add-measurements)"
+  jit-high-level-pipeline: "func.func(verify-no-cfg,add-measurements)"
   jit-mid-level-pipeline: "prepare-for-wireset{add-wireset=true unroll-only-aliasing-quantum-access-loops=true},qubit-mapping{device=bypass},decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,z(1),x(1)}"
   jit-low-level-pipeline: "symbol-dce%QUAKE_EMULATE_SUFFIX%"
   # Tell the rest-qpu that we are simply dumping CUDA-Q MLIR code.

--- a/unittests/nvqpp/backends/quake_backend/test_unwind_app.cpp
+++ b/unittests/nvqpp/backends/quake_backend/test_unwind_app.cpp
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include <cudaq.h>
+
+#include <string_view>
+
+__qpu__ bool synthesized_early_return_leaf(bool condition) {
+  cudaq::qubit q;
+  h(q);
+  if (condition)
+    return true;
+  x(q);
+  return false;
+}
+
+__qpu__ bool synthesized_early_return_middle(bool condition) {
+  return synthesized_early_return_leaf(condition);
+}
+
+__qpu__ bool synthesized_early_return(bool condition) {
+  return synthesized_early_return_middle(condition);
+}
+
+__qpu__ bool synthesized_break(bool condition) {
+  cudaq::qubit q;
+  for (int i = 0; i < 2; ++i) {
+    h(q);
+    if (condition)
+      break;
+    x(q);
+  }
+  return false;
+}
+
+__qpu__ bool synthesized_continue(bool condition) {
+  cudaq::qubit q;
+  for (int i = 0; i < 2; ++i) {
+    h(q);
+    if (condition)
+      continue;
+    x(q);
+  }
+  return false;
+}
+
+__qpu__ bool measurement_early_return() {
+  cudaq::qubit q;
+  x(q);
+  if (mz(q))
+    return true;
+  h(q);
+  return false;
+}
+
+__qpu__ bool measurement_break() {
+  cudaq::qubit q;
+  for (int i = 0; i < 2; ++i) {
+    x(q);
+    if (mz(q))
+      break;
+    h(q);
+  }
+  return false;
+}
+
+__qpu__ bool measurement_continue() {
+  cudaq::qubit q;
+  for (int i = 0; i < 2; ++i) {
+    x(q);
+    if (mz(q))
+      continue;
+    h(q);
+  }
+  return false;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2)
+    return 2;
+
+  const std::string_view testCase = argv[1];
+  if (testCase == "early-return")
+    cudaq::run(1, synthesized_early_return, true);
+  else if (testCase == "break")
+    cudaq::run(1, synthesized_break, true);
+  else if (testCase == "continue")
+    cudaq::run(1, synthesized_continue, true);
+  else if (testCase == "measurement-return")
+    cudaq::run(1, measurement_early_return);
+  else if (testCase == "measurement-break")
+    cudaq::run(1, measurement_break);
+  else if (testCase == "measurement-continue")
+    cudaq::run(1, measurement_continue);
+  else
+    return 2;
+}

--- a/unittests/nvqpp/backends/quake_backend/test_unwind_app.py
+++ b/unittests/nvqpp/backends/quake_backend/test_unwind_app.py
@@ -1,0 +1,95 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import cudaq
+import sys
+
+cudaq.set_target("quake_fake")
+
+
+@cudaq.kernel
+def synthesized_early_return(condition: bool) -> bool:
+    q = cudaq.qubit()
+    h(q)
+    if condition:
+        return True
+    x(q)
+    return False
+
+
+@cudaq.kernel
+def synthesized_break(condition: bool) -> bool:
+    q = cudaq.qubit()
+    for _ in range(2):
+        h(q)
+        if condition:
+            break
+        x(q)
+    return False
+
+
+@cudaq.kernel
+def synthesized_continue(condition: bool) -> bool:
+    q = cudaq.qubit()
+    for _ in range(2):
+        h(q)
+        if condition:
+            continue
+        x(q)
+    return False
+
+
+@cudaq.kernel
+def measurement_early_return() -> bool:
+    q = cudaq.qubit()
+    x(q)
+    if mz(q):
+        return True
+    h(q)
+    return False
+
+
+@cudaq.kernel
+def measurement_break() -> bool:
+    q = cudaq.qubit()
+    for _ in range(2):
+        x(q)
+        if mz(q):
+            break
+        h(q)
+    return False
+
+
+@cudaq.kernel
+def measurement_continue() -> bool:
+    q = cudaq.qubit()
+    for _ in range(2):
+        x(q)
+        if mz(q):
+            continue
+        h(q)
+    return False
+
+
+if len(sys.argv) != 2:
+    raise ValueError("expected one unwind case")
+
+if sys.argv[1] == "early-return":
+    cudaq.run(synthesized_early_return, True, shots_count=1)
+elif sys.argv[1] == "break":
+    cudaq.run(synthesized_break, True, shots_count=1)
+elif sys.argv[1] == "continue":
+    cudaq.run(synthesized_continue, True, shots_count=1)
+elif sys.argv[1] == "measurement-return":
+    cudaq.run(measurement_early_return, shots_count=1)
+elif sys.argv[1] == "measurement-break":
+    cudaq.run(measurement_break, shots_count=1)
+elif sys.argv[1] == "measurement-continue":
+    cudaq.run(measurement_continue, shots_count=1)
+else:
+    raise ValueError(f"unknown unwind case: {sys.argv[1]}")


### PR DESCRIPTION
(1) Add a pass to reject CFG in the IR. Targets that don't support CFG can use it in the pipeline to reject input programs on the client side.

**Note**: 

- Unwind operations (e.g. early return statements) may produce CFG ops even though lower-to-cfg is not executed. 

- These targets may run argument synthesis, so some CFG structures (e.g. early return based on a runtime argument) may be folded away. Hence, the IR should be supported. 


(2) Add lit test and quake fake server test: checking both the cases where unwind ops can be folded (hence, no CFG in the final JIT IR) and remain (e.g., early return based on a measurement result). The latter case should be rejected accordingly with a proper error message.