### PR TITLE
Fixing macOS wheel validation hang from duplicate AWS SDK linkage

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -338,6 +338,7 @@ jobs:
         python_version: ['3.11', '3.12', '3.13', '3.14']
       fail-fast: false
     runs-on: macos-26
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository

--- a/runtime/cudaq/platform/default/rest/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest/CMakeLists.txt
@@ -16,12 +16,8 @@ target_include_directories(cudaq-rest-qpu PRIVATE .
        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/runtime>
        $<INSTALL_INTERFACE:include>)
 
-if (AWSSDK_ROOT AND CUDAQ_ENABLE_BRAKET_BACKEND)
-  set(SERVICE_COMPONENTS braket s3-crt sts)
-  find_package(AWSSDK REQUIRED COMPONENTS ${SERVICE_COMPONENTS})
-else()
-  set(AWSSDK_LINK_LIBRARIES "")
-endif()
+# The AWS SDK belongs to `cudaq-serverhelper-braket` alone. See the note in
+# helpers/braket/CMakeLists.txt on why it must not be linked twice.
 
 target_link_libraries(cudaq-rest-qpu
   PUBLIC
@@ -34,7 +30,6 @@ target_link_libraries(cudaq-rest-qpu
     cudaq-platform-default
     nvqir
     ZLIB::ZLIB
-    cudaqMLIR
-    ${AWSSDK_LINK_LIBRARIES})
+    cudaqMLIR)
 
 install(TARGETS cudaq-rest-qpu DESTINATION lib COMPONENT Runtime)

--- a/runtime/cudaq/platform/default/rest/helpers/braket/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/CMakeLists.txt
@@ -8,7 +8,10 @@
 
 set(SERVICE_COMPONENTS braket s3-crt sts)
 find_package(AWSSDK REQUIRED COMPONENTS ${SERVICE_COMPONENTS})
-target_sources(cudaq-rest-qpu PRIVATE BraketExecutor.cpp BraketServerHelper.cpp)
+# Only this plugin builds these sources. The AWS SDK is linked statically, so
+# compiling them into `cudaq-rest-qpu` as well would put a second copy of the
+# CRT allocator state into the process, and selecting `braket` then `quera`
+# would abort in aws-c-common on `allocator != NULL`.
 add_target_config(braket)
 add_library(cudaq-serverhelper-braket SHARED BraketExecutor.cpp BraketServerHelper.cpp)
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -209,7 +209,7 @@ if (CUDA_FOUND AND TARGET nvqir-dynamics)
    gtest_main
    )
   target_include_directories(test_dynamics PRIVATE ${CMAKE_SOURCE_DIR}/runtime/nvqir/cudensitymat)
-  cudaq_gtest_discover_tests(test_dynamics PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+  cudaq_gtest_discover_tests(test_dynamics PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu" DISCOVERY_TIMEOUT 120)
 endif()
 
 add_executable(test_utils main.cpp utils/UtilsTester.cpp utils/Matrix.cpp)

--- a/unittests/backends/CMakeLists.txt
+++ b/unittests/backends/CMakeLists.txt
@@ -107,7 +107,8 @@ if (cuStateVec_FOUND)
       gtest_main)
     gtest_discover_tests(${target}
       TEST_PREFIX "CuStateVecEx."
-      PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+      PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu"
+      DISCOVERY_TIMEOUT 120)
   endfunction()
 
   add_custatevec_simulator_test(custatevec_tester custatevec-fp32 FP32)

--- a/unittests/nvqpp/CMakeLists.txt
+++ b/unittests/nvqpp/CMakeLists.txt
@@ -177,7 +177,7 @@ if (cuStateVec_FOUND)
     cudaq-mlir-runtime
     nvqir-custatevec-fp64
     gtest_main)
