### PR TITLE
[core] Add a loop cable rotation pass.

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1182,6 +1182,39 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
   ];
 }
 
+def LoopCableRotation : Pass<"loop-cable-rotation", "mlir::func::FuncOp"> {
+  let summary = "Rotate a cable around a counted loop over a fixed-size veq.";
+  let description = [{
+    A `cc.loop` that is a compile-time counted loop (a normalized, definite
+    trip count, no early exit - see `isaCountedLoop` in `LoopAnalysis.h`)
+    whose body contains exactly one `quake.extract_ref` indexing a
+    statically sized `veq` by the loop's own induction variable touches
+    every qubit of that `veq` exactly once, in order. Each iteration
+    ordinarily still pays for reference-form traffic (`unwrap`/gate/`wrap`)
+    even though the whole access pattern is known statically.
+
+    This pass rewrites that shape to thread a single `!quake.cable<C>`
+    value around the loop instead of leaving the `veq` in reference form:
+    a `quake.detach_wire` pulls the front wire off the cable in place of
+    the `extract_ref` each iteration, and a `quake.attach_wire` puts it
+    back on the back before the iteration ends, so after all `C`
+    iterations the cable is back in its original order. The detached wire
+    is bound to a fresh reference with `quake.wrap_new` so the body's gate
+    ops are left completely unchanged in reference form; this pass does
+    not itself linearize them; the existing `memtoreg` pass, run
+    afterwards, threads `quake.wrap_new`'s fresh reference into proper wire
+    SSA form the same way it already does elsewhere.
+
+    This pass is independent of, and does not modify, `cable-rough-in` -
+    that pass handles a whole veq passed to a call; this one handles a veq
+    walked element-by-element inside a loop. A loop that does not match
+    the required shape exactly (early exit, non-constant trip count, more
+    than one `extract_ref` in the body, an index expression other than the
+    bare induction variable, a `veq` of unknown size, or a `veq` with any
+    other use inside the loop) is left completely untouched.
+  }];
+}
+
 def LoopInductionFusion : Pass<"cc-loop-induction-fusion"> {
   let summary = "Fuse secondary loop inductions into the primary induction.";
   let description = [{

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ add_cudaq_library(OptTransforms
   LiftArrayAlloc.cpp
   LinearCtrlRelations.cpp
   LoopAnalysis.cpp
+  LoopCableRotation.cpp
   LoopInductionFusion.cpp
   LoopNormalize.cpp
   LoopPeeling.cpp

--- a/cudaq/lib/Optimizer/Transforms/LoopCableRotation.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LoopCableRotation.cpp
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "LoopAnalysis.h"
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_LOOPCABLEROTATION
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "loop-cable-rotation"
+
+using namespace mlir;
+
+/**
+   \file
+
+   See the `LoopCableRotation` description in Passes.td for the motivation.
+
+   This pass is independent of `cable-rough-in` and does not modify it:
+   `cable-rough-in` converts a whole `veq` passed to a *call* into wire form;
+   this pass converts a `veq` walked qubit-by-qubit by a counted loop's own
+   `extract_ref`. Nor does this pass linearize the gate ops inside the loop
+   body itself - the detached wire is bound to a fresh reference with
+   `quake.wrap_new`, so every existing use of the old `extract_ref` result
+   keeps working completely unchanged in reference form; the `memtoreg` pass,
+   run afterwards, threads that fresh reference into proper wire SSA form the
+   same way it already does elsewhere in the pipeline.
+ */
+
+namespace {
+
+struct MatchedLoop {
+  cudaq::quake::ExtractRefOp extractRef;
+  Value veq;            // the statically sized veq (relax_size stripped if any)
+  std::size_t size = 0; // C
+};
+
+// Recognize: a compile-time counted loop, no early exit, whose single-block
+// body contains exactly one `extract_ref` indexed by the loop's own
+// induction variable on a statically sized veq whose size matches the trip
+// count, and that veq has no other use anywhere in the loop.
+static std::optional<MatchedLoop> matchLoop(cudaq::cc::LoopOp loop) {
+  if (!cudaq::opt::isaCountedLoop(loop))
+    return std::nullopt;
+  auto components = cudaq::opt::getLoopComponents(loop);
+  if (!components || !components->induction)
+    return std::nullopt;
+  auto tripCount = components->getIterationsConstant();
+  if (!tripCount || *tripCount == 0)
+    return std::nullopt;
+
+  Region &body = loop.getBodyRegion();
+  if (!body.hasOneBlock())
+    return std::nullopt;
+  Block &bodyBlock = body.front();
+  unsigned inductionIdx = *components->induction;
+  if (inductionIdx >= bodyBlock.getNumArguments())
+    return std::nullopt;
+  Value inductionArg = bodyBlock.getArgument(inductionIdx);
+
+  cudaq::quake::ExtractRefOp match;
+  for (auto extractOp : bodyBlock.getOps<cudaq::quake::ExtractRefOp>()) {
+    if (match)
+      return std::nullopt; // more than one extract_ref in the body
+    match = extractOp;
+  }
+  if (!match || match.getIndex() != inductionArg)
+    return std::nullopt;
+
+  Value veq = match.getVeq();
+  Value sizedVeq = veq;
+  if (auto relax = veq.getDefiningOp<cudaq::quake::RelaxSizeOp>())
+    sizedVeq = relax.getInputVec();
+  auto veqTy = dyn_cast<cudaq::quake::VeqType>(sizedVeq.getType());
+  if (!veqTy || !veqTy.hasSpecifiedSize() || veqTy.getSize() != *tripCount)
+    return std::nullopt;
+
+  // Escape check: `veq` (the value extract_ref actually operates on, before
+  // any relax_size-stripping) must have no other use reachable from
+  // anywhere inside the loop besides `match` itself.
+  auto isInsideLoop = [&](Operation *op) {
+    for (Operation *p = op; p; p = p->getParentOp())
+      if (p == loop.getOperation())
+        return true;
+    return false;
+  };
+  for (OpOperand &use : veq.getUses())
+    if (use.getOwner() != match.getOperation() && isInsideLoop(use.getOwner()))
+      return std::nullopt;
+
+  return MatchedLoop{match, sizedVeq, veqTy.getSize()};
+}
+
+// Append `passthrough` as the trailing operand of every `cc.condition` in
+// `region` (the while region always has exactly one block).
+static void appendConditionOperand(Region &region, Value passthrough,
+                                   PatternRewriter &rewriter) {
+  auto cond = cast<cudaq::cc::ConditionOp>(region.front().back());
+  SmallVector<Value> results(cond.getResults());
+  results.push_back(passthrough);
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(cond);
+  rewriter.replaceOpWithNewOp<cudaq::cc::ConditionOp>(cond, cond.getCondition(),
+                                                      results);
+}
+
+// Append `passthrough` as the trailing operand of every `cc.continue` that
+// terminates a block with no successors in `region` (step/else may, in
+// principle, have more than one block).
+static void appendContinueOperands(Region &region, Value passthrough,
+                                   PatternRewriter &rewriter) {
+  for (auto &block : region)
+    if (block.hasNoSuccessors())
+      if (auto cont = dyn_cast<cudaq::cc::ContinueOp>(block.getTerminator())) {
+        SmallVector<Value> operands(cont.getOperands());
+        operands.push_back(passthrough);
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(cont);
+        rewriter.replaceOpWithNewOp<cudaq::cc::ContinueOp>(cont, operands);
+      }
+}
+
+class ThreadCablePattern : public OpRewritePattern<cudaq::cc::LoopOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::cc::LoopOp loop,
+                                PatternRewriter &rewriter) const override {
+    auto matched = matchLoop(loop);
+    if (!matched)
+      return failure();
+
+    auto loc = loop.getLoc();
+    auto *ctx = rewriter.getContext();
+    std::size_t C = matched->size;
+    Value veq = matched->veq;
+    auto refTy = cudaq::quake::RefType::get(ctx);
+    auto wireTy = cudaq::quake::WireType::get(ctx);
+    auto cableTy = cudaq::quake::CableType::get(ctx, C);
+    auto cableMinusOneTy = cudaq::quake::CableType::get(ctx, C - 1);
+
+    // Before the loop: unwrap every ref of `veq`, in order, and bundle them
+    // into the initial cable.
+    rewriter.setInsertionPoint(loop);
+    SmallVector<Value> refs;
+    SmallVector<Value> wires;
+    for (std::size_t j = 0; j < C; ++j) {
+      auto ref = cudaq::quake::ExtractRefOp::create(rewriter, loc, veq, j);
+      refs.push_back(ref);
+      wires.push_back(
+          cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, ref));
+    }
+    Value cable0 =
+        cudaq::quake::BundleCableOp::create(rewriter, loc, cableTy, wires);
+
+    // Add a trailing cable-typed block argument to every non-empty region's
+    // entry block.
+    for (Region *region : loop.getRegions())
+      if (!region->empty())
+        region->front().addArgument(cableTy, loc);
+
+    // Body: replace the matched extract_ref with detach_wire/wrap_new, and
+    // append unwrap/attach_wire just before the region's terminator.
+    Block &bodyBlock = loop.getBodyRegion().front();
+    Value cableArg = bodyBlock.getArguments().back();
+    rewriter.setInsertionPoint(matched->extractRef);
+    auto detach = cudaq::quake::DetachWireOp::create(
+        rewriter, loc, wireTy, cableMinusOneTy, cableArg, /*index=*/0);
+    auto wrapNew = cudaq::quake::WrapNewOp::create(rewriter, loc, refTy,
+                                                   detach.getWireOut());
+    rewriter.replaceOp(matched->extractRef, wrapNew.getResult());
+
+    auto bodyContinue = cast<cudaq::cc::ContinueOp>(bodyBlock.getTerminator());
+    rewriter.setInsertionPoint(bodyContinue);
+    auto unwrapBack = cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy,
+                                                     wrapNew.getResult());
+    auto attach = cudaq::quake::AttachWireOp::create(
+        rewriter, loc, cableTy, unwrapBack.getResult(), detach.getCableOut(),
+        /*index=*/C - 1);
+    SmallVector<Value> bodyOperands(bodyContinue.getOperands());
+    bodyOperands.push_back(attach.getResult());
+    rewriter.replaceOpWithNewOp<cudaq::cc::ContinueOp>(bodyContinue,
+                                                       bodyOperands);
+
+    // While/step/else: the cable simply passes through unchanged.
+    appendConditionOperand(loop.getWhileRegion(),
+                           loop.getWhileRegion().front().getArguments().back(),
+                           rewriter);
+    if (loop.hasStep())
+      appendContinueOperands(loop.getStepRegion(),
+                             loop.getStepRegion().front().getArguments().back(),
+                             rewriter);
+    if (loop.hasPythonElse())
+      appendContinueOperands(loop.getElseRegion(),
+                             loop.getElseRegion().front().getArguments().back(),
+                             rewriter);
+
+    // Rebuild the loop with the cable appended to its carried values, move
+    // the (already-rewritten) regions across, and redirect the original
+    // results.
+    SmallVector<Value> newInitArgs(loop.getInitialArgs());
+    newInitArgs.push_back(cable0);
+    SmallVector<Type> newResultTypes(loop.getResultTypes());
+    newResultTypes.push_back(cableTy);
+
+    rewriter.setInsertionPoint(loop);
+    auto newLoop = cudaq::cc::LoopOp::create(
+        rewriter, loc, newResultTypes, newInitArgs, loop.isPostConditional(),
+        [](OpBuilder &, Location, Region &) {},
+        [](OpBuilder &, Location, Region &) {},
+        /*stepBuilder=*/nullptr);
+    newLoop->setDiscardableAttrs(loop->getDiscardableAttrDictionary());
+    newLoop.getWhileRegion().takeBody(loop.getWhileRegion());
+    newLoop.getBodyRegion().takeBody(loop.getBodyRegion());
+    newLoop.getStepRegion().takeBody(loop.getStepRegion());
+    newLoop.getElseRegion().takeBody(loop.getElseRegion());
+
+    for (unsigned i = 0, n = loop.getNumResults(); i < n; ++i)
+      loop.getResult(i).replaceAllUsesWith(newLoop.getResult(i));
+    Value finalCable = newLoop.getResults().back();
+
+    // After the loop: split the final cable and wrap each wire back to its
+    // original ref - the cable is back in its original order after C
+    // detach-front/attach-back cycles.
+    rewriter.setInsertionPointAfter(newLoop);
+    SmallVector<Type> wireTys(C, wireTy);
+    auto split =
+        cudaq::quake::SplitCableOp::create(rewriter, loc, wireTys, finalCable);
+    for (auto [wire, ref] : llvm::zip(split.getResults(), refs))
+      cudaq::quake::WrapOp::create(rewriter, loc, wire, ref);
+
+    rewriter.eraseOp(loop);
+    return success();
+  }
+};
+
+class LoopCableRotationPass
+    : public cudaq::opt::impl::LoopCableRotationBase<LoopCableRotationPass> {
+public:
+  using LoopCableRotationBase::LoopCableRotationBase;
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<ThreadCablePattern>(ctx);
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // namespace

--- a/cudaq/test/Optimizer/loop_cable_rotation.qke
+++ b/cudaq/test/Optimizer/loop_cable_rotation.qke
@@ -1,0 +1,226 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --loop-cable-rotation %s | FileCheck %s
+
+// The motivating case: a counted loop applies a gate to each ref of a
+// statically sized veq, indexed by the loop's own induction variable. The
+// veq is rotated through a cable instead of staying in reference form.
+
+func.func @rotate_basic() {
+  %v = quake.alloca !quake.veq<3>
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %angle = arith.constant 1.0 : f64
+  cc.loop while ((%i = %c0) -> (i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i : i64)
+  } do {
+  ^bb0(%i: i64):
+    %r = quake.extract_ref %v[%i] : (!quake.veq<3>, i64) -> !quake.ref
+    quake.rx (%angle) %r : (f64, !quake.ref) -> ()
+    cc.continue %i : i64
+  } step {
+  ^bb0(%i: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next : i64
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @rotate_basic() {
+// CHECK:           %[[V:.*]] = quake.alloca !quake.veq<3>
+// CHECK:           %[[R0:.*]] = quake.extract_ref %[[V]][0] :
+// CHECK:           %[[W0:.*]] = quake.unwrap %[[R0]] :
+// CHECK:           %[[R1:.*]] = quake.extract_ref %[[V]][1] :
+// CHECK:           %[[W1:.*]] = quake.unwrap %[[R1]] :
+// CHECK:           %[[R2:.*]] = quake.extract_ref %[[V]][2] :
+// CHECK:           %[[W2:.*]] = quake.unwrap %[[R2]] :
+// CHECK:           %[[CABLE0:.*]] = quake.bundle_cable %[[W0]], %[[W1]], %[[W2]] : {{.*}} -> !quake.cable<3>
+// CHECK:           %[[LOOP:.*]]:2 = cc.loop while ((%{{.*}} = %{{.*}}, %[[CARG:.*]] = %[[CABLE0]]) -> (i64, !quake.cable<3>)) {
+// CHECK:             cc.condition
+// CHECK:           } do {
+// CHECK:           ^bb0(%{{.*}}: i64, %[[CARG2:.*]]: !quake.cable<3>):
+// CHECK:             %[[DW:.*]], %[[DC:.*]] = quake.detach_wire %[[CARG2]][0] : (!quake.cable<3>) -> (!quake.wire, !quake.cable<2>)
+// CHECK:             %[[WN:.*]] = quake.wrap_new %[[DW]] : (!quake.wire) -> !quake.ref
+// CHECK:             quake.rx ({{.*}}) %[[WN]] : (f64, !quake.ref) -> ()
+// CHECK:             %[[UW:.*]] = quake.unwrap %[[WN]] :
+// CHECK:             %[[AW:.*]] = quake.attach_wire %[[UW]], %[[DC]][2] : (!quake.wire, !quake.cable<2>) -> !quake.cable<3>
+// CHECK:             cc.continue %{{.*}}, %[[AW]] : i64, !quake.cable<3>
+// CHECK:           } step {
+// CHECK:           %[[SPLIT:.*]]:3 = quake.split_cable %[[LOOP]]#1 : (!quake.cable<3>) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           quake.wrap %[[SPLIT]]#0 to %[[R0]] :
+// CHECK:           quake.wrap %[[SPLIT]]#1 to %[[R1]] :
+// CHECK:           quake.wrap %[[SPLIT]]#2 to %[[R2]] :
+// CHECK:           return
+// CHECK:         }
+
+// A pre-existing secondary loop-carried value must be preserved in place;
+// the cable is appended after it, not disturbing its index.
+
+func.func @rotate_secondary() -> i64 {
+  %v = quake.alloca !quake.veq<3>
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %angle = arith.constant 1.0 : f64
+  %res:2 = cc.loop while ((%i = %c0, %acc = %c0) -> (i64, i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i, %acc : i64, i64)
+  } do {
+  ^bb0(%i: i64, %acc: i64):
+    %r = quake.extract_ref %v[%i] : (!quake.veq<3>, i64) -> !quake.ref
+    quake.rx (%angle) %r : (f64, !quake.ref) -> ()
+    %acc2 = arith.addi %acc, %c1 : i64
+    cc.continue %i, %acc2 : i64, i64
+  } step {
+  ^bb0(%i: i64, %acc: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next, %acc : i64, i64
+  }
+  return %res#1 : i64
+}
+
+// CHECK-LABEL:   func.func @rotate_secondary() -> i64 {
+// CHECK:           %[[LOOP:.*]]:3 = cc.loop while ((%{{.*}} = %{{.*}}, %[[ACC:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (i64, i64, !quake.cable<3>)) {
+// CHECK:             cc.condition
+// CHECK:           } do {
+// CHECK:           ^bb0(%{{.*}}: i64, %[[ACC2:.*]]: i64, %{{.*}}: !quake.cable<3>):
+// CHECK:             quake.detach_wire
+// CHECK:             quake.wrap_new
+// CHECK:             quake.rx
+// CHECK:             %[[ACC3:.*]] = arith.addi %[[ACC2]], %{{.*}} : i64
+// CHECK:             quake.unwrap
+// CHECK:             %[[AW:.*]] = quake.attach_wire
+// CHECK:             cc.continue %{{.*}}, %[[ACC3]], %[[AW]] : i64, i64, !quake.cable<3>
+// CHECK:           }
+// CHECK:           quake.split_cable %[[LOOP]]#2
+// CHECK:           return %[[LOOP]]#1 : i64
+// CHECK:         }
+
+// Negative: the loop has an early exit (break), so it is not a counted
+// loop - left untouched.
+
+func.func @no_rotate_break(%cond: i1) {
+  %v = quake.alloca !quake.veq<3>
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %angle = arith.constant 1.0 : f64
+  cc.loop while ((%i = %c0) -> (i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i : i64)
+  } do {
+  ^bb0(%i: i64):
+    %r = quake.extract_ref %v[%i] : (!quake.veq<3>, i64) -> !quake.ref
+    quake.rx (%angle) %r : (f64, !quake.ref) -> ()
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    cc.break %i : i64
+  ^bb2:
+    cc.continue %i : i64
+  } step {
+  ^bb0(%i: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next : i64
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @no_rotate_break(
+// CHECK-NOT:       quake.bundle_cable
+// CHECK:           cc.loop
+// CHECK-NOT:       quake.detach_wire
+
+// Negative: the veq's size is not statically known - left untouched.
+
+func.func @no_rotate_dynamic_size(%n: i64) {
+  %v = quake.alloca !quake.veq<?>[%n : i64]
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %angle = arith.constant 1.0 : f64
+  cc.loop while ((%i = %c0) -> (i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i : i64)
+  } do {
+  ^bb0(%i: i64):
+    %r = quake.extract_ref %v[%i] : (!quake.veq<?>, i64) -> !quake.ref
+    quake.rx (%angle) %r : (f64, !quake.ref) -> ()
+    cc.continue %i : i64
+  } step {
+  ^bb0(%i: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next : i64
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @no_rotate_dynamic_size(
+// CHECK-NOT:       quake.bundle_cable
+
+// Negative: the extract_ref's index is not exactly the loop's induction
+// variable (it is offset by a constant) - left untouched.
+
+func.func @no_rotate_offset_index() {
+  %v = quake.alloca !quake.veq<4>
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %angle = arith.constant 1.0 : f64
+  cc.loop while ((%i = %c0) -> (i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i : i64)
+  } do {
+  ^bb0(%i: i64):
+    %off = arith.addi %i, %c1 : i64
+    %r = quake.extract_ref %v[%off] : (!quake.veq<4>, i64) -> !quake.ref
+    quake.rx (%angle) %r : (f64, !quake.ref) -> ()
+    cc.continue %i : i64
+  } step {
+  ^bb0(%i: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next : i64
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @no_rotate_offset_index(
+// CHECK-NOT:       quake.bundle_cable
+
+// Negative: the veq has another use inside the loop besides the one
+// extract_ref (here, passed whole to a call) - left untouched.
+
+func.func private @callee(!quake.veq<3>)
+
+func.func @no_rotate_extra_use() {
+  %v = quake.alloca !quake.veq<3>
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c1 = arith.constant 1 : i64
+  %angle = arith.constant 1.0 : f64
+  cc.loop while ((%i = %c0) -> (i64)) {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    cc.condition %cmp(%i : i64)
+  } do {
+  ^bb0(%i: i64):
+    %r = quake.extract_ref %v[%i] : (!quake.veq<3>, i64) -> !quake.ref
+    quake.rx (%angle) %r : (f64, !quake.ref) -> ()
+    func.call @callee(%v) : (!quake.veq<3>) -> ()
+    cc.continue %i : i64
+  } step {
+  ^bb0(%i: i64):
+    %next = arith.addi %i, %c1 : i64
+    cc.continue %next : i64
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @no_rotate_extra_use(
+// CHECK-NOT:       quake.bundle_cable


### PR DESCRIPTION
This is a specialized pattern to convert loops over an entire veq value into loops that use a cable value and the syntactic sugar ops of Quake to rotate the wires in the cable as a shift-register. This pass will be used to preserve cc.loop structure *and* allow the loop to be written in SSI form using linear types. This is a boon to anyone lamenting that high-level loops (which are intentionally used to generate references) are not completely compatible with the so-called value-semantics (i.e. linear types).