### PR TITLE
Switch common quake pipeline to classical optimization

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.h
@@ -97,12 +97,15 @@ void registerJITPipelines();
 /// fully expanded to eliminate control flow.
 /// Default values are threshold = 1024, allow break = true, and allow closed
 /// interval = true. If loop unrolling is disabled (`disableLoopUnrolling` =
-/// true), the pipeline keeps cc.loop operations.
+/// true), the pipeline keeps cc.loop operations. The two selective unrolling
+/// options mirror the cc-loop-unroll options of the same name.
 void createClassicalOptimizationPipeline(
     mlir::OpPassManager &pm, std::optional<unsigned> threshold = std::nullopt,
     std::optional<bool> allowBreak = std::nullopt,
     std::optional<bool> allowClosedInterval = std::nullopt,
-    std::optional<bool> disableLoopUnrolling = std::nullopt);
+    std::optional<bool> disableLoopUnrolling = std::nullopt,
+    std::optional<bool> unrollOnlyAliasingQuantumAccessLoops = std::nullopt,
+    std::optional<bool> unrollOnlyIndexUseLoops = std::nullopt);
 
 std::unique_ptr<mlir::Pass> createExpandMeasurementsPass();
 void addLowerToCFG(mlir::OpPassManager &pm);

--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -368,6 +368,14 @@ def ClassicalOptimization : Pass<"classical-optimization"> {
     - lift-array-alloc
     - cc-loop-normalize
     - cc-loop-unroll
+
+    Running these together to a fix point unrolls loops that a fixed sequence
+    of the individual passes cannot, such as one whose trip count is a constant
+    array element indexed by an outer induction variable.
+
+    The two selective unrolling options mirror cc-loop-unroll and are mutually
+    exclusive. Unlike cc-loop-unroll, this pass never reports a loop it could
+    not unroll.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect", "cudaq::cc::CCDialect",
@@ -382,7 +390,17 @@ def ClassicalOptimization : Pass<"classical-optimization"> {
       "Allow unrolling of loop with early exit (i.e. break statement).">,
     Option<"disableLoopUnrolling", "no-loop-unroll", "bool",
       /*default=*/"false",
-      "Disable loop unrolling and preserve cc.loop operations.">
+      "Disable loop unrolling and preserve cc.loop operations.">,
+    Option<"unrollOnlyAliasingQuantumAccessLoops",
+      "unroll-only-aliasing-quantum-access-loops", "bool",
+      /*default=*/"false",
+      "Unroll only loops containing aliasing quantum accesses or exp_pauli "
+      "operands that must be resolved for wire-set lowering. See "
+      "cc-loop-unroll.">,
+    Option<"unrollOnlyIndexUseLoops", "unroll-only-index-use-loops", "bool",
+      /*default=*/"false",
+      "Unroll only index use loops, i.e. loops whose induction variable is "
+      "used in the loop body. See cc-loop-unroll.">
   ];
 }
 

