### PR TITLE
Fix integrator_options leaking across BaseIntegrator instances

### DIFF
--- a/python/cudaq/dynamics/integrator.py
+++ b/python/cudaq/dynamics/integrator.py
@@ -30,7 +30,10 @@ class BaseIntegrator(ABC, Generic[TState]):
 
     def __init__(self, **kwargs):
         self.state = None
-        self.integrator_options.update(kwargs)
+        # Use a fresh, per-instance dict rather than mutating the class-level
+        # default in place - otherwise options passed to one integrator leak
+        # into every other integrator instance created in the same process.
+        self.integrator_options = dict(self.integrator_options, **kwargs)
         self.t = None
         self.dimensions = None
         self.schedule = None

--- a/python/tests/dynamics/test_integrator_options.py
+++ b/python/tests/dynamics/test_integrator_options.py
@@ -1,0 +1,35 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""
+`integrator_options` must be per-instance. `BaseIntegrator.__init__` used to
+mutate a class-level dict via `.update(kwargs)` instead of assigning a fresh
+one, so two integrators created in the same process shared one options dict
+and silently inherited each other's settings. This does not need a GPU or a
+dynamics target: it is a plain object-construction bug.
+"""
+import pytest
+
+pytest.importorskip("cupy")
+
+from cudaq.dynamics.integrators.builtin_integrators import RungeKuttaIntegrator
+
+
+def test_integrator_options_not_shared_across_instances():
+    first = RungeKuttaIntegrator(order=1, max_step_size=0.01)
+    assert first.order == 1
+    assert first.max_step_size == 0.01
+
+    # A second integrator that only overrides `order` must not pick up
+    # `max_step_size` from the first one.
+    second = RungeKuttaIntegrator(order=2)
+    assert second.max_step_size is None
+    assert second.integrator_options == {'order': 2}
+
+    # The first integrator's options must also stay untouched by the second
+    # construction.
+    assert first.integrator_options == {'order': 1, 'max_step_size': 0.01}


### PR DESCRIPTION
Fixes #5344

### Bug

`BaseIntegrator.__init__` mutates the class-level `integrator_options = {}` in place via
`.update(kwargs)` instead of assigning a fresh per-instance dict. Every concrete integrator
(`RungeKuttaIntegrator`, `ScipyZvodeIntegrator`, `CUDATorchDiffEqIntegrator*`) only ever reads
from `self.integrator_options` in `__post_init__`, so a second integrator constructed later in
the same process silently inherits options it was never given, from a completely unrelated
earlier instance.

### Fix

Give each instance its own dict instead of mutating the shared class default:

```python
self.integrator_options = dict(self.integrator_options, **kwargs)
```

### Verification

Not a regression (introduced in `da31e1b7a` / #2817, untouched since; no test ever covered
per-instance isolation - confirmed via `git log -S`).

Negative control: added `python/tests/dynamics/test_integrator_options.py`, ran it against the
production `integrator.py` before this fix (reverted to the upstream version) and after,
using the CUDA-Q 0.15.1 wheel (`aca5853a7`, byte-identical to this file on current `main`):

```
without the fix: 1 failed in 0.62s
with the fix:     1 passed in 0.59s
```

Small, net-positive diff; touches only the one shared constructor and adds a regression test.
