### PR TITLE
[core] Remove the unnecessary linear type repair pass.

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
@@ -92,7 +92,6 @@ void cudaq::opt::addConvertToLinearValues(OpPassManager &pm) {
   pm.addNestedPass<func::FuncOp>(createCSEPass());
   pm.addNestedPass<func::FuncOp>(createMemToReg());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<func::FuncOp>(createRepairLinearType());
   pm.addNestedPass<func::FuncOp>(createLinearCtrlRelations());
 }
 


### PR DESCRIPTION
As we now patch MLIR to correctly handle SSI, we shouldn't need this band-aid repair to fix when MLIR dorks up our IR ... because it won't do the dorking in the first place.