### PR TITLE
[core] Deprecate quake.call_by_ref op

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -713,8 +713,15 @@ def quake_WrapNewOp : QuakeOp<"wrap_new"> {
 
 def quake_CallByRefOp : QuakeOp<"call_by_ref",
     [CallOpInterface, SymbolUserOpInterface, QuantumSideEffects]> {
-  let summary = "Call a kernel casting wires to refs.";
+  let summary = "[Deprecated] Call a kernel casting wires to refs.";
   let description = [{
+    DEPRECATED: `quake.apply` (a plain, unpredicated, uncontrolled apply) now
+    subsumes this op's capability -- coercing wire/cable actuals to a callee's
+    reference-typed formals and threading the results back. Nothing in the
+    compiler still produces `call_by_ref`; it is retained only so that
+    hand-written or previously-serialized IR using it continues to parse and
+    lower. Do not emit new `call_by_ref` ops; use `quake.apply` instead.
+
     This operation performs a wrap operation on the wire arguments, calls the
     kernel argument, and unwraps the reference arguments back to wires in a
     macro step.

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -1663,14 +1663,10 @@ struct ApplyOpTrap : public OpConversionPattern<cudaq::quake::ApplyOp> {
   matchAndRewrite(cudaq::quake::ApplyOp apply, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // A plain (unpredicated, uncontrolled) apply with a direct callee is a
-    // vanilla call: e.g. `cable-rough-in` emits these to bridge wire/cable
-    // actuals to a reference-semantics callee, deliberately leaving them for
-    // apply-op-specialization's earlier pipeline pass to miss (that pass
-    // already ran before cable-rough-in), so they survive to this point.
-    // Lower it straight to a `func.call`, forwarding the (by now uniformly
-    // QIR-typed) quantum arguments to the results -- exactly like
-    // CallByRefOpRewrite below, since reference and value semantics are no
-    // longer distinguishable once quantum types have been converted to QIR.
+    // vanilla call. Lower them straight to a `func.call`, forwarding the
+    // quantum arguments to the results, exactly like CallByRefOpRewrite
+    // below, since reference and value semantics are no longer distinguishable
+    // once quantum types have been converted to QIR.
     if (!apply.getIsAdj() && apply.getControls().empty()) {
       if (auto callee = apply.getCallee()) {
         auto fn =
@@ -1746,9 +1742,8 @@ struct CustomUnitaryCallOpTrap
 };
 
 // quake.call_by_ref is deprecated: a plain quake.apply now subsumes its
-// capability (see the fast path in ApplyOpTrap above), and nothing in the
-// compiler still emits call_by_ref. This lowering is kept only so that
-// hand-written or previously-serialized IR using it continues to work.
+// capability. This lowering is kept only so that hand-written or previously
+// serialized IR using it continues to work.
 struct CallByRefOpRewrite
     : public OpConversionPattern<cudaq::quake::CallByRefOp> {
   using OpConversionPattern::OpConversionPattern;

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -1662,6 +1662,37 @@ struct ApplyOpTrap : public OpConversionPattern<cudaq::quake::ApplyOp> {
   LogicalResult
   matchAndRewrite(cudaq::quake::ApplyOp apply, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // A plain (unpredicated, uncontrolled) apply with a direct callee is a
+    // vanilla call: e.g. `cable-rough-in` emits these to bridge wire/cable
+    // actuals to a reference-semantics callee, deliberately leaving them for
+    // apply-op-specialization's earlier pipeline pass to miss (that pass
+    // already ran before cable-rough-in), so they survive to this point.
+    // Lower it straight to a `func.call`, forwarding the (by now uniformly
+    // QIR-typed) quantum arguments to the results -- exactly like
+    // CallByRefOpRewrite below, since reference and value semantics are no
+    // longer distinguishable once quantum types have been converted to QIR.
+    if (!apply.getIsAdj() && apply.getControls().empty()) {
+      if (auto callee = apply.getCallee()) {
+        auto fn =
+            SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(apply, *callee);
+        if (fn) {
+          auto loc = apply.getLoc();
+          SmallVector<Value> quantumArgs;
+          for (auto [valarg, qirarg] :
+               llvm::zip(apply.getActuals(), adaptor.getActuals()))
+            if (cudaq::quake::isQuantumValueType(valarg.getType()))
+              quantumArgs.push_back(qirarg);
+          auto call = func::CallOp::create(
+              rewriter, loc, callee->getRootReference().getValue(),
+              fn.getFunctionType().getResults(), adaptor.getActuals());
+          SmallVector<Value> results{call.getResults().begin(),
+                                     call.getResults().end()};
+          results.append(quantumArgs.begin(), quantumArgs.end());
+          rewriter.replaceOp(apply, results);
+          return success();
+        }
+      }
+    }
     if (auto callee = apply.getCallee())
       apply.emitWarning("could not generate the specialized form of kernel '")
           << callee->getRootReference().getValue()
@@ -1714,6 +1745,10 @@ struct CustomUnitaryCallOpTrap
   mutable llvm::SmallDenseSet<StringAttr> reported;
 };
 
+// quake.call_by_ref is deprecated: a plain quake.apply now subsumes its
+// capability (see the fast path in ApplyOpTrap above), and nothing in the
+// compiler still emits call_by_ref. This lowering is kept only so that
+// hand-written or previously-serialized IR using it continues to work.
 struct CallByRefOpRewrite
     : public OpConversionPattern<cudaq::quake::CallByRefOp> {
   using OpConversionPattern::OpConversionPattern;

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -1663,29 +1663,62 @@ struct ApplyOpTrap : public OpConversionPattern<cudaq::quake::ApplyOp> {
   matchAndRewrite(cudaq::quake::ApplyOp apply, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // A plain (unpredicated, uncontrolled) apply with a direct callee is a
-    // vanilla call. Lower them straight to a `func.call`, forwarding the
-    // quantum arguments to the results, exactly like CallByRefOpRewrite
-    // below, since reference and value semantics are no longer distinguishable
-    // once quantum types have been converted to QIR.
+    // vanilla call. Lower it straight to a `func.call`. In the normal
+    // pipeline apply-op-specialization eliminates these before they ever
+    // reach codegen; this handles one that reaches here unresolved anyway
+    // (e.g. a forward-declared callee, or cudaq-opt invoked directly without
+    // that pass, as in a `--convert-to-qir-api`-only run).
     if (!apply.getIsAdj() && apply.getControls().empty()) {
       if (auto callee = apply.getCallee()) {
         auto fn =
             SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(apply, *callee);
         if (fn) {
-          auto loc = apply.getLoc();
           SmallVector<Value> quantumArgs;
           for (auto [valarg, qirarg] :
                llvm::zip(apply.getActuals(), adaptor.getActuals()))
             if (cudaq::quake::isQuantumValueType(valarg.getType()))
               quantumArgs.push_back(qirarg);
-          auto call = func::CallOp::create(
-              rewriter, loc, callee->getRootReference().getValue(),
-              fn.getFunctionType().getResults(), adaptor.getActuals());
-          SmallVector<Value> results{call.getResults().begin(),
-                                     call.getResults().end()};
-          results.append(quantumArgs.begin(), quantumArgs.end());
-          rewriter.replaceOp(apply, results);
-          return success();
+          // `fn`'s formal types can't tell us which actuals were coerced
+          // (wire/cable actual -> ref/veq formal) versus passed straight
+          // through to an already-linear formal: by this point
+          // FuncSignaturePattern may already have converted both shapes to
+          // the same QIR type. Distinguish the two provably-sound shapes
+          // from apply's own result arity instead (quake.apply's verifier
+          // guarantees exactly one appended result per coerced actual, in
+          // order, and none otherwise):
+          unsigned formalResultCount = fn.getFunctionType().getResults().size();
+          unsigned appliedResultCount = apply.getResultTypes().size();
+          auto loc = apply.getLoc();
+          if (appliedResultCount == formalResultCount) {
+            // No actual was coerced: every quantum-value actual already
+            // matched an already-linear formal, so the callee's own
+            // results (which already carry the threaded-through
+            // wires/cables) replace apply's results directly.
+            auto call = func::CallOp::create(
+                rewriter, loc, callee->getRootReference().getValue(),
+                fn.getFunctionType().getResults(), adaptor.getActuals());
+            rewriter.replaceOp(apply, call.getResults());
+            return success();
+          }
+          if (appliedResultCount == formalResultCount + quantumArgs.size()) {
+            // Every quantum-value actual was coerced to a reference-typed
+            // formal (the cable-rough-in shape): each gets an appended
+            // result recovering the same value passed in, exactly like
+            // CallByRefOpRewrite below, since a ref-taking callee mutates
+            // in place rather than returning a new handle.
+            auto call = func::CallOp::create(
+                rewriter, loc, callee->getRootReference().getValue(),
+                fn.getFunctionType().getResults(), adaptor.getActuals());
+            SmallVector<Value> results{call.getResults().begin(),
+                                       call.getResults().end()};
+            results.append(quantumArgs.begin(), quantumArgs.end());
+            rewriter.replaceOp(apply, results);
+            return success();
+          }
+          // A mix of coerced and passthrough quantum-value actuals: which
+          // ones were coerced can't be recovered here. Fall through to the
+          // trap below rather than construct a replacement with the wrong
+          // arity or the wrong values.
         }
       }
     }

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -399,11 +399,19 @@ LogicalResult cudaq::quake::ApplyOp::verify() {
         isa<cudaq::quake::RefType>(formal))
       return true;
     // (c) cable<N> → veq<N> or unsized veq<?>
-    if (isa<cudaq::quake::CableType>(actual))
+    if (isa<cudaq::quake::CableType>(actual)) {
       if (auto veqFormal = dyn_cast<cudaq::quake::VeqType>(formal))
         return !veqFormal.hasSpecifiedSize() ||
                cudaq::quake::getWireCount(actual) ==
                    cudaq::quake::getAllocationSize(formal);
+      // (d) cable<N> → struq, provided the struq's constant member sizes sum
+      // to N. Like (c), the individual wires making up the cable become the
+      // wrapped refs threaded into the struq's ref/veq members.
+      if (isa<cudaq::quake::StruqType>(formal))
+        return cudaq::quake::isConstantQuantumRefType(formal) &&
+               cudaq::quake::getWireCount(actual) ==
+                   cudaq::quake::getAllocationSize(formal);
+    }
     return false;
   };
 

--- a/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -891,6 +891,37 @@ struct ApplyOpPattern : public OpRewritePattern<cudaq::quake::ApplyOp> {
                                                      unsizedVeqTy, veqVal);
         linearActuals.push_back({static_cast<unsigned>(idx), veqVal, n});
         arg = veqVal;
+      } else if (auto cableTy = dyn_cast<cudaq::quake::CableType>(v.getType());
+                 cableTy && isa<cudaq::quake::StruqType>(toTy)) {
+        // cable<N> actual → struq formal: coercion required.
+        //   split_cable → wrap_new each wire → group per member (ref used
+        //   directly, veq member built via concat) → make_struq.
+        auto struqTy = cast<cudaq::quake::StruqType>(toTy);
+        unsigned n = cudaq::quake::getWireCount(v.getType());
+        SmallVector<Type> wireTys(n, wireTy);
+        auto split =
+            cudaq::quake::SplitCableOp::create(rewriter, loc, wireTys, v);
+        SmallVector<Value> memberVals;
+        unsigned wireIdx = 0;
+        for (Type memberTy : struqTy.getMembers()) {
+          if (isa<cudaq::quake::RefType>(memberTy)) {
+            memberVals.push_back(cudaq::quake::WrapNewOp::create(
+                rewriter, loc, refTy, split.getResult(wireIdx++)));
+            continue;
+          }
+          auto veqMemberTy = cast<cudaq::quake::VeqType>(memberTy);
+          unsigned memberSize = veqMemberTy.getSize();
+          SmallVector<Value> memberRefs;
+          for (unsigned i = 0; i < memberSize; ++i)
+            memberRefs.push_back(cudaq::quake::WrapNewOp::create(
+                rewriter, loc, refTy, split.getResult(wireIdx++)));
+          memberVals.push_back(cudaq::quake::ConcatOp::create(
+              rewriter, loc, veqMemberTy, memberRefs));
+        }
+        Value struqVal = cudaq::quake::MakeStruqOp::create(rewriter, loc,
+                                                           struqTy, memberVals);
+        linearActuals.push_back({static_cast<unsigned>(idx), struqVal, n});
+        arg = struqVal;
         // wire→wire or cable→cable: formal already accepts the linear type,
         // no coercion or extra result needed - pass through unchanged.
       } else if (toTy == unsizedVeqTy && arg.getType() != toTy) {
@@ -1004,11 +1035,13 @@ struct ApplyOpPattern : public OpRewritePattern<cudaq::quake::ApplyOp> {
     // left-to-right order the apply op appended them to its result list.
     SmallVector<Value> recoveredLinear;
     for (auto &info : linearActuals) {
-      if (info.numWires == 1) {
+      if (isa<cudaq::quake::RefType>(info.refOrVeq.getType())) {
         // ref → wire via unwrap.
         recoveredLinear.push_back(cudaq::quake::UnwrapOp::create(
             rewriter, loc, wireTy, info.refOrVeq));
-      } else {
+        continue;
+      }
+      if (isa<cudaq::quake::VeqType>(info.refOrVeq.getType())) {
         // veq → individual refs → unwrap each → bundle_cable.
         unsigned n = info.numWires;
         // Recover the sized veq in case we had relaxed to unsized.
@@ -1027,7 +1060,32 @@ struct ApplyOpPattern : public OpRewritePattern<cudaq::quake::ApplyOp> {
         auto cableTy = cudaq::quake::CableType::get(ctx, n);
         recoveredLinear.push_back(cudaq::quake::BundleCableOp::create(
             rewriter, loc, cableTy, extractedWires));
+        continue;
       }
+      // struq → per-member refs (ref used directly, veq member indexed via
+      // extract_ref) → unwrap each → bundle_cable, in member order.
+      auto struqTy = cast<cudaq::quake::StruqType>(info.refOrVeq.getType());
+      SmallVector<Value> extractedWires;
+      for (auto [memberIdx, memberTy] : llvm::enumerate(struqTy.getMembers())) {
+        Value member = cudaq::quake::GetMemberOp::create(
+            rewriter, loc, memberTy, info.refOrVeq,
+            static_cast<uint32_t>(memberIdx));
+        if (isa<cudaq::quake::RefType>(memberTy)) {
+          extractedWires.push_back(
+              cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, member));
+          continue;
+        }
+        auto veqMemberTy = cast<cudaq::quake::VeqType>(memberTy);
+        for (unsigned i = 0, msize = veqMemberTy.getSize(); i < msize; ++i) {
+          Value ref =
+              cudaq::quake::ExtractRefOp::create(rewriter, loc, member, i);
+          extractedWires.push_back(
+              cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, ref));
+        }
+      }
+      auto cableTy = cudaq::quake::CableType::get(ctx, info.numWires);
+      recoveredLinear.push_back(cudaq::quake::BundleCableOp::create(
+          rewriter, loc, cableTy, extractedWires));
     }
 
     // Recover wire controls: unwrap each wrapped-ref back to its wire.

--- a/cudaq/lib/Optimizer/Transforms/CableRoughIn.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CableRoughIn.cpp
@@ -24,7 +24,7 @@ namespace cudaq::opt {
 using namespace mlir;
 
 // Convert the quake.concat and func.call pattern into a quake.bundle_cable and
-// quake.call_by_ref pattern.
+// quake.apply pattern.
 //
 //   %2 = quake.concat %0, %1 : (!quake.ref, !quake.ref) -> !quake.veq<2>
 //   %3 = quake.relax_size %2 : (!quake.veq<2>) -> !quake.veq<?>
@@ -36,12 +36,18 @@ using namespace mlir;
 //   %b = quake.unwrap %1 : (!quake.ref) -> !quake.wire
 //   %c = quake.bundle_cable %a, %b : (!quake.wire, !quake.wire) ->
 //                                     !quake.cable<2>
-//   %d = quake.call_by_ref @callee(%c, %cst) : (!quake.cable<2>, f32) ->
-//                                               !quake.cable<2>
+//   %d = quake.apply @callee(%c, %cst) : (!quake.cable<2>, f32) ->
+//                                        !quake.cable<2>
 //   %e, %f = quake.split_cable %d : (!quake.cable<2>) ->
 //                                    (!quake.wire, !quake.wire)
 //   quake.wrap %e to %0 : !quake.wire, !quake.ref  // [%0/%4]
 //   quake.wrap %f to %1 : !quake.wire, !quake.ref  // [%1/%5]
+//
+// The `quake.apply` op emitted here is a plain, unpredicated call (no adj, no
+// controls), so `apply-op-specialization` resolves it straight to a direct
+// call of the original callee -- a subsequent run of that pass (scheduled
+// right after this one) is required to eliminate it before it reaches
+// codegen.
 //
 
 namespace {
@@ -156,14 +162,14 @@ public:
       newArgs.push_back(arg);
     }
 
-    // Create a quake.call_by_ref operation.
-    auto callByRef = cudaq::quake::CallByRefOp::create(
-        rewriter, loc, call.getCalleeAttr(), resultTys, newArgs);
+    // Create a quake.apply operation.
+    auto apply = cudaq::quake::ApplyOp::create(rewriter, loc, resultTys,
+                                               call.getCallee(), newArgs);
 
     // Wrap the wires and cables.
     std::size_t i = origCoarity;
-    SmallVector<Value> results{callByRef.getResults().begin(),
-                               callByRef.getResults().end()};
+    SmallVector<Value> results{apply.getResults().begin(),
+                               apply.getResults().end()};
     for (auto arg : call.getOperands()) {
       Type argTy = arg.getType();
       if (argTy == refTy) {
@@ -221,7 +227,7 @@ public:
     }
 
     rewriter.replaceOp(
-        call, callByRef.getResults().drop_back(resultTys.size() - origCoarity));
+        call, apply.getResults().drop_back(resultTys.size() - origCoarity));
     return success();
   }
 };

--- a/cudaq/test/Transforms/apply-9.qke
+++ b/cudaq/test/Transforms/apply-9.qke
@@ -1,0 +1,45 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --apply-op-specialization %s | FileCheck %s
+
+// A cable<N> actual may target a struq formal whose constant member sizes sum
+// to N. The cable's wires are split, wrapped, grouped per member (a ref
+// member takes a single wire; a veq member takes a concat of several), and
+// combined via make_struq. After the call, the struq's members are unwrapped
+// back via get_member (and extract_ref for veq members) and rebundled into a
+// fresh cable, mirroring quake.call_by_ref's struq handling.
+
+func.func @struq_kernel(%s : !quake.struq<!quake.veq<2>, !quake.ref>) {
+  return
+}
+
+func.func @do_struq_apply(%c : !quake.cable<3>) -> !quake.cable<3> {
+  %c1 = quake.apply @struq_kernel(%c) : (!quake.cable<3>) -> !quake.cable<3>
+  return %c1 : !quake.cable<3>
+}
+
+// CHECK-LABEL:   func.func @do_struq_apply(
+// CHECK-SAME:      %[[ARG0:.*]]: !quake.cable<3>) -> !quake.cable<3> {
+// CHECK:           %[[SPLIT_CABLE_0:.*]]:3 = quake.split_cable %[[ARG0]] : (!quake.cable<3>) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[WRAP_NEW_0:.*]] = quake.wrap_new %[[SPLIT_CABLE_0]]#0 : (!quake.wire) -> !quake.ref
+// CHECK:           %[[WRAP_NEW_1:.*]] = quake.wrap_new %[[SPLIT_CABLE_0]]#1 : (!quake.wire) -> !quake.ref
+// CHECK:           %[[CONCAT_0:.*]] = quake.concat %[[WRAP_NEW_0]], %[[WRAP_NEW_1]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
+// CHECK:           %[[WRAP_NEW_2:.*]] = quake.wrap_new %[[SPLIT_CABLE_0]]#2 : (!quake.wire) -> !quake.ref
+// CHECK:           %[[MAKE_STRUQ_0:.*]] = quake.make_struq %[[CONCAT_0]], %[[WRAP_NEW_2]] : (!quake.veq<2>, !quake.ref) -> !quake.struq<!quake.veq<2>, !quake.ref>
+// CHECK:           call @struq_kernel(%[[MAKE_STRUQ_0]]) : (!quake.struq<!quake.veq<2>, !quake.ref>) -> ()
+// CHECK:           %[[GET_MEMBER_0:.*]] = quake.get_member %[[MAKE_STRUQ_0]][0] : (!quake.struq<!quake.veq<2>, !quake.ref>) -> !quake.veq<2>
+// CHECK:           %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[GET_MEMBER_0]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           %[[UNWRAP_0:.*]] = quake.unwrap %[[EXTRACT_REF_0]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[GET_MEMBER_0]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           %[[UNWRAP_1:.*]] = quake.unwrap %[[EXTRACT_REF_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[GET_MEMBER_1:.*]] = quake.get_member %[[MAKE_STRUQ_0]][1] : (!quake.struq<!quake.veq<2>, !quake.ref>) -> !quake.ref
+// CHECK:           %[[UNWRAP_2:.*]] = quake.unwrap %[[GET_MEMBER_1]] : (!quake.ref) -> !quake.wire
+// CHECK:           %[[BUNDLE_CABLE_0:.*]] = quake.bundle_cable %[[UNWRAP_0]], %[[UNWRAP_1]], %[[UNWRAP_2]] : (!quake.wire, !quake.wire, !quake.wire) -> !quake.cable<3>
+// CHECK:           return %[[BUNDLE_CABLE_0]] : !quake.cable<3>
+// CHECK:         }

--- a/cudaq/test/Transforms/apply_qir_vanilla.qke
+++ b/cudaq/test/Transforms/apply_qir_vanilla.qke
@@ -1,0 +1,61 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --convert-to-qir-api='api=full' --split-input-file %s | FileCheck %s
+
+// A plain (unpredicated, uncontrolled) quake.apply that reaches codegen
+// without having been resolved by apply-op-specialization (deliberately not
+// run here) must still lower cleanly to a func.call, without a warning or a
+// trap: ApplyOpTrap's fast path handles this directly. Regression test for
+// an arity-mismatch crash in that fast path when the actual's type already
+// matched the callee's formal (no coercion needed, so no result should be
+// appended).
+
+// Wire actual, wire formal: no coercion. The callee's own result already
+// carries the threaded-through wire, so apply's single result is replaced
+// by the call's single result directly -- no appended result.
+
+func.func private @callee(!quake.wire) -> !quake.wire
+
+func.func @wire_passthrough() {
+  %0 = quake.null_wire
+  %1 = quake.apply @callee (%0) : (!quake.wire) -> !quake.wire
+  quake.sink %1 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @wire_passthrough() {
+// CHECK:           %[[VAL_0:.*]] = call @__quantum__rt__qubit_allocate()
+// CHECK:           %[[VAL_1:.*]] = call @callee(%[[VAL_0]])
+// CHECK:           call @__quantum__rt__qubit_release(%[[VAL_1]])
+// CHECK-NOT:       could not generate the specialized form
+// CHECK:           return
+// CHECK:         }
+
+// -----
+
+// Wire actual, ref formal: coercion. The ref-taking callee has no result of
+// its own, so apply's single result is an appended result recovering the
+// same qubit handle that was passed in.
+
+func.func private @callee2(!quake.ref)
+
+func.func @wire_coerced_to_ref() {
+  %0 = quake.null_wire
+  %1 = quake.apply @callee2 (%0) : (!quake.wire) -> !quake.wire
+  quake.sink %1 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @wire_coerced_to_ref() {
+// CHECK:           %[[VAL_0:.*]] = call @__quantum__rt__qubit_allocate()
+// CHECK:           call @callee2(%[[VAL_0]])
+// CHECK:           call @__quantum__rt__qubit_release(%[[VAL_0]])
+// CHECK-NOT:       could not generate the specialized form
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/Transforms/convert_to_linear_values.qke
+++ b/cudaq/test/Transforms/convert_to_linear_values.qke
@@ -34,7 +34,7 @@ func.func @linear_values(%dynamic : !quake.veq<?>) {
 // SIMPLIFIED-NOT: quake.h
 // LINEAR:         %[[CONTROLLED:.*]]:3 = quake.x [%{{.*}}, %{{.*}}] %{{.*}} : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
 // LINEAR:         %[[CABLE:.*]] = quake.bundle_cable %{{.*}}, %{{.*}} : (!quake.wire, !quake.wire) -> !quake.cable<2>
-// LINEAR:         %[[CALL:.*]] = quake.call_by_ref @callee(%[[CABLE]]) : (!quake.cable<2>) -> !quake.cable<2>
+// LINEAR:         %[[CALL:.*]] = quake.apply @callee (%[[CABLE]]) : (!quake.cable<2>) -> !quake.cable<2>
 // LINEAR:         %[[SPLIT:.*]]:2 = quake.split_cable %[[CALL]] : (!quake.cable<2>) -> (!quake.wire, !quake.wire)
 // LINEAR:         quake.sink %[[SPLIT]]#0 : !quake.wire
 // LINEAR:         quake.sink %[[SPLIT]]#1 : !quake.wire

--- a/cudaq/test/Transforms/invalid.qke
+++ b/cudaq/test/Transforms/invalid.qke
@@ -225,6 +225,23 @@ func.func private @wonk(!quake.veq<18>, i32) -> f64
 
 // -----
 
+// A cable<N> actual is only compatible with a struq formal if N equals the
+// sum of the struq's constant member sizes -- here the struq (veq<2> + ref)
+// wants 3 wires but a cable<4> is supplied.
+
+func.func private @wonk(!quake.struq<!quake.veq<2>, !quake.ref>)
+
+%1 = quake.null_wire
+%2 = quake.null_wire
+%3 = quake.null_wire
+%4 = quake.null_wire
+%5 = quake.bundle_cable %1, %2, %3, %4 :
+    (!quake.wire, !quake.wire, !quake.wire, !quake.wire) -> !quake.cable<4>
+// expected-error@+1 {{argument types must be compatible with callee}}
+%6 = quake.apply @wonk(%5) : (!quake.cable<4>) -> !quake.cable<4>
+
+// -----
+
 // expected-error@+1 {{cannot classically allocate quake abstract type}}
 %0 = cc.alloca !quake.measure
 

--- a/cudaq/test/Transforms/memtoreg-0.qke
+++ b/cudaq/test/Transforms/memtoreg-0.qke
@@ -24,7 +24,7 @@ func.func @test() {
 // CHECK:           %[[VAL_1:.*]] = quake.null_wire
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
 // CHECK:           %[[VAL_3:.*]] = quake.bundle_cable %[[VAL_1]], %[[VAL_2]] : (!quake.wire, !quake.wire) -> !quake.cable<2>
-// CHECK:           %[[VAL_4:.*]] = quake.call_by_ref @callee(%[[VAL_3]], %[[VAL_0]]) : (!quake.cable<2>, f32) -> !quake.cable<2>
+// CHECK:           %[[VAL_4:.*]] = quake.apply @callee (%[[VAL_3]], %[[VAL_0]]) : (!quake.cable<2>, f32) -> !quake.cable<2>
 // CHECK:           %[[VAL_5:.*]]:2 = quake.split_cable %[[VAL_4]] : (!quake.cable<2>) -> (!quake.wire, !quake.wire)
 // CHECK:           quake.sink %[[VAL_5]]#0 : !quake.wire
 // CHECK:           quake.sink %[[VAL_5]]#1 : !quake.wire
@@ -52,7 +52,7 @@ func.func @test_a() {
 // CHECK:           %[[VAL_4:.*]] = quake.null_wire
 // CHECK:           %[[VAL_5:.*]] = quake.bundle_cable %[[VAL_0]], %[[VAL_1]] : (!quake.wire, !quake.wire) -> !quake.cable<2>
 // CHECK:           %[[VAL_6:.*]] = quake.bundle_cable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]] : (!quake.wire, !quake.wire, !quake.wire) -> !quake.cable<3>
-// CHECK:           %[[VAL_7:.*]]:2 = quake.call_by_ref @callee_a(%[[VAL_5]], %[[VAL_6]]) : (!quake.cable<2>, !quake.cable<3>) -> (!quake.cable<2>, !quake.cable<3>)
+// CHECK:           %[[VAL_7:.*]]:2 = quake.apply @callee_a (%[[VAL_5]], %[[VAL_6]]) : (!quake.cable<2>, !quake.cable<3>) -> (!quake.cable<2>, !quake.cable<3>)
 // CHECK:           %[[VAL_8:.*]]:2 = quake.split_cable %[[VAL_7]]#0 : (!quake.cable<2>) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_9:.*]]:3 = quake.split_cable %[[VAL_7]]#1 : (!quake.cable<3>) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           quake.sink %[[VAL_8]]#0 : !quake.wire
@@ -86,7 +86,7 @@ func.func @test_b() {
 // CHECK:           %[[VAL_5:.*]] = quake.null_wire
 // CHECK:           %[[VAL_6:.*]] = quake.bundle_cable %[[VAL_0]], %[[VAL_1]] : (!quake.wire, !quake.wire) -> !quake.cable<2>
 // CHECK:           %[[VAL_7:.*]] = quake.bundle_cable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]] : (!quake.wire, !quake.wire, !quake.wire) -> !quake.cable<3>
-// CHECK:           %[[VAL_8:.*]]:3 = quake.call_by_ref @callee_b(%[[VAL_6]], %[[VAL_5]], %[[VAL_7]]) : (!quake.cable<2>, !quake.wire, !quake.cable<3>) -> (!quake.cable<2>, !quake.wire, !quake.cable<3>)
+// CHECK:           %[[VAL_8:.*]]:3 = quake.apply @callee_b (%[[VAL_6]], %[[VAL_5]], %[[VAL_7]]) : (!quake.cable<2>, !quake.wire, !quake.cable<3>) -> (!quake.cable<2>, !quake.wire, !quake.cable<3>)
 // CHECK:           %[[VAL_9:.*]]:2 = quake.split_cable %[[VAL_8]]#0 : (!quake.cable<2>) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_10:.*]]:3 = quake.split_cable %[[VAL_8]]#2 : (!quake.cable<3>) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           quake.sink %[[VAL_9]]#0 : !quake.wire
@@ -120,7 +120,7 @@ func.func @test_d() {
 // CHECK:           %[[VAL_7:.*]] = quake.null_wire
 // CHECK:           %[[VAL_8:.*]] = quake.bundle_cable %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : (!quake.wire, !quake.wire, !quake.wire) -> !quake.cable<3>
 // CHECK:           %[[VAL_9:.*]] = quake.bundle_cable %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_6]], %[[VAL_7]] : (!quake.wire, !quake.wire, !quake.wire, !quake.wire, !quake.wire) -> !quake.cable<5>
-// CHECK:           %[[VAL_10:.*]]:2 = quake.call_by_ref @callee_d(%[[VAL_8]], %[[VAL_9]]) : (!quake.cable<3>, !quake.cable<5>) -> (!quake.cable<3>, !quake.cable<5>)
+// CHECK:           %[[VAL_10:.*]]:2 = quake.apply @callee_d (%[[VAL_8]], %[[VAL_9]]) : (!quake.cable<3>, !quake.cable<5>) -> (!quake.cable<3>, !quake.cable<5>)
 // CHECK:           %[[VAL_11:.*]]:3 = quake.split_cable %[[VAL_10]]#0 : (!quake.cable<3>) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           %[[VAL_12:.*]]:5 = quake.split_cable %[[VAL_10]]#1 : (!quake.cable<5>) -> (!quake.wire, !quake.wire, !quake.wire, !quake.wire, !quake.wire)
 // CHECK:           quake.sink %[[VAL_12]]#0 : !quake.wire
@@ -145,6 +145,6 @@ func.func @test_e() -> i1 {
 
 // CHECK-LABEL:   func.func @test_e() -> i1 {
 // CHECK:           %[[VAL_0:.*]] = quake.null_wire
-// CHECK:           %[[VAL_1:.*]]:2 = quake.call_by_ref @callee_e(%[[VAL_0]]) : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_1:.*]]:2 = quake.apply @callee_e (%[[VAL_0]]) : (!quake.wire) -> (i1, !quake.wire)
 // CHECK:           return %[[VAL_1]]#0 : i1
 // CHECK:         }

--- a/cudaq/test/Translate/value-1.qke
+++ b/cudaq/test/Translate/value-1.qke
@@ -1,0 +1,35 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --convert-to-qir-api='api=full' %s | FileCheck %s
+
+// A plain (unpredicated, uncontrolled) quake.apply -- the shape cable-rough-in
+// emits to bridge wire/cable actuals to a reference-semantics callee -- lowers
+// directly to a func.call at codegen, the same as quake.call_by_ref, without
+// needing apply-op-specialization to run again: cudaq-translate/nvq++ always
+// run apply-op-specialization once, early in the pipeline, well before
+// cable-rough-in creates these applies, so they must be resolved by the QIR
+// conversion patterns themselves.
+
+func.func private @callee(!quake.veq<?>, f32)
+
+func.func @test() {
+  %0 = quake.null_cable<2>
+  %1 = arith.constant 1.0 : f32
+  %2 = quake.apply @callee (%0, %1) : (!quake.cable<2>, f32) -> !quake.cable<2>
+  quake.sink %2 : !quake.cable<2>
+  return
+}
+
+// CHECK-LABEL:   func.func @test() {
+// CHECK:           %[[SIZE:.*]] = arith.constant 2 : i64
+// CHECK:           %[[ARR:.*]] = call @__quantum__rt__qubit_allocate_array(%[[SIZE]])
+// CHECK:           call @callee(%[[ARR]], %{{.*}})
+// CHECK:           call @__quantum__rt__qubit_release_array(%[[ARR]])
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
quake.apply now subsumes quake.call_by_ref entirely. These changes deprecate call_by_ref to reduce IR clutter and duplication.