### PR TITLE
fix(dynamics): batched super-operators without a dissipator wrongly force a mixed state

### DIFF
--- a/python/cudaq/dynamics/cudm_solver.py
+++ b/python/cudaq/dynamics/cudm_solver.py
@@ -39,9 +39,6 @@ def should_use_mixed_state(
                 if len(collapse_ops) > 0:
                     return True
 
-    if isinstance(hamiltonian, Sequence):
-        return any(isinstance(op, SuperOperator) for op in hamiltonian)
-
     # Helper to check if the super-operator has right apply operators.
     def has_right_apply(super_op: SuperOperator) -> bool:
         for (left_op, right_op) in super_op:

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -235,6 +235,28 @@ def test_batching_bugs():
         assert len(evolution_result.intermediate_states()) == len(steps)
 
 
+def test_should_use_mixed_state_batch_no_right_apply():
+    """
+    `should_use_mixed_state` must only promote to a mixed (density-matrix)
+    state when a super-operator actually has a right-apply term (i.e. is a
+    genuine dissipator). A batch of super-operators that are all pure
+    left-multiplies (no dissipator) does not need a mixed state, same as a
+    single such super-operator.
+    """
+    from cudaq.dynamics.cudm_solver import should_use_mixed_state
+
+    hamiltonian = boson.create(0) * boson.annihilate(0)
+    pure_left_multiply = SuperOperator.left_multiply(-1j * hamiltonian)
+    dissipative = SuperOperator.left_right_multiply(boson.annihilate(0),
+                                                     boson.create(0))
+
+    assert should_use_mixed_state(pure_left_multiply, []) == False
+    assert should_use_mixed_state([pure_left_multiply, pure_left_multiply],
+                                  []) == False
+    assert should_use_mixed_state(dissipative, []) == True
+    assert should_use_mixed_state([dissipative, dissipative], []) == True
+
+
 def test_precision_info():
     """
     Test that the target info is correct: double precision for dynamics


### PR DESCRIPTION
Fixes #5356

### Bug

`should_use_mixed_state` (`python/cudaq/dynamics/cudm_solver.py:23-61`) decides whether
`cudaq.evolve()` on the `dynamics` target must promote the state to a density matrix. For a
single super-operator it correctly checks for a right-apply (dissipator) term via
`has_right_apply`, but for a *sequence* of super-operators an earlier, more permissive check
returns `True` as soon as any element is merely a `SuperOperator`, regardless of whether it has
a dissipator - making the correct, more specific `elif` branch a few lines below unreachable
for every sequence input. A batch of pure left-multiply super-operators (ordinary
Hamiltonian-only evolution, no dissipator) is therefore needlessly forced into a density-matrix
representation, squaring the memory/compute cost of the simulation. The C++ side of the same
feature (`CuDensityMatEvolution.cpp:794-795`) already gets this right by checking the
dissipator condition on every batch element.

### Fix

Remove the premature early return so the already-written, correct per-element check runs for
sequence inputs too.

### Verification

Not a regression from a deliberate choice: `should_use_mixed_state` was introduced whole-cloth
in `995dac165` (#3129); the correct `elif` branch was written in the same commit, immediately
below the unreachable `return` - an authoring oversight, not a decision. Confirmed via
`git log -S` that only that one commit and two unrelated distributed-batching commits have
ever touched this file. No existing test exercises a batched super-operator sequence with zero
dissipators.

This box has no GPU/local LLVM-MLIR build (see repo docs), so the negative control was run
against the CUDA-Q 0.15.1 wheel (unchanged from `main` for this file) with the unrelated
compiled `nvqir_dynamics_bindings` extension stubbed out in `sys.modules` before import -
`should_use_mixed_state` never references that extension at all (only `isinstance`/iteration
over `Operator`/`SuperOperator`/`Sequence`), so this is a benign substitution for an
import-time dependency the code under test never touches, not a change to it:

```
without the fix: FAIL: test_should_use_mixed_state_batch_no_right_apply
                  0 passed, 1 failed
with the fix:     PASS: test_should_use_mixed_state_batch_no_right_apply
                  1 passed, 0 failed
```

Added `test_should_use_mixed_state_batch_no_right_apply` to
`python/tests/dynamics/test_evolve_dynamics.py`, next to the existing
`test_batching_bugs` batched-super-operator coverage. It needs no GPU/dynamics target itself
(pure classification logic) but lives in this GPU-gated file since it exercises
`cudaq.dynamics.cudm_solver`, matching the file's existing convention; it will run for real
against the compiled extension in CI, where the stub above is unnecessary.

Small diff (`-3/+22`, mostly the new test); touches only the batched-super-operator
classification helper.

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
