### PR TITLE
[NFC] Rename operation to better reflect its evolved semantics.

### DIFF
--- a/cudaq/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -51,11 +51,11 @@ def DelayMeasurements : Pass<"delay-measurements", "mlir::func::FuncOp"> {
   }];
 }
 
-def EraseCompilerGeneratedLogOutput :
+def EraseCompilerGeneratedEvince :
     Pass<"erase-implicit-output", "mlir::func::FuncOp"> {
-  let summary = "Erase compiler-generated quake.log_output operations.";
+  let summary = "Erase compiler-generated quake.evince operations.";
   let description = [{
-    Erases all `quake.log_output` operations that carry the `cc.cg_output`
+    Erases all `quake.evince` operations that carry the `cc.cg_output`
     attribute, indicating they were injected by the compiler (e.g. by the
     `inject-implicit-output` pass) rather than written explicitly by the user.
   }];

--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -2048,23 +2048,30 @@ def QuakeOp_MaterializeStateOp : QuakeOp<"materialize_state", [Pure] > {
 }
 
 //===----------------------------------------------------------------------===//
-// LogOutputOp
+// EvinceOp
 //===----------------------------------------------------------------------===//
 
-def quake_LogOutputOp : QuakeOp<"log_output"> {
-  let summary = "Marks a value in the IR as observable.";
+def quake_EvinceOp : QuakeOp<"evince"> {
+  let summary = "Marks a value in the IR as evincive (observable).";
   let description = [{
     This operation is a high-level \e abstraction for the necessary and
-    sufficient functionality to log output results to a \e virtual output device
-    produced by a well-defined CUDA-Q kernel. \e How this to be accomplished and
-    the details thereof are not the concern of Quake. The presence of this
-    operation explicitly denotes that a \e value in Quake is \e observable in
-    the computational sense. This restricts the types of optimizations that may
+    sufficient functionality to make values evincive, observable to the outside.
+    This may lower further to actual recording of the value to a \e virtual
+    output device produced by a well-defined CUDA-Q kernel.
+
+    \e How this to be accomplished and the details thereof are not the concern
+    of Quake or the `evince` operation. The presence of this operation
+    explicitly denotes that a \e value in Quake is \e observable in the
+    computational sense. This restricts the types of optimizations that may
     be applied; such as, the value cannot be trivially erased.
+
+    This operation may be purely annotative to record that certain values in the
+    IR may not be fully optimized away.
 
     The semantics of this operation are very clear. Arguments are considered
     observable and live, and this operation \e explicitly denotes I/O
-    side-effects.
+    side-effects, whether those side-effects are reified in the final code
+    generation or not.
 
     The lowering of this operation is heavily context dependent. The target and
     launch policies of an entry-point kernel will interplay with an abstract
@@ -2077,7 +2084,7 @@ def quake_LogOutputOp : QuakeOp<"log_output"> {
 
     Do not read this overly literally. Using this operation on a value of
     quantum type simply does \e not mean that a qubit is anything more than
-    "of interest". A physical qubit isn't something one can email.
+    evincive and interesting.
   }];
 
   let arguments = (ins

--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -2059,7 +2059,7 @@ def quake_EvinceOp : QuakeOp<"evince"> {
     This may lower further to actual recording of the value to a \e virtual
     output device produced by a well-defined CUDA-Q kernel.
 
-    \e How this to be accomplished and the details thereof are not the concern
+    \e How this is accomplished and the details thereof are not the concern
     of Quake or the `evince` operation. The presence of this operation
     explicitly denotes that a \e value in Quake is \e observable in the
     computational sense. This restricts the types of optimizations that may

--- a/cudaq/include/cudaq/Optimizer/Dialect/Traits.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Traits.td
@@ -35,7 +35,7 @@ def QuantumMeasure : NativeOpTrait<"QuantumMeasure"> {
 // implicitly dereferences a `!quake.ref`/`!quake.veq` operand and modifies
 // the wire(s) it refers to (typically by macro-expanding to, or invoking,
 // one or more quantum operators), e.g. quake.apply, quake.compute_action,
-// quake.apply_noise, quake.call_by_ref, quake.log_output.
+// quake.apply_noise, quake.call_by_ref, quake.evince.
 def QuantumSideEffects : NativeOpTrait<"QuantumSideEffects"> {
   let cppNamespace = "::cudaq";
 }

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -951,10 +951,10 @@ def GlobalizeArrayValues : Pass<"globalize-array-values", "mlir::ModuleOp"> {
 }
 
 def InjectImplicitOutput : Pass<"inject-implicit-output", "mlir::func::FuncOp"> {
-  let summary = "Inject quake.log_output ops for implicitly output quantum values.";
+  let summary = "Inject quake.evince ops for implicitly output quantum values.";
   let description = [{
-    This pass inserts `quake.log_output` operations for each `quake.alloca` at
-    the top level of a `func.func`. The log_output ops are added to a new exit
+    This pass inserts `quake.evince` operations for each `quake.alloca` at
+    the top level of a `func.func`. The evince ops are added to a new exit
     block that all return ops are redirected through, preserving the declaration
     order of the allocations. Unlike `add-dealloc`, this pass does not recurse
     into nested regions.

--- a/cudaq/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -21,7 +21,7 @@ add_cudaq_library(OptCodeGen
   ConvertToQIR.cpp
   ConvertToQIRAPI.cpp
   DelayMeasurements.cpp
-  EraseCGLogOutput.cpp
+  EraseCGEvince.cpp
   OptUtils.cpp
   Passes.cpp
   Pipelines.cpp

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -2708,9 +2708,9 @@ struct QuakeToQIRAPIPass
     target.addIllegalDialect<cudaq::quake::QuakeDialect,
                              cudaq::codegen::CodeGenDialect,
                              cudaq::qec::QECDialect>();
-    // quake.log_output is lowered by ReturnToOutputLog (which runs after this
+    // quake.evince is lowered by ReturnToOutputLog (which runs after this
     // pass), not by QuakeToQIRAPI, so mark it legal to pass through unchanged.
-    target.addLegalOp<cudaq::quake::LogOutputOp>();
+    target.addLegalOp<cudaq::quake::EvinceOp>();
     target.addLegalOp<cudaq::codegen::MaterializeConstantArrayOp>();
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp fn) {
       return !needsTypeConversion(fn.getFunctionType()) &&
@@ -3113,8 +3113,8 @@ void cudaq::opt::addConvertToQIRAPIPipeline(OpPassManager &pm, StringRef api,
   QuakeToQIRAPIPrepOptions prepApiOpt{.api = api.str(), .opaquePtr = opaquePtr};
   pm.addPass(cudaq::opt::createQuakeToQIRAPIPrep(prepApiOpt));
   pm.addNestedPass<func::FuncOp>(
-      cudaq::opt::createEraseCompilerGeneratedLogOutput());
-  // Fuse SSI blocks after erasure of all fake quake.log_output.
+      cudaq::opt::createEraseCompilerGeneratedEvince());
+  // Fuse SSI blocks after erasure of all fake quake.evince.
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createLowerToCG());
   QuakeToQIRAPIOptions apiOpt{.api = api.str(), .opaquePtr = opaquePtr};

--- a/cudaq/lib/Optimizer/CodeGen/EraseCGEvince.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/EraseCGEvince.cpp
@@ -10,7 +10,7 @@
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 
 namespace cudaq::opt {
-#define GEN_PASS_DEF_ERASECOMPILERGENERATEDLOGOUTPUT
+#define GEN_PASS_DEF_ERASECOMPILERGENERATEDEVINCE
 #include "cudaq/Optimizer/CodeGen/Passes.h.inc"
 } // namespace cudaq::opt
 
@@ -20,24 +20,23 @@ using namespace mlir;
 
 namespace {
 
-class EraseCompilerGeneratedLogOutputPass
-    : public cudaq::opt::impl::EraseCompilerGeneratedLogOutputBase<
-          EraseCompilerGeneratedLogOutputPass> {
+class EraseCompilerGeneratedEvincePass
+    : public cudaq::opt::impl::EraseCompilerGeneratedEvinceBase<
+          EraseCompilerGeneratedEvincePass> {
 public:
-  using EraseCompilerGeneratedLogOutputBase::
-      EraseCompilerGeneratedLogOutputBase;
+  using EraseCompilerGeneratedEvinceBase::EraseCompilerGeneratedEvinceBase;
 
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    funcOp.walk([&](cudaq::quake::LogOutputOp logOut) {
-      if (!logOut.getCompilerGenerated())
+    funcOp.walk([&](cudaq::quake::EvinceOp evince) {
+      if (!evince.getCompilerGenerated())
         return;
       // For each wire/cable result, replace uses with the corresponding arg.
       unsigned resultIdx = 0;
-      for (Value arg : logOut.getArgs())
+      for (Value arg : evince.getArgs())
         if (cudaq::quake::isLinearType(arg.getType()))
-          logOut.getOuts()[resultIdx++].replaceAllUsesWith(arg);
-      logOut->erase();
+          evince.getOuts()[resultIdx++].replaceAllUsesWith(arg);
+      evince->erase();
     });
   }
 };

--- a/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -62,7 +62,7 @@ static void createPrepareForWiresetPipeline(
   auto &funcPM = pm.nest<func::FuncOp>();
   funcPM.addPass(cudaq::opt::createExpandMeasurementsPass());
   funcPM.addPass(cudaq::opt::createAddDeallocs());
-  funcPM.addPass(cudaq::opt::createEraseCompilerGeneratedLogOutput());
+  funcPM.addPass(cudaq::opt::createEraseCompilerGeneratedEvince());
   funcPM.addPass(cudaq::opt::createExpandControlVeqs());
   funcPM.addPass(cudaq::opt::createCombineQuantumAllocations());
   funcPM.addPass(createCanonicalizerPass());
@@ -181,7 +181,7 @@ createTargetCodegenPipeline(OpPassManager &pm,
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createDeadQuantumElimination());
   }
   pm.addNestedPass<func::FuncOp>(
-      cudaq::opt::createEraseCompilerGeneratedLogOutput());
+      cudaq::opt::createEraseCompilerGeneratedEvince());
 
   cudaq::opt::addPhaseLifecycle(pm);
   // LowerPhase can leave negative controls on the R1/Rz it creates, so we need
@@ -280,7 +280,7 @@ void cudaq::opt::addKernelBuilderJITLoweringPipeline(
 void cudaq::opt::createPipelineTransformsForPythonToOpenQASM(
     OpPassManager &pm) {
   pm.addNestedPass<func::FuncOp>(
-      cudaq::opt::createEraseCompilerGeneratedLogOutput());
+      cudaq::opt::createEraseCompilerGeneratedEvince());
   pm.addPass(createLambdaLifting());
   // Run most of the passes from hardware pipelines.
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -314,7 +314,7 @@ void cudaq::opt::createPipelineTransformsForPythonToOpenQASM(
 
 void cudaq::opt::addPipelineTranslateToOpenQASM(PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(
-      cudaq::opt::createEraseCompilerGeneratedLogOutput());
+      cudaq::opt::createEraseCompilerGeneratedEvince());
   pm.addNestedPass<func::FuncOp>(createClassicalMemToReg());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(createDeadStoreRemoval());
@@ -326,7 +326,7 @@ void cudaq::opt::addPipelineTranslateToOpenQASM(PassManager &pm) {
 
 void cudaq::opt::addPipelineTranslateToIQMJson(PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(
-      cudaq::opt::createEraseCompilerGeneratedLogOutput());
+      cudaq::opt::createEraseCompilerGeneratedEvince());
   pm.addNestedPass<func::FuncOp>(createExpandMeasurementsPass());
   pm.addNestedPass<func::FuncOp>(createCSEPass());
   pm.addNestedPass<func::FuncOp>(createLoopNormalize());

--- a/cudaq/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
@@ -26,7 +26,7 @@ namespace cudaq::opt {
 using namespace mlir;
 
 namespace {
-class ReturnRewrite : public OpRewritePattern<cudaq::quake::LogOutputOp> {
+class ReturnRewrite : public OpRewritePattern<cudaq::quake::EvinceOp> {
 public:
   ReturnRewrite(MLIRContext *ctx, bool allowDynamic)
       : OpRewritePattern(ctx), allowDynamic(allowDynamic) {}
@@ -34,7 +34,7 @@ public:
   // This is where the heavy lifting is done. We take the return op's operand(s)
   // and convert them to calls to the QIR output logging functions with the
   // appropriate label information.
-  LogicalResult matchAndRewrite(cudaq::quake::LogOutputOp log,
+  LogicalResult matchAndRewrite(cudaq::quake::EvinceOp log,
                                 PatternRewriter &rewriter) const override {
     auto loc = log.getLoc();
     // For each operand, generate a QIR logging call.

--- a/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
@@ -743,7 +743,7 @@ struct WireSetToProfileQIRPostPass
 void cudaq::opt::addWiresetToProfileQIRPipeline(OpPassManager &pm,
                                                 StringRef profile) {
   pm.addNestedPass<func::FuncOp>(
-      cudaq::opt::createEraseCompilerGeneratedLogOutput());
+      cudaq::opt::createEraseCompilerGeneratedEvince());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   cudaq::opt::addPhaseLifecycle(pm);
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createExpandControlNegations());

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -280,19 +280,19 @@ struct EraseApplyNoiseEmptyVeqQubitPattern
   }
 };
 
-// quake.log_output %r, %empty, %w : (..., !quake.veq<0>, ...) -> (...)
+// quake.evince %r, %empty, %w : (..., !quake.veq<0>, ...) -> (...)
 // ───────────────────────────────────────────────────────────────────
-// quake.log_output %r, %w : (..., ...) -> (...)
+// quake.evince %r, %w : (..., ...) -> (...)
 //
 // An empty veq has no observable qubit -- there is nothing there to log --
 // so it contributes nothing to what's being observed. A veq is never a
 // linear type, so dropping it never touches `outs`. If nothing observable
 // remains, the whole op is dead and is erased.
-struct DropEmptyVeqLogOutputArgsPattern
-    : public OpRewritePattern<cudaq::quake::LogOutputOp> {
+struct DropEmptyVeqEvinceArgsPattern
+    : public OpRewritePattern<cudaq::quake::EvinceOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(cudaq::quake::LogOutputOp log,
+  LogicalResult matchAndRewrite(cudaq::quake::EvinceOp log,
                                 PatternRewriter &rewriter) const override {
     auto args = log.getArgs();
     SmallVector<Value> keep;
@@ -307,7 +307,7 @@ struct DropEmptyVeqLogOutputArgsPattern
       return success();
     }
 
-    rewriter.replaceOpWithNewOp<cudaq::quake::LogOutputOp>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::EvinceOp>(
         log, keep, log.getCompilerGenerated());
     return success();
   }

--- a/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/cudaq/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -292,9 +292,9 @@ struct DropEmptyVeqEvinceArgsPattern
     : public OpRewritePattern<cudaq::quake::EvinceOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(cudaq::quake::EvinceOp log,
+  LogicalResult matchAndRewrite(cudaq::quake::EvinceOp evin,
                                 PatternRewriter &rewriter) const override {
-    auto args = log.getArgs();
+    auto args = evin.getArgs();
     SmallVector<Value> keep;
     for (Value arg : args)
       if (!isEmptyVeqType(arg))
@@ -303,12 +303,12 @@ struct DropEmptyVeqEvinceArgsPattern
       return failure();
 
     if (keep.empty()) {
-      rewriter.eraseOp(log);
+      rewriter.eraseOp(evin);
       return success();
     }
 
     rewriter.replaceOpWithNewOp<cudaq::quake::EvinceOp>(
-        log, keep, log.getCompilerGenerated());
+        evin, keep, evin.getCompilerGenerated());
     return success();
   }
 };

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -139,7 +139,7 @@ LogicalResult cudaq::quake::verifyWireArityAndCoarity(Operation *op) {
 
 bool cudaq::quake::isSupportedMappingOperation(Operation *op) {
   return isa<OperatorInterface, MeasurementInterface, ResetOp, SinkOp,
-             ReturnWireOp, LogOutputOp>(op);
+             ReturnWireOp, EvinceOp>(op);
 }
 
 ValueRange cudaq::quake::getQuantumTypesFromRange(ValueRange range) {
@@ -1697,10 +1697,10 @@ WIRE_OPS(INSTANTIATE_LINEAR_TYPE_VERIFY)
 BUILTIN_GATE_OPS(INSTANTIATE_OPERATOR_CANONICALIZATION)
 
 //===----------------------------------------------------------------------===//
-// LogOutputOp
+// EvinceOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult cudaq::quake::LogOutputOp::verify() {
+LogicalResult cudaq::quake::EvinceOp::verify() {
   SmallVector<Type> expected;
   for (Value v : getArgs())
     if (isLinearType(v.getType()))
@@ -1712,9 +1712,9 @@ LogicalResult cudaq::quake::LogOutputOp::verify() {
   return success();
 }
 
-void cudaq::quake::LogOutputOp::getCanonicalizationPatterns(
+void cudaq::quake::EvinceOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<DropEmptyVeqLogOutputArgsPattern>(context);
+  patterns.add<DropEmptyVeqEvinceArgsPattern>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/cudaq/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/cudaq/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -964,7 +964,7 @@ public:
           auto kern = func::CallOp::create(
               builder, loc, epKern.getFunctionType().getResults(),
               epKern.getName(), entry->getArguments());
-          cudaq::quake::LogOutputOp::create(builder, loc, kern.getResults());
+          cudaq::quake::EvinceOp::create(builder, loc, kern.getResults());
           func::ReturnOp::create(builder, loc);
           runKernels.push_back(runKern);
         }

--- a/cudaq/lib/Optimizer/Transforms/InjectImplicitOutput.cpp
+++ b/cudaq/lib/Optimizer/Transforms/InjectImplicitOutput.cpp
@@ -46,8 +46,7 @@ public:
       for (Operation &op : block) {
         if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op)) {
           orderedAllocs.push_back(alloc);
-        } else if (isa<cudaq::quake::EvinceOp, cudaq::quake::DeallocOp>(
-                       op)) {
+        } else if (isa<cudaq::quake::EvinceOp, cudaq::quake::DeallocOp>(op)) {
           LLVM_DEBUG({
             if (isa<cudaq::quake::EvinceOp>(op))
               llvm::dbgs() << "kernel already has evince ops, skipping.\n";

--- a/cudaq/lib/Optimizer/Transforms/InjectImplicitOutput.cpp
+++ b/cudaq/lib/Optimizer/Transforms/InjectImplicitOutput.cpp
@@ -65,8 +65,8 @@ public:
 
     // 1. At this point, we have a function that we want to process.
 
-    // λ to resolve the value to create an evince for.
-    auto logValue = [](cudaq::quake::AllocaOp alloc) -> Value {
+    // λ to resolve the value to create an evince op for.
+    auto evinceValue = [](cudaq::quake::AllocaOp alloc) -> Value {
       if (alloc.hasInitializedState())
         return alloc.getInitializedState().getResult();
       return alloc.getResult();
@@ -105,7 +105,7 @@ public:
     // block.
     builder.setInsertionPointToEnd(exitBlock);
     for (auto alloc : orderedAllocs)
-      emitEvince(builder, alloc.getLoc(), logValue(alloc));
+      emitEvince(builder, alloc.getLoc(), evinceValue(alloc));
     func::ReturnOp::create(builder, loc, exitBlock->getArguments());
 
     // 3. Redirect all existing func.return ops to branch to the exit block,
@@ -134,7 +134,7 @@ public:
           // this return, preserving declaration order.
           for (auto alloc : orderedAllocs)
             if (dom.dominates(alloc.getOperation(), ret.getOperation()))
-              emitEvince(builder, alloc.getLoc(), logValue(alloc));
+              emitEvince(builder, alloc.getLoc(), evinceValue(alloc));
         }
       }
     }

--- a/cudaq/lib/Optimizer/Transforms/InjectImplicitOutput.cpp
+++ b/cudaq/lib/Optimizer/Transforms/InjectImplicitOutput.cpp
@@ -36,7 +36,7 @@ public:
       return;
     if (!funcOp->hasAttr(cudaq::entryPointAttrName))
       return;
-    // If the kernel already contains any quake.log_output ops at the top level,
+    // If the kernel already contains any quake.evince ops at the top level,
     // it has output: do not inject implicit output.
     //
     // Also collect quake.alloca ops at the top level of this func.func only.
@@ -46,11 +46,11 @@ public:
       for (Operation &op : block) {
         if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op)) {
           orderedAllocs.push_back(alloc);
-        } else if (isa<cudaq::quake::LogOutputOp, cudaq::quake::DeallocOp>(
+        } else if (isa<cudaq::quake::EvinceOp, cudaq::quake::DeallocOp>(
                        op)) {
           LLVM_DEBUG({
-            if (isa<cudaq::quake::LogOutputOp>(op))
-              llvm::dbgs() << "kernel already has log_output ops, skipping.\n";
+            if (isa<cudaq::quake::EvinceOp>(op))
+              llvm::dbgs() << "kernel already has evince ops, skipping.\n";
             else
               llvm::dbgs() << "kernel already has deallocs, skipping.\n";
           });
@@ -66,27 +66,27 @@ public:
 
     // 1. At this point, we have a function that we want to process.
 
-    // λ to resolve the value to create a log_output for.
+    // λ to resolve the value to create an evince for.
     auto logValue = [](cudaq::quake::AllocaOp alloc) -> Value {
       if (alloc.hasInitializedState())
         return alloc.getInitializedState().getResult();
       return alloc.getResult();
     };
 
-    // λ to create compiler-generated log_output ops for a single value.
+    // λ to create compiler-generated evince ops for a single value.
     // Passes /*compilerGenerated=*/true to the builder so the attribute is
     // stored as a first-class op attribute rather than a discardable side attr.
-    auto emitLogOutput = [&](OpBuilder &b, Location l, Value v) {
-      // Emit a single log_output for the value regardless of whether it is a
-      // ref or a veq.  Using log_output %veq directly (rather than a per-
-      // element loop) is essential: the DQE pass recognises log_output as the
-      // keep-alive signal for a veq alloca.  A loop of extract_ref + log_output
+    auto emitEvince = [&](OpBuilder &b, Location l, Value v) {
+      // Emit a single evince for the value regardless of whether it is a
+      // ref or a veq.  Using evince %veq directly (rather than a per-
+      // element loop) is essential: the DQE pass recognises evince as the
+      // keep-alive signal for a veq alloca.  A loop of extract_ref + evince
       // %ref would hide the veq from DQE, causing the alloca to be treated as
-      // dead and eliminated.  log_output %veq also avoids the null-wire double-
-      // use issue in memtoreg because LogOutputOpPattern only fires on !ref
+      // dead and eliminated.  evince %veq also avoids the null-wire double-
+      // use issue in memtoreg because EvinceOpPattern only fires on !ref
       // operands (hasNonVectorReference returns false for veq).
-      cudaq::quake::LogOutputOp::create(b, l, ValueRange{v},
-                                        /*compilerGenerated=*/true);
+      cudaq::quake::EvinceOp::create(b, l, ValueRange{v},
+                                     /*compilerGenerated=*/true);
     };
 
     DominanceInfo dom(funcOp);
@@ -102,16 +102,16 @@ public:
     exitBlock->addArguments(returnTypes, returnLocs);
     funcOp.getBody().push_back(exitBlock);
 
-    // 3. Emit quake.log_output ops in declaration order into the new exit
+    // 3. Emit quake.evince ops in declaration order into the new exit
     // block.
     builder.setInsertionPointToEnd(exitBlock);
     for (auto alloc : orderedAllocs)
-      emitLogOutput(builder, alloc.getLoc(), logValue(alloc));
+      emitEvince(builder, alloc.getLoc(), logValue(alloc));
     func::ReturnOp::create(builder, loc, exitBlock->getArguments());
 
     // 3. Redirect all existing func.return ops to branch to the exit block,
     // provided the alloca set entirely dominates that return. Otherwise, emit
-    // log_output ops for the dominating subset inline before the return.
+    // evince ops for the dominating subset inline before the return.
     for (Block &block : funcOp.getBody()) {
       // Skip the exit block we just created.
       if (&block == exitBlock)
@@ -131,11 +131,11 @@ public:
                                ret.getOperands());
           ret.erase();
         } else {
-          // Fall back case. Emit log_output only for the allocas that dominate
+          // Fall back case. Emit evince only for the allocas that dominate
           // this return, preserving declaration order.
           for (auto alloc : orderedAllocs)
             if (dom.dominates(alloc.getOperation(), ret.getOperation()))
-              emitLogOutput(builder, alloc.getLoc(), logValue(alloc));
+              emitEvince(builder, alloc.getLoc(), logValue(alloc));
         }
       }
     }

--- a/cudaq/lib/Optimizer/Transforms/Mapping.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Mapping.cpp
@@ -2303,11 +2303,11 @@ Operation *findNonTerminalMeasuredWireUse(func::FuncOp func) {
       if (!isa<cudaq::quake::WireType>(result.getType()))
         continue;
       for (Operation *user : result.getUsers())
-        // quake.log_output is a transparent wire pass-through (compiler-
+        // quake.evince is a transparent wire pass-through (compiler-
         // generated bookkeeping that is erased before codegen); treat it
         // like a sink so it doesn't trigger a false mid-circuit diagnosis.
         if (!isa<cudaq::quake::ReturnWireOp, cudaq::quake::SinkOp,
-                 cudaq::quake::LogOutputOp>(user)) {
+                 cudaq::quake::EvinceOp>(user)) {
           found = measOp;
           return WalkResult::interrupt();
         }
@@ -2582,7 +2582,7 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
         for (Value res : loopOp->getResults())
           if (isa<cudaq::quake::WireType>(res.getType()))
             finalQubitWire[wireToVirtualQ[res].index] = res;
-      } else if (isa<cudaq::quake::LogOutputOp>(op) &&
+      } else if (isa<cudaq::quake::EvinceOp>(op) &&
                  cudaq::quake::getQuantumOperands(&op).empty()) {
         // Scalar output values do not participate in qubit mapping.
         continue;

--- a/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
@@ -87,8 +87,8 @@ static bool onlyTakesLinearTypeArguments(Operation *op) {
 /// `quake.compute_action`, `quake.apply_noise`, and `quake.call_by_ref`.
 /// Every other op only manages references/veqs — e.g. `quake.concat`,
 /// `quake.dealloc`, `quake.relax_size`, `cc.instantiate_callable`,
-/// `cc.callable_closure`, and (despite appearances) `quake.log_output` — and
-/// cannot alias or mutate a qubit we are tracking. `quake.log_output` merely
+/// `cc.callable_closure`, and (despite appearances) `quake.evince` — and
+/// cannot alias or mutate a qubit we are tracking. `quake.evince` merely
 /// marks a value as observable for later codegen; it does not dereference
 /// or modify anything, so it must not trigger the conservative
 /// wrap-and-cancel-everything path below.
@@ -1118,12 +1118,12 @@ public:
   }
 };
 
-/// The log_output operation is also an oddball like the reset operation.
-class LogOutputOpPattern : public OpRewritePattern<cudaq::quake::LogOutputOp> {
+/// The evince operation is also an oddball like the reset operation.
+class EvinceOpPattern : public OpRewritePattern<cudaq::quake::EvinceOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(cudaq::quake::LogOutputOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::EvinceOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto wireTy = cudaq::quake::WireType::get(rewriter.getContext());
@@ -1141,7 +1141,7 @@ public:
       }
     }
 
-    auto newOp = cudaq::quake::LogOutputOp::create(rewriter, loc, newArgs);
+    auto newOp = cudaq::quake::EvinceOp::create(rewriter, loc, newArgs);
     for (auto namedAttr : op->getAttrs())
       newOp->setAttr(namedAttr.getName(), namedAttr.getValue());
 
@@ -2102,11 +2102,11 @@ public:
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.insert<WRAPPER_QUANTUM_OPS, ResetOpPattern, DeallocOpPattern,
-                    LogOutputOpPattern>(ctx);
+                    EvinceOpPattern>(ctx);
     ConversionTarget target(*ctx);
     target.addDynamicallyLegalOp<RAW_QUANTUM_OPS, cudaq::quake::ResetOp,
                                  cudaq::quake::DeallocOp,
-                                 cudaq::quake::LogOutputOp>(
+                                 cudaq::quake::EvinceOp>(
         [](Operation *op) { return !cudaq::quake::hasNonVectorReference(op); });
     target.addLegalOp<cudaq::quake::UnwrapOp, cudaq::quake::WrapOp,
                       cudaq::quake::NullWireOp, cudaq::quake::SinkOp>();

--- a/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/cudaq/lib/Optimizer/Transforms/MemToReg.cpp
@@ -2104,10 +2104,12 @@ public:
     patterns.insert<WRAPPER_QUANTUM_OPS, ResetOpPattern, DeallocOpPattern,
                     EvinceOpPattern>(ctx);
     ConversionTarget target(*ctx);
-    target.addDynamicallyLegalOp<RAW_QUANTUM_OPS, cudaq::quake::ResetOp,
-                                 cudaq::quake::DeallocOp,
-                                 cudaq::quake::EvinceOp>(
-        [](Operation *op) { return !cudaq::quake::hasNonVectorReference(op); });
+    target
+        .addDynamicallyLegalOp<RAW_QUANTUM_OPS, cudaq::quake::ResetOp,
+                               cudaq::quake::DeallocOp, cudaq::quake::EvinceOp>(
+            [](Operation *op) {
+              return !cudaq::quake::hasNonVectorReference(op);
+            });
     target.addLegalOp<cudaq::quake::UnwrapOp, cudaq::quake::WrapOp,
                       cudaq::quake::NullWireOp, cudaq::quake::SinkOp>();
     if (failed(applyPartialConversion(func, target, std::move(patterns)))) {

--- a/cudaq/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/cudaq/lib/Optimizer/Transforms/RegToMem.cpp
@@ -510,11 +510,10 @@ struct EraseWiresIf : public OpRewritePattern<cudaq::cc::IfOp> {
 /// Convert a wire-form quake.evince back to ref form. Each wire result is
 /// replaced by its wire input (pass-through), and the op is rebuilt with the
 /// corresponding alloca refs so it is legal after regtomem.
-class CollapseEvinceWires
-    : public OpRewritePattern<cudaq::quake::EvinceOp> {
+class CollapseEvinceWires : public OpRewritePattern<cudaq::quake::EvinceOp> {
 public:
   explicit CollapseEvinceWires(MLIRContext *ctx, RegToMemAnalysis &analysis,
-                                  ArrayRef<Value> allocas)
+                               ArrayRef<Value> allocas)
       : OpRewritePattern(ctx), analysis(analysis), allocas(allocas) {}
 
   LogicalResult matchAndRewrite(cudaq::quake::EvinceOp op,
@@ -532,8 +531,7 @@ public:
         newArgs.push_back(arg);
       }
     }
-    auto newOp =
-        cudaq::quake::EvinceOp::create(rewriter, op.getLoc(), newArgs);
+    auto newOp = cudaq::quake::EvinceOp::create(rewriter, op.getLoc(), newArgs);
     for (auto namedAttr : op->getAttrs())
       newOp->setAttr(namedAttr.getName(), namedAttr.getValue());
     rewriter.eraseOp(op);

--- a/cudaq/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/cudaq/lib/Optimizer/Transforms/RegToMem.cpp
@@ -194,7 +194,7 @@ private:
             collectLinearValues(ArrayRef<Value>{reset.getTargets()});
         for (auto [t, r] : llvm::zip(wireTargs, reset.getResults()))
           insertToEqClass(t, r);
-      } else if (auto logOut = dyn_cast<cudaq::quake::LogOutputOp>(op)) {
+      } else if (auto logOut = dyn_cast<cudaq::quake::EvinceOp>(op)) {
         // Wire inputs and outputs are the same qubit; union them so that ops
         // downstream of the pass-through can still resolve their alloca id.
         unsigned resultIdx = 0;
@@ -507,17 +507,17 @@ struct EraseWiresIf : public OpRewritePattern<cudaq::cc::IfOp> {
   ArrayRef<Value> allocas;
 };
 
-/// Convert a wire-form quake.log_output back to ref form. Each wire result is
+/// Convert a wire-form quake.evince back to ref form. Each wire result is
 /// replaced by its wire input (pass-through), and the op is rebuilt with the
 /// corresponding alloca refs so it is legal after regtomem.
-class CollapseLogOutputWires
-    : public OpRewritePattern<cudaq::quake::LogOutputOp> {
+class CollapseEvinceWires
+    : public OpRewritePattern<cudaq::quake::EvinceOp> {
 public:
-  explicit CollapseLogOutputWires(MLIRContext *ctx, RegToMemAnalysis &analysis,
+  explicit CollapseEvinceWires(MLIRContext *ctx, RegToMemAnalysis &analysis,
                                   ArrayRef<Value> allocas)
       : OpRewritePattern(ctx), analysis(analysis), allocas(allocas) {}
 
-  LogicalResult matchAndRewrite(cudaq::quake::LogOutputOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::EvinceOp op,
                                 PatternRewriter &rewriter) const override {
     SmallVector<Value> newArgs;
     unsigned resultIdx = 0;
@@ -533,7 +533,7 @@ public:
       }
     }
     auto newOp =
-        cudaq::quake::LogOutputOp::create(rewriter, op.getLoc(), newArgs);
+        cudaq::quake::EvinceOp::create(rewriter, op.getLoc(), newArgs);
     for (auto namedAttr : op->getAttrs())
       newOp->setAttr(namedAttr.getName(), namedAttr.getValue());
     rewriter.eraseOp(op);
@@ -614,12 +614,12 @@ public:
     patterns.insert<NOWRAP_QUANTUM_OPS, CollapseWrappers<cudaq::quake::ResetOp>,
                     CollapseWrappers<cudaq::quake::ReturnWireOp>,
                     CollapseWrappers<cudaq::quake::SinkOp>, EraseWiresIf,
-                    CollapseLogOutputWires>(ctx, analysis, allocas);
+                    CollapseEvinceWires>(ctx, analysis, allocas);
     patterns.insert<EraseWiresBranch, EraseWiresCondBranch>(ctx, fixupBlocks);
     ConversionTarget target(*ctx);
     target.addDynamicallyLegalOp<RAW_QUANTUM_OPS, cudaq::quake::ResetOp,
                                  cf::BranchOp, cf::CondBranchOp,
-                                 cudaq::cc::IfOp, cudaq::quake::LogOutputOp>(
+                                 cudaq::cc::IfOp, cudaq::quake::EvinceOp>(
         [&](Operation *op) { return hasNoWires(op); });
     target.addIllegalOp<cudaq::quake::SinkOp, cudaq::quake::ReturnWireOp>();
     target.addLegalOp<cudaq::quake::UnwrapOp, cudaq::quake::DeallocOp>();

--- a/cudaq/lib/Optimizer/Transforms/ResetBeforeReuse.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ResetBeforeReuse.cpp
@@ -118,10 +118,10 @@ public:
           continue;
         }
 
-        // If this is a compiler-generated quake.log_output (injected by
+        // If this is a compiler-generated quake.evince (injected by
         // InjectImplicitOutput as bookkeeping, erased before codegen), it is
         // not a real reuse of the qubit. No reset is needed.
-        if (auto logOut = dyn_cast<cudaq::quake::LogOutputOp>(nextOp))
+        if (auto logOut = dyn_cast<cudaq::quake::EvinceOp>(nextOp))
           if (logOut.getCompilerGenerated())
             continue;
 

--- a/cudaq/test/NVQPP/run_vector_return.cpp
+++ b/cudaq/test/NVQPP/run_vector_return.cpp
@@ -49,5 +49,5 @@ int main() {
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__run_vector_return.run()
 // CHECK-NOT:   call @malloc
 // CHECK-NOT:   call @llvm.memcpy
-// CHECK:       quake.log_output
+// CHECK:       quake.evince
 // CHECK:       return

--- a/cudaq/test/Transforms/aot_run_vector_copy.qke
+++ b/cudaq/test/Transforms/aot_run_vector_copy.qke
@@ -41,7 +41,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__aot_run_vector_co
 // CHECK-NOT: call @__nvqpp_vectorCopyCtor
 // CHECK-NOT: call @malloc
 // CHECK-NOT: call @llvm.memcpy
-// CHECK: quake.log_output
+// CHECK: quake.evince
 // CHECK: return
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__aot_run_vector_copy.ruined()

--- a/cudaq/test/Transforms/atomic_quantum_region_codegen.qke
+++ b/cudaq/test/Transforms/atomic_quantum_region_codegen.qke
@@ -50,8 +50,8 @@ func.func @shielded_roundtrip() attributes {"cudaq-entrypoint", "cudaq-kernel"} 
   %m1 = quake.mz %q1 : (!quake.ref) -> !quake.measure
   %b0 = quake.discriminate %m0 : (!quake.measure) -> i1
   %b1 = quake.discriminate %m1 : (!quake.measure) -> i1
-  quake.log_output %b0 : (i1) -> ()
-  quake.log_output %b1 : (i1) -> ()
+  quake.evince %b0 : (i1) -> ()
+  quake.evince %b1 : (i1) -> ()
   return
 }
 
@@ -64,8 +64,8 @@ func.func @exposed_roundtrip() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %m1 = quake.mz %q1 : (!quake.ref) -> !quake.measure
   %b0 = quake.discriminate %m0 : (!quake.measure) -> i1
   %b1 = quake.discriminate %m1 : (!quake.measure) -> i1
-  quake.log_output %b0 : (i1) -> ()
-  quake.log_output %b1 : (i1) -> ()
+  quake.evince %b0 : (i1) -> ()
+  quake.evince %b1 : (i1) -> ()
   return
 }
 
@@ -79,7 +79,7 @@ func.func @run_dynamic_result(%size: i64) attributes {"cudaq-entrypoint", "cudaq
     %sequence = cc.sequence_init %storage, %size : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.sequence<i64>
     cc.continue %sequence : !cc.sequence<i64>
   }
-  quake.log_output %result : (!cc.sequence<i64>) -> ()
+  quake.evince %result : (!cc.sequence<i64>) -> ()
   return
 }
 

--- a/cudaq/test/Transforms/erase_vcc_with_scope.qke
+++ b/cudaq/test/Transforms/erase_vcc_with_scope.qke
@@ -134,7 +134,7 @@ func.func @__nvqpp__mlirgen__function_repro._Z5reprov.run() attributes {"cudaq-e
     quake.dealloc %1 : !quake.veq<8>
     cc.continue %15#0 : i32
   }
-  quake.log_output %0 : (i32) -> ()
+  quake.evince %0 : (i32) -> ()
   return
 }
 func.func private @malloc(i64) -> !cc.ptr<i8>

--- a/cudaq/test/Transforms/inject_implicit_output.qke
+++ b/cudaq/test/Transforms/inject_implicit_output.qke
@@ -10,7 +10,7 @@
 
 // Test a kernel with a mix of quake.alloca types: a single !quake.ref, a
 // statically-sized !quake.veq<N>, a dynamically-sized !quake.veq<?>, and a
-// !quake.veq<N> followed by a quake.init_state (where the log_output should
+// !quake.veq<N> followed by a quake.init_state (where the evince should
 // use the init_state result rather than the raw alloca).
 
 module {
@@ -24,7 +24,7 @@ module {
     // Dynamically-sized veq.
     %q2 = quake.alloca !quake.veq<?>[%arg0 : i64]
 
-    // veq with initialize_state — log_output should use the init_state result.
+    // veq with initialize_state — evince should use the init_state result.
     %0 = cc.address_of @__nvqpp__rodata_init_0 : !cc.ptr<!cc.array<f64 x 4>>
     %q3 = quake.alloca !quake.veq<4>
     %q3s = quake.init_state %q3, %0 : (!quake.veq<4>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<4>
@@ -48,10 +48,10 @@ module {
 // CHECK:         quake.h %[[Q0]]
 // CHECK:         cf.br ^[[EXIT:.*]]
 
-// Exit block: log_output ops in declaration order, then return.
+// Exit block: evince ops in declaration order, then return.
 // CHECK:       ^[[EXIT]]:
-// CHECK:         quake.log_output %[[Q0]] : (!quake.ref) -> ()
-// CHECK:         quake.log_output %[[Q1]] : (!quake.veq<4>) -> ()
-// CHECK:         quake.log_output %[[Q2]] : (!quake.veq<?>) -> ()
-// CHECK:         quake.log_output %[[Q3S]] : (!quake.veq<4>) -> ()
+// CHECK:         quake.evince %[[Q0]] : (!quake.ref) -> ()
+// CHECK:         quake.evince %[[Q1]] : (!quake.veq<4>) -> ()
+// CHECK:         quake.evince %[[Q2]] : (!quake.veq<?>) -> ()
+// CHECK:         quake.evince %[[Q3S]] : (!quake.veq<4>) -> ()
 // CHECK:         return

--- a/cudaq/test/Transforms/inject_implicit_output_erase.qke
+++ b/cudaq/test/Transforms/inject_implicit_output_erase.qke
@@ -10,7 +10,7 @@
 // RUN:   FileCheck %s
 
 // Same kernel as inject_implicit_output.qke. After inject-implicit-output adds
-// the compiler-generated quake.log_output ops and erase-cg-log-output removes
+// the compiler-generated quake.evince ops and erase-implicit-output removes
 // them, the exit block should contain only the return.
 
 module {
@@ -32,10 +32,10 @@ module {
   func.func @nested_output() {
     %q = quake.alloca !quake.ref
     cc.scope {
-      quake.log_output %q : (!quake.ref) -> () {compilerGenerated}
+      quake.evince %q : (!quake.ref) -> () {compilerGenerated}
       cc.continue
     }
-    quake.log_output %q : (!quake.ref) -> ()
+    quake.evince %q : (!quake.ref) -> ()
     return
   }
 
@@ -47,13 +47,13 @@ module {
 // CHECK:         quake.h
 // CHECK:         cf.br ^[[EXIT:.*]]
 // CHECK:       ^[[EXIT]]:
-// CHECK-NOT:     quake.log_output
+// CHECK-NOT:     quake.evince
 // CHECK:         return
 
 // CHECK-LABEL: func.func @nested_output()
 // CHECK:         %[[Q:.*]] = quake.alloca !quake.ref
 // CHECK:         cc.scope {
-// CHECK-NOT:       quake.log_output
+// CHECK-NOT:       quake.evince
 // CHECK:         }
-// CHECK:         quake.log_output %[[Q]] : (!quake.ref) -> ()
+// CHECK:         quake.evince %[[Q]] : (!quake.ref) -> ()
 // CHECK:         return

--- a/cudaq/test/Transforms/mapping_measurement_composable.qke
+++ b/cudaq/test/Transforms/mapping_measurement_composable.qke
@@ -70,6 +70,6 @@ func.func @adaptive_cfg_feedback_run() attributes {quake.cudaq_run = [i1]} {
 ^done:
   // CHECK: unsupported measurement-dependent behavior
   quake.return_wire %wire : !quake.wire
-  quake.log_output %bit : (i1) -> ()
+  quake.evince %bit : (i1) -> ()
   return
 }

--- a/cudaq/test/Transforms/mapping_run_entry.qke
+++ b/cudaq/test/Transforms/mapping_run_entry.qke
@@ -21,13 +21,13 @@ module {
     %1 = quake.x %0 : (!quake.wire) -> !quake.wire
     %measOut, %wires = quake.mz %1 : (!quake.wire) -> (!quake.measure, !quake.wire)
     quake.return_wire %wires : !quake.wire
-    quake.log_output %true : (i1) -> ()
+    quake.evince %true : (i1) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @bool_return.run() attributes {mapping_reorder_idx = [0], mapping_v2p = [0], quake.cudaq_run = [i1]}
   // CHECK:         quake.borrow_wire @mapped_wireset[0] : !quake.wire
-  // CHECK:         quake.log_output {{.*}} : (i1) -> ()
+  // CHECK:         quake.evince {{.*}} : (i1) -> ()
 
   func.func @int_return.run() attributes {quake.cudaq_run = [i32]} {
     %c5_i32 = arith.constant 5 : i32
@@ -35,13 +35,13 @@ module {
     %1 = quake.x %0 : (!quake.wire) -> !quake.wire
     %measOut, %wires = quake.mz %1 : (!quake.wire) -> (!quake.measure, !quake.wire)
     quake.return_wire %wires : !quake.wire
-    quake.log_output %c5_i32 : (i32) -> ()
+    quake.evince %c5_i32 : (i32) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @int_return.run() attributes {mapping_reorder_idx = [0], mapping_v2p = [0], quake.cudaq_run = [i32]}
   // CHECK:         quake.borrow_wire @mapped_wireset[0] : !quake.wire
-  // CHECK:         quake.log_output {{.*}} : (i32) -> ()
+  // CHECK:         quake.evince {{.*}} : (i32) -> ()
 
   func.func @float_return.run() attributes {quake.cudaq_run = [f32]} {
     %cst = arith.constant 1.500000e+00 : f32
@@ -49,13 +49,13 @@ module {
     %1 = quake.h %0 : (!quake.wire) -> !quake.wire
     %measOut, %wires = quake.mz %1 : (!quake.wire) -> (!quake.measure, !quake.wire)
     quake.return_wire %wires : !quake.wire
-    quake.log_output %cst : (f32) -> ()
+    quake.evince %cst : (f32) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @float_return.run() attributes {mapping_reorder_idx = [0], mapping_v2p = [0], quake.cudaq_run = [f32]}
   // CHECK:         quake.borrow_wire @mapped_wireset[0] : !quake.wire
-  // CHECK:         quake.log_output {{.*}} : (f32) -> ()
+  // CHECK:         quake.evince {{.*}} : (f32) -> ()
 
   func.func @scoped_return.run() attributes {quake.cudaq_run = [i1]} {
     %true = arith.constant true
@@ -66,14 +66,14 @@ module {
       quake.return_wire %wires : !quake.wire
       cc.continue %true : i1
     }
-    quake.log_output %0 : (i1) -> ()
+    quake.evince %0 : (i1) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @scoped_return.run() attributes {mapping_reorder_idx = [0], mapping_v2p = [0], quake.cudaq_run = [i1]}
   // CHECK:         cc.scope
   // CHECK:           quake.borrow_wire @mapped_wireset[0] : !quake.wire
-  // CHECK:         quake.log_output {{.*}} : (i1) -> ()
+  // CHECK:         quake.evince {{.*}} : (i1) -> ()
 
   // A run entry keeps measurements in place, so structured measurement
   // feedback can be mapped without changing its semantics.
@@ -91,7 +91,7 @@ module {
     }
     quake.return_wire %wire : !quake.wire
     quake.return_wire %2#0 : !quake.wire
-    quake.log_output %bit : (i1) -> ()
+    quake.evince %bit : (i1) -> ()
     return
   }
 
@@ -107,5 +107,5 @@ module {
   // CHECK:           %[[ELSE:.*]] = quake.h {{.*}} : (!quake.wire) -> !quake.wire
   // CHECK:           cc.continue %[[ELSE]] : !quake.wire
   // CHECK:         }
-  // CHECK:         quake.log_output %[[BIT]] : (i1) -> ()
+  // CHECK:         quake.evince %[[BIT]] : (i1) -> ()
 }

--- a/cudaq/test/Transforms/memtoreg-10.qke
+++ b/cudaq/test/Transforms/memtoreg-10.qke
@@ -24,7 +24,7 @@ func.func @if_mixed_promotion(%c: i1, %k: i32) {
   }
   quake.y %q : (!quake.ref) -> ()
   %f = cc.load %m : !cc.ptr<i32>
-  quake.log_output %f : (i32) -> () {compilerGenerated}
+  quake.evince %f : (i32) -> () {compilerGenerated}
   quake.dealloc %q : !quake.ref
   return
 }
@@ -40,7 +40,7 @@ func.func @if_mixed_promotion(%c: i1, %k: i32) {
 // CHECK:             cc.continue %[[ARG]], %[[UNDEF_0]] : !quake.wire, i32
 // CHECK:           }
 // CHECK:           %[[Y_0:.*]] = quake.y %[[IF_0]]#0 : (!quake.wire) -> !quake.wire
-// CHECK:           quake.log_output %[[IF_0]]#1 : (i32) -> () {compilerGenerated}
+// CHECK:           quake.evince %[[IF_0]]#1 : (i32) -> () {compilerGenerated}
 // CHECK:           quake.sink %[[Y_0]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/memtoreg-4.qke
+++ b/cudaq/test/Transforms/memtoreg-4.qke
@@ -376,7 +376,7 @@ func.func @bug_5286() {
     %2 = arith.addi %arg0, %c1_i64 : i64
     cc.continue %2 : i64
   }
-  quake.log_output %0 : (!quake.ref) -> () {compilerGenerated}
+  quake.evince %0 : (!quake.ref) -> () {compilerGenerated}
   quake.dealloc %0 : !quake.ref
   return
 }
@@ -405,7 +405,7 @@ func.func @bug_5286() {
 // CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_6]], %[[CONSTANT_0]] : i64
 // CHECK:             cc.continue %[[ADDI_0]], %[[VAL_7]] : i64, !quake.wire
 // CHECK:           }
-// CHECK:           %[[LOG_OUTPUT_0:.*]] = quake.log_output %[[LOOP_0]]#1 : (!quake.wire) -> !quake.wire {compilerGenerated}
-// CHECK:           quake.sink %[[LOG_OUTPUT_0]] : !quake.wire
+// CHECK:           %[[EVINCE_0:.*]] = quake.evince %[[LOOP_0]]#1 : (!quake.wire) -> !quake.wire {compilerGenerated}
+// CHECK:           quake.sink %[[EVINCE_0]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/memtoreg-9.qke
+++ b/cudaq/test/Transforms/memtoreg-9.qke
@@ -51,7 +51,7 @@ func.func @nested_loop_wire_alias(%arg0: i64, %arg1: i64) {
     %5 = arith.addi %arg2, %c1_i64 : i64
     cc.continue %5, %arg3 : i64, i64
   } {normalized}
-  quake.log_output %3 : (!quake.veq<2>) -> () {compilerGenerated}
+  quake.evince %3 : (!quake.veq<2>) -> () {compilerGenerated}
   quake.dealloc %1 : !quake.ref
   quake.dealloc %2 : !quake.ref
   return
@@ -81,7 +81,7 @@ func.func @nested_loop_wire_alias(%arg0: i64, %arg1: i64) {
 // CHECK:             cc.continue %{{.*}}, %{{.*}}, %[[X_1]] : i64, i64, !quake.wire
 // CHECK:           } step {
 // CHECK:           }
-// CHECK:           quake.log_output %[[CONCAT_0]]
+// CHECK:           quake.evince %[[CONCAT_0]]
 // CHECK:           quake.sink
 // CHECK:           return
 // CHECK:         }
@@ -164,8 +164,8 @@ func.func @control_operand_alias(%arg0: i64) {
     %5 = arith.addi %arg1, %c1_i64 : i64
     cc.continue %5 : i64
   } {normalized}
-  quake.log_output %2 : (!quake.veq<2>) -> () {compilerGenerated}
-  quake.log_output %3 : (!quake.ref) -> () {compilerGenerated}
+  quake.evince %2 : (!quake.veq<2>) -> () {compilerGenerated}
+  quake.evince %3 : (!quake.ref) -> () {compilerGenerated}
   quake.dealloc %3 : !quake.ref
   quake.dealloc %0 : !quake.ref
   quake.dealloc %1 : !quake.ref
@@ -188,7 +188,7 @@ func.func @control_operand_alias(%arg0: i64) {
 // CHECK:             cc.continue %{{.*}}, %[[X_0]]#0 : i64, !quake.wire
 // CHECK:           } step {
 // CHECK:           }
-// CHECK:           quake.log_output %[[CONCAT_0]]
+// CHECK:           quake.evince %[[CONCAT_0]]
 // CHECK:           quake.sink
 // CHECK:           return
 // CHECK:         }

--- a/cudaq/test/Transforms/run_semantics_hackery.qke
+++ b/cudaq/test/Transforms/run_semantics_hackery.qke
@@ -116,7 +116,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7de5b48
   func.func private @__nvqpp_cleanup_arrays()
   func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.run(%arg0: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [!cc.sequence<i64>]} {
     %0 = call @__nvqpp__mlirgen__kernel..0x7de5b482e030(%arg0) : (i64) -> !cc.sequence<i64>
-    quake.log_output %0 : (!cc.sequence<i64>) -> ()
+    quake.evince %0 : (!cc.sequence<i64>) -> ()
     return
   }
   func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.run.entry(%arg0: i64) attributes {no_this} {
@@ -127,7 +127,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel..0x7de5b48
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel..0x7de5b482e030.run(
 // CHECK-SAME:      %[[ARG0:.*]]: i64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [!cc.sequence<i64>]} {
 // CHECK:           %[[VAL_0:.*]] = call @__nvqpp__mlirgen__kernel..0x7de5b482e030.ruined(%[[ARG0]]) : (i64) -> !cc.sequence<i64>
-// CHECK:           quake.log_output %[[VAL_0]] : (!cc.sequence<i64>) -> ()
+// CHECK:           quake.evince %[[VAL_0]] : (!cc.sequence<i64>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/scoped_qalloc.qke
+++ b/cudaq/test/Transforms/scoped_qalloc.qke
@@ -45,7 +45,7 @@ module {
     }
     %3 = arith.addi %0, %1 : i64
     %4 = arith.addi %3, %2 : i64
-    quake.log_output %4 : (i64) -> ()
+    quake.evince %4 : (i64) -> ()
     return
   }
 }

--- a/cudaq/test/Transforms/sroa.qke
+++ b/cudaq/test/Transforms/sroa.qke
@@ -28,7 +28,7 @@ func.func @sroa_regression_1() {
   %7 = cc.compute_ptr %4[2] : (!cc.ptr<!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>>) -> !cc.ptr<f64>
   cc.store %cst, %7 : !cc.ptr<f64>
   %8 = cc.load %4 : !cc.ptr<!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>>
-  quake.log_output %8 : (!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>) -> ()
+  quake.evince %8 : (!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>) -> ()
   return
 }
 
@@ -49,7 +49,7 @@ func.func @sroa_regression_1() {
 // CHECK:           %[[VAL_13:.*]] = cc.insert_value %[[VAL_11]][1], %[[VAL_12]] : (!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>, i64) -> !cc.struct<"MyTuple" {i1, i64, f64} [192,8]>
 // CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_8]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_15:.*]] = cc.insert_value %[[VAL_13]][2], %[[VAL_14]] : (!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>, f64) -> !cc.struct<"MyTuple" {i1, i64, f64} [192,8]>
-// CHECK:           quake.log_output %[[VAL_15]] : (!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>) -> ()
+// CHECK:           quake.evince %[[VAL_15]] : (!cc.struct<"MyTuple" {i1, i64, f64} [192,8]>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/cudaq/test/Transforms/veq0_canonicalize.qke
+++ b/cudaq/test/Transforms/veq0_canonicalize.qke
@@ -153,23 +153,23 @@ func.func @get_member_empty_veq(%s: !quake.struq<!quake.veq<0>, !quake.ref>) -> 
 
 // An empty veq has no observable qubit, so it contributes nothing to what's
 // being logged and is dropped from the IR. We can't observe nothing.
-func.func @log_output_drop_empty_veq_arg(%r: !quake.ref, %e: !quake.veq<0>) {
-  quake.log_output %r, %e : (!quake.ref, !quake.veq<0>) -> ()
+func.func @evince_drop_empty_veq_arg(%r: !quake.ref, %e: !quake.veq<0>) {
+  quake.evince %r, %e : (!quake.ref, !quake.veq<0>) -> ()
   return
 }
 
-// CHECK-LABEL: func.func @log_output_drop_empty_veq_arg(
+// CHECK-LABEL: func.func @evince_drop_empty_veq_arg(
 // CHECK-SAME:    %[[R:[a-zA-Z0-9_.$-]+]]: !quake.ref
-// CHECK:         quake.log_output %[[R]] : (!quake.ref) -> ()
+// CHECK:         quake.evince %[[R]] : (!quake.ref) -> ()
 
-func.func @log_output_erase_all_empty_veq_args(%e0: !quake.veq<0>,
+func.func @evince_erase_all_empty_veq_args(%e0: !quake.veq<0>,
                                                %e1: !quake.veq<0>) {
-  quake.log_output %e0, %e1 : (!quake.veq<0>, !quake.veq<0>) -> ()
+  quake.evince %e0, %e1 : (!quake.veq<0>, !quake.veq<0>) -> ()
   return
 }
 
-// CHECK-LABEL: func.func @log_output_erase_all_empty_veq_args(
-// CHECK-NOT:     quake.log_output
+// CHECK-LABEL: func.func @evince_erase_all_empty_veq_args(
+// CHECK-NOT:     quake.evince
 // CHECK:         return
 
 // There are no qubits to free in an empty veq, so the dealloc is dead.

--- a/python/tests/mlir/bug_1777.py
+++ b/python/tests/mlir/bug_1777.py
@@ -66,7 +66,7 @@ def test_bug_1777():
 # CHECK:           } else {
 # CHECK:             cc.continue %[[UNDEF_0]] : !cc.sequence<!cc.measure_handle>
 # CHECK:           }
-# CHECK:           quake.log_output %[[ALLOCA_0]] : (!quake.veq<2>) -> ()
+# CHECK:           quake.evince %[[ALLOCA_0]] : (!quake.veq<2>) -> ()
 # CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<2>
 # CHECK:           return
 # CHECK:         }

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -39,9 +39,10 @@ constexpr const char *decoderConfigJobJsonPath = "/decoder_config";
 std::string rewriteLegacySpellings(std::string ir) {
   // Renamed the legacy `!cc.stdvec` type to `!cc.sequence`.
   ir = std::regex_replace(ir, std::regex(R"(cc\.sequence)"), "cc.stdvec");
-  // Moved output logging from `cc.log_output` to `quake.log_output`.
+  // Moved output logging from `cc.log_output` to `quake.evince` (renamed
+  // from `quake.log_output`).
   ir = std::regex_replace(
-      ir, std::regex(R"(quake\.log_output ([^\n]+) : \(([^\n]*)\) -> \(\))"),
+      ir, std::regex(R"(quake\.evince ([^\n]+) : \(([^\n]*)\) -> \(\))"),
       "cc.log_output $1 : $2");
   return ir;
 }

--- a/unittests/nvqpp/backends/quantum_machines/QuantumMachinesTester.cpp
+++ b/unittests/nvqpp/backends/quantum_machines/QuantumMachinesTester.cpp
@@ -67,7 +67,7 @@ CUDAQ_TEST(QuantumMachinesTester, gates) {
 namespace {
 constexpr std::string_view currentQuakeIR = R"mlir(module {
   func.func @kernel(%arg0: !cc.sequence<i64>) {
-    quake.log_output %arg0 : (!cc.sequence<i64>) -> ()
+    quake.evince %arg0 : (!cc.sequence<i64>) -> ()
     return
   }
 })mlir";
@@ -98,7 +98,7 @@ CUDAQ_TEST(QuantumMachinesTester, rewritesLegacySpellings) {
   EXPECT_NE(submittedIR.find("cc.log_output %arg0 : !cc.stdvec<i64>"),
             std::string::npos);
   EXPECT_EQ(submittedIR.find("cc.sequence"), std::string::npos);
-  EXPECT_EQ(submittedIR.find("quake.log_output"), std::string::npos);
+  EXPECT_EQ(submittedIR.find("quake.evince"), std::string::npos);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
It the compiler, we distinguish between output and return values. The exact meaning of "output" has steadily become more abstract and really tracks more closely to observability in the computer science sense at this point.

This change is a rename to remove the "output logging" terminology, which confused people, and replace it with evincive/evince. (Observe is already a term used in CUDA-Q for something else completely.)

evince: to make an internal state visible to the outside.

This is more precisely the semantics of this operation.