### PR TITLE
[Transformation] Allow expansion of negative controlled `phase` op

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/ExpandControlNegations.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ExpandControlNegations.cpp
@@ -160,6 +160,7 @@ struct ExpandControlNegationsPass
                 ReplaceNegativeControl<cudaq::quake::U3Op>,
                 ReplaceNegativeControl<cudaq::quake::SwapOp>,
                 ReplaceNegativeControl<cudaq::quake::ExpPauliOp>,
+                ReplaceNegativeControl<cudaq::quake::PhaseOp>,
                 ReplaceNegativeControl<cudaq::quake::CustomUnitaryCallOp>,
                 ReplaceNegativeControl<cudaq::quake::CustomUnitaryConstantOp>>(
             ctx);
@@ -168,11 +169,6 @@ struct ExpandControlNegationsPass
                            LLVM::LLVMDialect>();
     target.addDynamicallyLegalDialect<cudaq::quake::QuakeDialect>(
         [](Operation *op) {
-          // `quake.phase` handled during phase lifecycle pass so allow
-          // it to be legal here.
-          if (isa<cudaq::quake::PhaseOp>(op))
-            return true;
-
           auto quantumOp = dyn_cast<cudaq::quake::OperatorInterface>(op);
           if (!quantumOp)
             return true;

--- a/cudaq/test/Transforms/expand_control_negations.qke
+++ b/cudaq/test/Transforms/expand_control_negations.qke
@@ -8,7 +8,6 @@
 
 // Verify that `ExpandControlNegations` pass expands negated controls for
 // gates with negative controls specified in the pass, e.g., R1.
-// Allow `quake.phase` ops to survive the pass.
 
 // RUN: cudaq-opt --expand-control-negations %s | FileCheck %s
 
@@ -24,14 +23,18 @@ func.func @expand_gate(%theta: f64, %control: !quake.ref,
 // CHECK-NEXT: quake.r1 {{.*}}[%[[CONTROL]]] {{.*}}
 // CHECK-NEXT: quake.x %[[CONTROL]]
 
-func.func @defer_phase(%theta: f64, %control: !quake.ref,
+func.func @expand_phase(%theta: f64, %control: !quake.ref,
                        %anchor: !quake.ref) {
   quake.phase (%theta) [%control neg [true]] %anchor
       : (f64, !quake.ref, !quake.ref) -> ()
   return
 }
 
-// CHECK-LABEL: func.func @defer_phase(
-// CHECK-NEXT: quake.phase
-// CHECK-SAME: neg [true]
-// CHECK-NEXT: return
+// CHECK-LABEL: func.func @expand_phase(
+// CHECK-SAME:      %[[ARG0:.*]]: f64,
+// CHECK-SAME:      %[[ARG1:.*]]: !quake.ref,
+// CHECK-SAME:      %[[ARG2:.*]]: !quake.ref) {
+// CHECK:           quake.x %[[ARG1]] : (!quake.ref) -> ()
+// CHECK-NEXT:      quake.phase (%[[ARG0]]) {{\[}}%[[ARG1]]] %[[ARG2]] : (f64, !quake.ref, !quake.ref) -> ()
+// CHECK-NEXT:      quake.x %[[ARG1]] : (!quake.ref) -> ()
+// CHECK-NEXT:      return

--- a/cudaq/test/Translate/phase_lifecycle.qke
+++ b/cudaq/test/Translate/phase_lifecycle.qke
@@ -28,16 +28,11 @@ func.func @phase_lifecycle(%theta: f64, %outer: !quake.ref,
 // CHECK: llvm.call @__quantum__qis__r1(%[[THETA]], %[[OUTER]])
 // CHECK-NOT: quake.phase
 
-// handle negative controls on the inner phase
-// should be intermediately translated to
-// ```
-// quake.x %inner
-// quake.r1 (%theta) [%inner] %outer
-// quake.x %inner
-// ```
-// after `r1` with negative control is emitted during phase lifecycle pass.
-// Then the `ExpandControlNegations` pass should expand the negative control
-//on the R1 to X-R1-X.
+// Negation expansion runs before apply specialization in the QIR codegen
+// pipeline. It first produces X--positive-phase--X on the inner control;
+// specialization then adds the outer control to all three operations.
+// LowerPhase selects the inner control as the R1 target, leaving the outer
+// control on the R1 and on both surrounding X operations.
 func.func private @negative_phase_helper(
     %theta: f64, %inner: !quake.ref, %anchor: !quake.ref) {
   quake.phase (%theta) [%inner neg [true]] %anchor
@@ -58,20 +53,26 @@ func.func @negative_phase_lifecycle(
 // CHECK-SAME: %[[NEG_OUTER:[a-zA-Z0-9_.$-]+]]: !llvm.ptr
 // CHECK-SAME: %[[NEG_INNER:[a-zA-Z0-9_.$-]+]]: !llvm.ptr
 
-// Select the controlled R1 implementation.
+// Select the controlled R1 and X implementations.
 // CHECK: %[[R1_CTL:[a-zA-Z0-9_.$-]+]] = llvm.mlir.addressof @__quantum__qis__r1__ctl
+// CHECK: %[[X_CTL:[a-zA-Z0-9_.$-]+]] = llvm.mlir.addressof @__quantum__qis__x__ctl
 
-// Convert the negative inner control into a positive control.
-// CHECK: llvm.call @__quantum__qis__x(%[[NEG_INNER]])
+// Apply the first X to inner under the outer control.
+// CHECK: %[[OUTER_X0:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_OUTER]]
+// CHECK: %[[X_CTL_X0:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[X_CTL]]
+// CHECK: %[[INNER_X0:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_INNER]]
+// CHECK: llvm.call @generalizedInvokeWithRotationsControlsTargets({{.*}}%[[X_CTL_X0]], %[[OUTER_X0]], %[[INNER_X0]])
 
-// CHECK: %[[INNER_CAST:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_INNER]]
+// Apply the controlled R1 to inner with outer as its predicate.
+// CHECK: %[[OUTER_R1:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_OUTER]]
 // CHECK: %[[R1_CTL_CAST:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[R1_CTL]]
-// CHECK: %[[OUTER_CAST:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_OUTER]]
+// CHECK: %[[INNER_R1:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_INNER]]
+// CHECK: llvm.call @generalizedInvokeWithRotationsControlsTargets({{.*}}%[[R1_CTL_CAST]], %[[NEG_THETA]], %[[OUTER_R1]], %[[INNER_R1]])
 
-// Inner is the control; outer is the R1 target.
-// CHECK: llvm.call @generalizedInvokeWithRotationsControlsTargets({{.*}}%[[R1_CTL_CAST]], %[[NEG_THETA]], %[[INNER_CAST]], %[[OUTER_CAST]])
-
-// Restore the inner qubit.
-// CHECK: llvm.call @__quantum__qis__x(%[[NEG_INNER]])
+// Restore inner under the outer control.
+// CHECK: %[[OUTER_X1:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_OUTER]]
+// CHECK: %[[X_CTL_X1:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[X_CTL]]
+// CHECK: %[[INNER_X1:[a-zA-Z0-9_.$-]+]] = llvm.bitcast %[[NEG_INNER]]
+// CHECK: llvm.call @generalizedInvokeWithRotationsControlsTargets({{.*}}%[[X_CTL_X1]], %[[OUTER_X1]], %[[INNER_X1]])
 // CHECK: llvm.return
 // CHECK-NOT: quake.phase


### PR DESCRIPTION
## Summary

In highlighted in [this comment](https://github.com/NVIDIA/cuda-quantum/pull/5022#discussion_r3895674242) of #5022, `PhaseOp`s were marked as a legal op in the `--expand-control-negations` with the expectation that its negative controls would be expanded elsewhere. This PR marks `PhaseOp` for negative control expansion in this pass rather than punting to some other compiler pass. 