### PR TITLE
[core] Add a normalization of atomic quantum regions pass.

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1462,6 +1462,34 @@ def MultiControlDecomposition :
   }];
 }
 
+def NormalizeAtomicQuantumRegions :
+    Pass<"normalize-atomic-quantum-regions"> {
+  let summary =
+      "Hoist/sink non-unitary operations from marked atomic quantum region.";
+  let description = [{
+    An `atomic_quantum_region` `cc.scope` marks a sequence of quantum
+    operations that must execute without interleaving with allocations,
+    deallocations, or measurements. When such a scope contains its own
+    `quake.alloca`s, those allocations (and their associated `quake.dealloc`s)
+    are not something that needs to stay inside the atomic region but need to
+    be moved outside of it.
+
+    This pass wraps a `cc.scope` carrying the `atomic_quantum_region`
+    attribute with a new, plain (non-atomic) `cc.scope`. Any `quake.alloca`
+    found directly in the atomic scope's body is hoisted into the new outer
+    scope, ahead of the (now-nested) atomic scope. Any `quake.dealloc` that
+    deallocates one of those hoisted allocations is sunk into the outer scope.
+    Additionally any measurement op found in the body and the transitive closure
+    of every op that consumes a measurement's result is also sunk out of the
+    region. This means an atomic region may not contain mid-circuit
+    measurements.
+
+    For now, this pass only handles reference-semantics Quake IR and requires
+    the atomic scope to have a single block and zero results; it leaves any
+    other atomic scope unmodified.
+  }];
+}
+
 def NormalizePhasePlacement :
     Pass<"normalize-phase-placement", "mlir::func::FuncOp"> {
   let summary = "Normalize block-local placement of phase corrections";

--- a/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -2132,10 +2132,15 @@ void cudaq::cc::ScopeOp::print(OpAsmPrinter &p) {
     // Print terminator explicitly if the op defines values.
     printBlockTerminators = true;
   }
+  if (getAtomicQuantumRegionAttr())
+    p << " atomic";
   p << ' ';
   p.printRegion(getRegion(), /*printEntryBlockArgs=*/false,
                 printBlockTerminators);
-  p.printOptionalAttrDict((*this)->getAttrs());
+  // The `atomic_quantum_region` attribute is represented by the `atomic`
+  // keyword above, not the generic attribute dictionary.
+  p.printOptionalAttrDict((*this)->getAttrs(),
+                          /*elidedAttrs=*/{atomicQuantumRegionAttrName});
 }
 
 static void ensureScopeRegionTerminator(OpBuilder &builder,
@@ -2158,6 +2163,9 @@ ParseResult cudaq::cc::ScopeOp::parse(OpAsmParser &parser,
                                       OperationState &result) {
   if (parser.parseOptionalArrowTypeList(result.types))
     return failure();
+  if (succeeded(parser.parseOptionalKeyword("atomic")))
+    result.addAttribute(atomicQuantumRegionAttrName,
+                        UnitAttr::get(parser.getContext()));
   auto *body = result.addRegion();
   if (parser.parseRegion(*body, /*arguments=*/{}) ||
       parser.parseOptionalAttrDict(result.attributes))

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -62,6 +62,7 @@ add_cudaq_library(OptTransforms
   MemToReg.cpp
   DependencyAnalysis.cpp
   MultiControlDecomposition.cpp
+  NormalizeAtomicQuantumRegions.cpp
   NormalizePhasePlacement.cpp
   ObserveAnsatz.cpp
   OptimizeSingleQubitCliffordT.cpp

--- a/cudaq/lib/Optimizer/Transforms/NormalizeAtomicQuantumRegions.cpp
+++ b/cudaq/lib/Optimizer/Transforms/NormalizeAtomicQuantumRegions.cpp
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "llvm/ADT/SetVector.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_NORMALIZEATOMICQUANTUMREGIONS
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "normalize-atomic-quantum-regions"
+
+using namespace mlir;
+
+namespace {
+/// \returns true if any operation in \p region uses a value-semantics (wire,
+/// cable, or control) quantum type anywhere in its operands or results. This
+/// pass only reasons about reference-semantics (`quake.alloca`/
+/// `quake.dealloc`) Quake IR.
+static bool hasValueSemantics(Region &region) {
+  bool found = false;
+  region.walk([&](Operation *op) {
+    auto isQuantumValue = [](Value v) {
+      return cudaq::quake::isQuantumValueType(v.getType());
+    };
+    if (llvm::any_of(op->getOperands(), isQuantumValue) ||
+        llvm::any_of(op->getResults(), isQuantumValue)) {
+      found = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+/// Attempt to hoist `quake.alloca`s (and sink their paired `quake.dealloc`s
+/// and any measurement's transitive closure of users) out of \p scope, a
+/// `cc.scope` carrying the `atomic_quantum_region` attribute. Returns true if
+/// \p scope was rewritten.
+static bool processAtomicScope(cudaq::cc::ScopeOp scope) {
+  // For now, only rewrite a single-block, zero-result atomic scope. This
+  // sidesteps having to thread `cc.continue` operands (which would flow
+  // either through the still-nested atomic scope or through the sunk tail)
+  // and having to reason about which exit a multi-block region's allocations
+  // are live across.
+  if (scope.getNumResults() != 0 || !scope.getRegion().hasOneBlock())
+    return false;
+
+  if (hasValueSemantics(scope.getRegion()))
+    return false;
+
+  Block &block = scope.getRegion().front();
+
+  SmallVector<cudaq::quake::AllocaOp> allocas;
+  for (Operation &op : block)
+    if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op))
+      allocas.push_back(alloc);
+  if (allocas.empty())
+    return false;
+
+  llvm::DenseSet<Operation *> allocaSet;
+  for (auto alloc : allocas)
+    allocaSet.insert(alloc);
+
+  // A dynamically-sized alloca's `%size` operand must already dominate the
+  // scope (i.e. not be defined inside the block being hoisted out of); it is
+  // not itself something we try to hoist.
+  for (auto alloc : allocas)
+    if (Value size = alloc.getSize())
+      if (Operation *def = size.getDefiningOp())
+        if (def->getBlock() == &block)
+          return false;
+
+  // Deallocations of the hoisted allocations get sunk alongside them.
+  llvm::DenseSet<Operation *> sinkSet;
+  for (Operation &op : block)
+    if (auto dealloc = dyn_cast<cudaq::quake::DeallocOp>(op))
+      if (Operation *def = dealloc.getReference().getDefiningOp())
+        if (allocaSet.contains(def))
+          sinkSet.insert(dealloc);
+
+  // Measurements, and the transitive closure of every op that consumes a
+  // measurement's results, get sunk as well. If any such consumer lives
+  // outside this block (e.g. nested in nested control flow within the atomic
+  // scope), bail rather than attempt an unsound partial hoist.
+  SmallVector<Operation *> worklist;
+  for (Operation &op : block)
+    if (isa<cudaq::quake::MeasurementInterface>(op))
+      worklist.push_back(&op);
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (!sinkSet.insert(op).second)
+      continue;
+    if (op->getBlock() != &block)
+      return false;
+    for (Value result : op->getResults())
+      for (Operation *user : result.getUsers())
+        worklist.push_back(user);
+  }
+
+  // Every op being sunk must only depend on values defined outside the block
+  // or on other ops in the hoisted/sunk sets -- otherwise sinking it would
+  // reference a value left behind inside the (still nested) atomic scope,
+  // which is not visible from the new outer scope.
+  for (Operation *op : sinkSet)
+    for (Value operand : op->getOperands())
+      if (Operation *def = operand.getDefiningOp())
+        if (def->getBlock() == &block && !allocaSet.contains(def) &&
+            !sinkSet.contains(def))
+          return false;
+
+  // Collect the ops to sink in their original relative order.
+  SmallVector<Operation *> sinkOpsInOrder;
+  for (Operation &op : block)
+    if (sinkSet.contains(&op))
+      sinkOpsInOrder.push_back(&op);
+
+  OpBuilder builder(scope);
+  builder.setInsertionPoint(scope);
+  auto outerScope = cudaq::cc::ScopeOp::create(builder, scope.getLoc(),
+                                               [](OpBuilder &, Location) {});
+  Block &outerBlock = outerScope.getRegion().front();
+  OpBuilder terminatorBuilder(&outerBlock, outerBlock.end());
+  cudaq::cc::ContinueOp::create(terminatorBuilder, scope.getLoc());
+  Operation *terminator = &outerBlock.back();
+
+  scope->moveBefore(terminator);
+  for (auto alloc : allocas)
+    alloc->moveBefore(scope);
+  for (Operation *op : sinkOpsInOrder)
+    op->moveBefore(terminator);
+
+  return true;
+}
+
+class NormalizeAtomicQuantumRegionsPass
+    : public cudaq::opt::impl::NormalizeAtomicQuantumRegionsBase<
+          NormalizeAtomicQuantumRegionsPass> {
+public:
+  using NormalizeAtomicQuantumRegionsBase::NormalizeAtomicQuantumRegionsBase;
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    SmallVector<cudaq::cc::ScopeOp> atomicScopes;
+    op->walk([&](cudaq::cc::ScopeOp scope) {
+      if (scope.getAtomicQuantumRegionAttr())
+        atomicScopes.push_back(scope);
+    });
+    for (auto scope : atomicScopes)
+      processAtomicScope(scope);
+  }
+};
+} // namespace

--- a/cudaq/lib/Optimizer/Transforms/NormalizeAtomicQuantumRegions.cpp
+++ b/cudaq/lib/Optimizer/Transforms/NormalizeAtomicQuantumRegions.cpp
@@ -62,7 +62,7 @@ static bool isMeasurementSafeToSink(Operation *measureOp, Block &block) {
       if (targets.contains(dealloc.getReference()))
         continue;
     if (llvm::any_of(op.getOperands(),
-                      [&](Value v) { return targets.contains(v); }))
+                     [&](Value v) { return targets.contains(v); }))
       return false;
   }
   return true;

--- a/cudaq/lib/Optimizer/Transforms/NormalizeAtomicQuantumRegions.cpp
+++ b/cudaq/lib/Optimizer/Transforms/NormalizeAtomicQuantumRegions.cpp
@@ -11,6 +11,7 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace cudaq::opt {
 #define GEN_PASS_DEF_NORMALIZEATOMICQUANTUMREGIONS
@@ -40,6 +41,31 @@ static bool hasValueSemantics(Region &region) {
     return WalkResult::advance();
   });
   return found;
+}
+
+/// Check that is it safe to sink a measurement.
+static bool isMeasurementSafeToSink(Operation *measureOp, Block &block) {
+  auto measure = cast<cudaq::quake::MeasurementInterface>(measureOp);
+  llvm::SmallPtrSet<Value, 4> targets;
+  for (Value target : measure.getTargets())
+    targets.insert(target);
+
+  bool afterMeasure = false;
+  for (Operation &op : block) {
+    if (&op == measureOp) {
+      afterMeasure = true;
+      continue;
+    }
+    if (!afterMeasure)
+      continue;
+    if (auto dealloc = dyn_cast<cudaq::quake::DeallocOp>(op))
+      if (targets.contains(dealloc.getReference()))
+        continue;
+    if (llvm::any_of(op.getOperands(),
+                      [&](Value v) { return targets.contains(v); }))
+      return false;
+  }
+  return true;
 }
 
 /// Attempt to hoist `quake.alloca`s (and sink their paired `quake.dealloc`s
