### PR TITLE
Remove unused ExecutionContext fields

### DIFF
--- a/python/runtime/common/py_ExecutionContext.cpp
+++ b/python/runtime/common/py_ExecutionContext.cpp
@@ -31,7 +31,6 @@ void bindExecutionContext(nanobind::module_ &mod) {
            nanobind::arg("name"), nanobind::arg("shots"),
            nanobind::arg("qpu_id") = 0)
       .def_rw("kernelName", &cudaq::ExecutionContext::kernelName)
-      .def_ro("result", &cudaq::ExecutionContext::result)
       .def_rw("asyncExec", &cudaq::ExecutionContext::asyncExec)
       .def_ro("asyncResult", &cudaq::ExecutionContext::asyncResult)
       .def_rw("hasConditionalsOnMeasureResults",
@@ -47,8 +46,6 @@ void bindExecutionContext(nanobind::module_ &mod) {
              ctx.spin = spin;
              assert(cudaq::spin_op::canonicalize(spin) == spin);
            })
-      .def("getExpectationValue",
-           [](cudaq::ExecutionContext &ctx) { return ctx.expectationValue; })
       // ----- Context management using with blocks -----
       // Unlike in C++, we do not support nested execution contexts in Python.
       .def(

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -52,12 +52,6 @@ public:
   /// @brief An optional spin operator
   std::optional<cudaq::spin_op> spin;
 
-  /// @brief Measurement counts for a CUDA-Q kernel invocation
-  sample_result result;
-
-  /// @brief A computed expectation value
-  std::optional<double> expectationValue = std::nullopt;
-
   /// @brief An optimization result
   std::optional<cudaq::optimization_result> optResult = std::nullopt;
 
@@ -119,21 +113,6 @@ public:
   /// @brief Whether or not to simply concatenate measurements in execution
   /// order.
   bool explicitMeasurements = false;
-
-  /// @brief Probability of occurrence of each error mechanism (column) in
-  /// Measurement Syndrome Matrix (0-1 range).
-  std::optional<std::vector<double>> msm_probabilities;
-
-  /// @brief Error mechanism ID. From a probability perspective, each error
-  /// mechanism ID is independent of all other error mechanism ID. For all
-  /// errors with the *same* ID, only one of them can happen. That is - the
-  /// errors containing the same ID are correlated with each other.
-  std::optional<std::vector<std::size_t>> msm_prob_err_id;
-
-  /// @brief The number of rows and columns of a Measurement Syndrome Matrix.
-  /// Note: Measurement Syndrome Matrix is defined in
-  /// https://arxiv.org/pdf/2407.13826.
-  std::optional<std::pair<std::size_t, std::size_t>> msm_dimensions;
 
   /// @cond HIDDEN_MEMBERS
   /// @brief Pointer to the execution manager for the current execution context,

--- a/runtime/cudaq/algorithms/launch.h
+++ b/runtime/cudaq/algorithms/launch.h
@@ -152,7 +152,6 @@ msm_result launch(msm_policy policy, Callable &&f, Args &&...args) {
   ctx.kernelName = policy.kernelName;
   policy.noiseModel = platform.get_noise(qpu_id);
   ctx.noiseModel = policy.noiseModel;
-  ctx.msm_dimensions = policy.dimensions;
   return detail::launch(policy, qpu_id, ctx, platform,
                         std::forward<Callable>(f), std::forward<Args>(args)...);
 }

--- a/runtime/cudaq/algorithms/policy_dispatch.h
+++ b/runtime/cudaq/algorithms/policy_dispatch.h
@@ -30,7 +30,7 @@ namespace cudaq::policies {
 ///     [&]{ return finalizeExecutionContext(policy, context); },
 ///     [&](sample_result&&  r) { context.sample_data  = std::move(r.data); },
 ///     [&](run_result&&     r) { context.exit_code    = r.exit_code; },
-///     [&](void_result)        { context.result       = {}; }
+///     [&](void_result)        { /* nothing to store */ }
 ///   );
 /// });
 /// @endcode
@@ -193,7 +193,7 @@ void invokeVisitor(Visitor &&visitor, Func &&func) {
 ///     [&](run_result&&     r) { context.exit_code    = r.exit_code; },
 ///     [&](observe_result&& r) { context.observations =
 ///     std::move(r.observations); },
-///     [&](void_result)        { context.result       = {}; }
+///     [&](void_result)        { /* nothing to store */ }
 ///   );
 /// });
 /// @endcode

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -98,21 +98,22 @@ void ExecutionManager::configureExecutionContext(const orca::sample_policy &) {
 }
 
 void ExecutionManager::finalizeExecutionContext(ExecutionContext &ctx) {
+  // The execution context is no longer a result channel: every result-bearing
+  // policy returns its result by value from the typed launch path. This
+  // adapter therefore only serves the policies that have no result to deliver
+  // (tracer, extract-state, resource counting, ...). A named result-bearing
+  // policy arriving here means the caller went through the deprecated
+  // set_exec_ctx / with_execution_context route and would silently get no
+  // result, so fail loudly instead.
   policies::withPolicy(ctx.name, [&](auto policy) {
-    policies::visitResult(
-        [&]() { return cudaq::finalize_execution_manager(*this, policy, ctx); },
-        [&](sample_result &&r) { ctx.result = std::move(r); },
-        [&](observe_result &&r) {
-          ctx.result = r.raw_data();
-          ctx.expectationValue = r.expectation();
-        },
-        [&](run_result &&r) {},
-        [&](msm_dimensions &&r) { ctx.msm_dimensions = std::move(r); },
-        [&](msm_result &&r) {
-          ctx.result = std::move(r.samples);
-          ctx.msm_probabilities = std::move(r.probabilities);
-          ctx.msm_prob_err_id = std::move(r.probability_error_ids);
-        },
-        [&](policies::void_result &&r) {});
+    if constexpr (std::is_same_v<decltype(policy), other_policies>) {
+      cudaq::finalize_execution_manager(*this, policy, ctx);
+    } else {
+      throw std::runtime_error(
+          "Execution context '" + ctx.name +
+          "' names a result-bearing policy, which can no longer be finalized "
+          "through the execution context. Launch it with cudaq::launch or "
+          "cudaq::detail::launch and use the returned result instead.");
+    }
   });
 }

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -287,23 +287,24 @@ public:
   virtual void deallocateQubits(const std::vector<std::size_t> &qubits) = 0;
 
   /// @brief Process the results stored in the given execution context.
+  ///
+  /// Only valid for policies that deliver no result. Result-bearing policies
+  /// return their result by value from the typed launch path, so a named
+  /// result-bearing context arriving here would silently get nothing back;
+  /// reject it instead. In-tree this is unreachable — the mirrored guard in
+  /// `ExecutionManager::finalizeExecutionContext(ExecutionContext&)` catches it
+  /// first — but this entry point is public and callable directly.
   void finalizeExecutionContext(cudaq::ExecutionContext &ctx) {
     cudaq::policies::withPolicy(ctx.name, [&](auto policy) {
-      cudaq::policies::visitResult(
-          [&]() { return finalize_simulation_circuit(*this, policy, ctx); },
-          [&](cudaq::sample_result &&r) { ctx.result = std::move(r); },
-          [&](cudaq::observe_result &&r) {
-            ctx.result = r.raw_data();
-            ctx.expectationValue = r.expectation();
-          },
-          [&](cudaq::run_result &&r) {},
-          [&](cudaq::msm_dimensions &&r) { ctx.msm_dimensions = std::move(r); },
-          [&](cudaq::msm_result &&r) {
-            ctx.result = std::move(r.samples);
-            ctx.msm_probabilities = std::move(r.probabilities);
-            ctx.msm_prob_err_id = std::move(r.probability_error_ids);
-          },
-          [&](cudaq::policies::void_result &&r) {});
+      if constexpr (std::is_same_v<decltype(policy), cudaq::other_policies>) {
+        finalize_simulation_circuit(*this, policy, ctx);
+      } else {
+        throw std::runtime_error(
+            "Execution context '" + ctx.name +
+            "' names a result-bearing policy, which can no longer be finalized "
+            "through the execution context. Launch it with cudaq::launch or "
+            "cudaq::detail::launch and use the returned result instead.");
+      }
     });
   }
 

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -918,13 +918,6 @@ public:
     StimSimulatorBase::configureExecutionContextImpl(policy);
   }
 
-  // TODO - remove after CUDAQX use of the ExecutionContext is removed
-  void configureExecutionContext(cudaq::ExecutionContext &context) override {
-    is_msm_mode = context.name == "msm";
-    activeMsmDimensions = context.msm_dimensions;
-    StimSimulatorBase::configureExecutionContext(context);
-  }
-
   NVQIR_SIMULATOR_CLONE_IMPL(StimCircuitSimulator)
 };
 

--- a/unittests/nvqpp/integration/kernels_tester.cpp
+++ b/unittests/nvqpp/integration/kernels_tester.cpp
@@ -324,17 +324,17 @@ CUDAQ_TEST(KernelsTester, msmTester_mz_only) {
   cudaq::set_noise(noise);
 
   // Stage 1 - get the MSM size by running with "msm_size". The
-  // result will be returned in ctx_msm_size.shots.
+  // dimensions are returned by launch.
   auto msm_dimensions = cudaq::launch(
       cudaq::msm_size_policy{}, multi_round_ghz{}, num_qubits, num_rounds);
 
   // Stage 2 - get the MSM using the size calculated above
-  // (ctx_msm_size.msm_dimensions).
+  // (msm_dimensions).
   cudaq::msm_policy policy;
   policy.dimensions = msm_dimensions;
   auto msm = cudaq::launch(policy, multi_round_ghz{}, num_qubits, num_rounds);
 
-  // The MSM is now stored in ctx_msm.result. More precisely, the unfiltered
+  // The MSM is now stored in msm.samples. More precisely, the unfiltered
   // MSM is stored there, but some post-processing may be required to
   // eliminate duplicate columns.
   auto msm_as_strings = msm.samples.sequential_data();
@@ -381,19 +381,19 @@ CUDAQ_TEST(KernelsTester, msmTester_mz_and_depol1_corr) {
   cudaq::set_noise(noise);
 
   // Stage 1 - get the MSM size by running with "msm_size". The
-  // result will be returned in ctx_msm_size.shots.
+  // dimensions are returned by launch.
   auto msm_dimensions =
       cudaq::launch(cudaq::msm_size_policy{}, multi_round_ghz{}, num_qubits,
                     num_rounds, noise_bf_prob);
 
   // Stage 2 - get the MSM using the size calculated above
-  // (ctx_msm_size.msm_dimensions).
+  // (msm_dimensions).
   cudaq::msm_policy policy;
   policy.dimensions = msm_dimensions;
   auto msm = cudaq::launch(policy, multi_round_ghz{}, num_qubits, num_rounds,
                            noise_bf_prob);
 
-  // The MSM is now stored in ctx_msm.result. More precisely, the unfiltered
+  // The MSM is now stored in msm.samples. More precisely, the unfiltered
   // MSM is stored there, but some post-processing may be required to
   // eliminate duplicate columns.
   auto msm_as_strings = msm.samples.sequential_data();
@@ -456,12 +456,12 @@ get_msm_test(double noise_probability) {
   // the transposed MSM, the probabilities, and the error ids.
   auto run_msm = [&](auto kernel) {
     // Stage 1 - get the MSM size by running with "msm_size". The
-    // result will be returned in ctx_msm_size.shots.
+    // dimensions are returned by launch.
     auto msm_dimensions =
         cudaq::launch(cudaq::msm_size_policy{}, kernel, noise_probability);
 
     // Stage 2 - get the MSM using the size calculated above
-    // (ctx_msm_size.msm_dimensions).
+    // (msm_dimensions).
     cudaq::msm_policy policy;
     policy.dimensions = msm_dimensions;
     auto msm = cudaq::launch(policy, kernel, noise_probability);

--- a/unittests/nvqpp/qir/NVQIRTester.cpp
+++ b/unittests/nvqpp/qir/NVQIRTester.cpp
@@ -9,7 +9,9 @@
 #include "CUDAQTestUtils.h"
 #include "common/ExecutionContext.h"
 #include "nvqir/Gates.h"
+#include "cudaq/algorithms/sample/policy.h"
 #include "cudaq/platform.h"
+#include "cudaq/qis/execution_manager.h"
 #include <cmath>
 
 extern "C" {
@@ -385,21 +387,25 @@ CUDAQ_TEST(NVQIRTester, checkNisqMechanics) {
 
   const int shots = 100;
   cudaq::ExecutionContext ctx("sample", shots);
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
 
   // Quantum Kernel Code at the QIR level
-  cudaq::get_platform().with_execution_context(ctx, []() {
-    auto qubits = __quantum__rt__qubit_allocate_array(2);
-    Qubit *q1 = extract_qubit(qubits, 0);
-    Qubit *q2 = extract_qubit(qubits, 1);
-    __quantum__qis__h(q1);
-    __quantum__qis__cnot(q1, q2);
-    __quantum__qis__mz(q1);
-    __quantum__qis__mz(q2);
-    __quantum__rt__qubit_release_array(qubits);
-  });
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, ctx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, []() {
+          auto qubits = __quantum__rt__qubit_allocate_array(2);
+          Qubit *q1 = extract_qubit(qubits, 0);
+          Qubit *q2 = extract_qubit(qubits, 1);
+          __quantum__qis__h(q1);
+          __quantum__qis__cnot(q1, q2);
+          __quantum__qis__mz(q1);
+          __quantum__qis__mz(q2);
+          __quantum__rt__qubit_release_array(qubits);
+        });
+      });
   // Back to library code
 
-  cudaq::sample_result counts = ctx.result;
   int counter = 0;
   for (auto &[bits, count] :
        counts) { // std::size_t i = 0; i < counts_data.size(); i += 3) {
@@ -441,27 +447,31 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromStateVec) {
 
   const int shots = 1000;
   cudaq::ExecutionContext ctx("sample", shots);
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
 
   // Quantum Kernel Code at the QIR level
-  cudaq::get_platform().with_execution_context(ctx, []() {
-    std::vector<cudaq::complex> bellState{M_SQRT1_2, 0.0, 0.0, M_SQRT1_2};
-    Array *qubits = [](auto &state) {
-      if constexpr (std::is_same_v<cudaq::complex, std::complex<double>>)
-        return __quantum__rt__qubit_allocate_array_with_state_complex64(
-            2, state.data());
-      else
-        return __quantum__rt__qubit_allocate_array_with_state_complex32(
-            2, state.data());
-    }(bellState);
-    Qubit *q1 = extract_qubit(qubits, 0);
-    Qubit *q2 = extract_qubit(qubits, 1);
-    __quantum__qis__mz(q1);
-    __quantum__qis__mz(q2);
-    __quantum__rt__qubit_release_array(qubits);
-  });
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, ctx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, []() {
+          std::vector<cudaq::complex> bellState{M_SQRT1_2, 0.0, 0.0, M_SQRT1_2};
+          Array *qubits = [](auto &state) {
+            if constexpr (std::is_same_v<cudaq::complex, std::complex<double>>)
+              return __quantum__rt__qubit_allocate_array_with_state_complex64(
+                  2, state.data());
+            else
+              return __quantum__rt__qubit_allocate_array_with_state_complex32(
+                  2, state.data());
+          }(bellState);
+          Qubit *q1 = extract_qubit(qubits, 0);
+          Qubit *q2 = extract_qubit(qubits, 1);
+          __quantum__qis__mz(q1);
+          __quantum__qis__mz(q2);
+          __quantum__rt__qubit_release_array(qubits);
+        });
+      });
   // Back to library code
 
-  cudaq::sample_result counts = ctx.result;
   counts.dump();
   int counter = 0;
   for (auto &[bits, count] : counts) {
@@ -501,18 +511,22 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateSimple) {
   // Let's do some sampling
   const int shots = 1000;
   cudaq::ExecutionContext sampleCtx("sample", shots);
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
 
-  cudaq::get_platform().with_execution_context(sampleCtx, [&]() {
-    auto *qubits =
-        __quantum__rt__qubit_allocate_array_with_state_ptr(state.get());
-    Qubit *q1 = extract_qubit(qubits, 0);
-    Qubit *q2 = extract_qubit(qubits, 1);
-    __quantum__qis__mz(q1);
-    __quantum__qis__mz(q2);
-    __quantum__rt__qubit_release_array(qubits);
-  });
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, sampleCtx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, [&]() {
+          auto *qubits =
+              __quantum__rt__qubit_allocate_array_with_state_ptr(state.get());
+          Qubit *q1 = extract_qubit(qubits, 0);
+          Qubit *q2 = extract_qubit(qubits, 1);
+          __quantum__qis__mz(q1);
+          __quantum__qis__mz(q2);
+          __quantum__rt__qubit_release_array(qubits);
+        });
+      });
 
