### PR TITLE
[core] Improve canonicalization of cc.loop to handle dead args

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -484,7 +484,8 @@ def cc_ConditionOp : CCOp<"condition",
 }
 
 def cc_ContinueOp : CCOp<"continue", [Pure, ReturnLike, Terminator,
-        ParentOneOf<["LoopOp", "ScopeOp", "IfOp"]>]> {
+        ParentOneOf<["LoopOp", "ScopeOp", "IfOp"]>,
+        DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>]> {
   let summary = "Continue branch.";
   let description = [{
     A ContinueOp is a generalized exit terminator for the dialect operations
@@ -521,7 +522,8 @@ def cc_ContinueOp : CCOp<"continue", [Pure, ReturnLike, Terminator,
 }
 
 def cc_BreakOp : CCOp<"break",
-        [Pure, ReturnLike, Terminator, ParentOneOf<["LoopOp"]>]> {
+        [Pure, ReturnLike, Terminator, ParentOneOf<["LoopOp"]>,
+         DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>]> {
   let summary = "Break branch.";
   let description = [{
     A BreakOp can be used in a LoopOp's body region (only). A BreakOp is a

--- a/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -10,6 +10,7 @@
 #include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/IR/DataLayout.h"
@@ -2097,11 +2098,123 @@ struct HoistLoopInvariantArgs : public OpRewritePattern<cudaq::cc::LoopOp> {
     return failure();
   }
 };
+
+// For a loop which has an internally carried value that is never used (other
+// than to thread around the loop) and the same corresponding loop result is
+// also never used, is dead.
+//
+// We used this hand-rolled canonicalization, rather than try to use the MLIR
+// builtin generic `RegionBranchOpInterface` "tied successor inputs" machinery
+// because MLIR bakes in assumptions that do not apply for `cc.loop`. Those
+// assumptions result in MLIR's greedy rewriter destroying the composite
+// structure of `cc.loop`. It does not respect the multi-region internal
+// structure and the semantics of terminators between those regions cannot be
+// properly encoded into their algorithm. Hence, we want to avoid MLIR.
+struct EraseDeadCarriedValues : public OpRewritePattern<cudaq::cc::LoopOp> {
+  using Base = OpRewritePattern<cudaq::cc::LoopOp>;
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(cudaq::cc::LoopOp loop,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Operation *> terminators;
+    for (auto *reg : loop.getRegions())
+      for (auto &block : *reg)
+        if (block.hasNoSuccessors())
+          terminators.push_back(block.getTerminator());
+
+    const unsigned numArgs = loop.getInitialArgs().size();
+    llvm::BitVector dead(numArgs, true);
+    for (auto *reg : loop.getRegions()) {
+      if (reg->empty())
+        continue;
+      auto &entry = reg->front();
+      for (unsigned i = 0; i < numArgs; ++i) {
+        if (!dead[i])
+          continue;
+        Value arg = entry.getArgument(i);
+        for (auto *user : arg.getUsers()) {
+          if (llvm::none_of(terminators,
+                            [&](Operation *t) { return t == user; })) {
+            dead.reset(i);
+            break;
+          }
+        }
+      }
+    }
+    for (unsigned i = 0; i < numArgs; ++i)
+      if (dead[i] && !loop.getResult(i).use_empty())
+        dead.reset(i);
+
+    if (dead.none())
+      return failure();
+
+    // Fix terminators, dropping the dead-indexed operands.
+    auto keepLive = [&](ValueRange operands) {
+      SmallVector<Value> kept;
+      for (auto [i, v] : llvm::enumerate(operands))
+        if (!dead[i])
+          kept.push_back(v);
+      return kept;
+    };
+    for (auto *term : terminators) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(term);
+      if (auto cond = dyn_cast<cudaq::cc::ConditionOp>(term))
+        rewriter.replaceOpWithNewOp<cudaq::cc::ConditionOp>(
+            cond, cond.getCondition(), keepLive(cond.getResults()));
+      else if (auto cont = dyn_cast<cudaq::cc::ContinueOp>(term))
+        rewriter.replaceOpWithNewOp<cudaq::cc::ContinueOp>(
+            cont, keepLive(cont.getOperands()));
+      else if (auto brk = dyn_cast<cudaq::cc::BreakOp>(term))
+        rewriter.replaceOpWithNewOp<cudaq::cc::BreakOp>(
+            brk, keepLive(brk.getOperands()));
+    }
+
+    // Erase the dead block arguments from every region's entry, descending so
+    // earlier indices stay valid.
+    for (auto *reg : loop.getRegions()) {
+      if (reg->empty())
+        continue;
+      for (int i = numArgs - 1; i >= 0; --i)
+        if (dead[i])
+          reg->front().eraseArgument(i);
+    }
+
+    // Assemble the new initial args and result types, then rebuild.
+    SmallVector<Value> newInitArgs;
+    SmallVector<Type> newResultTypes;
+    for (unsigned i = 0; i < numArgs; ++i)
+      if (!dead[i]) {
+        newInitArgs.push_back(loop.getInitialArgs()[i]);
+        newResultTypes.push_back(loop.getResultTypes()[i]);
+      }
+
+    rewriter.setInsertionPoint(loop);
+    auto newLoop = cudaq::cc::LoopOp::create(
+        rewriter, loop.getLoc(), newResultTypes, newInitArgs,
+        loop.isPostConditional(), [](OpBuilder &, Location, Region &) {},
+        [](OpBuilder &, Location, Region &) {},
+        /*stepBuilder=*/nullptr);
+    newLoop->setDiscardableAttrs(loop->getDiscardableAttrDictionary());
+    newLoop.getWhileRegion().takeBody(loop.getWhileRegion());
+    newLoop.getBodyRegion().takeBody(loop.getBodyRegion());
+    newLoop.getStepRegion().takeBody(loop.getStepRegion());
+    newLoop.getElseRegion().takeBody(loop.getElseRegion());
+
+    unsigned newIdx = 0;
+    for (unsigned i = 0; i < numArgs; ++i)
+      if (!dead[i])
+        loop.getResult(i).replaceAllUsesWith(newLoop.getResult(newIdx++));
+
+    rewriter.eraseOp(loop);
+    return success();
+  }
+};
 } // namespace
 
 void cudaq::cc::LoopOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                     MLIRContext *context) {
-  patterns.add<HoistLoopInvariantArgs>(context);
+  patterns.add<HoistLoopInvariantArgs, EraseDeadCarriedValues>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/cudaq/test/Transforms/loop_dead_carried_value.qke
+++ b/cudaq/test/Transforms/loop_dead_carried_value.qke
@@ -1,0 +1,119 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --canonicalize %s | FileCheck %s
+
+// Regression test for the reversal failure behind issue #5232/#5233 (see
+// apply-8.qke): a carried value (`j`) whose backing memory lived outside the
+// loop it is really scoped to gets promoted by `memtoreg` into a value
+// threaded around the loop, even though nothing ever uses it. `j` is
+// overwritten before any use on every iteration (not truly live-in), and its
+// "final" value is never used anywhere (dead-out). This looks live-in to the
+// inner loop only because `memtoreg`'s promotion conservatively assumes a
+// store to memory inside a loop may be live-out of it, before the
+// enclosing scope has been walked to know otherwise. `LoopOp`'s canonicalizer
+// is the necessary complement, pruning the slot once it is actually known
+// nothing uses it.
+
+func.func private @sink(i32)
+
+func.func @dead_carried_value(%n: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %u = cc.undef i32
+  %0:2 = cc.loop while ((%i = %c0, %j = %u) -> (i32, i32)) {
+    %1 = arith.cmpi slt, %i, %n : i32
+    cc.condition %1(%i, %j : i32, i32)
+  } do {
+  ^bb0(%i: i32, %j: i32):
+    %1 = arith.addi %i, %c1 : i32
+    %2 = cc.loop while ((%k = %1) -> (i32)) {
+      %3 = arith.cmpi slt, %k, %n : i32
+      cc.condition %3(%k : i32)
+    } do {
+    ^bb0(%k: i32):
+      func.call @sink(%k) : (i32) -> ()
+      cc.continue %k : i32
+    } step {
+    ^bb0(%k: i32):
+      %3 = arith.addi %k, %c1 : i32
+      cc.continue %3 : i32
+    }
+    cc.continue %i, %2 : i32, i32
+  } step {
+  ^bb0(%i: i32, %j: i32):
+    %1 = arith.addi %i, %c1 : i32
+    cc.continue %1, %j : i32, i32
+  }
+  return %0#0 : i32
+}
+
+// CHECK-LABEL:   func.func @dead_carried_value(
+// CHECK-SAME:      %[[N:.*]]: i32) -> i32 {
+// CHECK:           %[[C0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[C1:.*]] = arith.constant 1 : i32
+// CHECK:           %[[OUTER:.*]] = cc.loop while ((%[[I:.*]] = %[[C0]]) -> (i32)) {
+// CHECK:             %[[CMP0:.*]] = arith.cmpi slt, %[[I]], %[[N]] : i32
+// CHECK:             cc.condition %[[CMP0]](%[[I]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[I2:.*]]: i32):
+// CHECK:             %[[NEXT:.*]] = arith.addi %[[I2]], %[[C1]] : i32
+// CHECK:             cc.loop while ((%[[K:.*]] = %[[NEXT]]) -> (i32)) {
+// CHECK:               %[[CMP1:.*]] = arith.cmpi slt, %[[K]], %[[N]] : i32
+// CHECK:               cc.condition %[[CMP1]](%[[K]] : i32)
+// CHECK:             } do {
+// CHECK:             ^bb0(%[[K2:.*]]: i32):
+// CHECK:               func.call @sink(%[[K2]]) : (i32) -> ()
+// CHECK:               cc.continue %[[K2]] : i32
+// CHECK:             } step {
+// CHECK:             }
+// CHECK:             cc.continue %[[I2]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[I3:.*]]: i32):
+// CHECK:             %[[STEP:.*]] = arith.addi %[[I3]], %[[C1]] : i32
+// CHECK:             cc.continue %[[STEP]] : i32
+// CHECK:           }
+// CHECK:           return %[[OUTER]] : i32
+// CHECK:         }
+
+// Negative: the same shape, but the carried value's final value IS read after
+// the loop.
+
+func.func @not_dead_when_read_after(%n: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %u = cc.undef i32
+  %0:2 = cc.loop while ((%i = %c0, %j = %u) -> (i32, i32)) {
+    %1 = arith.cmpi slt, %i, %n : i32
+    cc.condition %1(%i, %j : i32, i32)
+  } do {
+  ^bb0(%i: i32, %j: i32):
+    %1 = arith.addi %i, %c1 : i32
+    %2 = cc.loop while ((%k = %1) -> (i32)) {
+      %3 = arith.cmpi slt, %k, %n : i32
+      cc.condition %3(%k : i32)
+    } do {
+    ^bb0(%k: i32):
+      func.call @sink(%k) : (i32) -> ()
+      cc.continue %k : i32
+    } step {
+    ^bb0(%k: i32):
+      %3 = arith.addi %k, %c1 : i32
+      cc.continue %3 : i32
+    }
+    cc.continue %i, %2 : i32, i32
+  } step {
+  ^bb0(%i: i32, %j: i32):
+    %1 = arith.addi %i, %c1 : i32
+    cc.continue %1, %j : i32, i32
+  }
+  return %0#1 : i32
+}
+
+// CHECK-LABEL:   func.func @not_dead_when_read_after(
+// CHECK:           %{{.*}}:2 = cc.loop while ((%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (i32, i32)) {

--- a/python/tests/mlir/measure_handle.py
+++ b/python/tests/mlir/measure_handle.py
@@ -464,13 +464,18 @@ def test_handle_vector_cross_round_reassignment():
     print(kernel_handle_vec_cross_round)
 
 
+# `use` is assigned but never read, so `mvec`'s final value is transitively
+# dead too: neither `mvec` nor `m_new` is threaded as a loop-carried value at
+# all - the loop only carries its own induction variable.
+
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_handle_vec_cross_round
 # CHECK-SAME:      attributes {"cudaq-entrypoint"
 # CHECK:           %[[VEQ:.*]] = quake.alloca !quake.veq<3>
 # CHECK:           %[[MVEC:.*]] = quake.mz %[[VEQ]] name "mvec" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
-# CHECK:           cc.loop while
+# CHECK:           cc.loop while ((%{{.*}} = %{{.*}}) -> (i64)) {
+# CHECK:           } do {
 # CHECK:             %[[MNEW:.*]] = quake.mz %[[VEQ]] name "m_new" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
-# CHECK:             cc.continue {{.*}}%[[MNEW]], %[[MNEW]]
+# CHECK:             cc.continue %{{.*}} : i64
 # CHECK-NOT:       quake.discriminate
 # CHECK:           return
 

--- a/python/tests/mlir/qec_ops.py
+++ b/python/tests/mlir/qec_ops.py
@@ -274,22 +274,26 @@ def test_rep_code_d3():
     print(kernel_rep_code_d3)
 
 
+# `s0`/`s1` are locals assigned fresh on every iteration before any read
+# reaches back to a previous iteration's value, so the `cc.loop`
+# canonicalizer prunes them from the carried-value list entirely; only
+# `prev_s0`/`prev_s1` - genuinely read (via the `cc.if` below) before being
+# overwritten - remain threaded.
+
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_rep_code_d3
 # CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 # CHECK-DAG:       %[[CONSTANT_0:.*]] = arith.constant 1 : i64
 # CHECK-DAG:       %[[CONSTANT_1:.*]] = arith.constant 0 : i64
-# CHECK:           %[[UNDEF_0:.*]] = cc.undef !cc.measure_handle
-# CHECK:           %[[UNDEF_1:.*]] = cc.undef !cc.measure_handle
 # CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<3>
 # CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[ALLOCA_2:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[UNDEF_2:.*]] = cc.undef !cc.measure_handle
-# CHECK:           %[[UNDEF_3:.*]] = cc.undef !cc.measure_handle
-# CHECK:           %[[LOOP_0:.*]]:5 = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]], %[[VAL_2:.*]] = %[[UNDEF_2]], %[[VAL_3:.*]] = %[[UNDEF_3]], %[[VAL_4:.*]] = %[[UNDEF_1]], %[[VAL_5:.*]] = %[[UNDEF_0]]) -> (i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle)) {
+# CHECK:           %[[UNDEF_0:.*]] = cc.undef !cc.measure_handle
+# CHECK:           %[[UNDEF_1:.*]] = cc.undef !cc.measure_handle
+# CHECK:           %[[LOOP_0:.*]]:3 = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]], %[[VAL_2:.*]] = %[[UNDEF_0]], %[[VAL_3:.*]] = %[[UNDEF_1]]) -> (i64, !cc.measure_handle, !cc.measure_handle)) {
 # CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[ARG0]] : i64
-# CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle)
+# CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]], %[[VAL_2]], %[[VAL_3]] : i64, !cc.measure_handle, !cc.measure_handle)
 # CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_6:.*]]: i64, %[[VAL_8:.*]]: !cc.measure_handle, %[[VAL_9:.*]]: !cc.measure_handle, %[[VAL_10:.*]]: !cc.measure_handle, %[[VAL_11:.*]]: !cc.measure_handle):
+# CHECK:           ^bb0(%[[VAL_6:.*]]: i64, %[[VAL_8:.*]]: !cc.measure_handle, %[[VAL_9:.*]]: !cc.measure_handle):
 # CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_0]][0] : (!quake.veq<3>) -> !quake.ref
 # CHECK:             quake.x {{\[}}%[[EXTRACT_REF_0]]] %[[ALLOCA_1]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:             %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_0]][1] : (!quake.veq<3>) -> !quake.ref
@@ -307,11 +311,11 @@ def test_rep_code_d3():
 # CHECK:               qec.detector %[[VAL_9]], %[[MZ_1]] : !cc.measure_handle, !cc.measure_handle
 # CHECK:             } else {
 # CHECK:             }
-# CHECK:             cc.continue %[[VAL_6]], %[[MZ_0]], %[[MZ_1]], %[[MZ_0]], %[[MZ_1]] : i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
+# CHECK:             cc.continue %[[VAL_6]], %[[MZ_0]], %[[MZ_1]] : i64, !cc.measure_handle, !cc.measure_handle
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_12:.*]]: i64, %[[VAL_14:.*]]: !cc.measure_handle, %[[VAL_15:.*]]: !cc.measure_handle, %[[VAL_16:.*]]: !cc.measure_handle, %[[VAL_17:.*]]: !cc.measure_handle):
+# CHECK:           ^bb0(%[[VAL_12:.*]]: i64, %[[VAL_14:.*]]: !cc.measure_handle, %[[VAL_15:.*]]: !cc.measure_handle):
 # CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_12]], %[[CONSTANT_0]] : i64
-# CHECK:             cc.continue %[[ADDI_0]], %[[VAL_14]], %[[VAL_15]], %[[VAL_16]], %[[VAL_17]] : i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
+# CHECK:             cc.continue %[[ADDI_0]], %[[VAL_14]], %[[VAL_15]] : i64, !cc.measure_handle, !cc.measure_handle
 # CHECK:           }
 # CHECK:           %[[MZ_2:.*]] = quake.mz %[[ALLOCA_0]] name "readout" : (!quake.veq<3>) -> !cc.sequence<!cc.measure_handle>
 # CHECK:           qec.observable %[[MZ_2]] : !cc.sequence<!cc.measure_handle>

--- a/python/tests/mlir/qft.py
+++ b/python/tests/mlir/qft.py
@@ -39,7 +39,6 @@ def test_qft():
 # CHECK-DAG:       %[[CONSTANT_2:.*]] = arith.constant 2 : i64
 # CHECK-DAG:       %[[CONSTANT_3:.*]] = arith.constant 1 : i64
 # CHECK-DAG:       %[[CONSTANT_4:.*]] = arith.constant 0 : i64
-# CHECK-DAG:       %[[UNDEF_1:.*]] = cc.undef i64
 # CHECK:           %[[VEQ_SIZE_0:.*]] = quake.veq_size %[[ARG0]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[FLOORDIVSI_0:.*]] = arith.floordivsi %[[VEQ_SIZE_0]], %[[CONSTANT_2]] : i64
 # CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_4]]) -> (i64)) {
@@ -57,13 +56,13 @@ def test_qft():
 # CHECK:           ^bb0(%[[VAL_2:.*]]: i64):
 # CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_2]], %[[CONSTANT_3]] : i64
 # CHECK:             cc.continue %[[ADDI_0]] : i64
-# CHECK:           } {normalized}
+# CHECK:           }
 # CHECK:           %[[SUBI_2:.*]] = arith.subi %[[VEQ_SIZE_0]], %[[CONSTANT_3]] : i64
-# CHECK:           %[[LOOP_1:.*]]:2 = cc.loop while ((%[[VAL_3:.*]] = %[[CONSTANT_4]], %[[VAL_4:.*]] = %[[UNDEF_1]]) -> (i64, i64)) {
+# CHECK:           %[[LOOP_1:.*]] = cc.loop while ((%[[VAL_3:.*]] = %[[CONSTANT_4]]) -> (i64)) {
 # CHECK:             %[[CMPI_1:.*]] = arith.cmpi slt, %[[VAL_3]], %[[SUBI_2]] : i64
-# CHECK:             cc.condition %[[CMPI_1]](%[[VAL_3]], %[[VAL_4]] : i64, i64)
+# CHECK:             cc.condition %[[CMPI_1]](%[[VAL_3]] : i64)
 # CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_6:.*]]: i64, %[[VAL_7:.*]]: i64):
+# CHECK:           ^bb0(%[[VAL_6:.*]]: i64):
 # CHECK:             %[[EXTRACT_REF_2:.*]] = quake.extract_ref %[[ARG0]]{{\[}}%[[VAL_6]]] : (!quake.veq<?>, i64) -> !quake.ref
 # CHECK:             quake.h %[[EXTRACT_REF_2]] : (!quake.ref) -> ()
 # CHECK:             %[[ADDI_1:.*]] = arith.addi %[[VAL_6]], %[[CONSTANT_3]] : i64
@@ -90,12 +89,12 @@ def test_qft():
 # CHECK:               %[[ADDI_2:.*]] = arith.addi %[[VAL_11]], %[[CONSTANT_3]] : i64
 # CHECK:               cc.continue %[[ADDI_2]] : i64
 # CHECK:             } {normalized}
-# CHECK:             cc.continue %[[VAL_6]], %[[ADDI_1]] : i64, i64
+# CHECK:             cc.continue %[[VAL_6]] : i64
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_12:.*]]: i64, %[[VAL_13:.*]]: i64):
+# CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
 # CHECK:             %[[ADDI_3:.*]] = arith.addi %[[VAL_12]], %[[CONSTANT_3]] : i64
-# CHECK:             cc.continue %[[ADDI_3]], %[[VAL_13]] : i64, i64
-# CHECK:           } {normalized}
+# CHECK:             cc.continue %[[ADDI_3]] : i64
+# CHECK:           }
 # CHECK:           %[[SUBI_7:.*]] = arith.subi %[[VEQ_SIZE_0]], %[[CONSTANT_3]] : i64
 # CHECK:           %[[EXTRACT_REF_5:.*]] = quake.extract_ref %[[ARG0]]{{\[}}%[[SUBI_7]]] : (!quake.veq<?>, i64) -> !quake.ref
 # CHECK:           quake.h %[[EXTRACT_REF_5]] : (!quake.ref) -> ()


### PR DESCRIPTION
Improve canonicalization of loops to properly eliminate conservative threading of dead variables as values through the loop regions.