@@ -93,9 +119,18 @@ static bool processAtomicScope(cudaq::cc::ScopeOp scope) {
   // outside this block (e.g. nested in nested control flow within the atomic
   // scope), bail rather than attempt an unsound partial hoist.
   SmallVector<Operation *> worklist;
-  for (Operation &op : block)
-    if (isa<cudaq::quake::MeasurementInterface>(op))
-      worklist.push_back(&op);
+  for (Operation &op : block) {
+    if (!isa<cudaq::quake::MeasurementInterface>(op))
+      continue;
+    if (!isMeasurementSafeToSink(&op, block)) {
+      op.emitWarning(
+          "measurement in an atomic quantum region will not be sunk out of "
+          "the region because the measured reference is used again "
+          "afterwards");
+      continue;
+    }
+    worklist.push_back(&op);
+  }
   while (!worklist.empty()) {
     Operation *op = worklist.pop_back_val();
     if (!sinkSet.insert(op).second)

--- a/cudaq/test/CodeGen/OpenQASM/atomic_quantum_region_scope.qke
+++ b/cudaq/test/CodeGen/OpenQASM/atomic_quantum_region_scope.qke
@@ -14,10 +14,10 @@
 func.func @scope_result() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
   %q = quake.alloca !quake.ref
   %half = arith.constant 5.000000e-01 : f64
-  %theta = cc.scope -> (f64) {
+  %theta = cc.scope -> (f64) atomic {
     quake.h %q : (!quake.ref) -> ()
     cc.continue %half : f64
-  } {atomic_quantum_region}
+  }
   quake.rx (%theta) %q : (f64, !quake.ref) -> ()
   return
 }

--- a/cudaq/test/Optimizer/Mapping/mapping_scope.qke
+++ b/cudaq/test/Optimizer/Mapping/mapping_scope.qke
@@ -53,7 +53,7 @@ func.func @atomic_scope_live_lane() attributes {quake.cudaq_run = []} {
     %q0 = quake.borrow_wire @wires[0] : !quake.wire
     %q1 = quake.borrow_wire @wires[1] : !quake.wire
     %q2 = quake.borrow_wire @wires[2] : !quake.wire
-    %outer:2 = cc.scope -> (!quake.wire, !quake.wire) {
+    %outer:2 = cc.scope -> (!quake.wire, !quake.wire) atomic {
       %inner:2 = cc.scope -> (!quake.wire, !quake.wire) {
         %gate:2 = quake.x [%q0] %q2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
         cc.continue %gate#0, %gate#1 : !quake.wire, !quake.wire
@@ -61,7 +61,7 @@ func.func @atomic_scope_live_lane() attributes {quake.cudaq_run = []} {
       %slot = cc.alloca i1
       cc.store %cond, %slot : !cc.ptr<i1>
       cc.continue %inner#0, %inner#1 : !quake.wire, !quake.wire
-    } {atomic_quantum_region}
+    }
     %if:1 = cc.if (%cond) ((%arg = %q1)) -> (!quake.wire) {
       %then = quake.h %arg : (!quake.wire) -> !quake.wire
       cc.continue %then : !quake.wire

--- a/cudaq/test/Optimizer/Mapping/mapping_scope.qke
+++ b/cudaq/test/Optimizer/Mapping/mapping_scope.qke
@@ -26,7 +26,7 @@ quake.wire_set @wires[2147483647]
 // PATH:       %[[Q0:.*]] = quake.borrow_wire @mapped_wireset[0]
 // PATH:       %[[Q1:.*]] = quake.borrow_wire @mapped_wireset[1]
 // PATH:       %[[Q2:.*]] = quake.borrow_wire @mapped_wireset[2]
-// PATH:       %[[OUTER:.*]]:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
+// PATH:       %[[OUTER:.*]]:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) atomic {
 // PATH:         %[[INNER:.*]]:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
 // PATH:           %[[SWAP:.*]]:2 = quake.swap %[[Q0]], %[[Q1]]
 // PATH:           %[[GATE:.*]]:2 = quake.x [%[[SWAP]]#1] %[[Q2]]
@@ -35,7 +35,7 @@ quake.wire_set @wires[2147483647]
 // PATH:         %[[SLOT:.*]] = cc.alloca i1
 // PATH:         cc.store {{.*}}, %[[SLOT]] : !cc.ptr<i1>
 // PATH:         cc.continue %[[INNER]]#0, %[[INNER]]#1, %[[INNER]]#2
-// PATH:       } {atomic_quantum_region}
+// PATH:       }
 // PATH:       cc.if{{.*}}%[[OUTER]]#2
 // AUTO-LABEL: func.func @atomic_scope_live_lane()
 // AUTO-SAME:  mapping_v2p = [1, 2, 0]

--- a/cudaq/test/Optimizer/atomic_quantum_region_errors.qke
+++ b/cudaq/test/Optimizer/atomic_quantum_region_errors.qke
@@ -73,13 +73,13 @@ func.func @allocation_caller() {
 // -----
 
 func.func @marked_scope(%q: !quake.ref) {
-  cc.scope {
+  cc.scope atomic {
     // expected-error@+1 {{qubit allocations are not supported inside an atomic quantum region; allocate in the caller and pass the qubits as arguments}}
     %local = quake.alloca !quake.ref
     // expected-error@+1 {{measurement operations are not supported inside an atomic quantum region; measure outside the region}}
     %m = quake.mz %q : (!quake.ref) -> !quake.measure
     cc.continue
-  } {atomic_quantum_region}
+  }
   return
 }
 

--- a/cudaq/test/Optimizer/atomic_quantum_region_inlining.qke
+++ b/cudaq/test/Optimizer/atomic_quantum_region_inlining.qke
@@ -58,29 +58,29 @@ module attributes {quake.mangled_name_map = {marked = "indirect_marked"}} {
 // CHECK-LABEL:   func.func @caller(
 // CHECK-SAME:                      %[[ARG0:.*]]: !quake.ref,
 // CHECK-SAME:                      %[[ARG1:.*]]: i1) {
-// CHECK:           cc.scope {
+// CHECK:           cc.scope atomic {
 // CHECK:             quake.h %[[ARG0]] : (!quake.ref) -> ()
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK-NEXT:      quake.x %[[ARG0]] : (!quake.ref) -> ()
-// CHECK-NEXT:      cc.scope {
-// CHECK-NEXT:        cc.scope {
+// CHECK-NEXT:      cc.scope atomic {
+// CHECK-NEXT:        cc.scope atomic {
 // CHECK-NEXT:          quake.h %[[ARG0]] : (!quake.ref) -> ()
-// CHECK-NEXT:        } {atomic_quantum_region}
+// CHECK-NEXT:        }
 // CHECK-NEXT:        quake.y %[[ARG0]] : (!quake.ref) -> ()
-// CHECK-NEXT:      } {atomic_quantum_region}
-// CHECK-NEXT:      cc.scope {
+// CHECK-NEXT:      }
+// CHECK-NEXT:      cc.scope atomic {
 // CHECK-NEXT:        cc.if(%[[ARG1]]) {
 // CHECK-NEXT:          quake.z %[[ARG0]] : (!quake.ref) -> ()
 // CHECK-NEXT:        }
-// CHECK-NEXT:      } {atomic_quantum_region}
+// CHECK-NEXT:      }
 // CHECK-NEXT:      cc.if(%[[ARG1]]) {
 // CHECK-NEXT:        quake.z %[[ARG0]] : (!quake.ref) -> ()
 // CHECK-NEXT:      }
-// CHECK-NEXT:      cc.scope {
+// CHECK-NEXT:      cc.scope atomic {
 // CHECK-NEXT:        quake.h %[[ARG0]] : (!quake.ref) -> ()
-// CHECK-NEXT:      } {atomic_quantum_region}
+// CHECK-NEXT:      }
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
 
-// COUNT-COUNT-5: atomic_quantum_region
-// COUNT-NOT: atomic_quantum_region
+// COUNT-COUNT-5: cc.scope{{( -> \([^)]*\))?}} atomic
+// COUNT-NOT: cc.scope{{( -> \([^)]*\))?}} atomic

--- a/cudaq/test/Optimizer/atomic_quantum_region_scope.qke
+++ b/cudaq/test/Optimizer/atomic_quantum_region_scope.qke
@@ -10,11 +10,11 @@
 // RUN: cudaq-opt --verify-each --canonicalize %s | FileCheck --check-prefix=COUNT %s
 
 func.func @marked_scope(%arg: i64) -> i64 {
-  %result = cc.scope -> (i64) {
+  %result = cc.scope -> (i64) atomic {
     %zero = arith.constant 0 : i64
     %sum = arith.addi %arg, %zero : i64
     cc.continue %sum : i64
-  } {atomic_quantum_region}
+  }
   return %result : i64
 }
 

--- a/cudaq/test/Optimizer/atomic_quantum_region_scope.qke
+++ b/cudaq/test/Optimizer/atomic_quantum_region_scope.qke
@@ -29,9 +29,9 @@ func.func @ordinary_scope(%arg: i64) -> i64 {
 
 // CHECK-LABEL:   func.func @marked_scope(
 // CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (i64) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (i64) atomic {
 // CHECK:             cc.continue %[[ARG0]] : i64
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]] : i64
 // CHECK:         }
 
@@ -41,5 +41,5 @@ func.func @ordinary_scope(%arg: i64) -> i64 {
 // CHECK:           return %[[ARG0]] : i64
 // CHECK:         }
 
-// COUNT-COUNT-1: atomic_quantum_region
-// COUNT-NOT: atomic_quantum_region
+// COUNT-COUNT-1: cc.scope -> (i64) atomic
+// COUNT-NOT: atomic

--- a/cudaq/test/Optimizer/atomic_quantum_region_specialization.qke
+++ b/cudaq/test/Optimizer/atomic_quantum_region_specialization.qke
@@ -82,15 +82,15 @@ func.func @caller(%control: !quake.ref, %target: !quake.ref) {
 
 // INLINE-LABEL:   func.func @caller(
 // INLINE-SAME:      %[[ARG0:.*]]: !quake.ref, %[[ARG1:.*]]: !quake.ref) {
-// INLINE:           cc.scope {
+// INLINE:           cc.scope atomic {
 // INLINE:             quake.t<adj> %[[ARG1]] : (!quake.ref) -> ()
-// INLINE:           } {atomic_quantum_region}
+// INLINE:           }
 // INLINE:           %[[CONCAT_0:.*]] = quake.concat %[[ARG0]] : (!quake.ref) -> !quake.veq<1>
-// INLINE:           cc.scope {
+// INLINE:           cc.scope atomic {
 // INLINE:             quake.t {{\[}}%[[CONCAT_0]]] %[[ARG1]] : (!quake.veq<1>, !quake.ref) -> ()
-// INLINE:           } {atomic_quantum_region}
+// INLINE:           }
 // INLINE:           %[[CONCAT_1:.*]] = quake.concat %[[ARG0]] : (!quake.ref) -> !quake.veq<1>
-// INLINE:           cc.scope {
+// INLINE:           cc.scope atomic {
 // INLINE:             quake.t<adj> {{\[}}%[[CONCAT_1]]] %[[ARG1]] : (!quake.veq<1>, !quake.ref) -> ()
-// INLINE:           } {atomic_quantum_region}
+// INLINE:           }
 // INLINE:           quake.t<adj> %[[ARG1]] : (!quake.ref) -> ()

--- a/cudaq/test/Optimizer/atomic_quantum_region_target_codegen.qke
+++ b/cudaq/test/Optimizer/atomic_quantum_region_target_codegen.qke
@@ -24,16 +24,16 @@ func.func @atomic_round_trip() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %q0 = quake.extract_ref %q[0] : (!quake.veq<3>) -> !quake.ref
   %q1 = quake.extract_ref %q[1] : (!quake.veq<3>) -> !quake.ref
   %q2 = quake.extract_ref %q[2] : (!quake.veq<3>) -> !quake.ref
-  cc.scope {
+  cc.scope atomic {
     quake.h %q0 : (!quake.ref) -> ()
     quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     quake.x [%q1] %q2 : (!quake.ref, !quake.ref) -> ()
-  } {atomic_quantum_region}
-  cc.scope {
+  }
+  cc.scope atomic {
     quake.x [%q1] %q2 : (!quake.ref, !quake.ref) -> ()
     quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     quake.h %q0 : (!quake.ref) -> ()
-  } {atomic_quantum_region}
+  }
   %m0 = quake.mz %q0 : (!quake.ref) -> !cc.measure_handle
   %m1 = quake.mz %q1 : (!quake.ref) -> !cc.measure_handle
   %m2 = quake.mz %q2 : (!quake.ref) -> !cc.measure_handle

--- a/cudaq/test/Optimizer/atomic_quantum_region_unwind.qke
+++ b/cudaq/test/Optimizer/atomic_quantum_region_unwind.qke
@@ -27,7 +27,7 @@ func.func @caller(%q: !quake.ref, %condition: i1) {
 // CHECK-LABEL:   func.func @caller(
 // CHECK-SAME:                      %[[ARG0:.*]]: !quake.ref,
 // CHECK-SAME:                      %[[ARG1:.*]]: i1) {
-// CHECK:           cc.scope {
+// CHECK:           cc.scope atomic {
 // CHECK:             cf.cond_br %[[ARG1]], ^bb1, ^bb2
 // CHECK:           ^bb1:
 // CHECK:             quake.h %[[ARG0]] : (!quake.ref) -> ()
@@ -37,10 +37,10 @@ func.func @caller(%q: !quake.ref, %condition: i1) {
 // CHECK:             cf.br ^bb3
 // CHECK:           ^bb3:
 // CHECK:             cc.continue
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           quake.y %[[ARG0]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
-// COUNT-COUNT-1: atomic_quantum_region
-// COUNT-NOT: atomic_quantum_region
+// COUNT-COUNT-1: cc.scope atomic
+// COUNT-NOT: cc.scope atomic

--- a/cudaq/test/Optimizer/memtoreg-4.qke
+++ b/cudaq/test/Optimizer/memtoreg-4.qke
@@ -290,7 +290,7 @@ func.func @scope_entry_alias(%idx: i64) {
 // CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[WRAP_NEW_0]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[Y_0:.*]] = quake.y %[[UNWRAP_1]] : (!quake.wire) -> !quake.wire
 // CHECK:           quake.wrap %[[Y_0]] to %[[ALLOCA_0]] : !quake.wire, !quake.ref
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[CONCAT_0]]{{\[}}%[[ARG0]]] : (!quake.veq<1>, i64) -> !quake.ref
 // CHECK:             %[[UNWRAP_2:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
 // CHECK:             %[[H_0:.*]] = quake.h %[[UNWRAP_2]] : (!quake.wire) -> !quake.wire
@@ -298,7 +298,7 @@ func.func @scope_entry_alias(%idx: i64) {
 // CHECK:             %[[UNWRAP_3:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
 // CHECK:             %[[X_0:.*]] = quake.x %[[UNWRAP_3]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[X_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           quake.sink %[[SCOPE_0]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Optimizer/memtoreg-4.qke
+++ b/cudaq/test/Optimizer/memtoreg-4.qke
@@ -271,12 +271,12 @@ func.func @scope_entry_alias(%idx: i64) {
   %r = quake.alloca !quake.ref
   %v = quake.concat %r : (!quake.ref) -> !quake.veq<1>
   quake.y %r : (!quake.ref) -> ()
-  cc.scope {
+  cc.scope atomic {
     %q = quake.extract_ref %v[%idx] : (!quake.veq<1>, i64) -> !quake.ref
     quake.h %q : (!quake.ref) -> ()
     quake.x %r : (!quake.ref) -> ()
     cc.continue
-  } {atomic_quantum_region}
+  }
   quake.dealloc %r : !quake.ref
   return
 }

--- a/cudaq/test/Optimizer/memtoreg-9.qke
+++ b/cudaq/test/Optimizer/memtoreg-9.qke
@@ -117,7 +117,7 @@ func.func @scope_internal_alias(%idx: i64) {
 // CHECK:           %[[CONCAT_0:.*]] = quake.concat %[[ALLOCA_0]] : (!quake.ref) -> !quake.veq<1>
 // CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %[[ALLOCA_0]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[Y_0:.*]] = quake.y %[[UNWRAP_0]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[CMPI_0:.*]] = arith.cmpi ugt, %[[ARG0]], %[[CONSTANT_0]] : i64
 // CHECK:             cf.cond_br %[[CMPI_0]], ^bb2(%[[Y_0]] : !quake.wire), ^bb1(%[[Y_0]] : !quake.wire)
 // CHECK:           ^bb1(%[[VAL_0:.*]]: !quake.wire):
@@ -132,7 +132,7 @@ func.func @scope_internal_alias(%idx: i64) {
 // CHECK:           ^bb2(%[[VAL_1:.*]]: !quake.wire):
 // CHECK:             %[[Z_0:.*]] = quake.z %[[VAL_1]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[Z_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           quake.sink %[[SCOPE_0]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Optimizer/memtoreg-9.qke
+++ b/cudaq/test/Optimizer/memtoreg-9.qke
@@ -94,7 +94,7 @@ func.func @scope_internal_alias(%idx: i64) {
   %r = quake.alloca !quake.ref
   %v = quake.concat %r : (!quake.ref) -> !quake.veq<1>
   quake.y %r : (!quake.ref) -> ()
-  cc.scope {
+  cc.scope atomic {
     %cond = arith.cmpi ugt, %idx, %c0 : i64
     cf.cond_br %cond, ^exit, ^body
   ^body:
@@ -105,7 +105,7 @@ func.func @scope_internal_alias(%idx: i64) {
   ^exit:
     quake.z %r : (!quake.ref) -> ()
     cc.continue
-  } {atomic_quantum_region}
+  }
   quake.dealloc %r : !quake.ref
   return
 }

--- a/cudaq/test/Optimizer/normalize_atomic_quantum_regions.qke
+++ b/cudaq/test/Optimizer/normalize_atomic_quantum_regions.qke
@@ -1,0 +1,206 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --normalize-atomic-quantum-regions %s | FileCheck %s
+
+// A `quake.alloca` found directly in the body of an `atomic_quantum_region`
+// `cc.scope` is hoisted into a new, plain wrapping `cc.scope`. Its paired
+// `quake.dealloc` sinks alongside it, after the (now-nested) atomic scope.
+
+func.func @basic_hoist() {
+  cc.scope {
+    %q = quake.alloca !quake.ref
+    quake.h %q : (!quake.ref) -> ()
+    quake.dealloc %q : !quake.ref
+    cc.continue
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @basic_hoist() {
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:             cc.scope atomic {
+// CHECK:               quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:             }
+// CHECK:             quake.dealloc %[[VAL_0]] : !quake.ref
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// A measurement, and the transitive closure of every op that consumes its
+// result, also sinks out of the atomic scope, in original relative order
+// with the dealloc.
+
+func.func @with_measurement() -> i64 {
+  %total = cc.alloca i64
+  cc.scope {
+    %q = quake.alloca !quake.ref
+    quake.h %q : (!quake.ref) -> ()
+    %m = quake.mz %q : (!quake.ref) -> !quake.measure
+    %b = quake.discriminate %m : (!quake.measure) -> i1
+    %i = cc.cast unsigned %b : (i1) -> i64
+    cc.store %i, %total : !cc.ptr<i64>
+    quake.dealloc %q : !quake.ref
+    cc.continue
+  } {atomic_quantum_region}
+  %r = cc.load %total : !cc.ptr<i64>
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @with_measurement() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = cc.alloca i64
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_1:.*]] = quake.alloca !quake.ref
+// CHECK:             cc.scope atomic {
+// CHECK:               quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:             }
+// CHECK:             %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!quake.measure) -> i1
+// CHECK:             %[[VAL_4:.*]] = cc.cast unsigned %[[VAL_3]] : (i1) -> i64
+// CHECK:             cc.store %[[VAL_4]], %[[VAL_0]] : !cc.ptr<i64>
+// CHECK:             quake.dealloc %[[VAL_1]] : !quake.ref
+// CHECK:           }
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_0]] : !cc.ptr<i64>
+// CHECK:           return %[[VAL_5]] : i64
+// CHECK:         }
+
+// A user of the measurement result that is itself a direct child of the
+// atomic scope's block (e.g. a `cc.if`) sinks as a whole, carrying its
+// nested body with it.
+
+func.func @nested_use() {
+  cc.scope {
+    %q = quake.alloca !quake.ref
+    quake.h %q : (!quake.ref) -> ()
+    %m = quake.mz %q : (!quake.ref) -> !quake.measure
+    %b = quake.discriminate %m : (!quake.measure) -> i1
+    cc.if(%b) {
+      quake.x %q : (!quake.ref) -> ()
+      cc.continue
+    }
+    quake.dealloc %q : !quake.ref
+    cc.continue
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @nested_use() {
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:             cc.scope atomic {
+// CHECK:               quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:             }
+// CHECK:             %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!quake.measure) -> i1
+// CHECK:             cc.if(%[[VAL_2]]) {
+// CHECK:               quake.x %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:             }
+// CHECK:             quake.dealloc %[[VAL_0]] : !quake.ref
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// A user of the measurement result that is nested *inside* another op's
+// body (rather than that containing op itself being a direct consumer)
+// cannot be soundly extracted alone, so the whole atomic scope is left
+// unmodified.
+
+func.func @nested_use_bail(%cond: i1) {
+  cc.scope {
+    %q = quake.alloca !quake.ref
+    quake.h %q : (!quake.ref) -> ()
+    %m = quake.mz %q : (!quake.ref) -> !quake.measure
+    %b = quake.discriminate %m : (!quake.measure) -> i1
+    cc.if(%cond) {
+      %y = arith.andi %b, %cond : i1
+      cc.continue
+    }
+    quake.dealloc %q : !quake.ref
+    cc.continue
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @nested_use_bail(
+// CHECK-SAME:                               %[[VAL_0:.*]]: i1) {
+// CHECK:           cc.scope atomic {
+// CHECK:             %[[VAL_1:.*]] = quake.alloca !quake.ref
+// CHECK:             quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:             %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!quake.measure) -> i1
+// CHECK:             cc.if(%[[VAL_0]]) {
+// CHECK:               %[[VAL_4:.*]] = arith.andi %[[VAL_3]], %[[VAL_0]] : i1
+// CHECK:             }
+// CHECK:             quake.dealloc %[[VAL_1]] : !quake.ref
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// This pass only reasons about reference-semantics Quake IR. An atomic
+// scope containing any value-semantics (wire) op is left unmodified.
+
+func.func @mixed_semantics_voidscope(%w0: !quake.wire) {
+  cc.scope {
+    %q = quake.alloca !quake.ref
+    quake.h %q : (!quake.ref) -> ()
+    quake.dealloc %q : !quake.ref
+    %w1 = quake.h %w0 : (!quake.wire) -> !quake.wire
+    cc.continue
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @mixed_semantics_voidscope(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: !quake.wire) {
+// CHECK:           cc.scope atomic {
+// CHECK:             %[[VAL_1:.*]] = quake.alloca !quake.ref
+// CHECK:             quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:             quake.dealloc %[[VAL_1]] : !quake.ref
+// CHECK:             %[[VAL_2:.*]] = quake.h %[[VAL_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// A `cc.scope` producing a result is left unmodified for now.
+
+func.func @nonzero_result(%w0: !quake.wire) -> !quake.wire {
+  %r = cc.scope -> (!quake.wire) {
+    %w1 = quake.h %w0 : (!quake.wire) -> !quake.wire
+    cc.continue %w1 : !quake.wire
+  } {atomic_quantum_region}
+  return %r : !quake.wire
+}
+
+// CHECK-LABEL:   func.func @nonzero_result(
+// CHECK-SAME:                              %[[VAL_0:.*]]: !quake.wire) -> !quake.wire {
+// CHECK:           %[[VAL_1:.*]] = cc.scope -> (!quake.wire) atomic {
+// CHECK:             %[[VAL_2:.*]] = quake.h %[[VAL_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             cc.continue %[[VAL_2]] : !quake.wire
+// CHECK:           }
+// CHECK:           return %[[VAL_1]] : !quake.wire
+// CHECK:         }
+
+// An atomic scope with no `quake.alloca` in its body has nothing to hoist
+// and is left unmodified.
+
+func.func @no_alloca(%q: !quake.ref) {
+  cc.scope {
+    quake.h %q : (!quake.ref) -> ()
+    cc.continue
+  } {atomic_quantum_region}
+  return
+}
+
+// CHECK-LABEL:   func.func @no_alloca(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !quake.ref) {
+// CHECK:           cc.scope atomic {
+// CHECK:             quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/Optimizer/normalize_atomic_quantum_regions.qke
+++ b/cudaq/test/Optimizer/normalize_atomic_quantum_regions.qke
@@ -7,18 +7,19 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt --normalize-atomic-quantum-regions %s | FileCheck %s
+// RUN: cudaq-opt --normalize-atomic-quantum-regions %s -verify-diagnostics -o /dev/null
 
 // A `quake.alloca` found directly in the body of an `atomic_quantum_region`
 // `cc.scope` is hoisted into a new, plain wrapping `cc.scope`. Its paired
 // `quake.dealloc` sinks alongside it, after the (now-nested) atomic scope.
 
 func.func @basic_hoist() {
-  cc.scope {
+  cc.scope atomic {
     %q = quake.alloca !quake.ref
     quake.h %q : (!quake.ref) -> ()
     quake.dealloc %q : !quake.ref
     cc.continue
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -39,7 +40,7 @@ func.func @basic_hoist() {
 
 func.func @with_measurement() -> i64 {
   %total = cc.alloca i64
-  cc.scope {
+  cc.scope atomic {
     %q = quake.alloca !quake.ref
     quake.h %q : (!quake.ref) -> ()
     %m = quake.mz %q : (!quake.ref) -> !quake.measure
@@ -48,7 +49,7 @@ func.func @with_measurement() -> i64 {
     cc.store %i, %total : !cc.ptr<i64>
     quake.dealloc %q : !quake.ref
     cc.continue
-  } {atomic_quantum_region}
+  }
   %r = cc.load %total : !cc.ptr<i64>
   return %r : i64
 }
@@ -75,7 +76,7 @@ func.func @with_measurement() -> i64 {
 // nested body with it.
 
 func.func @nested_use() {
-  cc.scope {
+  cc.scope atomic {
     %q = quake.alloca !quake.ref
     quake.h %q : (!quake.ref) -> ()
     %m = quake.mz %q : (!quake.ref) -> !quake.measure
@@ -86,7 +87,7 @@ func.func @nested_use() {
     }
     quake.dealloc %q : !quake.ref
     cc.continue
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -112,7 +113,7 @@ func.func @nested_use() {
 // unmodified.
 
 func.func @nested_use_bail(%cond: i1) {
-  cc.scope {
+  cc.scope atomic {
     %q = quake.alloca !quake.ref
     quake.h %q : (!quake.ref) -> ()
     %m = quake.mz %q : (!quake.ref) -> !quake.measure
@@ -123,7 +124,7 @@ func.func @nested_use_bail(%cond: i1) {
     }
     quake.dealloc %q : !quake.ref
     cc.continue
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -146,13 +147,13 @@ func.func @nested_use_bail(%cond: i1) {
 // scope containing any value-semantics (wire) op is left unmodified.
 
 func.func @mixed_semantics_voidscope(%w0: !quake.wire) {
-  cc.scope {
+  cc.scope atomic {
     %q = quake.alloca !quake.ref
     quake.h %q : (!quake.ref) -> ()
     quake.dealloc %q : !quake.ref
     %w1 = quake.h %w0 : (!quake.wire) -> !quake.wire
     cc.continue
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -170,10 +171,10 @@ func.func @mixed_semantics_voidscope(%w0: !quake.wire) {
 // A `cc.scope` producing a result is left unmodified for now.
 
 func.func @nonzero_result(%w0: !quake.wire) -> !quake.wire {
-  %r = cc.scope -> (!quake.wire) {
+  %r = cc.scope -> (!quake.wire) atomic {
     %w1 = quake.h %w0 : (!quake.wire) -> !quake.wire
     cc.continue %w1 : !quake.wire
-  } {atomic_quantum_region}
+  }
   return %r : !quake.wire
 }
 
@@ -190,10 +191,10 @@ func.func @nonzero_result(%w0: !quake.wire) -> !quake.wire {
 // and is left unmodified.
 
 func.func @no_alloca(%q: !quake.ref) {
-  cc.scope {
+  cc.scope atomic {
     quake.h %q : (!quake.ref) -> ()
     cc.continue
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -201,6 +202,64 @@ func.func @no_alloca(%q: !quake.ref) {
 // CHECK-SAME:                         %[[VAL_0:.*]]: !quake.ref) {
 // CHECK:           cc.scope atomic {
 // CHECK:             quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// A reference-semantics measurement whose measured qubit is used again
+// afterwards in the block (here, another gate) is not at the bottom of the
+// block, so sinking it would reorder it past that later use. It is left in
+// place (with a warning) rather than sunk.
+
+func.func @measurement_not_at_bottom() {
+  cc.scope atomic {
+    %q = quake.alloca !quake.ref
+    quake.h %q : (!quake.ref) -> ()
+    // expected-warning@+1 {{measurement in an atomic quantum region will not be sunk out of the region because the measured reference is used again afterwards}}
+    %m = quake.mz %q : (!quake.ref) -> !quake.measure
+    quake.x %q : (!quake.ref) -> ()
+    quake.dealloc %q : !quake.ref
+    cc.continue
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @measurement_not_at_bottom() {
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:             cc.scope atomic {
+// CHECK:               quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:               %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
+// CHECK:               quake.x %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:             }
+// CHECK:             quake.dealloc %[[VAL_0]] : !quake.ref
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// A reference-semantics measurement is still safely sunk if the only thing
+// following it (besides the dealloc) is `cc.continue` -- i.e. it truly is at
+// the bottom of the block.
+
+func.func @measurement_at_bottom() {
+  cc.scope atomic {
+    %q = quake.alloca !quake.ref
+    quake.h %q : (!quake.ref) -> ()
+    %m = quake.mz %q : (!quake.ref) -> !quake.measure
+    quake.dealloc %q : !quake.ref
+    cc.continue
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @measurement_at_bottom() {
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:             cc.scope atomic {
+// CHECK:               quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:             }
+// CHECK:             %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
+// CHECK:             quake.dealloc %[[VAL_0]] : !quake.ref
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Optimizer/optimize_single_qubit_clifford_t.qke
+++ b/cudaq/test/Optimizer/optimize_single_qubit_clifford_t.qke
@@ -112,15 +112,15 @@ func.func @atomic_scope_permitted(%inside: !quake.wire, %outer: !quake.wire,
                                   %nested: !quake.wire)
     -> (!quake.wire, !quake.wire, !quake.wire) {
   %0 = quake.t %outer : (!quake.wire) -> !quake.wire
-  %1 = cc.scope -> (!quake.wire) {
+  %1 = cc.scope -> (!quake.wire) atomic {
     %2 = quake.t %inside : (!quake.wire) -> !quake.wire
     %3 = quake.s %2 : (!quake.wire) -> !quake.wire
     %4 = quake.t %3 : (!quake.wire) -> !quake.wire
     cc.continue %4 : !quake.wire
-  } {atomic_quantum_region}
+  }
   %5 = quake.s %0 : (!quake.wire) -> !quake.wire
   %6 = quake.t %5 : (!quake.wire) -> !quake.wire
-  %7 = cc.scope -> (!quake.wire) {
+  %7 = cc.scope -> (!quake.wire) atomic {
     %8 = quake.t %nested : (!quake.wire) -> !quake.wire
     %9 = cc.scope -> (!quake.wire) {
       %10 = quake.s %8 : (!quake.wire) -> !quake.wire
@@ -128,7 +128,7 @@ func.func @atomic_scope_permitted(%inside: !quake.wire, %outer: !quake.wire,
     }
     %11 = quake.t %9 : (!quake.wire) -> !quake.wire
     cc.continue %11 : !quake.wire
-  } {atomic_quantum_region}
+  }
   return %1, %6, %7 : !quake.wire, !quake.wire, !quake.wire
 }
 
@@ -155,16 +155,16 @@ func.func @atomic_scope_permitted(%inside: !quake.wire, %outer: !quake.wire,
 func.func @atomic_scope_boundaries(%entry: !quake.wire, %exit: !quake.wire)
     -> (!quake.wire, !quake.wire) {
   %0 = quake.t %entry : (!quake.wire) -> !quake.wire
-  %1 = cc.scope -> (!quake.wire) {
+  %1 = cc.scope -> (!quake.wire) atomic {
     %2 = quake.s %0 : (!quake.wire) -> !quake.wire
     %3 = quake.t %2 : (!quake.wire) -> !quake.wire
     cc.continue %3 : !quake.wire
-  } {atomic_quantum_region}
-  %4 = cc.scope -> (!quake.wire) {
+  }
+  %4 = cc.scope -> (!quake.wire) atomic {
     %5 = quake.t %exit : (!quake.wire) -> !quake.wire
     %6 = quake.s %5 : (!quake.wire) -> !quake.wire
     cc.continue %6 : !quake.wire
-  } {atomic_quantum_region}
+  }
   %7 = quake.t %4 : (!quake.wire) -> !quake.wire
   return %1, %7 : !quake.wire, !quake.wire
 }
@@ -469,14 +469,14 @@ func.func @non_linear_boundary(%arg0: !quake.wire)
 // CHECK-NEXT:    return %[[LEFT_T1]], %[[RIGHT_T1]]
 
 func.func @sibling_atomic_scopes(%arg0: !quake.wire) -> !quake.wire {
-  %0 = cc.scope -> (!quake.wire) {
+  %0 = cc.scope -> (!quake.wire) atomic {
     %1 = quake.h %arg0 : (!quake.wire) -> !quake.wire
     cc.continue %1 : !quake.wire
-  } {atomic_quantum_region}
-  %2 = cc.scope -> (!quake.wire) {
+  }
+  %2 = cc.scope -> (!quake.wire) atomic {
     %3 = quake.h %0 : (!quake.wire) -> !quake.wire
     cc.continue %3 : !quake.wire
-  } {atomic_quantum_region}
+  }
   return %2 : !quake.wire
 }
 

--- a/cudaq/test/Optimizer/optimize_single_qubit_clifford_t.qke
+++ b/cudaq/test/Optimizer/optimize_single_qubit_clifford_t.qke
@@ -135,19 +135,19 @@ func.func @atomic_scope_permitted(%inside: !quake.wire, %outer: !quake.wire,
 // CHECK-LABEL: func.func @atomic_scope_permitted
 // CHECK:         %[[OUTER_S0:.*]] = quake.s %arg1
 // CHECK-NEXT:    %[[OUTER_S1:.*]] = quake.s %[[OUTER_S0]]
-// CHECK-NEXT:    %[[INSIDE:.*]] = cc.scope -> (!quake.wire) {
+// CHECK-NEXT:    %[[INSIDE:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK-NEXT:      %[[INSIDE_S0:.*]] = quake.s %arg0
 // CHECK-NEXT:      %[[INSIDE_S1:.*]] = quake.s %[[INSIDE_S0]]
 // CHECK-NEXT:      cc.continue %[[INSIDE_S1]] : !quake.wire
-// CHECK-NEXT:    } {atomic_quantum_region}
-// CHECK-NEXT:    %[[NESTED:.*]] = cc.scope -> (!quake.wire) {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[NESTED:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK-NEXT:      %[[NESTED_S0:.*]] = quake.s %arg2
 // CHECK-NEXT:      %[[NESTED_S1:.*]] = quake.s %[[NESTED_S0]]
 // CHECK-NEXT:      %[[ORDINARY:.*]] = cc.scope -> (!quake.wire) {
 // CHECK-NEXT:        cc.continue %[[NESTED_S1]] : !quake.wire
 // CHECK-NEXT:      }
 // CHECK-NEXT:      cc.continue %[[ORDINARY]] : !quake.wire
-// CHECK-NEXT:    } {atomic_quantum_region}
+// CHECK-NEXT:    }
 // CHECK-NEXT:    return %[[INSIDE]], %[[OUTER_S1]], %[[NESTED]]
 
 // The entry and exit cases are independent: neither an outer wire entering
@@ -171,16 +171,16 @@ func.func @atomic_scope_boundaries(%entry: !quake.wire, %exit: !quake.wire)
 
 // CHECK-LABEL: func.func @atomic_scope_boundaries
 // CHECK-NEXT:    %[[ENTRY_T:.*]] = quake.t %arg0 : (!quake.wire) -> !quake.wire
-// CHECK-NEXT:    %[[ENTRY_SCOPE:.*]] = cc.scope -> (!quake.wire) {
+// CHECK-NEXT:    %[[ENTRY_SCOPE:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK-NEXT:      %[[ENTRY_S:.*]] = quake.s %[[ENTRY_T]] : (!quake.wire) -> !quake.wire
 // CHECK-NEXT:      %[[ENTRY_INNER_T:.*]] = quake.t %[[ENTRY_S]] : (!quake.wire) -> !quake.wire
 // CHECK-NEXT:      cc.continue %[[ENTRY_INNER_T]] : !quake.wire
-// CHECK-NEXT:    } {atomic_quantum_region}
-// CHECK-NEXT:    %[[EXIT_SCOPE:.*]] = cc.scope -> (!quake.wire) {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[EXIT_SCOPE:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK-NEXT:      %[[EXIT_T:.*]] = quake.t %arg1 : (!quake.wire) -> !quake.wire
 // CHECK-NEXT:      %[[EXIT_S:.*]] = quake.s %[[EXIT_T]] : (!quake.wire) -> !quake.wire
 // CHECK-NEXT:      cc.continue %[[EXIT_S]] : !quake.wire
-// CHECK-NEXT:    } {atomic_quantum_region}
+// CHECK-NEXT:    }
 // CHECK-NEXT:    %[[EXIT_OUTER_T:.*]] = quake.t %[[EXIT_SCOPE]] : (!quake.wire) -> !quake.wire
 // CHECK-NEXT:    return %[[ENTRY_SCOPE]], %[[EXIT_OUTER_T]]
 
@@ -482,13 +482,13 @@ func.func @sibling_atomic_scopes(%arg0: !quake.wire) -> !quake.wire {
 
 // CHECK-LABEL:   func.func @sibling_atomic_scopes(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[H_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
-// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           }
+// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[H_1:.*]] = quake.h %[[SCOPE_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[H_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_1]] : !quake.wire
 // CHECK:         }

--- a/cudaq/test/Optimizer/phase_folding_atomic_region.qke
+++ b/cudaq/test/Optimizer/phase_folding_atomic_region.qke
@@ -41,16 +41,16 @@ func.func @fold_named_phases_across_ordinary_scope() {
 func.func @nested_marked_scopes_do_not_share_phases() {
   %control = quake.null_wire
   %target = quake.null_wire
-  %outer = cc.scope -> (!quake.wire) {
+  %outer = cc.scope -> (!quake.wire) atomic {
     %before = quake.s %target : (!quake.wire) -> !quake.wire
-    %inner = cc.scope -> (!quake.wire) {
+    %inner = cc.scope -> (!quake.wire) atomic {
       %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
       %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
       %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
       cc.continue %after : !quake.wire
-    } {atomic_quantum_region}
+    }
     cc.continue %inner : !quake.wire
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -75,16 +75,16 @@ func.func @nested_marked_scopes_do_not_share_phases() {
 func.func @sibling_marked_scopes_do_not_share_phases() {
   %control = quake.null_wire
   %target = quake.null_wire
-  %first = cc.scope -> (!quake.wire) {
+  %first = cc.scope -> (!quake.wire) atomic {
     %before = quake.s %target : (!quake.wire) -> !quake.wire
     cc.continue %before : !quake.wire
-  } {atomic_quantum_region}
-  %second = cc.scope -> (!quake.wire) {
+  }
+  %second = cc.scope -> (!quake.wire) atomic {
     %cx0:2 = quake.x [%control] %first : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
     cc.continue %after : !quake.wire
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -267,10 +267,10 @@ func.func @fold_named_phases_backward_through_ordinary_scope() {
 func.func @phases_do_not_fold_backward_through_marked_scope() {
   %control = quake.null_wire
   %target = quake.null_wire
-  %scope = cc.scope -> (!quake.wire) {
+  %scope = cc.scope -> (!quake.wire) atomic {
     %inside = quake.s %target : (!quake.wire) -> !quake.wire
     cc.continue %inside : !quake.wire
-  } {atomic_quantum_region}
+  }
   %cx0:2 = quake.x [%control] %scope : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %outside = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
@@ -297,12 +297,12 @@ func.func @phases_do_not_fold_across_marked_scope_entry() {
   %control = quake.null_wire
   %target = quake.null_wire
   %outside = quake.s %target : (!quake.wire) -> !quake.wire
-  %scope = cc.scope -> (!quake.wire) {
+  %scope = cc.scope -> (!quake.wire) atomic {
     %cx0:2 = quake.x [%control] %outside : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %inside = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
     cc.continue %inside : !quake.wire
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -324,12 +324,12 @@ func.func @phases_do_not_fold_across_marked_scope_entry() {
 func.func @phases_do_not_fold_across_marked_scope_exit() {
   %control = quake.null_wire
   %target = quake.null_wire
-  %scope = cc.scope -> (!quake.wire) {
+  %scope = cc.scope -> (!quake.wire) atomic {
     %inside = quake.s %target : (!quake.wire) -> !quake.wire
     %cx0:2 = quake.x [%control] %inside : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     cc.continue %cx1#1 : !quake.wire
-  } {atomic_quantum_region}
+  }
   %outside = quake.s %scope : (!quake.wire) -> !quake.wire
   return
 }
@@ -352,13 +352,13 @@ func.func @phases_do_not_fold_across_marked_scope_exit() {
 func.func @phases_fold_inside_marked_scope() {
   %control = quake.null_wire
   %target = quake.null_wire
-  %scope = cc.scope -> (!quake.wire) {
+  %scope = cc.scope -> (!quake.wire) atomic {
     %before = quake.s %target : (!quake.wire) -> !quake.wire
     %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
     cc.continue %after : !quake.wire
-  } {atomic_quantum_region}
+  }
   return
 }
 
@@ -382,10 +382,10 @@ func.func @disjoint_phases_fold_around_marked_scope() {
   %disjoint = quake.null_wire
   %before = quake.s %target : (!quake.wire) -> !quake.wire
   %cx0:2 = quake.x [%control] %before : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  %scope = cc.scope -> (!quake.wire) {
+  %scope = cc.scope -> (!quake.wire) atomic {
     %inside = quake.x %disjoint : (!quake.wire) -> !quake.wire
     cc.continue %inside : !quake.wire
-  } {atomic_quantum_region}
+  }
   %cx1:2 = quake.x [%cx0#0] %cx0#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %after = quake.s %cx1#1 : (!quake.wire) -> !quake.wire
   return

--- a/cudaq/test/Optimizer/phase_folding_atomic_region.qke
+++ b/cudaq/test/Optimizer/phase_folding_atomic_region.qke
@@ -57,16 +57,16 @@ func.func @nested_marked_scopes_do_not_share_phases() {
 // CHECK-LABEL:   func.func @nested_marked_scopes_do_not_share_phases() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
-// CHECK:             %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:               %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[S_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:               %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:               %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
 // CHECK:               cc.continue %[[S_1]] : !quake.wire
-// CHECK:             } {atomic_quantum_region}
+// CHECK:             }
 // CHECK:             cc.continue %[[SCOPE_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 
@@ -91,16 +91,16 @@ func.func @sibling_marked_scopes_do_not_share_phases() {
 // CHECK-LABEL:   func.func @sibling_marked_scopes_do_not_share_phases() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[S_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
-// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           }
+// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[SCOPE_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[S_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 
@@ -280,10 +280,10 @@ func.func @phases_do_not_fold_backward_through_marked_scope() {
 // CHECK-LABEL:   func.func @phases_do_not_fold_backward_through_marked_scope() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[S_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[SCOPE_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
@@ -310,12 +310,12 @@ func.func @phases_do_not_fold_across_marked_scope_entry() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
 // CHECK:           %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[S_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             %[[S_1:.*]] = quake.s %[[X_1]]#1 : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[S_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 
@@ -337,12 +337,12 @@ func.func @phases_do_not_fold_across_marked_scope_exit() {
 // CHECK-LABEL:   func.func @phases_do_not_fold_across_marked_scope_exit() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[S_0:.*]] = quake.s %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
 // CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[S_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             cc.continue %[[X_1]]#1 : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           %[[S_1:.*]] = quake.s %[[SCOPE_0]] : (!quake.wire) -> !quake.wire
 // CHECK:           return
 // CHECK:         }
@@ -365,12 +365,12 @@ func.func @phases_fold_inside_marked_scope() {
 // CHECK-LABEL:   func.func @phases_fold_inside_marked_scope() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             %[[X_1:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             %[[Z_0:.*]] = quake.z %[[X_1]]#1 : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[Z_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 
@@ -396,10 +396,10 @@ func.func @disjoint_phases_fold_around_marked_scope() {
 // CHECK:           %[[NULL_WIRE_1:.*]] = quake.null_wire
 // CHECK:           %[[NULL_WIRE_2:.*]] = quake.null_wire
 // CHECK:           %[[X_0:.*]]:2 = quake.x {{\[}}%[[NULL_WIRE_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[X_1:.*]] = quake.x %[[NULL_WIRE_2]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[X_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           %[[X_2:.*]]:2 = quake.x {{\[}}%[[X_0]]#0] %[[X_0]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[Z_0:.*]] = quake.z %[[X_2]]#1 : (!quake.wire) -> !quake.wire
 // CHECK:           return

--- a/cudaq/test/Optimizer/quake_simplify_atomic_region.qke
+++ b/cudaq/test/Optimizer/quake_simplify_atomic_region.qke
@@ -174,19 +174,19 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 // CHECK-LABEL:   func.func @preserve_atomic_scope_entry() {
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK:           %[[H_0:.*]] = quake.h %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[H_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           quake.sink %[[SCOPE_0]] : !quake.wire
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @simplify_inside_atomic_scope(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             cc.continue %[[ARG0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]] : !quake.wire
 // CHECK:         }
 
@@ -220,14 +220,14 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 
 // CHECK-LABEL:   func.func @nested_atomic_scopes_block(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
-// CHECK:             %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:             %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:               %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
 // CHECK:               cc.continue %[[H_1]] : !quake.wire
-// CHECK:             } {atomic_quantum_region}
+// CHECK:             }
 // CHECK:             cc.continue %[[SCOPE_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]] : !quake.wire
 // CHECK:         }
 
@@ -235,10 +235,10 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 // CHECK-NEXT:      %[[NULL_WIRE_0:.*]] = quake.null_wire
 // CHECK-NEXT:      %[[NULL_WIRE_1:.*]] = quake.null_wire
 // CHECK-NEXT:      %[[X_0:.*]] = quake.x %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
-// CHECK-NEXT:      %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK-NEXT:      %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK-NEXT:        %[[H_0:.*]] = quake.h %[[NULL_WIRE_1]] : (!quake.wire) -> !quake.wire
 // CHECK-NEXT:        cc.continue %[[H_0]] : !quake.wire
-// CHECK-NEXT:      } {atomic_quantum_region}
+// CHECK-NEXT:      }
 // CHECK-NEXT:      %[[X_1:.*]] = quake.x %[[X_0]] : (!quake.wire) -> !quake.wire
 // CHECK-NEXT:      return %[[X_1]], %[[SCOPE_0]] : !quake.wire, !quake.wire
 // CHECK-NEXT:    }
@@ -246,23 +246,23 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 // CHECK-LABEL:   func.func @conditional_region_stops_rewrite(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1) {
-// CHECK:           cc.scope {
+// CHECK:           cc.scope atomic {
 // CHECK:             %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.if(%[[ARG1]]) {
 // CHECK:               %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
 // CHECK:               quake.sink %[[H_1]] : !quake.wire
 // CHECK:             }
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @marked_scope_use_prevents_outside_rewrite(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> (!quake.wire, !quake.wire) {
 // CHECK:           %[[H_0:.*]] = quake.h %[[ARG0]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[X_0:.*]] = quake.x %[[H_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[X_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           %[[H_1:.*]] = quake.h %[[H_0]] : (!quake.wire) -> !quake.wire
 // CHECK:           return %[[SCOPE_0]], %[[H_1]] : !quake.wire, !quake.wire
 // CHECK:         }
@@ -271,10 +271,10 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> (!quake.wire, !quake.wire) {
 // CHECK:           %[[SWAP_0:.*]]:2 = quake.swap %[[ARG0]], %[[ARG1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[SCOPE_0:.*]]:2 = cc.scope -> (!quake.wire, !quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]]:2 = cc.scope -> (!quake.wire, !quake.wire) atomic {
 // CHECK:             %[[SWAP_1:.*]]:2 = quake.swap %[[SWAP_0]]#1, %[[SWAP_0]]#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:             cc.continue %[[SWAP_1]]#0, %[[SWAP_1]]#1 : !quake.wire, !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]]#0, %[[SCOPE_0]]#1 : !quake.wire, !quake.wire
 // CHECK:         }
 
@@ -285,12 +285,12 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 // CHECK:           %[[S_0:.*]] = quake.s %[[ARG0]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[S_1:.*]] = quake.s %[[ARG1]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[T_0:.*]] = quake.t %[[ARG2]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]]:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]]:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) atomic {
 // CHECK:             %[[S_2:.*]] = quake.s<adj> %[[S_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             %[[S_3:.*]] = quake.s %[[S_1]] : (!quake.wire) -> !quake.wire
 // CHECK:             %[[T_1:.*]] = quake.t %[[T_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[S_2]], %[[S_3]], %[[T_1]] : !quake.wire, !quake.wire, !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]]#0, %[[SCOPE_0]]#1, %[[SCOPE_0]]#2 : !quake.wire, !quake.wire, !quake.wire
 // CHECK:         }
 
@@ -299,21 +299,21 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1.000000e+00 : f64
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2.000000e+00 : f64
 // CHECK:           %[[RX_0:.*]] = quake.rx (%[[CONSTANT_0]]) %[[ARG0]] : (f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[RX_1:.*]] = quake.rx (%[[CONSTANT_1]]) %[[RX_0]] : (f64, !quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[RX_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]] : !quake.wire
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @preserve_ysx_at_atomic_entry(
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> !quake.wire {
 // CHECK:           %[[Y_0:.*]] = quake.y %[[ARG0]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[S_0:.*]] = quake.s %[[Y_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             %[[X_0:.*]] = quake.x %[[S_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[X_0]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]] : !quake.wire
 // CHECK:         }
 
@@ -321,18 +321,18 @@ func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wir
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire,
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !quake.wire) -> (!quake.wire, !quake.wire) {
 // CHECK:           %[[RESET_0:.*]] = quake.reset %[[ARG0]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_0:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[RESET_1:.*]] = quake.reset %[[RESET_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[RESET_1]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           %[[NULL_WIRE_0:.*]] = quake.null_wire
-// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:           %[[SCOPE_1:.*]] = cc.scope -> (!quake.wire) atomic {
 // CHECK:             %[[RESET_2:.*]] = quake.reset %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
 // CHECK:             cc.continue %[[RESET_2]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           %[[RESET_3:.*]] = quake.reset %[[ARG1]] : (!quake.wire) -> !quake.wire
-// CHECK:           cc.scope {
+// CHECK:           cc.scope atomic {
 // CHECK:             quake.sink %[[RESET_3]] : !quake.wire
-// CHECK:           } {atomic_quantum_region}
+// CHECK:           }
 // CHECK:           return %[[SCOPE_0]], %[[SCOPE_1]] : !quake.wire, !quake.wire
 // CHECK:         }

--- a/cudaq/test/Optimizer/quake_simplify_atomic_region.qke
+++ b/cudaq/test/Optimizer/quake_simplify_atomic_region.qke
@@ -17,20 +17,20 @@
 func.func @preserve_atomic_scope_entry() {
   %q0 = quake.null_wire
   %q1 = quake.h %q0 : (!quake.wire) -> !quake.wire
-  %q2 = cc.scope -> (!quake.wire) {
+  %q2 = cc.scope -> (!quake.wire) atomic {
     %q3 = quake.h %q1 : (!quake.wire) -> !quake.wire
     cc.continue %q3 : !quake.wire
-  } {atomic_quantum_region}
+  }
   quake.sink %q2 : !quake.wire
   return
 }
 
 func.func @simplify_inside_atomic_scope(%arg0: !quake.wire) -> !quake.wire {
-  %0 = cc.scope -> (!quake.wire) {
+  %0 = cc.scope -> (!quake.wire) atomic {
     %1 = quake.h %arg0 : (!quake.wire) -> !quake.wire
     %2 = quake.h %1 : (!quake.wire) -> !quake.wire
     cc.continue %2 : !quake.wire
-  } {atomic_quantum_region}
+  }
   return %0 : !quake.wire
 }
 
@@ -64,14 +64,14 @@ func.func @ordinary_scope_unresolved_swap_is_preserved(%arg0: !quake.wire, %arg1
 }
 
 func.func @nested_atomic_scopes_block(%arg0: !quake.wire) -> !quake.wire {
-  %0 = cc.scope -> (!quake.wire) {
+  %0 = cc.scope -> (!quake.wire) atomic {
     %1 = quake.h %arg0 : (!quake.wire) -> !quake.wire
-    %2 = cc.scope -> (!quake.wire) {
+    %2 = cc.scope -> (!quake.wire) atomic {
       %3 = quake.h %1 : (!quake.wire) -> !quake.wire
       cc.continue %3 : !quake.wire
-    } {atomic_quantum_region}
+    }
     cc.continue %2 : !quake.wire
-  } {atomic_quantum_region}
+  }
   return %0 : !quake.wire
 }
 
@@ -79,42 +79,42 @@ func.func @marked_scope_preserves_disjoint_outside_pair() -> (!quake.wire, !quak
   %0 = quake.null_wire
   %1 = quake.null_wire
   %2 = quake.x %0 : (!quake.wire) -> !quake.wire
-  %3 = cc.scope -> (!quake.wire) {
+  %3 = cc.scope -> (!quake.wire) atomic {
     %4 = quake.h %1 : (!quake.wire) -> !quake.wire
     cc.continue %4 : !quake.wire
-  } {atomic_quantum_region}
+  }
   %5 = quake.x %2 : (!quake.wire) -> !quake.wire
   return %5, %3 : !quake.wire, !quake.wire
 }
 
 func.func @conditional_region_stops_rewrite(%arg0: !quake.wire, %cond: i1) {
-  cc.scope {
+  cc.scope atomic {
     %0 = quake.h %arg0 : (!quake.wire) -> !quake.wire
     cc.if(%cond) {
       %1 = quake.h %0 : (!quake.wire) -> !quake.wire
       quake.sink %1 : !quake.wire
     }
     cc.continue
-  } {atomic_quantum_region}
+  }
   return
 }
 
 func.func @marked_scope_use_prevents_outside_rewrite(%arg0: !quake.wire) -> (!quake.wire, !quake.wire) {
   %0 = quake.h %arg0 : (!quake.wire) -> !quake.wire
-  %1 = cc.scope -> (!quake.wire) {
+  %1 = cc.scope -> (!quake.wire) atomic {
     %2 = quake.x %0 : (!quake.wire) -> !quake.wire
     cc.continue %2 : !quake.wire
-  } {atomic_quantum_region}
+  }
   %3 = quake.h %0 : (!quake.wire) -> !quake.wire
   return %1, %3 : !quake.wire, !quake.wire
 }
 
 func.func @preserve_swap_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wire) -> (!quake.wire, !quake.wire) {
   %0:2 = quake.swap %arg0, %arg1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  %1:2 = cc.scope -> (!quake.wire, !quake.wire) {
+  %1:2 = cc.scope -> (!quake.wire, !quake.wire) atomic {
     %2:2 = quake.swap %0#1, %0#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     cc.continue %2#0, %2#1 : !quake.wire, !quake.wire
-  } {atomic_quantum_region}
+  }
   return %1#0, %1#1 : !quake.wire, !quake.wire
 }
 
@@ -122,12 +122,12 @@ func.func @preserve_phase_pairs_at_atomic_entry(%arg0: !quake.wire, %arg1: !quak
   %0 = quake.s %arg0 : (!quake.wire) -> !quake.wire
   %1 = quake.s %arg1 : (!quake.wire) -> !quake.wire
   %2 = quake.t %arg2 : (!quake.wire) -> !quake.wire
-  %3:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) {
+  %3:3 = cc.scope -> (!quake.wire, !quake.wire, !quake.wire) atomic {
     %4 = quake.s<adj> %0 : (!quake.wire) -> !quake.wire
     %5 = quake.s %1 : (!quake.wire) -> !quake.wire
     %6 = quake.t %2 : (!quake.wire) -> !quake.wire
     cc.continue %4, %5, %6 : !quake.wire, !quake.wire, !quake.wire
-  } {atomic_quantum_region}
+  }
   return %3#0, %3#1, %3#2 : !quake.wire, !quake.wire, !quake.wire
 }
 
@@ -135,39 +135,39 @@ func.func @preserve_rotation_at_atomic_entry(%arg0: !quake.wire) -> !quake.wire 
   %a = arith.constant 1.0 : f64
   %b = arith.constant 2.0 : f64
   %0 = quake.rx (%a) %arg0 : (f64, !quake.wire) -> !quake.wire
-  %1 = cc.scope -> (!quake.wire) {
+  %1 = cc.scope -> (!quake.wire) atomic {
     %2 = quake.rx (%b) %0 : (f64, !quake.wire) -> !quake.wire
     cc.continue %2 : !quake.wire
-  } {atomic_quantum_region}
+  }
   return %1 : !quake.wire
 }
 
 func.func @preserve_ysx_at_atomic_entry(%arg0: !quake.wire) -> !quake.wire {
   %0 = quake.y %arg0 : (!quake.wire) -> !quake.wire
-  %1 = cc.scope -> (!quake.wire) {
+  %1 = cc.scope -> (!quake.wire) atomic {
     %2 = quake.s %0 : (!quake.wire) -> !quake.wire
     %3 = quake.x %2 : (!quake.wire) -> !quake.wire
     cc.continue %3 : !quake.wire
-  } {atomic_quantum_region}
+  }
   return %1 : !quake.wire
 }
 
 func.func @preserve_resets_at_atomic_entry(%arg0: !quake.wire, %arg1: !quake.wire) -> (!quake.wire, !quake.wire) {
   %0 = quake.reset %arg0 : (!quake.wire) -> !quake.wire
-  %1 = cc.scope -> (!quake.wire) {
+  %1 = cc.scope -> (!quake.wire) atomic {
     %2 = quake.reset %0 : (!quake.wire) -> !quake.wire
     cc.continue %2 : !quake.wire
-  } {atomic_quantum_region}
+  }
   %3 = quake.null_wire
-  %4 = cc.scope -> (!quake.wire) {
+  %4 = cc.scope -> (!quake.wire) atomic {
     %5 = quake.reset %3 : (!quake.wire) -> !quake.wire
     cc.continue %5 : !quake.wire
-  } {atomic_quantum_region}
+  }
   %6 = quake.reset %arg1 : (!quake.wire) -> !quake.wire
-  cc.scope {
+  cc.scope atomic {
     quake.sink %6 : !quake.wire
     cc.continue
-  } {atomic_quantum_region}
+  }
   return %1, %4 : !quake.wire, !quake.wire
 }
 

--- a/cudaq/test/Optimizer/wireset_phase_lifecycle.qke
+++ b/cudaq/test/Optimizer/wireset_phase_lifecycle.qke
@@ -34,14 +34,14 @@ func.func @negative_wire_phase()
 
 func.func @atomic_wire_regions() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %wire = quake.borrow_wire @phys[0] : !quake.wire
-  %forward = cc.scope -> (!quake.wire) {
+  %forward = cc.scope -> (!quake.wire) atomic {
     %next = quake.h %wire : (!quake.wire) -> !quake.wire
     cc.continue %next : !quake.wire
-  } {atomic_quantum_region}
-  %inverse = cc.scope -> (!quake.wire) {
+  }
+  %inverse = cc.scope -> (!quake.wire) atomic {
     %next = quake.h %forward : (!quake.wire) -> !quake.wire
     cc.continue %next : !quake.wire
-  } {atomic_quantum_region}
+  }
   quake.return_wire %inverse : !quake.wire
   return
 }


### PR DESCRIPTION
Also change the printing of atomic quantum regions so that the attribute is clearly readable at the start of the region.