-  cudaq::sample_result counts = sampleCtx.result;
   counts.dump();
   int counter = 0;
   for (auto &[bits, count] : counts) {
@@ -552,29 +566,33 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateExpand) {
   // Let's do some sampling
   const int shots = 1000;
   cudaq::ExecutionContext sampleCtx("sample", shots);
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
 
-  cudaq::get_platform().with_execution_context(sampleCtx, [&]() {
-    // Allocate some qubits in 0 state
-    auto *someQubits = __quantum__rt__qubit_allocate_array(2);
-    // Allocate some more in a specific state
-    auto *qubits =
-        __quantum__rt__qubit_allocate_array_with_state_ptr(state.get());
-    Qubit *q1 = extract_qubit(someQubits, 0);
-    Qubit *q2 = extract_qubit(someQubits, 1);
-    Qubit *q3 = extract_qubit(qubits, 0);
-    Qubit *q4 = extract_qubit(qubits, 1);
-    // Spread the entanglement...
-    __quantum__qis__cnot(q3, q1);
-    __quantum__qis__cnot(q4, q2);
-    __quantum__qis__mz(q1);
-    __quantum__qis__mz(q2);
-    __quantum__qis__mz(q3);
-    __quantum__qis__mz(q4);
-    __quantum__rt__qubit_release_array(qubits);
-    __quantum__rt__qubit_release_array(someQubits);
-  });
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, sampleCtx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, [&]() {
+          // Allocate some qubits in 0 state
+          auto *someQubits = __quantum__rt__qubit_allocate_array(2);
+          // Allocate some more in a specific state
+          auto *qubits =
+              __quantum__rt__qubit_allocate_array_with_state_ptr(state.get());
+          Qubit *q1 = extract_qubit(someQubits, 0);
+          Qubit *q2 = extract_qubit(someQubits, 1);
+          Qubit *q3 = extract_qubit(qubits, 0);
+          Qubit *q4 = extract_qubit(qubits, 1);
+          // Spread the entanglement...
+          __quantum__qis__cnot(q3, q1);
+          __quantum__qis__cnot(q4, q2);
+          __quantum__qis__mz(q1);
+          __quantum__qis__mz(q2);
+          __quantum__qis__mz(q3);
+          __quantum__qis__mz(q4);
+          __quantum__rt__qubit_release_array(qubits);
+          __quantum__rt__qubit_release_array(someQubits);
+        });
+      });
 
