### PR TITLE
[python] Reject kernels whose only return is inside a dynamic-bound loop

### DIFF
--- a/python/cudaq/kernel/analysis.py
+++ b/python/cudaq/kernel/analysis.py
@@ -188,8 +188,97 @@ class ValidateReturnStatements(ast.NodeVisitor):
         if node.returns is None or is_none_ret:
             return self.generic_visit(node)
 
+        def literal_int(node, known):
+            if isinstance(node, ast.Constant) and isinstance(
+                    node.value, int) and not isinstance(node.value, bool):
+                return node.value
+            if isinstance(node, ast.UnaryOp) and isinstance(
+                    node.op, ast.USub):
+                v = literal_int(node.operand, known)
+                return None if v is None else -v
+            if isinstance(node, ast.Name):
+                return known.get(node.id)
+            return None
+
+        compare_ops = {
+            ast.Lt: lambda a, b: a < b,
+            ast.LtE: lambda a, b: a <= b,
+            ast.Gt: lambda a, b: a > b,
+            ast.GtE: lambda a, b: a >= b,
+            ast.Eq: lambda a, b: a == b,
+            ast.NotEq: lambda a, b: a != b,
+        }
+
+        def while_test_is_statically_true(test, known):
+            if isinstance(test, ast.Constant):
+                return bool(test.value)
+            if isinstance(test, ast.Compare) and len(test.ops) == 1 and len(
+                    test.comparators) == 1 and type(
+                        test.ops[0]) in compare_ops:
+                left = literal_int(test.left, known)
+                right = literal_int(test.comparators[0], known)
+                if left is None or right is None:
+                    return False
+                return compare_ops[type(test.ops[0])](left, right)
+            return False
+
+        def loop_provably_runs(stmt, known):
+            """A `for`/`while` loop's `orelse` always runs when the loop
+            finishes without `break`, including zero iterations, so it needs
+            no special handling. The body is only trustworthy for "all paths
+            return" when the loop is statically guaranteed to execute at
+            least once -- otherwise control can fall through the loop
+            without ever taking it, reaching the end of the function with no
+            return and no error.
+
+            This check is intentionally narrow. It only tightens the two
+            shapes that can be proven unsound from the syntax alone: a
+            `while` whose condition is not a statically-true comparison, and
+            a `for` over `range(...)` whose bound is not a compile-time
+            constant. Iteration over any other iterable (a plain variable, a
+            list literal, `enumerate(...)`, a qvector, ...) keeps the
+            pre-existing lenient treatment, since it is a compile-time
+            unknown either way and this file's own test suite relies on
+            that leniency for unrelated reasons in exactly that case.
+            """
+            if isinstance(stmt, ast.While):
+                return while_test_is_statically_true(stmt.test, known)
+            it = stmt.iter
+            if not (isinstance(it, ast.Call) and
+                    isinstance(it.func, ast.Name) and
+                    it.func.id == 'range' and 1 <= len(it.args) <= 3):
+                return True
+            bounds = [literal_int(a, known) for a in it.args]
+            if any(b is None for b in bounds):
+                return False
+            if len(bounds) == 1:
+                start, stop, step = 0, bounds[0], 1
+            elif len(bounds) == 2:
+                start, stop, step = bounds[0], bounds[1], 1
+            else:
+                start, stop, step = bounds
+            if step == 0:
+                return False
+            span = stop - start
+            return span > 0 if step > 0 else span < 0
+
         def all_paths_return(stmts):
+            # Tracks variables assigned a compile-time-constant int earlier in
+            # this same statement list, so a following `while <var> <op>
+            # <literal>:` can be recognized as provably entered -- the
+            # established idiom throughout this file's own test suite (e.g.
+            # `i = 0` then `while i < 6:`).
+            known_ints = {}
             for stmt in stmts:
+                if isinstance(stmt, ast.Assign) and len(
+                        stmt.targets) == 1 and isinstance(
+                            stmt.targets[0], ast.Name):
+                    v = literal_int(stmt.value, known_ints)
+                    if v is None:
+                        known_ints.pop(stmt.targets[0].id, None)
+                    else:
+                        known_ints[stmt.targets[0].id] = v
+
                 if isinstance(stmt, ast.Return):
                     return True
 
@@ -199,8 +288,9 @@ class ValidateReturnStatements(ast.NodeVisitor):
                         return True
 
                 if isinstance(stmt, (ast.For, ast.While)):
-                    if all_paths_return(stmt.body) or all_paths_return(
-                            stmt.orelse):
+                    if (loop_provably_runs(stmt, known_ints) and
+                            all_paths_return(stmt.body)) or all_paths_return(
+                                stmt.orelse):
                         return True
 
             return False

--- a/python/tests/kernel/test_run_kernel.py
+++ b/python/tests/kernel/test_run_kernel.py
@@ -1600,6 +1600,54 @@ def test_return_from_outside_the_for_loop():
     assert results[0] == 0
 
 
