### PR TITLE
Fixing lit target enumeration in wheel builds

### DIFF
--- a/python/tests/mlir/lit.cfg.py
+++ b/python/tests/mlir/lit.cfg.py
@@ -52,7 +52,11 @@ for arch in config.targets_to_build.split():
 # are registered, and every test gated on one silently becomes "Unsupported"
 # instead of running -- a green run that tested nothing.
 _py_pkg_dir = os.path.join(os.path.dirname(config.cudaq_lib_dir), 'python')
-_python = config.python_executable or sys.executable
+# The configured interpreter may be gone by test time. scikit-build wheel
+# builds configure in a temporary environment that is later deleted.
+_python = config.python_executable
+if not _python or not os.path.isfile(_python):
+    _python = sys.executable
 try:
     _targets = subprocess.check_output([
         _python, '-c',


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/33454501306/job/99696113113#step:15:60667

For wheel builds, `scikit-build` configures inside a temporary environment that is deleted before the tests
run, so that interpreter no longer exists and enumeration fails.

Using the recorded interpreter only if it still exists, otherwise falling back to the interpreter running lit.