### PR TITLE
[subprojects] Move runtime tests out of core subproject

### DIFF
--- a/cudaq/test/ArgumentConversion/test_argument_conversion.cpp
+++ b/cudaq/test/ArgumentConversion/test_argument_conversion.cpp
@@ -1,1 +1,0 @@
-../../../runtime/test/test_argument_conversion.cpp

--- a/cudaq/test/CMakeLists.txt
+++ b/cudaq/test/CMakeLists.txt
@@ -63,11 +63,6 @@ set(CUDAQ_TEST_DEPENDS
     CustomPassPlugin
     FileCheck
     nvq++
-    test_argument_conversion
-    test_compile_target
-    test_compile_target_conditional_feedback_crash
-    test_resource_count_phase
-    test_resource_count_wireset
 )
 
 if (CUDA_FOUND AND CUDAQ_ENABLE_REALTIME AND NOT CUDAQ_DISABLE_CPP_FRONTEND AND

--- a/cudaq/test/CompileTarget/test_compile_target.cpp
+++ b/cudaq/test/CompileTarget/test_compile_target.cpp
@@ -1,1 +1,0 @@
-../../../runtime/test/test_compile_target.cpp

--- a/cudaq/test/CompileTarget/test_compile_target_conditional_feedback_crash.cpp
+++ b/cudaq/test/CompileTarget/test_compile_target_conditional_feedback_crash.cpp
@@ -1,1 +1,0 @@
-../../../runtime/test/test_compile_target_conditional_feedback_crash.cpp

--- a/cudaq/test/ResourceCount/test_resource_count_phase.cpp
+++ b/cudaq/test/ResourceCount/test_resource_count_phase.cpp
@@ -1,1 +1,0 @@
-../../../runtime/test/test_resource_count_phase.cpp

--- a/cudaq/test/ResourceCount/test_resource_count_wireset.cpp
+++ b/cudaq/test/ResourceCount/test_resource_count_wireset.cpp
@@ -1,1 +1,0 @@
-../../../runtime/test/test_resource_count_wireset.cpp

--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -396,7 +396,7 @@ RUN cd /cuda-quantum && source scripts/configure_build.sh && \
     fi && \
     "$LLVM_INSTALL_PREFIX/bin/llvm-lit" -v build/targettests \
         --param cudaq_site_config=build/targettests/lit.site.cfg.py ${filtered} && \
-    filtered=""; \
+    filtered="" && \
     if [ ! -x "$(command -v nvcc)" ]; then \
         # The test is marked correctly as requiring nvcc, but since nvcc
         # is available during the build we need to filter it manually.

--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -364,7 +364,7 @@ RUN if [ ! -x "$(command -v nvidia-smi)" ] || [ -z "$(nvidia-smi | egrep -o "CUD
     # Exclude lit test suites from ctest. They are run individually above/below.
     # FIXME: Tensor unit tests for runtime errors throw a different exception.
     # Issue: https://github.com/NVIDIA/cuda-quantum/issues/2321
-    excludes+=" --exclude-regex ctest-cudaq|ctest-targettests|pycudaq-mlir|Tensor.*Error" && \
+    excludes+=" --exclude-regex ctest-cudaq|ctest-targettests|ctest-runtime|pycudaq-mlir|Tensor.*Error" && \
     ctest --output-on-failure --test-dir build $excludes
 
 ENV PATH="${PATH}:/usr/local/cuda/bin" 
@@ -384,7 +384,7 @@ RUN cd /cuda-quantum && source scripts/configure_build.sh && \
         # The tests is marked correctly as requiring nvcc, but since nvcc
         # is available during the build we need to filter it manually.
         filtered=" --filter-out MixedLanguage/cuda-1"; \
-	filtered+="|AST-Quake/calling_convention|test_argument_conversion"; \
+	filtered+="|AST-Quake/calling_convention"; \
     fi && \
     "$LLVM_INSTALL_PREFIX/bin/llvm-lit" -v build/cudaq/test \
         --param cudaq_site_config=build/cudaq/test/lit.site.cfg.py ${filtered} && \
@@ -395,7 +395,15 @@ RUN cd /cuda-quantum && source scripts/configure_build.sh && \
         filtered+="|TargetConfig/check_compile"; \
     fi && \
     "$LLVM_INSTALL_PREFIX/bin/llvm-lit" -v build/targettests \
-        --param cudaq_site_config=build/targettests/lit.site.cfg.py ${filtered}
+        --param cudaq_site_config=build/targettests/lit.site.cfg.py ${filtered} && \
+    filtered=""; \
+    if [ ! -x "$(command -v nvcc)" ]; then \
+        # The test is marked correctly as requiring nvcc, but since nvcc
+        # is available during the build we need to filter it manually.
+        filtered=" --filter-out argument_conversion"; \
+    fi && \
+    "$LLVM_INSTALL_PREFIX/bin/llvm-lit" -v build/runtime/test \
+        --param cudaq_site_config=build/runtime/test/lit.site.cfg.py ${filtered}
 
 # Export ccache data so CI can extract it for persistence.
 # Tar inside the container to export a single file instead of thousands of

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -1555,7 +1555,7 @@ def test_repeated_builder_launch_no_segfault():
 
     The crash only surfaces when the bit-packed ``std::vector<bool>`` padding is
     nonzero, so run under ``MALLOC_PERTURB_`` (set before the process starts) in
-    a subprocess. See ``runtime/test/test_argument_conversion.cpp`` for the
+    a subprocess. See ``runtime/test/Regress/argument_conversion.cpp`` for the
     unit-level regression.
     """
     script = (

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -11,7 +11,7 @@
 link_directories(${CMAKE_BINARY_DIR}/lib)
 
 function(add_cudaq_hybrid_test TEST_NAME)
-  add_llvm_executable(${TEST_NAME} ${TEST_NAME}.cpp PARTIAL_SOURCES_INTENDED)
+  add_llvm_executable(${TEST_NAME} Regress/${TEST_NAME}.cpp PARTIAL_SOURCES_INTENDED)
 
   target_compile_options(${TEST_NAME} PUBLIC -Wno-type-limits -fexceptions -DCUDAQ_RTTI_DISABLED)
 
@@ -30,9 +30,66 @@ function(add_cudaq_hybrid_test TEST_NAME)
   set_property(TARGET ${TEST_NAME} PROPERTY FOLDER test)
 endfunction()
 
-add_cudaq_hybrid_test(test_argument_conversion)
-add_cudaq_hybrid_test(test_compile_target)
-add_cudaq_hybrid_test(test_compile_target_conditional_feedback_crash)
-add_cudaq_hybrid_test(test_resource_count_phase)
-add_cudaq_hybrid_test(test_resource_count_qubit_indices)
-add_cudaq_hybrid_test(test_resource_count_wireset)
+add_cudaq_hybrid_test(argument_conversion)
+add_cudaq_hybrid_test(compile_target)
+add_cudaq_hybrid_test(compile_target_conditional_feedback_crash)
+add_cudaq_hybrid_test(resource_count_phase)
+add_cudaq_hybrid_test(resource_count_qubit_indices)
+add_cudaq_hybrid_test(resource_count_wireset)
+
+# lit-based regression testing over the hybrid tests above. Each is a
+# self-contained executable invoked directly by its own embedded RUN line
+# (see add_cudaq_hybrid_test). This gives the runtime subsystem its own
+# llvm-lit test area, separate from cudaq/test, so these tests are not
+# piggybacking on the cudaq lit suite for their test infrastructure.
+if (CUDAQ_BUILD_TESTS AND NOT CUDAQ_DISABLE_CPP_FRONTEND)
+  if(NOT TARGET FileCheck)
+    add_executable(FileCheck IMPORTED)
+    set_target_properties(FileCheck PROPERTIES IMPORTED_LOCATION "/usr/local/llvm/bin/FileCheck")
+  endif()
+
+  configure_lit_site_cfg(
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+    MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  )
+
+  set(RUNTIME_TEST_PARAMS
+    cudaq_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py)
+
+  set(RUNTIME_TEST_DEPENDS
+    FileCheck
+    argument_conversion
+    compile_target
+    compile_target_conditional_feedback_crash
+    resource_count_phase
+    resource_count_qubit_indices
+    resource_count_wireset
+  )
+
+  add_custom_target(runtime-test-depends DEPENDS ${RUNTIME_TEST_DEPENDS})
+  set_target_properties(runtime-test-depends PROPERTIES FOLDER "Tests")
+
+  add_lit_testsuite(check-runtime "Running the runtime regression tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    PARAMS ${RUNTIME_TEST_PARAMS}
+    DEPENDS ${RUNTIME_TEST_DEPENDS}
+  )
+  set_target_properties(check-runtime PROPERTIES FOLDER "Tools")
+
+  # Add runtime tests to the ctest suite.
+  add_test(NAME ctest-runtime
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target check-runtime
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  # This test runs llvm-lit internally with parallelism, so have ctest
+  # reserve all processors to prevent concurrent scheduling.
+  include(ProcessorCount)
+  ProcessorCount(NPROC)
+  if(NPROC EQUAL 0)
+    set(NPROC 1)
+  endif()
+  set_tests_properties(ctest-runtime PROPERTIES
+    TIMEOUT 3600
+    PROCESSORS ${NPROC})
+endif()

--- a/runtime/test/Regress/argument_conversion.cpp
+++ b/runtime/test/Regress/argument_conversion.cpp
@@ -9,7 +9,7 @@
 // This test is compiled inside the runtime directory tree. We include it as a
 // regression test and use FileCheck to verify the output.
 
-// RUN: test_argument_conversion | FileCheck %s
+// RUN: argument_conversion | FileCheck %s
 
 #include "common/ArgumentWrapper.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"

--- a/runtime/test/Regress/compile_target.cpp
+++ b/runtime/test/Regress/compile_target.cpp
@@ -9,7 +9,7 @@
 // This test is compiled inside the runtime directory tree. We include it as a
 // regression test and use FileCheck to verify the output.
 
-// RUN: test_compile_target | FileCheck %s
+// RUN: compile_target | FileCheck %s
 
 #include "common/KernelArgs.h"
 #include "cudaq_internal/compiler/CompiledModuleHelper.h"

--- a/runtime/test/Regress/compile_target_conditional_feedback_crash.cpp
+++ b/runtime/test/Regress/compile_target_conditional_feedback_crash.cpp
@@ -11,7 +11,7 @@
 // reliably catchable in this test binary (RTTI disabled), so this runs in its
 // own process and expects a crash.
 
-// RUN: not --crash test_compile_target_conditional_feedback_crash
+// RUN: not --crash compile_target_conditional_feedback_crash
 
 #include "common/KernelArgs.h"
 #include "cudaq_internal/compiler/Compiler.h"

--- a/runtime/test/Regress/resource_count_phase.cpp
+++ b/runtime/test/Regress/resource_count_phase.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: test_resource_count_phase | FileCheck %s
+// RUN: resource_count_phase | FileCheck %s
 
 #include "cudaq_internal/compiler/ResourceCount.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"

--- a/runtime/test/Regress/resource_count_qubit_indices.cpp
+++ b/runtime/test/Regress/resource_count_qubit_indices.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: test_resource_count_qubit_indices | FileCheck %s
+// RUN: resource_count_qubit_indices | FileCheck %s
 
 #include "cudaq_internal/compiler/ResourceCount.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"

--- a/runtime/test/Regress/resource_count_wireset.cpp
+++ b/runtime/test/Regress/resource_count_wireset.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: test_resource_count_wireset | FileCheck %s
+// RUN: resource_count_wireset | FileCheck %s
 
 #include "cudaq_internal/compiler/ResourceCount.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"

--- a/runtime/test/lit.cfg.py
+++ b/runtime/test/lit.cfg.py
@@ -1,0 +1,46 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                        #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import os
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+
+# Configuration file for the 'lit' test runner.
+
+# The name of this test suite.
+config.name = 'RUNTIME'
+
+# The test format to use to interpret tests.
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# Each test under Regress/ is a "hybrid" test: a compiled executable (see
+# add_cudaq_hybrid_test in CMakeLists.txt) whose own RUN line, embedded in a
+# leading comment, invokes itself by name and pipes the output through
+# FileCheck. Only the .cpp source carries that RUN line, so it is the only
+# suffix lit needs to look for.
+config.suffixes = ['.cpp']
+
+llvm_config.use_default_substitutions()
+
+# Exclude non-test files from the test suite.
+local_excludes = ['CMakeLists.txt']
+config.excludes = [exclude for exclude in config.excludes] + local_excludes
+
+# The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# The root path where tests should be run.
+config.test_exec_root = os.path.join(config.runtime_obj_root, 'runtime', 'test')
+
+# Tweak the PATH to include the tools directory so the hybrid test
+# executables built by CMake (and FileCheck/not) can be found.
+llvm_config.with_environment('PATH', config.runtime_tools_dir, append_path=True)
+llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)

--- a/runtime/test/lit.site.cfg.py.in
+++ b/runtime/test/lit.site.cfg.py.in
@@ -1,0 +1,20 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                        #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_BINARY_DIR@")
+config.runtime_obj_root = "@CUDAQ_BINARY_DIR@"
+config.runtime_src_dir = "@CUDAQ_SOURCE_DIR@"
+config.runtime_tools_dir = "@CUDAQ_TOOLS_DIR@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@CUDAQ_SOURCE_DIR@/runtime/test/lit.cfg.py")

--- a/scripts/generate_cc.sh
+++ b/scripts/generate_cc.sh
@@ -98,17 +98,19 @@ if $gen_cpp_coverage; then
 
     # Run tests (C++ Unittests)
     python3 -m pip install -r ${repo_root}/requirements-tests-backend.txt --break-system-packages
-    ctest --output-on-failure --test-dir ${repo_root}/build -E ctest-cudaq -E ctest-targettests
+    ctest --output-on-failure --test-dir ${repo_root}/build -E ctest-cudaq -E ctest-targettests -E ctest-runtime
     ctest_status=$?
     /usr/local/llvm/bin/llvm-lit -v --param cudaq_site_config=${repo_root}/build/cudaq/test/lit.site.cfg.py ${repo_root}/build/cudaq/test
     lit_status=$?
+    /usr/local/llvm/bin/llvm-lit -v --param cudaq_site_config=${repo_root}/build/runtime/test/lit.site.cfg.py ${repo_root}/build/runtime/test
+    runtime_status=$?
     /usr/local/llvm/bin/llvm-lit -v --param cudaq_site_config=${repo_root}/build/targettests/lit.site.cfg.py ${repo_root}/build/targettests
     targ_status=$?
     /usr/local/llvm/bin/llvm-lit -v --param cudaq_site_config=${repo_root}/build/python/tests/mlir/lit.site.cfg.py ${repo_root}/build/python/tests/mlir
     pymlir_status=$?
-    if [ ! $ctest_status -eq 0 ] || [ ! $lit_status -eq 0 ] || [ $targ_status -ne 0 ] || [ $pymlir_status -ne 0 ]; then
+    if [ ! $ctest_status -eq 0 ] || [ ! $lit_status -eq 0 ] || [ $runtime_status -ne 0 ] || [ $targ_status -ne 0 ] || [ $pymlir_status -ne 0 ]; then
         echo "::error C++ tests failed (ctest status $ctest_status, llvm-lit status $lit_status, \
-    target tests status $targ_status, Python MLIR status $pymlir_status)."
+    runtime tests status $runtime_status, target tests status $targ_status, Python MLIR status $pymlir_status)."
         exit 1
     fi
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -106,7 +106,7 @@ fi
 # On machines without a GPU, $gpu_excludes skips gpu_required tests.
 echo "=== Running ctest ==="
 ctest --output-on-failure --test-dir "$build_dir" -j "$num_jobs" \
-  -E "^(ctest-cudaq|ctest-targettests|pycudaq-mlir)$" $gpu_excludes
+  -E "^(ctest-cudaq|ctest-targettests|ctest-runtime|pycudaq-mlir)$" $gpu_excludes
 ctest_status=$?
 if [ $ctest_status -ne 0 ]; then
   echo "::error::ctest failed with status $ctest_status"
@@ -124,7 +124,18 @@ if [ $lit_status -ne 0 ]; then
   status_sum=$((status_sum + 1))
 fi
 
-# 3. Target tests
+# 3. Runtime tests
+echo "=== Running llvm-lit (build/runtime/test) ==="
+"$LLVM_INSTALL_PREFIX/bin/llvm-lit" $verbose --time-tests -j "$parallel_jobs" \
+  --param cudaq_site_config="$build_dir/runtime/test/lit.site.cfg.py" \
+  "$build_dir/runtime/test"
+runtime_status=$?
+if [ $runtime_status -ne 0 ]; then
+  echo "::error::llvm-lit (build/runtime/test) failed with status $runtime_status"
+  status_sum=$((status_sum + 1))
+fi
+
+# 4. Target tests
 echo "=== Running llvm-lit (build/targettests) ==="
 "$LLVM_INSTALL_PREFIX/bin/llvm-lit" $verbose --time-tests -j "$parallel_jobs" \
   --param cudaq_site_config="$build_dir/targettests/lit.site.cfg.py" \
@@ -135,7 +146,7 @@ if [ $targ_status -ne 0 ]; then
   status_sum=$((status_sum + 1))
 fi
 
-# 4. Python MLIR tests
+# 5. Python MLIR tests
 echo "=== Running llvm-lit (python/tests/mlir) ==="
 "$LLVM_INSTALL_PREFIX/bin/llvm-lit" $verbose --time-tests -j "$parallel_jobs" \
   --param cudaq_site_config="$build_dir/python/tests/mlir/lit.site.cfg.py" \
@@ -146,7 +157,7 @@ if [ $pymlir_status -ne 0 ]; then
   status_sum=$((status_sum + 1))
 fi
 
-# 5. Python interop tests
+# 6. Python interop tests
 echo "=== Running pytest (interop tests) ==="
 python3 -m pytest $verbose --durations=0 "$build_dir/python/tests/interop/"
 pytest_status=$?


### PR DESCRIPTION
The runtime llvm-lit tests were co-mingled in the cudaq subproject folders, where they didn't belong. This PR establishes a new testing area for runtime independent from the core subproject. It removes symlinks, sets up build targets, and fixes some tests that were being lost because of the cross-project odd structure that was used.