### PR TITLE
Pinning node version in the doc to match CI version

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -102,7 +102,9 @@ some checks require system dependencies:
 
 ```bash
 # Ubuntu/Debian
-sudo apt-get install aspell aspell-en nodejs npm golang
+sudo apt-get install aspell aspell-en nodejs golang
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
 
 # macOS
 brew install aspell node go

--- a/Developing.md
+++ b/Developing.md
@@ -102,9 +102,12 @@ some checks require system dependencies:
 
 ```bash
 # Ubuntu/Debian
-sudo apt-get install aspell aspell-en nodejs golang
+sudo apt-get install aspell aspell-en golang
+# Node from NodeSource, not apt: markdown-link-check needs Node 20 or newer,
+# and Ubuntu 24.04's nodejs package is 18. NodeSource's nodejs bundles npm,
+# so do not also install the apt npm package -- the two conflict.
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-sudo apt-get install -y nodejs
+sudo apt-get install nodejs
 
 # macOS
 brew install aspell node go

--- a/scripts/pre-commit/check_markdown_links.sh
+++ b/scripts/pre-commit/check_markdown_links.sh
@@ -23,6 +23,26 @@ if ! command -v markdown-link-check &> /dev/null; then
     exit 1
 fi
 
+# markdown-link-check reaches marked >= 16, which ships only an ESM build, via a
+# CommonJS markdown-link-extractor that requires() it. That combination needs a
+# Node able to require() an ES module: 20.19 or newer. On older Node the tool
+# exits with ERR_REQUIRE_ESM, which this script would otherwise report as broken
+# links.
+REQUIRED_NODE=20.19.0
+NODE_VERSION=$(node --version 2>/dev/null | sed 's/^v//')
+
+if [ -z "$NODE_VERSION" ]; then
+    echo "ERROR: node not found; markdown-link-check needs Node >= $REQUIRED_NODE" >&2
+    exit 1
+fi
+
+if [ "$(printf '%s\n%s\n' "$REQUIRED_NODE" "$NODE_VERSION" | sort -V | head -1)" != "$REQUIRED_NODE" ]; then
+    echo "ERROR: node $NODE_VERSION is too old for markdown-link-check" >&2
+    echo "       (need >= $REQUIRED_NODE for its ESM-only 'marked' dependency)" >&2
+    echo "       See the Prerequisites section of Developing.md to install Node 20." >&2
+    exit 1
+fi
+
 EXIT_CODE=0
 FILES=("$@")
 


### PR DESCRIPTION
## Why

Following the Ubuntu/Debian prerequisites in `Developing.md` produces a machine where the
link hook cannot run at all:

```
$ pre-commit run markdown-link-check --hook-stage pre-push
Checking: realtime/docs/cudaq_realtime_host_api.md
Error [ERR_REQUIRE_ESM]: require() of ES Module
  .../markdown-link-check/node_modules/marked/lib/marked.esm.js
  from .../markdown-link-extractor/index.js not supported.
FAILED: realtime/docs/cudaq_realtime_host_api.md has broken links
```

`sudo apt-get install nodejs` on Ubuntu 24.04 installs Node 18.19.1. The current
`markdown-link-check` (3.15.0) depends on `markdown-link-extractor` 4.0.4, which depends
on `marked` 18. `marked` dropped its CommonJS build at v16 and declares
`engines: { node: ">= 20" }`, while `markdown-link-extractor` is CommonJS and `require`s
it statically. Node only gained the ability to `require()` an ES module in 20.19, so on
Node 18 the tool aborts before reading a single link.

Note the last line of that output: the wrapper script reports "has broken links" for a
failure that has nothing to do with links, sending you off to audit URLs that are fine.

Pinning an older `markdown-link-check` is not a viable workaround. Versions 3.12.2
through 3.14.0 all declare `markdown-link-extractor: ^4.0.2`, and the caret floats to
4.0.4, pulling in `marked` 18 regardless of which version is requested.

## What

**`Developing.md`** -- Ubuntu/Debian stanza only: install Node 20 from NodeSource instead
of the distro package, and drop `npm` from the apt list. The NodeSource `nodejs` package
bundles npm, and the Debian `npm` deb actively conflicts with it: it depends on the distro
`nodejs` plus roughly 28 `node-*` library debs, so apt refuses the combination with "held
broken packages". The comment records both constraints so neither gets helpfully
"fixed" back.

Node 20 is what the rest of the repository already assumes:
`.github/actions/setup-precommit/action.yml` uses `actions/setup-node` with
`node-version: '20'`, and `.devcontainer/devcontainer.json` pins the node dev container
feature to `"version": "20"`. Node 18 has been end-of-life since April 2025.

**`scripts/pre-commit/check_markdown_links.sh`** -- the script checked only that
`markdown-link-check` was on `PATH`, so an installed-but-unusable tool reached the link
loop and got misreported as broken links. It now also checks the Node version and fails
up front with the actionable message:

```
ERROR: node 18.19.1 is too old for markdown-link-check
       (need >= 20.19.0 for its ESM-only 'marked' dependency)
       See the Prerequisites section of Developing.md to install Node 20.
```

## Testing

Reproduced and fixed in an Ubuntu 24.04 container:

- Before: Node 18.19.1, `ERR_REQUIRE_ESM` on every file checked.
- After the NodeSource install: Node v20.20.2 with bundled npm 10.8.2, and
  `markdown-link-check` 3.15.0 loads and runs instead of crashing.

The version guard was exercised on both sides of the threshold using a `node` shim on
`PATH`: 18.19.1 and 20.18.3 are rejected, while 20.19.0 (equality), 20.20.2, 22.12.0 and
24.0.1 are accepted. `bash -n` is clean and `markdownlint` passes on `Developing.md`.

## Not in scope

The macOS (`brew install node`) and Fedora/RHEL lines are unchanged. Worth noting for a
follow-up: on the el8/el9 tested distributions (CentOS 8, RHEL 8/9, Rocky 8/9) a plain
`dnf install nodejs npm` yields Node 18 or older, because RHEL 9 defines no default module
stream and its initial AppStream RPM predates 20.19. Those users need an explicit
`sudo dnf module switch-to nodejs:22` before the hook will run.