-  cudaq_gtest_discover_tests(test_mqpu PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+  cudaq_gtest_discover_tests(test_mqpu PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu" DISCOVERY_TIMEOUT 120)
 
   # Test CUDAQ_OBSERVE_FROM_SAMPLING=ON mode.
   # (term-by-term expectation value calculation by applying change-of-basis gates then reverting them)
@@ -205,7 +205,7 @@ if (cuStateVec_FOUND)
     nvqir-custatevec-fp32
     gtest_main)
   # Run this test with "CUDAQ_OBSERVE_FROM_SAMPLING=1"
-  cudaq_gtest_discover_tests(test_custatevec_observe_from_sampling TEST_SUFFIX _DirectObserve PROPERTIES ENVIRONMENT "CUDAQ_OBSERVE_FROM_SAMPLING=1" PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+  cudaq_gtest_discover_tests(test_custatevec_observe_from_sampling TEST_SUFFIX _DirectObserve PROPERTIES ENVIRONMENT "CUDAQ_OBSERVE_FROM_SAMPLING=1" PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu" DISCOVERY_TIMEOUT 120)
 
   if (MPI_CXX_FOUND)
     # Count the number of GPUs
@@ -247,7 +247,7 @@ if (cuStateVec_FOUND)
       cudaq-mlir-runtime
       nvqir-custatevec-fp64
       gtest_main)
-      cudaq_gtest_discover_tests(test_gpu_get_state PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+      cudaq_gtest_discover_tests(test_gpu_get_state PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu" DISCOVERY_TIMEOUT 120)
   endif()
 endif()
 
@@ -305,7 +305,7 @@ if(TARGET nvqir-tensornet)
     nvqir-tensornet
     gtest_main)
   # Run this test with "CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=TRUE"
-  cudaq_gtest_discover_tests(test_tensornet_observe_path_reuse TEST_SUFFIX _PathReuse PROPERTIES ENVIRONMENT "CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=ON" PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+  cudaq_gtest_discover_tests(test_tensornet_observe_path_reuse TEST_SUFFIX _PathReuse PROPERTIES ENVIRONMENT "CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=ON" PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu" DISCOVERY_TIMEOUT 120)
 endif()
 
 # build the test qudit execution manager
@@ -398,7 +398,7 @@ if (CUDA_FOUND AND TARGET nvqir-dynamics)
     execute_process(COMMAND bash -c "nvidia-smi --list-gpus | wc -l" OUTPUT_VARIABLE NGPUS)
     # Only add this test if we have more than 1 GPU
     if (${NGPUS} GREATER_EQUAL 2)
-      cudaq_gtest_discover_tests(test_evolve_async PROPERTIES LABELS "gpu_required;mgpus_required" RESOURCE_LOCK "gpu")
+      cudaq_gtest_discover_tests(test_evolve_async PROPERTIES LABELS "gpu_required;mgpus_required" RESOURCE_LOCK "gpu" DISCOVERY_TIMEOUT 120)
 
       # Multi-GPU batching test: this test needs MPI as well
       if (MPI_CXX_FOUND)

--- a/unittests/nvqpp/custatevec/CMakeLists.txt
+++ b/unittests/nvqpp/custatevec/CMakeLists.txt
@@ -70,10 +70,12 @@ add_custatevec_backend_test(custatevec_trajectory_fp64
   TrajectorySingleDeviceTester.cpp custatevec-fp64 FP64)
 gtest_discover_tests(custatevec_trajectory_fp32
   TEST_PREFIX "CuStateVecEx."
-  PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+  PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu"
+  DISCOVERY_TIMEOUT 120)
 gtest_discover_tests(custatevec_trajectory_fp64
   TEST_PREFIX "CuStateVecEx."
-  PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu")
+  PROPERTIES LABELS "gpu_required" RESOURCE_LOCK "gpu"
+  DISCOVERY_TIMEOUT 120)
 
 
 add_custatevec_backend_test(custatevec_host_migration


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/33479578047/job/99843115515#step:7:3692

The macOS `Validate wheel` job hung until manually cancelled, always near the end of `test_run_kernel.py` but on a different test each run.

`BraketExecutor.cpp` was compiled into both `cudaq-rest-qpu` and the `cudaq-serverhelper-braket` plugin, each statically linking the AWS SDK, which put two copies of the AWS CRT allocator state in one process. Selecting
`braket` and then `quera` built a client against the uninitialized copy and aborted on `allocator != NULL`, killing an xdist worker and wedging pytest at session teardown. The reported test name varied because it was whatever a surviving worker had started next.