+def test_return_only_inside_for_loop_over_dynamic_range_is_rejected():
+    # A `for` loop whose trip count is a runtime value may execute zero
+    # times, so a return statement that only exists inside its body does not
+    # guarantee the function returns. Compiling this must raise the same
+    # error as any other missing-return kernel, not silently accept it and
+    # read the return slot uninitialized when the loop is skipped.
+    with pytest.raises(RuntimeError) as e:
+
+        @cudaq.kernel
+        def kernel(n: int) -> int:
+            for i in range(n):
+                return 5
+
+        kernel.compile()
+    assert 'cudaq.kernel functions with return type annotations must have a return statement.' in str(
+        e.value)
+
+
+def test_return_only_inside_while_loop_over_dynamic_condition_is_rejected():
+    with pytest.raises(RuntimeError) as e:
+
+        @cudaq.kernel
+        def kernel(n: int) -> int:
+            i = 0
+            while i < n:
+                return 5
+                i = i + 1
+
+        kernel.compile()
+    assert 'cudaq.kernel functions with return type annotations must have a return statement.' in str(
+        e.value)
+
+
+def test_return_inside_for_loop_over_statically_nonzero_range_is_allowed():
+    # A literal, statically non-empty `range(...)` is provably entered at
+    # least once, so a return inside its body does guarantee the function
+    # returns -- this must keep compiling as before.
+
+    @cudaq.kernel
+    def kernel() -> int:
+        for i in range(6):
+            return 3
+
+    results = cudaq.run(kernel, shots_count=1)
+    assert len(results) == 1
+    assert results[0] == 3
+
+
 def test_return_with_true_condition_with_variable_defined_outside_the_loop():
 
     @cudaq.kernel


### PR DESCRIPTION
Fixes #5369

### Bug

`ValidateReturnStatements.all_paths_return` (`python/cudaq/kernel/analysis.py:191-206`) treats a
`for`/`while` loop as guaranteeing a return whenever its body alone always returns, regardless of
whether the loop ever executes:

```python
if isinstance(stmt, (ast.For, ast.While)):
    if all_paths_return(stmt.body) or all_paths_return(
            stmt.orelse):
        return True
```

For a loop with a runtime-dependent trip count (`for i in range(n):`, `while i < n:`), this is
unsound: a zero-trip loop falls through with no return statement having run, and
`cudaq.kernel functions with return type annotations must have a return statement.` never fires.
The kernel compiles and the backend's `cc.UndefOp` fallback silently manufactures the returned
value instead of erroring. The sibling `ast.If` check just above requires **both** branches to
return (`and`); this is the same soundness rule, just not applied to loops.

### Fix

Only tighten the two shapes that are provably unsound from the syntax alone: a `while` whose
condition is not a statically-true comparison, and a `for` over `range(...)` whose bound is not a
compile-time constant with a non-empty span. Any other iterable (a plain variable, a list literal,
a qvector, ...) keeps the existing lenient treatment, since it is a compile-time unknown either way
and this file's own test suite already relies on that leniency for unrelated reasons in exactly
that case. The pre-existing `while <var> <op> <literal>:` idiom used throughout this file's own
tests (`i = 0` then `while i < 6:`) is preserved by tracking compile-time-constant integer
variables assigned earlier in the same statement list.

### Verification

Not a regression from a deliberate choice: introduced with the validator itself in `cb16d1e59`
(#3148, "Handling return from loop variations in a kernel") with no comment addressing the
`and`/`or` asymmetry with the `If` case just above — confirmed via `git log -S`. Unchanged since:
`git log <wheel-sha>..main -- python/cudaq/kernel/analysis.py` is empty, and the file is
byte-identical between the 0.15.1 wheel and current `main`.

Negative control, both directions, run directly against the installed wheel (this box has no
local LLVM/MLIR build; `analysis.py` is pure Python with no compiled-extension dependency, so
this file is not subject to that limitation — the worktree's file was copied into the wheel's
`site-packages` before each run):

```
without the fix: 2 failed
  test_return_only_inside_for_loop_over_dynamic_range_is_rejected: Failed: DID NOT RAISE RuntimeError
  test_return_only_inside_while_loop_over_dynamic_condition_is_rejected: Failed: DID NOT RAISE RuntimeError
with the fix:     3 passed
```

Also ran the full existing `test_run_kernel.py` suite with the fix applied: 80 passed, 4 skipped,
no regressions — including every `test_return_from_*`/`test_return_with_*` case that already
exercises this validator (54 tests), specifically
`test_return_from_if_and_else_loop_with_true_condition_in_for_loop` and
`..._in_while_loop`, whose `range(6)` / `i = 0; while i < 6:` bodies are exactly the shapes this
fix must keep accepting.

Small diff; touches only the loop-soundness branch of one validator and adds three regression
tests.

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