-  cudaq::sample_result counts = sampleCtx.result;
   counts.dump();
   int counter = 0;
   // We should have a bigger GHZ state: |0000> + |1111>
@@ -655,25 +673,29 @@ CUDAQ_TEST(NVQIRTester, checkKrausApply) {
   cudaq::ExecutionContext ctx("sample", shots);
   cudaq::noise_model noise;
   noise.register_channel<test::hello::hello_world>();
-  ctx.noiseModel = &noise;
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
+  policy.noiseModel = &noise;
 
   std::vector<double> params{0.2};
 
-  cudaq::get_platform().with_execution_context(ctx, [&]() {
-    __quantum__rt__initialize(0, nullptr);
-    auto qubits = __quantum__rt__qubit_allocate_array(1);
-    Qubit *q = *reinterpret_cast<Qubit **>(
-        __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, ctx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, [&]() {
+          __quantum__rt__initialize(0, nullptr);
+          auto qubits = __quantum__rt__qubit_allocate_array(1);
+          Qubit *q = *reinterpret_cast<Qubit **>(
+              __quantum__rt__array_get_element_ptr_1d(qubits, 0));
 
-    __quantum__qis__x(q);
-    __quantum__qis__apply_kraus_channel_double(
-        test::hello::hello_world::get_key(), params.data(), params.size(),
-        qubits);
+          __quantum__qis__x(q);
+          __quantum__qis__apply_kraus_channel_double(
+              test::hello::hello_world::get_key(), params.data(), params.size(),
+              qubits);
 
-    __quantum__rt__qubit_release_array(qubits);
-  });
+          __quantum__rt__qubit_release_array(qubits);
+        });
+      });
 
