### PR TITLE
[cleanup] Avoid copying mutable control vectors unnecessarily

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/LowerPhase.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LowerPhase.cpp
@@ -70,7 +70,7 @@ static bool isScalarGateTarget(Value value) {
 
 static void lowerWithScalarControl(IRRewriter &rewriter,
                                    cudaq::quake::PhaseOp phase, Value angle,
-                                   SmallVector<Value> controls,
+                                   SmallVectorImpl<Value> &controls,
                                    ArrayRef<bool> polarities,
                                    unsigned selectedControl) {
   Value anchor = phase.getTarget();
@@ -114,7 +114,7 @@ static void lowerWithScalarControl(IRRewriter &rewriter,
 
 static void lowerWithAnchorFallback(IRRewriter &rewriter,
                                     cudaq::quake::PhaseOp phase, Value angle,
-                                    SmallVector<Value> controls,
+                                    SmallVectorImpl<Value> &controls,
                                     ArrayRef<bool> polarities) {
   Value anchor = phase.getTarget();
   Location location = phase.getLoc();
@@ -171,9 +171,8 @@ static LogicalResult lowerPhase(IRRewriter &rewriter,
   std::optional<unsigned> selected =
       positiveScalar ? positiveScalar : scalarControl;
   if (selected) {
-    lowerWithScalarControl(rewriter, phase, angle,
-                           std::move(predicate.controls), predicate.polarities,
-                           *selected);
+    lowerWithScalarControl(rewriter, phase, angle, predicate.controls,
+                           predicate.polarities, *selected);
     return success();
   }
 
@@ -186,7 +185,7 @@ static LogicalResult lowerPhase(IRRewriter &rewriter,
           "cannot lower with an anchor that aliases a control operand");
       return failure();
     }
-  lowerWithAnchorFallback(rewriter, phase, angle, std::move(predicate.controls),
+  lowerWithAnchorFallback(rewriter, phase, angle, predicate.controls,
                           predicate.polarities);
   return success();
 }


### PR DESCRIPTION
## Summary
From [this comment](https://github.com/NVIDIA/cuda-quantum/pull/5022#discussion_r3895778774) in #5022, there are a couple of instances where a vector is unnecessarily newly constructed as part of a function call. This PR removes a couple of those instances in the `phase` op lowering work.