### PR TITLE
[python] Fix OperatorSum.evaluate() adding a spurious zero-coefficient identity term

### DIFF
--- a/python/cudaq/operators/manipulation.py
+++ b/python/cudaq/operators/manipulation.py
@@ -173,18 +173,29 @@ def _sum_transformation(operator: OperatorSum,
                 padded_term *= identity(degree)
         return padded_term
 
-    evaluated = arithmetics.evaluate(ScalarOperator.const(0))
+    # Seeding the accumulation with the first evaluated term (rather than
+    # arithmetics.evaluate(ScalarOperator.const(0)) and adding every term to
+    # it) avoids feeding a scalar zero into arithmetics.add. For the default
+    # evaluation arithmetics that resolves to a plain `0 + term`, which the
+    # C++ operator classes turn into an explicit, spurious zero-coefficient
+    # identity term rather than simplifying it away - polluting the result
+    # of `OperatorSum.evaluate()` with an extra term nobody asked for.
+    evaluated = None
     if pad_terms:
         degrees = operator.degrees
         for term in operator:
             evaluated_term = _product_transformation(padded_term(term, degrees),
                                                      arithmetics, pad_terms)
-            evaluated = arithmetics.add(evaluated, evaluated_term)
+            evaluated = evaluated_term if evaluated is None else arithmetics.add(
+                evaluated, evaluated_term)
     else:
         for term in operator:
             evaluated_term = _product_transformation(term, arithmetics,
                                                      pad_terms)
-            evaluated = arithmetics.add(evaluated, evaluated_term)
+            evaluated = evaluated_term if evaluated is None else arithmetics.add(
+                evaluated, evaluated_term)
+    if evaluated is None:
+        evaluated = arithmetics.evaluate(ScalarOperator.const(0))
     return evaluated
 
 

--- a/python/tests/operator/test_matrix_op.py
+++ b/python/tests/operator/test_matrix_op.py
@@ -495,6 +495,23 @@ def test_evaluation():
     check_evaluation(coeff * displace_op + squeeze_op)
 
 
+def test_evaluate_no_spurious_zero_term():
+    # `OperatorSum.evaluate()` used to seed its accumulation with
+    # `arithmetics.evaluate(ScalarOperator.const(0))` and add every term to
+    # that, including the first. For the default evaluation arithmetics that
+    # resolves to a plain `0 + term`, and the underlying operator classes
+    # turn that into an explicit, spurious zero-coefficient identity term
+    # (degrees == []) rather than simplifying it away - so a multi-term
+    # operator gained an extra term nobody asked for every time it was
+    # evaluated.
+    op = boson.create(0) + boson.annihilate(1)
+    assert op.term_count == 2
+    evaluated = op.evaluate()
+    assert evaluated.term_count == op.term_count
+    for term in evaluated:
+        assert len(term.degrees) > 0
+
+
 def test_term_distribution():
     op = empty()
     for target in range(7):


### PR DESCRIPTION
Fixes #5348

### Bug

`_sum_transformation` (`python/cudaq/operators/manipulation.py:154-188`) seeds its accumulator
with `arithmetics.evaluate(ScalarOperator.const(0))` and adds every term to it, including the
first. For the default arithmetics used by `OperatorSum.evaluate()`, that first add is a plain
`0 + term1`, and the underlying C++ operator classes turn `scalar + operator` into an explicit
zero-coefficient identity term (`degrees == []`) instead of simplifying it away. So evaluating a
multi-term `SpinOperator`/`BosonOperator`/`FermionOperator`/`MatrixOperator` always grows one
extra term that acts on no degrees of freedom, inflating `term_count` by one every time. This is
not just cosmetic: `python/cudaq/dynamics/evolution.py:303,608` calls `.evaluate(**step_parameters)`
on every user-supplied observable at every time step of `cudaq.evolve()`.

### Fix

Seed the accumulation with the first evaluated term instead of a scalar zero, and only fall back
to evaluating `ScalarOperator.const(0)` when the operator has no terms at all - so `arithmetics.add`
is never called with a scalar zero as either operand.

### Verification

Not a regression (introduced with the class in `da31e1b7a` / #2817, untouched since except a
copyright-year bump - confirmed via `git log -S`/`git log --follow`). No existing test checks
`term_count` or per-term `degrees` after `.evaluate()`.

Negative control: added `test_evaluate_no_spurious_zero_term` to
`python/tests/operator/test_matrix_op.py`, ran it against the production `manipulation.py`
before this fix (reverted to the upstream version) and after, using the CUDA-Q 0.15.1 wheel
(`aca5853a7`, byte-identical to this file on current `main` - zero commits touch
`python/cudaq/operators` between the wheel commit and `main`):

```
without the fix: assert 3 == 2 (1 failed)
with the fix:    1 passed
```

Also ran the full existing `python/tests/operator/` suite (`test_matrix_op.py`,
`test_spin_op.py`, `test_fermion_op.py`, `test_boson_op.py`, `test_scalar_op.py`,
`test_conversions.py`) with the fix applied: 59 passed (one pre-existing, unrelated native
`test_file_serialization` crash deselected - reproduces identically with or without this
change, in unrelated spin-operator file-deserialization code).

Small, net-positive diff; touches only the shared accumulation helper and adds one regression
test.

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