-  cudaq::sample_result counts = ctx.result;
   counts.dump();
   __quantum__rt__finalize();
 }
@@ -684,25 +706,29 @@ CUDAQ_TEST(NVQIRTester, checkKrausApplyGeneralUno) {
   cudaq::ExecutionContext ctx("sample", shots);
   cudaq::noise_model noise;
   noise.register_channel<test::hello::hello_world>();
-  ctx.noiseModel = &noise;
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
+  policy.noiseModel = &noise;
 
   std::vector<double> params{0.2};
 
-  cudaq::get_platform().with_execution_context(ctx, [&]() {
-    __quantum__rt__initialize(0, nullptr);
-    auto qubits = __quantum__rt__qubit_allocate_array(1);
-    Qubit *q = *reinterpret_cast<Qubit **>(
-        __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, ctx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, [&]() {
+          __quantum__rt__initialize(0, nullptr);
+          auto qubits = __quantum__rt__qubit_allocate_array(1);
+          Qubit *q = *reinterpret_cast<Qubit **>(
+              __quantum__rt__array_get_element_ptr_1d(qubits, 0));
 
-    __quantum__qis__x(q);
-    __quantum__qis__apply_kraus_channel_generalized(
-        1, test::hello::hello_world::get_key(), 1, 0, 1, params.data(),
-        params.size(), qubits);
+          __quantum__qis__x(q);
+          __quantum__qis__apply_kraus_channel_generalized(
+              1, test::hello::hello_world::get_key(), 1, 0, 1, params.data(),
+              params.size(), qubits);
 
-    __quantum__rt__qubit_release_array(qubits);
-  });
+          __quantum__rt__qubit_release_array(qubits);
+        });
+      });
 
