### PR TITLE
[core] Add a shrink-wrap optimization pass.

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1963,6 +1963,32 @@ def SROA : Pass<"cc-sroa"> {
   let dependentDialects = ["cudaq::cc::CCDialect"];
 }
 
+def ShrinkWrap : Pass<"shrink-wrap", "mlir::func::FuncOp"> {
+  let summary = "Sink stack allocations into the conditional region that "
+                "actually needs them.";
+  let description = [{
+    A `cc.alloca` that lives at the top of a function is allocated (and, per
+    the rest of its lifetime, stored to and loaded from) on every call, even
+    when the variable it backs is only used along a specific control-flow path.
+    This pass moves such an allocation into a `cc.scope` nested within the
+    control-flow path, distributing the overhead and minimizing the variable's
+    lifetime to where it is actually used.
+
+    This is the exact converse of `stack-frame-prealloc`. It is a near converse
+    of `variable-coalesce`, which hoists allocations in the other direction
+    (into the entry block) but also performs merging on same-type,
+    disjoint-lifetime variables into a single slot to shrink total stack
+    footprint. This pass and `variable-coalesse` then are not merely
+    independent. `variable-coalesce`'s own candidate search only considers
+    allocations already nested inside a `cc.scope`. Since some front ends place
+    every local's `cc.alloca` in the entry block unconditionally, they leave
+    `variable-coalesce` no nested-scope candidates to find and coalesce at all.
+    Running `shrink-wrap` first, to push locals back down into the narrowest
+    scope their uses actually require, is what gives `variable-coalesce`
+    disjoint-lifetime candidates to work with in the first place.
+  }];
+}
+
 def StackFramePrealloc : Pass<"stack-frame-prealloc", "mlir::func::FuncOp"> {
   let summary = "Stack frame preallocation.";
   let description = [{

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -84,6 +84,7 @@ add_cudaq_library(OptTransforms
   ResourceCountPreprocess.cpp
   RunSemanticsHackery.cpp
   SROA.cpp
+  ShrinkWrap.cpp
   StackFramePrealloc.cpp
   StatePreparation.cpp
   UnitarySynthesis.cpp

--- a/cudaq/lib/Optimizer/Transforms/ShrinkWrap.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ShrinkWrap.cpp
@@ -129,39 +129,144 @@ static bool collectUses(Value addr, SmallVectorImpl<Operation *> &uses) {
   return true;
 }
 
-// Move `alloca` into a `cc.scope` nested in `targetBlock`, reusing an
-// already-present wrapping `cc.scope` if the target's only content is one.
-static void shrinkWrapInto(cudaq::cc::AllocaOp alloca, Block &targetBlock) {
-  OpBuilder builder(alloca.getContext());
+// Move `alloca` into a `cc.scope` covering the entirety of `targetRegion`'s
+// existing content: reusing an already-present wrapping `cc.scope` if the
+// region is a single block whose only content already is one, otherwise
+// relocating the entire region into a freshly built `cc.scope`.
+//
+// Every exit found is required to be a plain `cc.continue` or, if in a
+// `cc.loop` body, `cc.break`. For every case of `cc.continue` the moved CFG
+// must rethread through the `cc.scope`'s results and back through the enclosing
+// control-flow operation to preserve proper semantics. If the region has a mix
+// of `cc.continue` and `cc.break` (which we will discover here), then we fall
+// back to converting those control-flow operations to a bit of extra dataflow
+// to preserve the semantics and thread the values correctly. This is necessary,
+// because `cc.break` is invalid within the body of the new `cc.scope` and
+// sufficient because `cc.loop`'s semantics require all `cc.continue` and
+// `cc.break` to properly conform to the `cc.loop`'s physical structure. The
+// extra `bool` is merely used to select which goto semantics was originally
+// present for the block in the body region, a `cc.continue` or a `cc.break`.
+static void shrinkWrapInto(cudaq::cc::AllocaOp alloca, Region &targetRegion) {
+  MLIRContext *ctx = alloca.getContext();
+  OpBuilder builder(ctx);
   Location loc = alloca.getLoc();
 
-  cudaq::cc::ScopeOp scope;
-  if (!targetBlock.empty())
-    if (auto s = dyn_cast<cudaq::cc::ScopeOp>(targetBlock.front()))
-      if (s->getNextNode() == targetBlock.getTerminator())
-        scope = s;
-
-  if (!scope) {
-    builder.setInsertionPointToStart(&targetBlock);
-    scope =
-        cudaq::cc::ScopeOp::create(builder, loc, [](OpBuilder &b, Location l) {
-          cudaq::cc::ContinueOp::create(b, l);
-        });
-    Block &scopeBlock = scope.getInitRegion().front();
-    Operation *scopeTerminator = scopeBlock.getTerminator();
-    Block::iterator firstOrig = std::next(scope->getIterator());
-    Operation *blockTerminator = targetBlock.getTerminator();
-    scopeBlock.getOperations().splice(scopeTerminator->getIterator(),
-                                      targetBlock.getOperations(), firstOrig,
-                                      blockTerminator->getIterator());
+  // Fast path: the region is a single block whose only content already is a
+  // wrapping cc.scope - just add the alloca to it.
+  if (targetRegion.hasOneBlock()) {
+    Block &only = targetRegion.front();
+    if (!only.empty())
+      if (auto s = dyn_cast<cudaq::cc::ScopeOp>(only.front()))
+        if (s->getNextNode() == only.getTerminator()) {
+          builder.setInsertionPointToStart(&s.getInitRegion().front());
+          auto newAlloca = cudaq::cc::AllocaOp::create(
+              builder, loc, alloca.getElementType(), alloca.getSeqSize());
+          alloca.getResult().replaceAllUsesWith(newAlloca.getResult());
+          alloca.erase();
+          return;
+        }
   }
 
-  Block &scopeBlock = scope.getInitRegion().front();
-  builder.setInsertionPointToStart(&scopeBlock);
+  // Collect every exit, and bail (leaving the region untouched) unless every
+  // one is a plain cc.continue or cc.break.
+  SmallVector<Operation *> exits;
+  SmallVector<Type> payloadTypes;
+  bool hasBreak = false;
+  for (Block &b : targetRegion)
+    if (b.hasNoSuccessors()) {
+      Operation *term = b.getTerminator();
+      if (!isa<cudaq::cc::ContinueOp, cudaq::cc::BreakOp>(term))
+        return;
+      exits.push_back(term);
+      hasBreak |= isa<cudaq::cc::BreakOp>(term);
+      if (payloadTypes.empty())
+        payloadTypes.assign(term->getOperandTypes().begin(),
+                            term->getOperandTypes().end());
+    }
+  if (exits.empty())
+    return;
+
+  SmallVector<Type> scopeResultTypes(payloadTypes);
+  if (hasBreak)
+    scopeResultTypes.push_back(builder.getI1Type());
+
+  SmallVector<Type> carriedTypes(targetRegion.front().getArgumentTypes());
+
+  // Build the new scope in a fresh, not-yet-attached block, so relocating
+  // the region's existing blocks into the scope below cannot be circular.
+  auto *newEntry = new Block;
+  for (Type ty : carriedTypes)
+    newEntry->addArgument(ty, loc);
+  builder.setInsertionPointToStart(newEntry);
+  cudaq::cc::ScopeOp::BodyBuilderFn noBody;
+  auto scope =
+      cudaq::cc::ScopeOp::create(builder, loc, scopeResultTypes, noBody);
+  Region &scopeRegion = scope.getInitRegion();
+  Block &placeholder = scopeRegion.front();
+  scopeRegion.getBlocks().splice(scopeRegion.end(), targetRegion.getBlocks());
+  placeholder.erase();
+
+  Block &scopeEntry = scopeRegion.front();
+  for (auto [oldArg, newArg] :
+       llvm::zip(scopeEntry.getArguments(), newEntry->getArguments()))
+    oldArg.replaceAllUsesWith(newArg);
+  while (scopeEntry.getNumArguments() > 0)
+    scopeEntry.eraseArgument(scopeEntry.getNumArguments() - 1);
+
+  // Rewrite every exit's terminator: fold it into a `cc.continue`, adding
+  // the break/continue discriminant only if some exit needs one.
+  for (Operation *term : exits) {
+    SmallVector<Value> operands(term->getOperands());
+    builder.setInsertionPoint(term);
+    if (hasBreak) {
+      bool wasBreak = isa<cudaq::cc::BreakOp>(term);
+      Value flag = arith::ConstantOp::create(builder, loc,
+                                             builder.getBoolAttr(wasBreak));
+      operands.push_back(flag);
+    }
+    cudaq::cc::ContinueOp::create(builder, loc, operands);
+    term->erase();
+  }
+
+  // Sink the alloca to the front of the (relocated) entry block.
+  builder.setInsertionPointToStart(&scopeEntry);
   auto newAlloca = cudaq::cc::AllocaOp::create(
       builder, loc, alloca.getElementType(), alloca.getSeqSize());
   alloca.getResult().replaceAllUsesWith(newAlloca.getResult());
   alloca.erase();
+
+  SmallVector<Value> scopeResults(scope.getResults());
+  targetRegion.getBlocks().push_back(newEntry);
+
+  if (!hasBreak) {
+    // Every exit agreed on one terminator kind (cc.continue): a plain
+    // terminator after the scope suffices, no further reconstruction
+    // needed.
+    builder.setInsertionPointToEnd(newEntry);
+    cudaq::cc::ContinueOp::create(builder, loc, scopeResults);
+    return;
+  }
+
+  // Rebuild the region as three blocks: the scope, then a cf.cond_br on its
+  // trailing i1 picking between a fresh cc.break and a fresh cc.continue.
+  Value flagResult = scopeResults.back();
+  SmallVector<Value> payload(scopeResults.begin(),
+                             std::prev(scopeResults.end()));
+
+  auto *trueBlock = new Block;
+  auto *falseBlock = new Block;
+  targetRegion.getBlocks().push_back(trueBlock);
+  targetRegion.getBlocks().push_back(falseBlock);
+
+  builder.setInsertionPointToEnd(newEntry);
+  cf::CondBranchOp::create(builder, loc, flagResult, trueBlock, ValueRange{},
+                           falseBlock, ValueRange{});
+
+  builder.setInsertionPointToStart(trueBlock);
+  cudaq::cc::BreakOp::create(builder, loc, payload);
+
+  builder.setInsertionPointToStart(falseBlock);
+  cudaq::cc::ContinueOp::create(builder, loc, payload);
 }
 
 class ShrinkWrapPass : public cudaq::opt::impl::ShrinkWrapBase<ShrinkWrapPass> {
@@ -215,11 +320,7 @@ private:
       return;
 
     SinkTarget target = common.back();
-    Region &targetRegion = target.region();
-    if (!targetRegion.hasOneBlock())
-      return;
-
-    shrinkWrapInto(alloca, targetRegion.front());
+    shrinkWrapInto(alloca, target.region());
   }
 };
 } // namespace

--- a/cudaq/lib/Optimizer/Transforms/ShrinkWrap.cpp
+++ b/cudaq/lib/Optimizer/Transforms/ShrinkWrap.cpp
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_SHRINKWRAP
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "shrink-wrap"
+
+using namespace mlir;
+
+/**
+   \file
+
+   Structural shrink-wrapping of classical stack allocations.
+
+   See the `ShrinkWrap` description in `Passes.td` for the motivation and the
+   relationship to `stack-frame-prealloc` and `variable-coalesce`.
+
+   This pass reasons purely about IR structure, not dataflow: a
+   `cc.alloca`'s only legal consumers are direct `cc.load`/`cc.store` and
+   `cc.compute_ptr` chains rooted at it. Other uses are considered escaping and
+   cancel any transformation from happening. Given that, the set of structured
+   control-flow operations an `alloca`'s uses are nested in is exactly the set
+   of places its allocation could legally move to; no `mlir::Liveness` or
+   `mlir::DominanceInfo` is needed. A position at the front of a region
+   structurally containing every use dominates all of them unconditionally.
+
+   Sinking into a `cc.loop`'s body region is safe for the same structural
+   reason, with no separate cross-iteration liveness analysis needed: a
+   `cc.loop`'s `while`/`step` regions are where the loop's control condition
+   and per-iteration update actually live, and those two regions are
+   deliberately \e not recognized as valid nesting targets. A variable whose
+   address is truly threaded across iterations is already excluded. The address
+   itself never appears as a plain `load`/`store`/`compute_ptr` operand in that
+   case, so `collectUses` already treats it as an escape. What remains eligible
+   in the body is exactly a variable declared and fully consumed within a single
+   pass through the body on every iteration, which is exactly what a fresh,
+   scope-exited-and-reallocated-per-iteration `cc.scope` inside the body gives
+   it.
+
+   The `else` region of `cc.loop` is different from `while`/`step` as it runs at
+   most once, which is structurally the same "executes zero or one times" shape
+   as a `cc.if` arm, not a per-iteration region. It is therefore recognized as a
+   sink target below just like a `cc.if` arm is.
+ */
+
+namespace {
+
+// A structurally nested region a `cc.alloca` could legally be sunk into:
+// one arm of a `cc.if`, or the body or else region of a `cc.loop`.
+struct SinkTarget {
+  enum class Kind { IfThen, IfElse, LoopBody, LoopElse };
+
+  Operation *op = nullptr; // a cudaq::cc::IfOp or cudaq::cc::LoopOp
+  Kind kind = Kind::IfThen;
+
+  bool operator==(const SinkTarget &other) const {
+    return op == other.op && kind == other.kind;
+  }
+
+  Region &region() const {
+    if (auto ifOp = dyn_cast<cudaq::cc::IfOp>(op))
+      return kind == Kind::IfThen ? ifOp.getThenRegion() : ifOp.getElseRegion();
+    auto loopOp = cast<cudaq::cc::LoopOp>(op);
+    return kind == Kind::LoopBody ? loopOp.getBodyRegion()
+                                  : loopOp.getElseRegion();
+  }
+};
+
+// The chain of sink targets structurally containing `op`, from outermost to
+// innermost, stopping at (not including) `funcBody`. A `cc.loop`'s
+// `while`/`step` regions are intentionally not recognized as targets. The
+// `else` region is recognized, the same as a `cc.if` arm.
+static SmallVector<SinkTarget> sinkTargetChain(Operation *op,
+                                               Region &funcBody) {
+  SmallVector<SinkTarget> chain;
+  for (Region *region = op->getParentRegion(); region && region != &funcBody;
+       region = region->getParentOp()->getParentRegion()) {
+    Operation *parent = region->getParentOp();
+    if (auto ifOp = dyn_cast<cudaq::cc::IfOp>(parent)) {
+      chain.push_back(SinkTarget{ifOp, region == &ifOp.getThenRegion()
+                                           ? SinkTarget::Kind::IfThen
+                                           : SinkTarget::Kind::IfElse});
+    } else if (auto loopOp = dyn_cast<cudaq::cc::LoopOp>(parent)) {
+      if (region == &loopOp.getBodyRegion())
+        chain.push_back(SinkTarget{loopOp, SinkTarget::Kind::LoopBody});
+      else if (region == &loopOp.getElseRegion())
+        chain.push_back(SinkTarget{loopOp, SinkTarget::Kind::LoopElse});
+    }
+  }
+  std::reverse(chain.begin(), chain.end());
+  return chain;
+}
+
+// Collect every direct/transitive use of `addr` (a `cc.alloca`'s result, or a
+// `cc.compute_ptr` rooted at one), following `cc.compute_ptr` chains. Returns
+// false if any use is not a plain load/store through `addr` or a further
+// `cc.compute_ptr` off of it - i.e. if the address escapes in some way this
+// purely structural analysis cannot reason about.
+static bool collectUses(Value addr, SmallVectorImpl<Operation *> &uses) {
+  for (Operation *user : addr.getUsers()) {
+    if (isa<cudaq::cc::LoadOp>(user)) {
+      uses.push_back(user);
+    } else if (auto store = dyn_cast<cudaq::cc::StoreOp>(user)) {
+      // `addr` must be the *pointer* operand; if it is the *value* being
+      // stored, the address itself is escaping into memory.
+      if (store.getPtrvalue() != addr)
+        return false;
+      uses.push_back(user);
+    } else if (auto computePtr = dyn_cast<cudaq::cc::ComputePtrOp>(user)) {
+      uses.push_back(user);
+      if (!collectUses(computePtr.getResult(), uses))
+        return false;
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Move `alloca` into a `cc.scope` nested in `targetBlock`, reusing an
+// already-present wrapping `cc.scope` if the target's only content is one.
+static void shrinkWrapInto(cudaq::cc::AllocaOp alloca, Block &targetBlock) {
+  OpBuilder builder(alloca.getContext());
+  Location loc = alloca.getLoc();
+
+  cudaq::cc::ScopeOp scope;
+  if (!targetBlock.empty())
+    if (auto s = dyn_cast<cudaq::cc::ScopeOp>(targetBlock.front()))
+      if (s->getNextNode() == targetBlock.getTerminator())
+        scope = s;
+
+  if (!scope) {
+    builder.setInsertionPointToStart(&targetBlock);
+    scope =
+        cudaq::cc::ScopeOp::create(builder, loc, [](OpBuilder &b, Location l) {
+          cudaq::cc::ContinueOp::create(b, l);
+        });
+    Block &scopeBlock = scope.getInitRegion().front();
+    Operation *scopeTerminator = scopeBlock.getTerminator();
+    Block::iterator firstOrig = std::next(scope->getIterator());
+    Operation *blockTerminator = targetBlock.getTerminator();
+    scopeBlock.getOperations().splice(scopeTerminator->getIterator(),
+                                      targetBlock.getOperations(), firstOrig,
+                                      blockTerminator->getIterator());
+  }
+
+  Block &scopeBlock = scope.getInitRegion().front();
+  builder.setInsertionPointToStart(&scopeBlock);
+  auto newAlloca = cudaq::cc::AllocaOp::create(
+      builder, loc, alloca.getElementType(), alloca.getSeqSize());
+  alloca.getResult().replaceAllUsesWith(newAlloca.getResult());
+  alloca.erase();
+}
+
+class ShrinkWrapPass : public cudaq::opt::impl::ShrinkWrapBase<ShrinkWrapPass> {
+public:
+  using ShrinkWrapBase::ShrinkWrapBase;
+
+  void runOnOperation() override {
+    auto func = getOperation();
+    if (func.getBody().empty())
+      return;
+    Region &funcBody = func.getBody();
+    Block &entryBlock = funcBody.front();
+
+    // Snapshot the candidates first: `shrinkWrapInto` erases the original
+    // alloca, which would invalidate an in-flight walk of the same block. A
+    // dynamically sized (`seqSize`) alloca is as eligible as a fixed-size one:
+    // in the entry block, `seqSize` can only be a function argument or the
+    // result of some earlier op in that same entry block, so it necessarily
+    // dominates the entire function body - moving the alloca that uses it into
+    // any nested scope is exactly as safe as moving one with no size operand at
+    // all.
+    auto allocaOps = entryBlock.getOps<cudaq::cc::AllocaOp>();
+    SmallVector<cudaq::cc::AllocaOp> candidates(allocaOps.begin(),
+                                                allocaOps.end());
+
+    for (auto alloca : candidates)
+      trySink(alloca, funcBody);
+  }
+
+private:
+  void trySink(cudaq::cc::AllocaOp alloca, Region &funcBody) {
+    SmallVector<Operation *> uses;
+    if (!collectUses(alloca.getResult(), uses) || uses.empty())
+      return;
+
+    // The target is the deepest sink target (cc.if arm or cc.loop body)
+    // structurally containing every use: the longest common prefix of each
+    // use's root-to-leaf target chain.
+    SmallVector<SinkTarget> common = sinkTargetChain(uses.front(), funcBody);
+    for (Operation *use : llvm::drop_begin(uses)) {
+      if (common.empty())
+        return;
+      SmallVector<SinkTarget> chain = sinkTargetChain(use, funcBody);
+      size_t n = std::min(common.size(), chain.size());
+      size_t i = 0;
+      for (; i < n && common[i] == chain[i]; ++i)
+        ;
+      common.resize(i);
+    }
+    if (common.empty())
+      return;
+
+    SinkTarget target = common.back();
+    Region &targetRegion = target.region();
+    if (!targetRegion.hasOneBlock())
+      return;
+
+    shrinkWrapInto(alloca, targetRegion.front());
+  }
+};
+} // namespace

--- a/cudaq/test/Optimizer/shrink_wrap.qke
+++ b/cudaq/test/Optimizer/shrink_wrap.qke
@@ -219,13 +219,13 @@ func.func @atomic_scope_reused(%cond: i1) -> i64 {
   %j = cc.alloca i64
   %c4 = arith.constant 4 : i64
   cc.if(%cond) {
-    cc.scope {
+    cc.scope atomic {
       cc.store %c4, %j : !cc.ptr<i64>
       %v = cc.load %j : !cc.ptr<i64>
       %v2 = arith.addi %v, %c4 : i64
       cc.store %v2, %j : !cc.ptr<i64>
       cc.continue
-    } {atomic_quantum_region}
+    }
     cc.continue
   }
   %c0 = arith.constant 0 : i64
@@ -236,13 +236,13 @@ func.func @atomic_scope_reused(%cond: i1) -> i64 {
 // CHECK-SAME:      %[[ARG0:.*]]: i1) -> i64 {
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : i64
 // CHECK:           cc.if(%[[ARG0]]) {
-// CHECK:             cc.scope {
+// CHECK:             cc.scope atomic {
 // CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
 // CHECK:               cc.store %[[CONSTANT_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
 // CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
 // CHECK:               %[[ADDI_0:.*]] = arith.addi %[[LOAD_0]], %[[CONSTANT_0]] : i64
 // CHECK:               cc.store %[[ADDI_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
-// CHECK:             } {atomic_quantum_region}
+// CHECK:             }
 // CHECK:           }
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
 // CHECK:           return %[[CONSTANT_1]] : i64
@@ -275,4 +275,238 @@ func.func @sink_dynamic_size(%cond: i1, %n: i64) -> i64 {
 // CHECK:           }
 // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
 // CHECK:           return %[[CONSTANT_1]] : i64
+// CHECK:         }
+
+// A `cc.if` arm whose `cc.continue` carries an operand computed from the
+// sunk variable: the value can't simply stay defined outside the new
+// `cc.scope`, so the scope must be built to yield it as its own result, and
+// the arm's `cc.continue` rewritten to forward that result instead.
+func.func @sink_with_operand_continue(%cond: i1) -> i64 {
+  %j = cc.alloca i64
+  %c4 = arith.constant 4 : i64
+  %r = cc.if(%cond) -> i64 {
+    cc.store %c4, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    %v2 = arith.addi %v, %c4 : i64
+    cc.continue %v2 : i64
+  } else {
+    cc.continue %c4 : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @sink_with_operand_continue(
+// CHECK-SAME:      %[[ARG0:.*]]: i1) -> i64 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : i64
+// CHECK:           %[[IF:.*]] = cc.if(%[[ARG0]]) -> i64 {
+// CHECK:             %[[SCOPE:.*]] = cc.scope -> (i64) {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store %[[CONSTANT_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:               %[[ADDI_0:.*]] = arith.addi %[[LOAD_0]], %[[CONSTANT_0]] : i64
+// CHECK:               cc.continue %[[ADDI_0]] : i64
+// CHECK:             }
+// CHECK:             cc.continue %[[SCOPE]] : i64
+// CHECK:           } else {
+// CHECK:             cc.continue %[[CONSTANT_0]] : i64
+// CHECK:           }
+// CHECK:           return %[[IF]] : i64
+// CHECK:         }
+
+// A `cc.loop` whose body unconditionally breaks. `cc.break` can never
+// terminate a `cc.scope`, so the whole body (here, its one block) is moved
+// wholesale into a new scope that also yields a trailing `i1` discriminant,
+// and the body region is rebuilt as three blocks: the scope followed by a
+// `cf.cond_br` on that `i1`, branching to a block re-issuing the real
+// `cc.break` or one re-issuing the real `cc.continue`.
+func.func @sink_loop_body_unconditional_break(%cond: i1) -> i64 {
+  %j = cc.alloca i64
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %c4 = arith.constant 4 : i64
+  %r = cc.loop while ((%i = %c0) -> (i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i : i64)
+  } do {
+  ^bb0(%i: i64):
+    cc.store %c4, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    cc.break %v : i64
+  } step {
+  ^bb0(%i: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @sink_loop_body_unconditional_break(
+// CHECK:           cc.loop while
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[I:.*]]: i64):
+// CHECK:             %[[SCOPE:.*]]:2 = cc.scope -> (i64, i1) {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store {{.*}}, %[[ALLOCA_0]]
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]]
+// CHECK:               %[[TRUE:.*]] = arith.constant true
+// CHECK:               cc.continue %[[LOAD_0]], %[[TRUE]] : i64, i1
+// CHECK:             }
+// CHECK:             cf.cond_br %[[SCOPE]]#1, ^bb1, ^bb2
+// CHECK:           ^bb1:
+// CHECK:             cc.break %[[SCOPE]]#0 : i64
+// CHECK:           ^bb2:
+// CHECK:             cc.continue %[[SCOPE]]#0 : i64
+// CHECK:           } step {
+
+// The genuinely conditional case: the original body already branches (via
+// `cf.cond_br`) to two separate exits, one `cc.break`, one `cc.continue`.
+// The scope retains that internal branch as-is, with each exit's terminator
+// rewritten to carry the discriminant; only the region-level reconstruction
+// outside the scope is new.
+func.func @sink_loop_body_conditional_break(%cond: i1) -> i64 {
+  %j = cc.alloca i64
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %c4 = arith.constant 4 : i64
+  %r = cc.loop while ((%i = %c0) -> (i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i : i64)
+  } do {
+  ^bb0(%i: i64):
+    cc.store %c4, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    cc.break %v : i64
+  ^bb2:
+    cc.continue %v : i64
+  } step {
+  ^bb0(%i: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @sink_loop_body_conditional_break(
+// CHECK:           cc.loop while
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[I:.*]]: i64):
+// CHECK:             %[[SCOPE:.*]]:2 = cc.scope -> (i64, i1) {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store {{.*}}, %[[ALLOCA_0]]
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]]
+// CHECK:               cf.cond_br %{{.*}}, ^bb1, ^bb2
+// CHECK:             ^bb1:
+// CHECK:               %[[TRUE:.*]] = arith.constant true
+// CHECK:               cc.continue %[[LOAD_0]], %[[TRUE]] : i64, i1
+// CHECK:             ^bb2:
+// CHECK:               %[[FALSE:.*]] = arith.constant false
+// CHECK:               cc.continue %[[LOAD_0]], %[[FALSE]] : i64, i1
+// CHECK:             }
+// CHECK:             cf.cond_br %[[SCOPE]]#1, ^bb1, ^bb2
+// CHECK:           ^bb1:
+// CHECK:             cc.break %[[SCOPE]]#0 : i64
+// CHECK:           ^bb2:
+// CHECK:             cc.continue %[[SCOPE]]#0 : i64
+// CHECK:           } step {
+
+// Moving the whole region wholesale is the general case, not just something
+// done for a `cc.loop` body with a `cc.break`: a `cc.if` arm can equally
+// well have multiple blocks (here, from an ordinary internal `cf.cond_br`
+// unrelated to any break/continue split - there is none, `cc.break` can
+// never occur in an `if` arm at all). With no `cc.break` among its exits,
+// no `i1` discriminant is needed - the scope just yields the shared payload
+// and a single `cc.continue` follows it.
+func.func @sink_multiblock_if_arm(%cond: i1, %branch: i1) -> i64 {
+  %j = cc.alloca i64
+  %c4 = arith.constant 4 : i64
+  %c9 = arith.constant 9 : i64
+  %r = cc.if(%cond) -> i64 {
+    cc.store %c4, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    cf.cond_br %branch, ^bb1, ^bb2
+  ^bb1:
+    %v2 = arith.addi %v, %c9 : i64
+    cc.continue %v2 : i64
+  ^bb2:
+    cc.continue %v : i64
+  } else {
+    cc.continue %c4 : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @sink_multiblock_if_arm(
+// CHECK-SAME:      %[[ARG0:.*]]: i1, %[[ARG1:.*]]: i1) -> i64 {
+// CHECK:           %[[IF:.*]] = cc.if(%[[ARG0]]) -> i64 {
+// CHECK:             %[[SCOPE:.*]] = cc.scope -> (i64) {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store {{.*}}, %[[ALLOCA_0]]
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]]
+// CHECK:               cf.cond_br %[[ARG1]], ^bb1, ^bb2
+// CHECK:             ^bb1:
+// CHECK:               %[[ADDI_0:.*]] = arith.addi %[[LOAD_0]], %{{.*}} : i64
+// CHECK:               cc.continue %[[ADDI_0]] : i64
+// CHECK:             ^bb2:
+// CHECK:               cc.continue %[[LOAD_0]] : i64
+// CHECK:             }
+// CHECK:             cc.continue %[[SCOPE]] : i64
+// CHECK:           } else {
+// CHECK:             cc.continue %{{.*}} : i64
+// CHECK:           }
+// CHECK:           return %[[IF]] : i64
+// CHECK:         }
+
+// The same for a `cc.loop`'s `else` region: multiple blocks, no `cc.break`
+// possible there either, so no discriminant - only its own (loop-carried)
+// block arguments need threading into the relocated scope.
+func.func @sink_multiblock_loop_else(%n: i64, %branch: i1) -> i64 {
+  %j = cc.alloca i64
+  %c0 = arith.constant 0 : i64
+  %c9 = arith.constant 9 : i64
+  %r:2 = cc.loop while ((%i = %c0, %acc = %c0) -> (i64, i64)) {
+    %cmp = arith.cmpi slt, %i, %n : i64
+    cc.condition %cmp(%i, %acc : i64, i64)
+  } do {
+  ^bb0(%i: i64, %acc: i64):
+    %next = arith.addi %i, %c0 : i64
+    cc.continue %next, %acc : i64, i64
+  } step {
+  ^bb0(%i: i64, %acc: i64):
+    %next = arith.addi %i, %c0 : i64
+    cc.continue %next, %acc : i64, i64
+  } else {
+  ^bb0(%i: i64, %acc: i64):
+    cc.store %c9, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    cf.cond_br %branch, ^bb1, ^bb2
+  ^bb1:
+    %v2 = arith.addi %v, %acc : i64
+    cc.continue %i, %v2 : i64, i64
+  ^bb2:
+    cc.continue %i, %acc : i64, i64
+  }
+  return %r#1 : i64
+}
+
+// CHECK-LABEL:   func.func @sink_multiblock_loop_else(
+// CHECK:           } else {
+// CHECK:           ^bb0(%[[I:.*]]: i64, %[[ACC:.*]]: i64):
+// CHECK:             %[[SCOPE:.*]]:2 = cc.scope -> (i64, i64) {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store {{.*}}, %[[ALLOCA_0]]
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]]
+// CHECK:               cf.cond_br %{{.*}}, ^bb1, ^bb2
+// CHECK:             ^bb1:
+// CHECK:               %[[ADDI_0:.*]] = arith.addi %[[LOAD_0]], %[[ACC]] : i64
+// CHECK:               cc.continue %[[I]], %[[ADDI_0]] : i64, i64
+// CHECK:             ^bb2:
+// CHECK:               cc.continue %[[I]], %[[ACC]] : i64, i64
+// CHECK:             }
+// CHECK:             cc.continue %[[SCOPE]]#0, %[[SCOPE]]#1 : i64, i64
+// CHECK:           }
+// CHECK:           return %{{.*}} : i64
 // CHECK:         }

--- a/cudaq/test/Optimizer/shrink_wrap.qke
+++ b/cudaq/test/Optimizer/shrink_wrap.qke
@@ -1,0 +1,278 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --shrink-wrap %s | FileCheck %s
+
+// A variable used only in the `then` arm, with no `cc.scope` surviving to
+// wrap it (as if canonicalization already removed an empty one): the pass
+// must create one.
+func.func @sink_creates_scope(%cond: i1) -> i64 {
+  %j = cc.alloca i64
+  %c4 = arith.constant 4 : i64
+  cc.if(%cond) {
+    cc.store %c4, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    %v2 = arith.addi %v, %c4 : i64
+    cc.store %v2, %j : !cc.ptr<i64>
+    cc.continue
+  }
+  %c0 = arith.constant 0 : i64
+  return %c0 : i64
+}
+
+// CHECK-LABEL:   func.func @sink_creates_scope(
+// CHECK-SAME:      %[[ARG0:.*]]: i1) -> i64 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : i64
+// CHECK:           cc.if(%[[ARG0]]) {
+// CHECK:             cc.scope {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store %[[CONSTANT_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:               %[[ADDI_0:.*]] = arith.addi %[[LOAD_0]], %[[CONSTANT_0]] : i64
+// CHECK:               cc.store %[[ADDI_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
+// CHECK:           return %[[CONSTANT_1]] : i64
+// CHECK:         }
+
+// Same shape, but a `cc.scope` already wraps the whole arm: the pass must
+// relocate into it rather than creating a redundant nested one.
+func.func @sink_reuses_scope(%cond: i1) -> i64 {
+  %j = cc.alloca i64
+  %c4 = arith.constant 4 : i64
+  cc.if(%cond) {
+    cc.scope {
+      cc.store %c4, %j : !cc.ptr<i64>
+      cc.continue
+    }
+    cc.continue
+  }
+  %c0 = arith.constant 0 : i64
+  return %c0 : i64
+}
+
+// CHECK-LABEL:   func.func @sink_reuses_scope(
+// CHECK-SAME:      %[[ARG0:.*]]: i1) -> i64 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : i64
+// CHECK:           cc.if(%[[ARG0]]) {
+// CHECK:             cc.scope {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store %[[CONSTANT_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
+// CHECK:           return %[[CONSTANT_1]] : i64
+// CHECK:         }
+
+// A variable used in both arms, and read again after the `cc.if`: it is
+// genuinely live across the whole function and must NOT be sunk.
+// CHECK-LABEL:   func.func @no_sink_used_after_if(
+func.func @no_sink_used_after_if(%cond: i1) -> i64 {
+  // CHECK:  %[[ALLOCA_0:.*]] = cc.alloca i64
+  %j = cc.alloca i64
+  %c4 = arith.constant 4 : i64
+  %c5 = arith.constant 5 : i64
+  // CHECK:  cc.if
+  cc.if(%cond) {
+    // CHECK:  cc.store {{.*}}, %[[ALLOCA_0]]
+    cc.store %c4, %j : !cc.ptr<i64>
+    cc.continue
+  } else {
+    // CHECK:  cc.store {{.*}}, %[[ALLOCA_0]]
+    cc.store %c5, %j : !cc.ptr<i64>
+    cc.continue
+  }
+  // CHECK:  cc.load %[[ALLOCA_0]]
+  %v = cc.load %j : !cc.ptr<i64>
+  return %v : i64
+}
+
+// A variable used only inside a `cc.loop`'s body region (never in its
+// `while`/`step` regions, never loop-carried): the pass must sink it into a
+// `cc.scope` in the body, giving it a fresh per-iteration slot. `%counter`
+// (the loop's own condition variable, live across `while`/`do`/`step`) must
+// NOT be sunk.
+func.func @sink_into_loop_body(%n: i64) -> i64 {
+  %counter = cc.alloca i64
+  %c0 = arith.constant 0 : i64
+  cc.store %c0, %counter : !cc.ptr<i64>
+  %j = cc.alloca i64
+  cc.loop while {
+    %i = cc.load %counter : !cc.ptr<i64>
+    %cmp = arith.cmpi slt, %i, %n : i64
+    cc.condition %cmp
+  } do {
+    %i = cc.load %counter : !cc.ptr<i64>
+    cc.store %i, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    %v2 = arith.muli %v, %v : i64
+    cc.store %v2, %j : !cc.ptr<i64>
+    cc.continue
+  } step {
+    %i = cc.load %counter : !cc.ptr<i64>
+    %c1 = arith.constant 1 : i64
+    %i2 = arith.addi %i, %c1 : i64
+    cc.store %i2, %counter : !cc.ptr<i64>
+  }
+  %result = cc.load %counter : !cc.ptr<i64>
+  return %result : i64
+}
+
+// CHECK-LABEL:   func.func @sink_into_loop_body(
+// CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
+// CHECK:           cc.store %[[CONSTANT_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:           cc.loop while {
+// CHECK:             %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[LOAD_0]], %[[ARG0]] : i64
+// CHECK:             cc.condition %[[CMPI_0]]
+// CHECK:           } do {
+// CHECK:             cc.scope {
+// CHECK:               %[[ALLOCA_1:.*]] = cc.alloca i64
+// CHECK:               %[[LOAD_1:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:               cc.store %[[LOAD_1]], %[[ALLOCA_1]] : !cc.ptr<i64>
+// CHECK:               %[[LOAD_2:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<i64>
+// CHECK:               %[[MULI_0:.*]] = arith.muli %[[LOAD_2]], %[[LOAD_2]] : i64
+// CHECK:               cc.store %[[MULI_0]], %[[ALLOCA_1]] : !cc.ptr<i64>
+// CHECK:             }
+// CHECK:           } step {
+// CHECK:             %[[LOAD_3:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:             %[[CONSTANT_1:.*]] = arith.constant 1 : i64
+// CHECK:             %[[ADDI_0:.*]] = arith.addi %[[LOAD_3]], %[[CONSTANT_1]] : i64
+// CHECK:             cc.store %[[ADDI_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:           }
+// CHECK:           %[[LOAD_4:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:           return %[[LOAD_4]] : i64
+// CHECK:         }
+
+// A variable used only inside a `cc.loop`'s `else` region (the Python
+// `for`/`while`-`else` case, run at most once, when the loop ends without a
+// `break`): the pass must sink it there too, the same as a `cc.if` arm.
+func.func @sink_into_loop_else(%n: i64) -> i64 {
+  %counter = cc.alloca i64
+  %c0 = arith.constant 0 : i64
+  cc.store %c0, %counter : !cc.ptr<i64>
+  %j = cc.alloca i64
+  %c9 = arith.constant 9 : i64
+  cc.loop while {
+    %i = cc.load %counter : !cc.ptr<i64>
+    %cmp = arith.cmpi slt, %i, %n : i64
+    cc.condition %cmp
+  } do {
+    %i = cc.load %counter : !cc.ptr<i64>
+    %c1 = arith.constant 1 : i64
+    %i2 = arith.addi %i, %c1 : i64
+    cc.store %i2, %counter : !cc.ptr<i64>
+    cc.continue
+  } else {
+    cc.store %c9, %j : !cc.ptr<i64>
+    %v = cc.load %j : !cc.ptr<i64>
+    %v2 = arith.muli %v, %v : i64
+    cc.store %v2, %j : !cc.ptr<i64>
+    cc.continue
+  }
+  %result = cc.load %counter : !cc.ptr<i64>
+  return %result : i64
+}
+
+// CHECK-LABEL:   func.func @sink_into_loop_else(
+// CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
+// CHECK:           cc.store %[[CONSTANT_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 9 : i64
+// CHECK:           cc.loop while {
+// CHECK:             %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[LOAD_0]], %[[ARG0]] : i64
+// CHECK:             cc.condition %[[CMPI_0]]
+// CHECK:           } do {
+// CHECK:             %[[LOAD_1:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:             %[[CONSTANT_2:.*]] = arith.constant 1 : i64
+// CHECK:             %[[ADDI_0:.*]] = arith.addi %[[LOAD_1]], %[[CONSTANT_2]] : i64
+// CHECK:             cc.store %[[ADDI_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:           } else {
+// CHECK:             cc.scope {
+// CHECK:               %[[ALLOCA_1:.*]] = cc.alloca i64
+// CHECK:               cc.store %[[CONSTANT_1]], %[[ALLOCA_1]] : !cc.ptr<i64>
+// CHECK:               %[[LOAD_2:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<i64>
+// CHECK:               %[[MULI_0:.*]] = arith.muli %[[LOAD_2]], %[[LOAD_2]] : i64
+// CHECK:               cc.store %[[MULI_0]], %[[ALLOCA_1]] : !cc.ptr<i64>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[RESULT:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:           return %[[RESULT]] : i64
+// CHECK:         }
+
+// The `cc.if` arm's sole content is a `cc.scope` tagged
+// `atomic_quantum_region`. That tag only means canonicalization will not
+// erase the scope for having no allocation of its own - it does not stop
+// this pass from reusing it as the sink target, and reuse is what avoids
+// building a second, redundant wrapping `cc.scope` around it.
+func.func @atomic_scope_reused(%cond: i1) -> i64 {
+  %j = cc.alloca i64
+  %c4 = arith.constant 4 : i64
+  cc.if(%cond) {
+    cc.scope {
+      cc.store %c4, %j : !cc.ptr<i64>
+      %v = cc.load %j : !cc.ptr<i64>
+      %v2 = arith.addi %v, %c4 : i64
+      cc.store %v2, %j : !cc.ptr<i64>
+      cc.continue
+    } {atomic_quantum_region}
+    cc.continue
+  }
+  %c0 = arith.constant 0 : i64
+  return %c0 : i64
+}
+
+// CHECK-LABEL:   func.func @atomic_scope_reused(
+// CHECK-SAME:      %[[ARG0:.*]]: i1) -> i64 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : i64
+// CHECK:           cc.if(%[[ARG0]]) {
+// CHECK:             cc.scope {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64
+// CHECK:               cc.store %[[CONSTANT_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:               %[[ADDI_0:.*]] = arith.addi %[[LOAD_0]], %[[CONSTANT_0]] : i64
+// CHECK:               cc.store %[[ADDI_0]], %[[ALLOCA_0]] : !cc.ptr<i64>
+// CHECK:             } {atomic_quantum_region}
+// CHECK:           }
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
+// CHECK:           return %[[CONSTANT_1]] : i64
+// CHECK:         }
+
+// A dynamically sized alloca (`seqSize`) is just as eligible as a
+// fixed-size one: `%n` is a function argument, so it dominates the entire
+// function body regardless of where the alloca that uses it ends up.
+func.func @sink_dynamic_size(%cond: i1, %n: i64) -> i64 {
+  %j = cc.alloca i64[%n : i64]
+  %c0 = arith.constant 0 : i64
+  cc.if(%cond) {
+    %addr = cc.compute_ptr %j[0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+    cc.store %c0, %addr : !cc.ptr<i64>
+    cc.continue
+  }
+  %c1 = arith.constant 1 : i64
+  return %c1 : i64
+}
+
+// CHECK-LABEL:   func.func @sink_dynamic_size(
+// CHECK-SAME:      %[[ARG0:.*]]: i1, %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
+// CHECK:           cc.if(%[[ARG0]]) {
+// CHECK:             cc.scope {
+// CHECK:               %[[ALLOCA_0:.*]] = cc.alloca i64[%[[ARG1]] : i64]
+// CHECK:               %[[GEP_0:.*]] = cc.compute_ptr %[[ALLOCA_0]][0] :
+// CHECK:               cc.store %[[CONSTANT_0]], %[[GEP_0]] : !cc.ptr<i64>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
+// CHECK:           return %[[CONSTANT_1]] : i64
+// CHECK:         }


### PR DESCRIPTION
This pass implements the classical optimization, shrink wrapping. This optimization refines the scope of variables to be deliberately control dependent and over shorter lifetimes.