### PR TITLE
fix(runtime): preserve fixed scalar arguments in broadcast sample/observe calls

### DIFF
--- a/python/cudaq/runtime/utils.py
+++ b/python/cudaq/runtime/utils.py
@@ -137,12 +137,22 @@ def __createArgumentSet(*args):
     for j in range(nArgSets):
         currentArgs = [0 for i in range(len(args))]
         for i, arg in enumerate(args):
+            handled = False
 
             if isinstance(arg, list) or isinstance(arg, List):
                 currentArgs[i] = arg[j]
+                handled = True
 
             if arrayRanks[i] is not None:
                 currentArgs[i] = materializedArgs[i][j]
+                handled = True
+
+            if not handled:
+                # A plain scalar argument (e.g. a fixed `int`/`float` kernel
+                # parameter passed alongside a broadcast list/array) is not a
+                # per-call value to index into; hold it constant across every
+                # generated argument set instead of leaving the `0` placeholder.
+                currentArgs[i] = arg
 
         argSet.append(tuple(currentArgs))
     return argSet

--- a/python/tests/kernel/test_observe_kernel.py
+++ b/python/tests/kernel/test_observe_kernel.py
@@ -408,3 +408,26 @@ def test_observe_list_multi_term_operators():
     results_id = cudaq.observe(simple_kernel, [op_with_id])
     result_id = cudaq.observe(simple_kernel, op_with_id)
     assert np.isclose(results_id[0].expectation(), result_id.expectation())
+
+
+def test_broadcast_fixed_scalar_argument_preserved():
+    """
+    Regression test: in a broadcast `observe`/`sample` call, a plain scalar
+    argument that is not itself a list/array (a value meant to stay fixed
+    across every generated call) must be forwarded unchanged, not silently
+    replaced by the internal placeholder default of `0`.
+    """
+
+    @cudaq.kernel
+    def kernel(theta: float, offset: float):
+        q = cudaq.qvector(1)
+        rx(theta + offset, q[0])
+
+    hamiltonian = spin.z(0)
+    thetas = [0.3, 0.5, 0.7]
+    offset = 0.4
+
+    results = cudaq.observe(kernel, hamiltonian, thetas, offset)
+    expected = [np.cos(theta + offset) for theta in thetas]
+    for result, exp in zip(results, expected):
+        assert np.isclose(result.expectation(), exp)


### PR DESCRIPTION
Fixes #5353

### Bug

`__createArgumentSet` (`python/cudaq/runtime/utils.py:116-148`), the shared helper behind
`cudaq.observe`/`cudaq.sample`/`cudaq.ptsbe.sample` broadcast calls, initializes every per-call
argument slot to a placeholder `0` and only overwrites it when the argument is a `list` or
array-like (`hasattr(arg, "tolist")`). A plain scalar argument passed alongside a broadcast
list/array - meant to stay fixed across the whole sweep - is neither, so its slot is silently
left at `0` for every generated call, independent of the value actually passed. `__isBroadcast`
only rejects a bare scalar when a genuine 2D array argument is also present; a 1D list
broadcast has no such guard.

### Fix

Track whether an argument's slot was ever written by the list/array branches; if not, forward
the argument unchanged instead of leaving the `0` placeholder.

### Verification

Not a regression from a deliberate choice: the zero-placeholder shape predates the class
(`da88cb550` / #1312) and the function was touched twice since for unrelated reasons
(`13c440577` #5069, `b44f9b4a0` #5089) without adding scalar handling - confirmed via
`git log -S`/`git log --follow`. No existing test passes a non-list fixed scalar alongside a
broadcast argument.

Negative control: added `test_broadcast_fixed_scalar_argument_preserved` to
`python/tests/kernel/test_observe_kernel.py`. This box has no local LLVM/MLIR build (see repo
docs), so the test was run against the CUDA-Q 0.15.1 wheel by dynamically loading
`__createArgumentSet` from the file under test and substituting it for the wheel's own copy in
the real, running `cudaq.runtime.{observe,sample,ptsbe}` modules - never touching
`__isBroadcast` or any MLIR-dialect-typed code, so the real compiled kernel-compilation and
execution path is exercised unmodified either way:

```
without the fix: observed=[0.9553364891256059, 0.8775825618903726, 0.7648421872844884]
                  0 passed, 3 failed
with the fix:     observed=[0.7648421872844884, 0.6216099682706644, 0.45359612142557726]
                  3 passed, 0 failed
```
(expected: `[0.7648421872844885, 0.6216099682706644, 0.4535961214255773]` = `cos(theta+offset)`)

Also ran the full existing broadcast coverage the same way (patched `__createArgumentSet`,
real wheel otherwise) with no regressions: `test_broadcast`/`test_broadcast_py39Plus` in both
`test_observe_kernel.py` and `test_sample_kernel.py`, and all 8 cases in
`python/tests/ptsbe/test_async_broadcast.py` - all pass. One unrelated pre-existing failure
(`test_observe_list`, a `disable_quantum_optimization` kwarg the 0.15.1 wheel's
`PyKernelDecorator` does not have) reproduces identically with or without this change.

Small diff; touches only the shared broadcast argument-set builder and adds one regression
test.

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