-  cudaq::sample_result counts = ctx.result;
   counts.dump();
   __quantum__rt__finalize();
 }
@@ -713,24 +739,29 @@ CUDAQ_TEST(NVQIRTester, checkKrausApplyGeneralDue) {
   cudaq::ExecutionContext ctx("sample", shots);
   cudaq::noise_model noise;
   noise.register_channel<test::hello::hello_world>();
-  ctx.noiseModel = &noise;
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
+  policy.noiseModel = &noise;
 
   std::vector<double> params{0.2};
 
-  cudaq::get_platform().with_execution_context(ctx, [&]() {
-    __quantum__rt__initialize(0, nullptr);
-    auto qubits = __quantum__rt__qubit_allocate_array(1);
-    Qubit *q = *reinterpret_cast<Qubit **>(
-        __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, ctx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, [&]() {
+          __quantum__rt__initialize(0, nullptr);
+          auto qubits = __quantum__rt__qubit_allocate_array(1);
+          Qubit *q = *reinterpret_cast<Qubit **>(
+              __quantum__rt__array_get_element_ptr_1d(qubits, 0));
 
-    __quantum__qis__x(q);
-    __quantum__qis__apply_kraus_channel_generalized(
-        1, test::hello::hello_world::get_key(), 0, 1, 1, params.data(), qubits);
+          __quantum__qis__x(q);
+          __quantum__qis__apply_kraus_channel_generalized(
+              1, test::hello::hello_world::get_key(), 0, 1, 1, params.data(),
+              qubits);
 
-    __quantum__rt__qubit_release_array(qubits);
-  });
+          __quantum__rt__qubit_release_array(qubits);
+        });
+      });
 