--- a/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -67,20 +67,36 @@ static void createPrepareForWiresetPipeline(
   funcPM.addPass(cudaq::opt::createCombineQuantumAllocations());
   funcPM.addPass(createCanonicalizerPass());
   funcPM.addPass(cudaq::opt::createLoopNormalize());
-  funcPM.addPass(cudaq::opt::createLoopUnroll(loopUnrollOptions));
-  funcPM.addPass(createCanonicalizerPass());
-  funcPM.addPass(createCSEPass());
+  // Unroll and fold together. A loop whose trip count is a constant array
+  // element indexed by an outer induction variable only becomes counted once
+  // that outer loop is unrolled and the array is lifted back out of memory, so
+  // the two have to be interleaved.
+  cudaq::opt::createClassicalOptimizationPipeline(
+      pm, loopUnrollOptions.threshold, loopUnrollOptions.allowBreak,
+      /*allowClosedInterval=*/std::nullopt, /*disableLoopUnrolling=*/false,
+      loopUnrollOptions.unrollOnlyAliasingQuantumAccessLoops,
+      loopUnrollOptions.unrollOnlyIndexUseLoops);
+  // That pipeline nests its own func.func passes on pm, so continue in a fresh
+  // nest to keep the order clear.
+  auto &postFuncPM = pm.nest<func::FuncOp>();
+  // Classical optimization never signals failure, so run the unroller again to
+  // report anything left rolled.
+  postFuncPM.addPass(cudaq::opt::createLoopUnroll(loopUnrollOptions));
+  postFuncPM.addPass(createCanonicalizerPass());
+  postFuncPM.addPass(createCSEPass());
   // Fold constant array element reads now that the loop is unrolled and the
   // indices are constants. Kernels that interpret a captured gate array reach
   // memtoreg with a dynamic `quake.extract_ref` index otherwise, and the
   // register cannot be promoted to wires.
-  funcPM.addPass(cudaq::opt::createConstantPropagation());
-  funcPM.addPass(createCanonicalizerPass());
+  postFuncPM.addPass(cudaq::opt::createConstantPropagation());
+  postFuncPM.addPass(createCanonicalizerPass());
   // Classically scalarize and promote Pauli words for early exp_pauli
-  // decomposition because quantum mem2reg cannot handle that operation.
-  funcPM.addPass(cudaq::opt::createSROA());
-  funcPM.addPass(cudaq::opt::createClassicalMemToReg());
-  funcPM.addPass(createCanonicalizerPass());
+  // decomposition because quantum mem2reg cannot handle that operation. The
+  // pipeline above runs these too, but too early to help: a Pauli word is only
+  // promotable once the loop reading it has been unrolled.
+  postFuncPM.addPass(cudaq::opt::createSROA());
+  postFuncPM.addPass(cudaq::opt::createClassicalMemToReg());
+  postFuncPM.addPass(createCanonicalizerPass());
   cudaq::opt::addDecomposition(pm, {"ExpPauliDecomposition"});
   cudaq::opt::addConvertToLinearValues(pm);
   pm.addPass(createCanonicalizerPass());

--- a/cudaq/lib/Optimizer/Transforms/ClassicalOptimization.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ClassicalOptimization.cpp
@@ -43,6 +43,12 @@ public:
   void runOnOperation() override {
     auto *ctx = &getContext();
     auto *op = getOperation();
+    if (unrollOnlyAliasingQuantumAccessLoops && unrollOnlyIndexUseLoops) {
+      op->emitOpError("unroll-only-aliasing-quantum-access-loops and "
+                      "unroll-only-index-use-loops are mutually exclusive");
+      signalPassFailure();
+      return;
+    }
     DominanceInfo domInfo(op);
     auto func = dyn_cast<func::FuncOp>(op);
     auto numLoops = countLoopOps(op);
@@ -61,9 +67,10 @@ public:
     patterns.insert<AllocaPattern>(
         ctx, domInfo, func == nullptr ? "unknown" : func.getName());
     if (numLoops && !disableLoopUnrolling)
-      patterns.insert<UnrollCountedLoop>(ctx, threshold,
-                                         /*signalFailure=*/false, allowBreak,
-                                         progress);
+      patterns.insert<UnrollCountedLoop>(
+          ctx, threshold,
+          /*signalFailure=*/false, allowBreak, progress,
+          unrollOnlyAliasingQuantumAccessLoops, unrollOnlyIndexUseLoops);
 
     FrozenRewritePatternSet frozen(std::move(patterns));
     // Iterate over the loops until a fixed-point is reached. Some loops can
@@ -118,6 +125,18 @@ struct ClassicalOptimizationPipelineOptions
       llvm::cl::desc("Disable loop unrolling and preserve cc.loop operations. "
                      "(default: false)"),
       llvm::cl::init(false)};
+  PassOptions::Option<bool> unrollOnlyAliasingQuantumAccessLoops{
+      *this, "unroll-only-aliasing-quantum-access-loops",
+      llvm::cl::desc(
+          "Unroll only loops containing aliasing quantum accesses or "
+          "exp_pauli operands that must be resolved for wire-set lowering. "
+          "(default: false)"),
+      llvm::cl::init(false)};
+  PassOptions::Option<bool> unrollOnlyIndexUseLoops{
+      *this, "unroll-only-index-use-loops",
+      llvm::cl::desc("Unroll only loops whose induction variable is used in "
+                     "the loop body. (default: false)"),
+      llvm::cl::init(false)};
 };
 } // namespace
 
@@ -137,6 +156,9 @@ static void createClassicalOptPipeline(
   opts.allowClosedInterval = options.allowClosedInterval;
   opts.allowBreak = options.allowBreak;
   opts.disableLoopUnrolling = options.disableLoopUnrolling;
+  opts.unrollOnlyAliasingQuantumAccessLoops =
+      options.unrollOnlyAliasingQuantumAccessLoops;
+  opts.unrollOnlyIndexUseLoops = options.unrollOnlyIndexUseLoops;
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createClassicalOptimization(opts));
   pm.addNestedPass<func::FuncOp>(createCSEPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createClassicalOptimization(opts));
@@ -146,7 +168,9 @@ static void createClassicalOptPipeline(
 void cudaq::opt::createClassicalOptimizationPipeline(
     OpPassManager &pm, std::optional<unsigned> threshold,
     std::optional<bool> allowBreak, std::optional<bool> allowClosedInterval,
-    std::optional<bool> disableLoopUnrolling) {
+    std::optional<bool> disableLoopUnrolling,
+    std::optional<bool> unrollOnlyAliasingQuantumAccessLoops,
+    std::optional<bool> unrollOnlyIndexUseLoops) {
   ClassicalOptimizationPipelineOptions options;
   if (threshold.has_value())
     options.threshold = *threshold;
@@ -156,6 +180,11 @@ void cudaq::opt::createClassicalOptimizationPipeline(
     options.allowBreak = *allowBreak;
   if (disableLoopUnrolling.has_value())
     options.disableLoopUnrolling = *disableLoopUnrolling;
+  if (unrollOnlyAliasingQuantumAccessLoops.has_value())
+    options.unrollOnlyAliasingQuantumAccessLoops =
+        *unrollOnlyAliasingQuantumAccessLoops;
+  if (unrollOnlyIndexUseLoops.has_value())
+    options.unrollOnlyIndexUseLoops = *unrollOnlyIndexUseLoops;
   ::createClassicalOptPipeline(pm, options);
 }
 


### PR DESCRIPTION
The common quake pipeline provides options to unroll certain loops. However, for some loops (e.g., a nested loop over a 2D array), one step of loop unrolling is insufficient to fully unroll loops we want to unroll. Therefore, switch to the classical-optimization pipeline, adding in the options to select which loops to unroll, so we can fully unroll them iteratively with some constant propagation work.