### PR TITLE
[python] Fix Args/Arguments docstring section matching in ScalarOperator.parameters

### DIFF
--- a/python/cudaq/operators/helpers.py
+++ b/python/cudaq/operators/helpers.py
@@ -48,7 +48,7 @@ def _parameter_docs(param_name: str, docs: Optional[str]) -> str:
     # Also, Python caches already used patterns, so compiling on
     # the fly seems fine.
     def keyword_pattern(word):
-        return r"(?:^\s*" + word + r":\s*\r?\n)"
+        return r"(?:^\s*(?:" + word + r"):\s*\r?\n)"
 
     def param_pattern(param_name):
         return r"(?:^\s*" + param_name + r"\s*(\(.*\))?:)\s*(.*)$"

--- a/python/tests/operator/test_scalar_op.py
+++ b/python/tests/operator/test_scalar_op.py
@@ -236,6 +236,26 @@ def test_parameter_docs():
         'args'] == 'Description of `args`. Multiple lines are supported.'
 
 
+def test_parameter_docs_word_arguments_in_prose():
+    # A docstring line that starts with the literal word "Arguments" (matching
+    # the "Arguments|Args" alternation used to locate the Args: section) but
+    # is prose, not the section header itself, must not confuse the parser -
+    # the real Args: section below still has to be found.
+    def generator(x):
+        """Some function.
+
+        Arguments passed to callers of this function must be numeric.
+
+        Args:
+            x: the value of x
+        """
+        return x
+
+    so = ScalarOperator(generator)
+    assert 'x' in so.parameters
+    assert so.parameters['x'] == "the value of x"
+
+
 def test_equality():
 
     assert ScalarOperator.const(5) == ScalarOperator.const(5)


### PR DESCRIPTION
Fixes #5361

### Bug

`keyword_pattern` in `_parameter_docs` (`python/cudaq/operators/helpers.py:50-51`) builds:

```python
r"(?:^\s*" + "Arguments|Args" + r":\s*\r?\n)"
```

`|` has lower precedence than concatenation, so this compiles to
`(?:^\s*Arguments)|(?:Args:\s*\r?\n)`, not `(?:^\s*(?:Arguments|Args):\s*\r?\n)`. The first
alternative matches the bare word "Arguments" at the start of any line, with no colon or newline
required. If that word starts a line of prose above the real `Args:` header, `re.split()` produces
3 parts instead of 2, `len(split) == 2` fails, and `_parameter_docs()` silently returns `""` -
dropping real parameter documentation on `ScalarOperator`/custom `MatrixOperatorElement` definitions.

### Fix

Group the alternation so the colon+newline requirement applies to both spellings.

### Verification

Not a regression: unchanged since introduced in `da31e1b7a` (#2817) except a copyright-year bump
(`git log -S`/`git log --follow`); `python/cudaq/operators/helpers.py` is byte-identical between the
CUDA-Q 0.15.1 wheel (`aca5853a7`) and current `main`.

Negative control: added `test_parameter_docs_word_arguments_in_prose` to
`python/tests/operator/test_scalar_op.py`, ran it against production `helpers.py` reverted to
`upstream/main` (the pre-fix state, byte-identical to the wheel), then with this fix applied, using
the CUDA-Q 0.15.1 wheel:

```
without the fix: 1 failed
with the fix:    1 passed
```

Also ran the full existing `python/tests/operator/` suite with the fix applied: 59 passed, no
regressions (matches the pre-fix baseline count).

Small, net-positive diff; touches only the regex used to locate the `Args:`/`Arguments:` section and
adds one regression test.

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