-  cudaq::sample_result counts = ctx.result;
   counts.dump();
   __quantum__rt__finalize();
 }
@@ -741,28 +772,32 @@ CUDAQ_TEST(NVQIRTester, checkKrausApplyGeneralTre) {
   cudaq::ExecutionContext ctx("sample", shots);
   cudaq::noise_model noise;
   noise.register_channel<test::hello::adios>();
-  ctx.noiseModel = &noise;
+  cudaq::sample_policy policy;
+  policy.options.shots = shots;
+  policy.noiseModel = &noise;
 
   std::vector<double> params{0.2, 0.4};
 
-  cudaq::get_platform().with_execution_context(ctx, [&]() {
-    __quantum__rt__initialize(0, nullptr);
-    auto qubits = __quantum__rt__qubit_allocate_array(2);
-    Qubit *q = *reinterpret_cast<Qubit **>(
-        __quantum__rt__array_get_element_ptr_1d(qubits, 0));
-    Qubit *r = *reinterpret_cast<Qubit **>(
-        __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+  cudaq::sample_result counts =
+      cudaq::detail::with_policy_and_ctx(policy, ctx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(policy, [&]() {
+          __quantum__rt__initialize(0, nullptr);
+          auto qubits = __quantum__rt__qubit_allocate_array(2);
+          Qubit *q = *reinterpret_cast<Qubit **>(
+              __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+          Qubit *r = *reinterpret_cast<Qubit **>(
+              __quantum__rt__array_get_element_ptr_1d(qubits, 0));
 
-    __quantum__qis__x(q);
-    __quantum__qis__x(r);
-    __quantum__qis__apply_kraus_channel_generalized(
-        1, test::hello::adios::get_key(), 1, 0, 2, params.data(), params.size(),
-        qubits);
+          __quantum__qis__x(q);
+          __quantum__qis__x(r);
+          __quantum__qis__apply_kraus_channel_generalized(
+              1, test::hello::adios::get_key(), 1, 0, 2, params.data(),
+              params.size(), qubits);
 
-    __quantum__rt__qubit_release_array(qubits);
-  });
+          __quantum__rt__qubit_release_array(qubits);
+        });
+      });
 
-  cudaq::sample_result counts = ctx.result;
   counts.dump();
   __quantum__rt__finalize();
 }


### PR DESCRIPTION
There is still some work to switch all algorithms to policies but after analog backend where migrated to policies there is now an opportunity to clean up some fields from the ExecutionContext.