### PR TITLE
Removing Quantum Machines legacy IR spelling shim

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -14,19 +14,16 @@
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/Support/Base64.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <bitset>
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <regex>
 #include <sstream>
 #include <stdexcept>
 #include <thread>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 using json = nlohmann::json;
@@ -34,18 +31,6 @@ using json = nlohmann::json;
 namespace {
 constexpr const char *decoderConfigPayloadType = "gpu_decoder_config";
 constexpr const char *decoderConfigJobJsonPath = "/decoder_config";
-
-/// Rewrite the IR to match the legacy spellings used by the remote server.
-std::string rewriteLegacySpellings(std::string ir) {
-  // Renamed the legacy `!cc.stdvec` type to `!cc.sequence`.
-  ir = std::regex_replace(ir, std::regex(R"(cc\.sequence)"), "cc.stdvec");
-  // Moved output logging from `cc.log_output` to `quake.evince` (renamed
-  // from `quake.log_output`).
-  ir = std::regex_replace(
-      ir, std::regex(R"(quake\.evince ([^\n]+) : \(([^\n]*)\) -> \(\))"),
-      "cc.log_output $1 : $2");
-  return ir;
-}
 } // namespace
 
 namespace cudaq {
@@ -168,12 +153,7 @@ public:
         executionContext ? executionContext->name : "unknown";
     const bool isRunRequest = requestType == "run";
     ServerMessage job;
-    std::vector<char> decodedContent;
-    if (auto error = llvm::decodeBase64(circuitCodes[0].code, decodedContent))
-      throw std::runtime_error("Failed to decode QM Quake payload.");
-    std::string content(decodedContent.begin(), decodedContent.end());
-    content = rewriteLegacySpellings(std::move(content));
-    job["content"] = llvm::encodeBase64(content);
+    job["content"] = circuitCodes[0].code;
     job["source"] = "quake";
     job["shots"] = shots;
     job["executor"] = backendConfig["executor"];

--- a/unittests/nvqpp/backends/quantum_machines/CMakeLists.txt
+++ b/unittests/nvqpp/backends/quantum_machines/CMakeLists.txt
@@ -10,7 +10,6 @@ add_backend_unittest_executable(test_quantum_machines
   SOURCES QuantumMachinesTester.cpp
   BACKEND quantum_machines
   BACKEND_CONFIG "quantum_machines url=http://localhost:62448"
-  LINK_LIBS ${default_backend_unittest_libs} cudaqMLIR
 )
 
 configure_file(QuantumMachinesStartServerAndTest.sh.in QuantumMachinesStartServerAndTest.sh @ONLY)

--- a/unittests/nvqpp/backends/quantum_machines/QuantumMachinesTester.cpp
+++ b/unittests/nvqpp/backends/quantum_machines/QuantumMachinesTester.cpp
@@ -7,16 +7,10 @@
  ******************************************************************************/
 
 #include "CUDAQTestUtils.h"
-#include "common/ServerHelper.h"
 #include "math.h"
-#include "nlohmann/json.hpp"
 #include "cudaq/algorithm.h"
-#include "llvm/Support/Base64.h"
 #include <gtest/gtest.h>
-#include <stdexcept>
 #include <stdlib.h>
-#include <string_view>
-#include <vector>
 
 CUDAQ_TEST(QuantumMachinesTester, minimal3Hadamard) {
   auto kernel = cudaq::make_kernel();
@@ -62,43 +56,6 @@ CUDAQ_TEST(QuantumMachinesTester, gates) {
   auto counts = cudaq::sample(1001, kernel);
   counts.dump();
   EXPECT_EQ(counts.size(), 8);
-}
-
-namespace {
-constexpr std::string_view currentQuakeIR = R"mlir(module {
-  func.func @kernel(%arg0: !cc.sequence<i64>) {
-    quake.evince %arg0 : (!cc.sequence<i64>) -> ()
-    return
-  }
-})mlir";
-
-std::string createSubmittedIR(cudaq::ServerHelper &helper) {
-  std::vector<cudaq::KernelExecution> executions{
-      {.name = "kernel", .code = llvm::encodeBase64(currentQuakeIR)}};
-  const auto payload = helper.createJob(executions);
-  const auto &jobs = std::get<2>(payload);
-  if (jobs.size() != 1)
-    throw std::runtime_error("Expected one QM job payload.");
-
-  std::vector<char> decodedContent;
-  const auto encodedContent = jobs.front().at("content").get<std::string>();
-  if (auto error = llvm::decodeBase64(encodedContent, decodedContent))
-    throw std::runtime_error("Failed to decode QM test payload.");
-  return {decodedContent.begin(), decodedContent.end()};
-}
-} // namespace
-
-CUDAQ_TEST(QuantumMachinesTester, rewritesLegacySpellings) {
-  auto helper = cudaq::registry::get<cudaq::ServerHelper>("quantum_machines");
-  ASSERT_TRUE(helper);
-  helper->initialize({{"url", "http://localhost:62448"}});
-
-  const auto submittedIR = createSubmittedIR(*helper);
-  EXPECT_NE(submittedIR.find("!cc.stdvec<i64>"), std::string::npos);
-  EXPECT_NE(submittedIR.find("cc.log_output %arg0 : !cc.stdvec<i64>"),
-            std::string::npos);
-  EXPECT_EQ(submittedIR.find("cc.sequence"), std::string::npos);
-  EXPECT_EQ(submittedIR.find("quake.evince"), std::string::npos);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The QM server helper rewrote the payload to legacy spellings before submitting it (`cc.sequence` to `cc.stdvec` and `quake.evince` to `cc.log_output`). That shim was added in #5198 for a server pinned to an older CUDA-Q version.

The server now runs a current CUDA-Q, which has neither op, so the shim is what breaks it:
```
error: "-":4:5: custom op 'cc.log_output' is unknown
```